### PR TITLE
refactor(output): extract shared syslog framing/payload/peer-parse helpers

### DIFF
--- a/crates/limpid/src/modules/output/persistent_conn.rs
+++ b/crates/limpid/src/modules/output/persistent_conn.rs
@@ -1,7 +1,7 @@
 //! Shared persistent-connection orchestration for stream-oriented outputs.
 //!
-//! TCP and Unix-socket outputs both hold a `Mutex<Option<Stream>>` and
-//! follow the same dance on every `write()`:
+//! Outputs with a single persistent stream can hold a
+//! `Mutex<Option<Stream>>` and follow the same dance on every `write()`:
 //!
 //! 1. Lock the slot.
 //! 2. If a stream is cached, try the framed write. On success bump the
@@ -10,14 +10,9 @@
 //! 4. If the slot is empty (initial call, or just-dropped broken conn),
 //!    dial a fresh connection, cache it, and write once more.
 //!
-//! The framing (octet counting vs. newline-terminated, etc.) and the
-//! concrete stream type live in the caller — this helper only owns the
-//! reconnect + metric-increment loop so that a third persistent-conn
-//! output (e.g. TLS) can plug in without reimplementing the dance.
-//!
-//! Dispatch stays hardcoded per-output (TCP, Unix socket) because
-//! there are currently only two implementations; if a third
-//! persistent-conn sink lands (e.g. TLS), promote to a registry.
+//! The framing and the concrete stream type live in the caller — this
+//! helper only owns the reconnect + metric-increment loop for outputs
+//! that use one cached connection rather than a peer list.
 //!
 //! Kept `pub(crate)` — internal implementation detail of the output
 //! layer, not part of the module contract.

--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -6,7 +6,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
+use bytes::Bytes;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::Mutex;
+
+use crate::dsl::ast::Property;
+use crate::dsl::props;
 
 /// Per-peer cooldown after a send/connect failure. Hardcoded for now;
 /// may later be exposed as a DSL property.
@@ -24,6 +30,22 @@ pub const PEER_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 
 type PeerAttemptFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
 
+/// Payload carried from `render` to `write` for every syslog output.
+/// All sinks ship one frame's bytes; nothing else is needed.
+pub struct SyslogPayload {
+    pub egress: Bytes,
+}
+
+/// Syslog over TCP framing per RFC 6587. Shared between syslog_tcp
+/// and syslog_tls outputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyslogFraming {
+    /// RFC 6587 §3.4.1: `MSG-LEN SP SYSLOG-MSG`.
+    OctetCounting,
+    /// RFC 6587 §3.4.2: messages terminated by LF.
+    NonTransparent,
+}
+
 /// A configured destination. `tls` is `Some(...)` only for outputs
 /// that negotiate client-side TLS; plaintext outputs leave it `None`.
 #[derive(Debug, Clone)]
@@ -37,6 +59,77 @@ impl Peer {
     pub fn address(&self) -> String {
         format!("{}:{}", self.host, self.port)
     }
+}
+
+/// Parse `host` and `port` properties from a peer block. The caller
+/// supplies the default port and the label used in error messages.
+pub fn parse_host_port(
+    properties: &[Property],
+    default_port: u16,
+    label: &str,
+) -> anyhow::Result<(String, u16)> {
+    let host = props::get_string(properties, "host")
+        .ok_or_else(|| anyhow::anyhow!("{} requires 'host'", label))?;
+    let port = match props::get_int(properties, "port") {
+        Some(port) => {
+            u16::try_from(port).with_context(|| format!("{} port must be 0..=65535", label))?
+        }
+        None => default_port,
+    };
+    Ok((host, port))
+}
+
+/// Iterate `peer` blocks inside a `peers` block, invoking the provided
+/// per-peer parser for each one.
+pub fn iter_peers_block<T, F>(
+    peers_block: &[Property],
+    label: &str,
+    mut parse_one: F,
+) -> anyhow::Result<Vec<T>>
+where
+    F: FnMut(&[Property]) -> anyhow::Result<T>,
+{
+    let mut out = Vec::new();
+    for prop in peers_block {
+        if let Property::Block {
+            key,
+            properties: inner,
+            ..
+        } = prop
+            && key == "peer"
+        {
+            out.push(parse_one(inner)?);
+        }
+    }
+    if out.is_empty() {
+        anyhow::bail!("{} block must contain at least one peer", label);
+    }
+    Ok(out)
+}
+
+/// Write one syslog message with RFC 6587 framing.
+pub async fn write_framed<S>(
+    stream: &mut S,
+    framing: SyslogFraming,
+    payload: &Bytes,
+) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    match framing {
+        SyslogFraming::OctetCounting => {
+            let header = format!("{} ", payload.len());
+            stream.write_all(header.as_bytes()).await?;
+            stream.write_all(payload).await?;
+        }
+        SyslogFraming::NonTransparent => {
+            stream.write_all(payload).await?;
+            stream.write_all(b"\n").await?;
+        }
+    }
+
+    stream.flush().await?;
+    Ok(())
 }
 
 /// Per-peer mutable state. C is the connection type (TcpStream,

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
-use bytes::Bytes;
-use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
 use crate::dsl::arena::EventArena;
