### PR TITLE
fix: align array primitive null handling

### DIFF
--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -5,13 +5,13 @@
 //! never enters this module. Boundary conversions happen at the
 //! pipeline level (`pipeline::run_pipeline` entry/exit).
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use bytes::Bytes;
 use thiserror::Error;
 
 use super::arena::EventArena;
 use super::ast::*;
-use super::eval::{eval_expr_with_scope, value_to_string, values_match, LocalScope};
+use super::eval::{LocalScope, eval_expr_with_scope, value_to_string, values_match};
 use super::value::Value;
 use crate::event::BorrowedEvent;
 use crate::functions::FunctionRegistry;
@@ -1296,6 +1296,14 @@ mod tests {
                 call_fn("last", vec![xs()]),
             ),
             ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["first_null".into()]),
+                call_fn("first", vec![e(ExprKind::Null)]),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["last_null".into()]),
+                call_fn("last", vec![e(ExprKind::Null)]),
+            ),
+            ProcessStatement::Assign(
                 AssignTarget::Workspace(vec!["distinct".into()]),
                 call_fn("distinct", vec![xs()]),
             ),
@@ -1359,6 +1367,8 @@ mod tests {
             ExecResult::Continue(ev) => {
                 assert_eq!(ev.workspace_get("first"), Some(Value::Int(1)));
                 assert_eq!(ev.workspace_get("last"), Some(Value::Int(3)));
+                assert_eq!(ev.workspace_get("first_null"), Some(Value::Null));
+                assert_eq!(ev.workspace_get("last_null"), Some(Value::Null));
                 assert_eq!(
                     ev.workspace_get("distinct").unwrap().to_owned_value(),
                     OwnedValue::Array(vec![
@@ -1383,6 +1393,30 @@ mod tests {
             }
             ExecResult::Dropped => panic!("unexpected drop"),
         }
+    }
+
+    #[test]
+    fn test_exec_sum_rejects_null_input() {
+        let _bump = ::bumpalo::Bump::new();
+        let arena = crate::dsl::arena::EventArena::new(&_bump);
+        let event = make_event();
+        let bevent = event.view_in(&arena);
+        let stmts = vec![ProcessStatement::Assign(
+            AssignTarget::Workspace(vec!["sum".into()]),
+            call_fn("sum", vec![e(ExprKind::Null)]),
+        )];
+        let err = expect_exec_err(exec_process_body(
+            &stmts,
+            bevent,
+            &NoopRegistry,
+            &make_funcs(),
+            &arena,
+        ));
+        assert!(
+            err.to_string().contains("sum() expects an Array, got null"),
+            "expected sum(null) to fail loudly, got: {}",
+            err
+        );
     }
 
     #[test]

--- a/crates/limpid/src/functions/primitives/first.rs
+++ b/crates/limpid/src/functions/primitives/first.rs
@@ -10,7 +10,7 @@ use crate::modules::schema::FieldType;
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "first",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Any),
+        FunctionSig::fixed(&[FieldType::Any], FieldType::Any),
         |_arena, args, _event| Ok(head(&args[0])),
     );
 }

--- a/crates/limpid/src/functions/primitives/last.rs
+++ b/crates/limpid/src/functions/primitives/last.rs
@@ -7,7 +7,7 @@ use crate::modules::schema::FieldType;
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "last",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Any),
+        FunctionSig::fixed(&[FieldType::Any], FieldType::Any),
         |_arena, args, _event| Ok(tail(&args[0])),
     );
 }

--- a/crates/limpid/src/functions/primitives/sum.rs
+++ b/crates/limpid/src/functions/primitives/sum.rs
@@ -23,7 +23,6 @@ pub fn register(reg: &mut FunctionRegistry) {
 fn add<'bump>(v: &Value<'bump>) -> anyhow::Result<Value<'bump>> {
     let items = match v {
         Value::Array(items) => *items,
-        Value::Null => return Ok(Value::Int(0)),
         other => bail!("sum() expects an Array, got {}", other.type_name()),
     };
     let mut int_acc: i64 = 0;


### PR DESCRIPTION
## Summary
- align first/last signatures with their documented null-safe behavior
- make sum(null) fail loudly instead of coercing to 0
- add DSL exec regression coverage for first(null), last(null), and sum(null)

## Verification
- cargo check -p limpid
- cargo test -p limpid
- cargo clippy -p limpid --all-targets -- -D warnings
- git diff --check HEAD^..HEAD
- uchgs verify push: 7/7 PASS

## Notes
- Responds to CodeRabbit comments on the 0.7.5 array primitive surface.
- last() was updated alongside first() because it has the same null-safe runtime contract.