### PR TITLE
ci: update checkout action to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # pin-audit:2026-05-21 34e1148 | v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # pin-audit:2026-06-03 de0fac2 | v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- update the CI workflow checkout action to the audited Node 24 pin
- keep the action SHA-pinned with the matching pin-audit comment
- preserve persist-credentials: false

## Verification
- code-audit cicd-pipeline audit.py
- git diff --check HEAD^..HEAD
- uchgs verify push: 7/7 PASS

## Notes
- The existing release workflow contents: write Info is carry-over and not introduced by this PR.