### PR TITLE
release: 0.7.4 — multi-destination syslog outputs + TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-1.0 releases may introduce breaking changes freely as the DSL and
 runtime shape converge. After 1.0, changes will follow semver strictly.
 
-## [Unreleased]
+## [0.7.4] - 2026-06-03
 > multi-destination syslog outputs + TLS
 
 ### Added — `syslog_tls` output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true


### PR DESCRIPTION
## Summary

Release 0.7.4. Version bump + CHANGELOG header transition only.

- `crates/limpid`, `crates/limpidctl`, `crates/limpid-prometheus`: `0.7.3` → `0.7.4`
- `Cargo.lock`: refreshed for the three workspace crates
- `CHANGELOG.md`: `[Unreleased]` → `[0.7.4] - 2026-06-03` (body byte-identical, already published under [Unreleased] by prior PRs that landed on release/0.7.4)

## Release content

The release body was already written under `[Unreleased]` across the PRs that landed in this branch:

- **`syslog_tls` output** (TLS-encrypted syslog over TCP, RFC 5425, port 6514; custom CA / Mozilla roots / optional mTLS / named profiles)
- **Multi-destination peer lists** for `syslog_tcp` / `syslog_udp` / `syslog_tls` (`peer { ... }` single / `peers { peer { ... } ... }` round-robin with 5s cooldown on failure)
- **BREAKING — output module rename**: `output tcp` / `output udp` → `output syslog_tcp` / `output syslog_udp` (no alias)
- **BREAKING — DSL surface**: top-level `address` / `host`+`port` removed in favour of `peer { host port }`
- Hardening: connect / TLS handshake / write timeouts; test PEM moved off-source via rcgen

## After merge

1. Merge release/0.7.4 → main
2. Tag v0.7.4 on main
3. Push tag → release.yml fires (`.deb` artifacts + GitHub Release)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (452 limpid unit + 24 cli_check + 9 limpidctl, all passing)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] uchgs push-gate audit (7 scopes, Phase 1D from inherited prior session at parent 2a93122)

🤖 Generated with [Claude Code](https://claude.com/claude-code)