@@ -16,7 +14,8 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
-    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList,
+    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogFraming, SyslogPayload,
+    iter_peers_block, parse_host_port, write_framed,
 };
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 
@@ -70,20 +69,10 @@ const SYSLOG_TCP_OUTPUT_SCHEMA: &[PropertySpec] = &[
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 
-struct SyslogTcpPayload {
-    egress: Bytes,
-}
-
 pub struct SyslogTcpOutput {
-    pub framing: SyslogTcpFraming,
+    pub framing: SyslogFraming,
     peers: PeerList<TcpStream>,
     metrics: Arc<OutputMetrics>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SyslogTcpFraming {
-    OctetCounting,
-    NonTransparent,
 }
 
 impl Module for SyslogTcpOutput {
@@ -103,10 +92,10 @@ impl Module for SyslogTcpOutput {
     }
 }
 
-fn parse_framing(name: &str, properties: &[Property]) -> Result<SyslogTcpFraming> {
+fn parse_framing(name: &str, properties: &[Property]) -> Result<SyslogFraming> {
     match props::get_ident(properties, "framing").as_deref() {
-        Some("non_transparent") => Ok(SyslogTcpFraming::NonTransparent),
-        Some("octet_counting") | None => Ok(SyslogTcpFraming::OctetCounting),
+        Some("non_transparent") => Ok(SyslogFraming::NonTransparent),
+        Some("octet_counting") | None => Ok(SyslogFraming::OctetCounting),
         Some(other) => anyhow::bail!(
             "output '{}': unknown framing '{}' (expected octet_counting | non_transparent)",
             name,
@@ -121,38 +110,18 @@ fn parse_peers(name: &str, properties: &[Property]) -> Result<Vec<Peer>> {
     }
 
     if let Some(peers_block) = props::get_block(properties, "peers") {
-        let mut out = Vec::new();
-        for prop in peers_block {
-            if let Property::Block {
-                key,
-                properties: inner,
-                ..
-            } = prop
-                && key == "peer"
-            {
-                out.push(parse_peer(name, "peers.peer", inner)?);
-            }
-        }
-        if out.is_empty() {
-            anyhow::bail!(
-                "output '{}': peers block must contain at least one peer",
-                name
-            );
-        }
-        return Ok(out);
+        let label = format!("output '{}': peers", name);
+        return iter_peers_block(peers_block, &label, |inner| {
+            parse_peer(name, "peers.peer", inner)
+        });
     }
 
     anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name)
 }
 
 fn parse_peer(name: &str, label: &str, properties: &[Property]) -> Result<Peer> {
-    let host = props::get_string(properties, "host")
-        .ok_or_else(|| anyhow::anyhow!("output '{}': {} requires 'host'", name, label))?;
-    let port = match props::get_int(properties, "port") {
-        Some(port) => u16::try_from(port)
-            .with_context(|| format!("output '{}': {} port must be 0..=65535", name, label))?,
-        None => 514,
-    };
+    let label = format!("output '{}': {}", name, label);
+    let (host, port) = parse_host_port(properties, 514, &label)?;
     Ok(Peer {
         host,
         port,
@@ -174,13 +143,13 @@ impl Output for SyslogTcpOutput {
         event: &BorrowedEvent<'_>,
         _arena: &EventArena<'_>,
     ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(SyslogTcpPayload {
+        Ok(RenderedPayload::new(SyslogPayload {
             egress: event.egress.clone(),
         }))
     }
 
     async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: SyslogTcpPayload = payload.downcast()?;
+        let payload: SyslogPayload = payload.downcast()?;
         let framing = self.framing;
         let metrics = Arc::clone(&self.metrics);
         let result = self
@@ -203,7 +172,7 @@ impl Output for SyslogTcpOutput {
                     let stream = state.conn.as_mut().expect("connection should be present");
                     let write_result = tokio::time::timeout(
                         PEER_WRITE_TIMEOUT,
-                        write_syslog_tcp_framed(stream, framing, &egress),
+                        write_framed(stream, framing, &egress),
                     )
                     .await
                     .map_err(|_| anyhow::anyhow!("syslog_tcp write to {} timed out", address))
@@ -224,27 +193,6 @@ impl Output for SyslogTcpOutput {
             Err(err) => Err(anyhow::anyhow!("{}", err)),
         }
     }
-}
-
-async fn write_syslog_tcp_framed(
-    stream: &mut TcpStream,
-    framing: SyslogTcpFraming,
-    payload: &Bytes,
-) -> Result<()> {
-    match framing {
-        SyslogTcpFraming::OctetCounting => {
-            let header = format!("{} ", payload.len());
-            stream.write_all(header.as_bytes()).await?;
-            stream.write_all(payload).await?;
-        }
-        SyslogTcpFraming::NonTransparent => {
-            stream.write_all(payload).await?;
-            stream.write_all(b"\n").await?;
-        }
-    }
-
-    stream.flush().await?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -294,7 +242,7 @@ mod tests {
         let tcp = SyslogTcpOutput::build("relay", &mp(&props)).expect("should build");
         assert_eq!(tcp.peers.len(), 1);
         assert_eq!(tcp.peers.peers()[0].address(), "127.0.0.1:514");
-        assert_eq!(tcp.framing, SyslogTcpFraming::OctetCounting);
+        assert_eq!(tcp.framing, SyslogFraming::OctetCounting);
     }
 
     #[test]
@@ -323,7 +271,7 @@ mod tests {
             kv("framing", ExprKind::Ident(vec!["non_transparent".into()])),
         ];
         let tcp = SyslogTcpOutput::build("relay", &mp(&props)).expect("should build");
-        assert_eq!(tcp.framing, SyslogTcpFraming::NonTransparent);
+        assert_eq!(tcp.framing, SyslogFraming::NonTransparent);
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/syslog_tls.rs
+++ b/crates/limpid/src/modules/output/syslog_tls.rs
@@ -6,8 +6,6 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
-use bytes::Bytes;
-use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector;
 use tokio_rustls::client::TlsStream;
@@ -21,8 +19,8 @@ use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
     PEER_CONNECT_TIMEOUT, PEER_HANDSHAKE_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList,
+    SyslogFraming, SyslogPayload, iter_peers_block, parse_host_port, write_framed,
 };
-use crate::modules::output::syslog_tcp::SyslogTcpFraming;
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::tls::{ClientTlsConfig, build_client_config_sync};
 
@@ -119,12 +117,8 @@ const SYSLOG_TLS_OUTPUT_SCHEMA: &[PropertySpec] = &[
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 
-struct SyslogTlsPayload {
-    egress: Bytes,
-}
-
 pub struct SyslogTlsOutput {
-    pub framing: SyslogTcpFraming,
+    pub framing: SyslogFraming,
     peers: PeerList<TlsStream<TcpStream>>,
     connectors: Vec<TlsConnector>,
     metrics: Arc<OutputMetrics>,
@@ -162,10 +156,10 @@ impl Module for SyslogTlsOutput {
     }
 }
 
-fn parse_framing(name: &str, properties: &[Property]) -> Result<SyslogTcpFraming> {
+fn parse_framing(name: &str, properties: &[Property]) -> Result<SyslogFraming> {
     match props::get_ident(properties, "framing").as_deref() {
-        Some("non_transparent") => Ok(SyslogTcpFraming::NonTransparent),
-        Some("octet_counting") | None => Ok(SyslogTcpFraming::OctetCounting),
+        Some("non_transparent") => Ok(SyslogFraming::NonTransparent),
+        Some("octet_counting") | None => Ok(SyslogFraming::OctetCounting),
         Some(other) => anyhow::bail!(
             "output '{}': unknown framing '{}' (expected octet_counting | non_transparent)",
             name,
@@ -209,25 +203,10 @@ fn parse_peers(
     }
 
     if let Some(peers_block) = props::get_block(properties, "peers") {
-        let mut out = Vec::new();
-        for prop in peers_block {
-            if let Property::Block {
-                key,
-                properties: inner,
-                ..
-            } = prop
-                && key == "peer"
-            {
-                out.push(parse_peer(name, "peers.peer", inner, profiles)?);
-            }
-        }
-        if out.is_empty() {
-            anyhow::bail!(
-                "output '{}': peers block must contain at least one peer",
-                name
-            );
-        }
-        return Ok(out);
+        let label = format!("output '{}': peers", name);
+        return iter_peers_block(peers_block, &label, |inner| {
+            parse_peer(name, "peers.peer", inner, profiles)
+        });
     }
 
     anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name)
@@ -239,13 +218,8 @@ fn parse_peer(
     properties: &[Property],
     profiles: &HashMap<String, ClientTlsConfig>,
 ) -> Result<Peer> {
-    let host = props::get_string(properties, "host")
-        .ok_or_else(|| anyhow::anyhow!("output '{}': {} requires 'host'", name, label))?;
-    let port = match props::get_int(properties, "port") {
-        Some(port) => u16::try_from(port)
-            .with_context(|| format!("output '{}': {} port must be 0..=65535", name, label))?,
-        None => 6514,
-    };
+    let host_port_label = format!("output '{}': {}", name, label);
+    let (host, port) = parse_host_port(properties, 6514, &host_port_label)?;
     let tls = parse_peer_tls(name, label, properties, profiles)?;
     Ok(Peer { host, port, tls })
 }
@@ -313,13 +287,13 @@ impl Output for SyslogTlsOutput {
         event: &BorrowedEvent<'_>,
         _arena: &EventArena<'_>,
     ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(SyslogTlsPayload {
+        Ok(RenderedPayload::new(SyslogPayload {
             egress: event.egress.clone(),
         }))
     }
 
     async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: SyslogTlsPayload = payload.downcast()?;
+        let payload: SyslogPayload = payload.downcast()?;
         let framing = self.framing;
         let metrics = Arc::clone(&self.metrics);
         let connectors = self.connectors.clone();
@@ -361,7 +335,7 @@ impl Output for SyslogTlsOutput {
                     let stream = state.conn.as_mut().expect("connection should be present");
                     let write_result = tokio::time::timeout(
                         PEER_WRITE_TIMEOUT,
-                        write_syslog_tls_framed(stream, framing, &egress),
+                        write_framed(stream, framing, &egress),
                     )
                     .await
                     .map_err(|_| anyhow::anyhow!("syslog_tls write to {} timed out", address))
@@ -382,27 +356,6 @@ impl Output for SyslogTlsOutput {
             Err(err) => Err(anyhow::anyhow!("{}", err)),
         }
     }
-}
-
-async fn write_syslog_tls_framed(
-    stream: &mut TlsStream<TcpStream>,
-    framing: SyslogTcpFraming,
-    payload: &Bytes,
-) -> Result<()> {
-    match framing {
-        SyslogTcpFraming::OctetCounting => {
-            let header = format!("{} ", payload.len());
-            stream.write_all(header.as_bytes()).await?;
-            stream.write_all(payload).await?;
-        }
-        SyslogTcpFraming::NonTransparent => {
-            stream.write_all(payload).await?;
-            stream.write_all(b"\n").await?;
-        }
-    }
-
-    stream.flush().await?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
-use bytes::Bytes;
 use tokio::net::UdpSocket;
 
 use crate::dsl::arena::EventArena;
@@ -14,7 +13,8 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
-    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList,
+    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogPayload, iter_peers_block,
+    parse_host_port,
 };
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 
@@ -61,10 +61,6 @@ const SYSLOG_UDP_OUTPUT_SCHEMA: &[PropertySpec] = &[
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 
-struct SyslogUdpPayload {
-    egress: Bytes,
-}
-
 pub struct SyslogUdpOutput {
     peers: PeerList<UdpSocket>,
     metrics: Arc<OutputMetrics>,
@@ -91,38 +87,18 @@ fn parse_peers(name: &str, properties: &[Property]) -> Result<Vec<Peer>> {
     }
 
     if let Some(peers_block) = props::get_block(properties, "peers") {
-        let mut out = Vec::new();
-        for prop in peers_block {
-            if let Property::Block {
-                key,
-                properties: inner,
-                ..
-            } = prop
-                && key == "peer"
-            {
-                out.push(parse_peer(name, "peers.peer", inner)?);
-            }
-        }
-        if out.is_empty() {
-            anyhow::bail!(
-                "output '{}': peers block must contain at least one peer",
-                name
-            );
-        }
-        return Ok(out);
+        let label = format!("output '{}': peers", name);
+        return iter_peers_block(peers_block, &label, |inner| {
+            parse_peer(name, "peers.peer", inner)
+        });
     }
 
     anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name)
 }
 
 fn parse_peer(name: &str, label: &str, properties: &[Property]) -> Result<Peer> {
-    let host = props::get_string(properties, "host")
-        .ok_or_else(|| anyhow::anyhow!("output '{}': {} requires 'host'", name, label))?;
-    let port = match props::get_int(properties, "port") {
-        Some(port) => u16::try_from(port)
-            .with_context(|| format!("output '{}': {} port must be 0..=65535", name, label))?,
-        None => 514,
-    };
+    let label = format!("output '{}': {}", name, label);
+    let (host, port) = parse_host_port(properties, 514, &label)?;
     Ok(Peer {
         host,
         port,
@@ -144,13 +120,13 @@ impl Output for SyslogUdpOutput {
         event: &BorrowedEvent<'_>,
         _arena: &EventArena<'_>,
     ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(SyslogUdpPayload {
+        Ok(RenderedPayload::new(SyslogPayload {
             egress: event.egress.clone(),
         }))
     }
 
     async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: SyslogUdpPayload = payload.downcast()?;
+        let payload: SyslogPayload = payload.downcast()?;
         let metrics = Arc::clone(&self.metrics);
         let result = self
             .peers


### PR DESCRIPTION
## Summary

Pure refactor addressing 6 abstraction-scope audit findings (1-1, 2-1, 2-2, 2-3, 6-1, 6-2) carried over from the syslog multi-destination work that landed in release/0.7.4. Functional behavior, DSL surface, and test results are unchanged.

## Changes

- `SyslogTcpFraming` → `SyslogFraming` and moved to `syslog_peers` (1-1). `syslog_tls` no longer reaches into `syslog_tcp` for a framing enum it conceptually shares rather than borrows.
- `write_syslog_tcp_framed` / `write_syslog_tls_framed` collapse into one generic `write_framed<S: AsyncWrite + Unpin>` in `syslog_peers` (2-2).
- `SyslogTcpPayload` / `SyslogTlsPayload` / `SyslogUdpPayload` (all `{ egress: Bytes }`) collapse into one `SyslogPayload` (2-3).
- `parse_host_port` and `iter_peers_block` extracted to `syslog_peers`; per-sink `parse_peer` becomes a thin wrapper that only adds sink-specific fields (`tls` for syslog_tls; nothing for tcp/udp) (2-1). Error message wording preserved.
- `persistent_conn.rs` module / trait / function docstrings rewritten to describe the remaining caller (unix_socket) instead of the long-gone TCP sink (6-1, 6-2).

The 4-1 finding (`PersistentConn` trait now single-implementation) is **not** addressed here — removing it touches `unix_socket` which is out of scope for this PR. Tracked for a separate follow-up.

## Net diff

5 files changed, +139 / -174 (-35 LOC). The three sink files shrink; the bulk moves into the shared module that is already the natural home for cross-sink syslog plumbing.

## Test plan

- [x] `cargo build -p limpid`
- [x] `cargo test -p limpid` (452 unit + 24 cli_check, all passing — same count as before refactor)
- [x] `cargo clippy -p limpid -- -D warnings`
- [x] uchgs push-gate audit (7 scopes)

## Audit summary

All 7 push-gate scopes confirmed. ci-precheck and readme-current passed with no findings. cicd-pipeline (1 Info, pre-existing release permission), abstraction (1 Warning, the deferred 4-1), confidentiality and security (1 Warning each on a pre-existing Postfix corpus wording), and rust (7 pre-existing dependency-version warnings) were each confirmed with documented disposition. Receipts issued under `user/naoto256` because the audit was run via Codex as a remote auditor while uchgs CLI invocation happened on the coordinator host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)