### PR TITLE
ci: trigger on release/* branches and allow manual dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/*']
+  workflow_dispatch:
 
 # Minimum required for `actions/checkout` (read the repo). Cache via
 # `Swatinem/rust-cache` works in read-only fallback without an explicit


### PR DESCRIPTION
## Why

`.github/workflows/ci.yml` only listened on `main` (push + PR). Every PR landing in this repo since 2026-05-20 has targeted `release/0.7.4`, so no CI run fired for ~2 weeks of branch work. PRs #5 / #6 / #7 had no CI signal — the workflow was effectively dormant.

## What

```diff
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/*']
+  workflow_dispatch:
```

- Add `release/*` to both push and pull_request triggers so PRs landing into a release branch get build/test/clippy coverage, and any direct push to a release branch (rare) also fires.
- Add `workflow_dispatch` so a maintainer can re-run manually for back-fill / debugging without an empty commit.

No other CI changes; SHA-pinned action references and `persist-credentials: false` posture stay as they are.

## After merge

Once this lands on release/0.7.4, future PRs targeting release/0.7.4 (and the eventual release/0.7.4 → main PR) will run CI.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (452 + 24 + 9 = 485 passed)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] uchgs push-gate audit (7 scopes; ci.yml diff-scoped clean for cicd-pipeline / confidentiality, Tier A elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)