### PR TITLE
ci: SHA-pin all third-party actions with audit comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 # Minimum required for `actions/checkout` (read the repo). Cache via
-# `actions/cache@v4` works in read-only fallback without an explicit
+# `Swatinem/rust-cache` works in read-only fallback without an explicit
 # `actions: write` grant — fine for a solo-dev workflow where the
 # cache hit rate is acceptable. No GitHub API writes from this job.
 permissions:
@@ -20,21 +20,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # pin-audit:2026-05-21 34e1148 | v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable
         with:
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # pin-audit:2026-05-21 e18b497 | v2
 
       - name: Build
         run: cargo build --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # pin-audit:2026-05-21 34e1148 | v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # pin-audit:2026-05-21 34e1148 | v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
   build-deb:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # pin-audit:2026-05-21 34e1148 | v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libsystemd-dev
@@ -65,7 +65,7 @@ jobs:
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # pin-audit:2026-05-21 3bb1273 | v2.6.2
         with:
           name: ${{ steps.notes.outputs.name }}
           files: target/debian/*.deb


### PR DESCRIPTION
## Summary
- Tag/branch refs are mutable; pin to full-SHA refs to harden against tag-bump supply-chain attacks (tj-actions/changed-files 2025-03).
- Each `uses:` line now carries a `# pin-audit:<date> <sha7> | <tag>` comment so future SHA bumps surface as a re-audit trigger.
- `actions/cache@v4` (manual path/key) replaced with `Swatinem/rust-cache@e18b497` — same caching role, higher-precision keys from Cargo.lock + toolchain.

## Pinned actions

| action | SHA | source tag/branch |
|---|---|---|
| actions/checkout | 34e1148 | v4.3.1 |
| dtolnay/rust-toolchain | 29eef33 | stable (branch HEAD at audit time) |
| Swatinem/rust-cache | e18b497 | v2 |
| softprops/action-gh-release | 3bb1273 | v2.6.2 |

## Test plan
- [ ] CI workflow runs successfully on this PR (checkout / rust-toolchain / rust-cache / build / test / clippy)
- [ ] On next tag push, Release workflow uploads .deb assets via softprops at the pinned SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security and reliability by pinning action dependencies to specific versions.
  * Simplified caching configuration in the continuous integration pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naoto256/limpid/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->