### PR TITLE
feat(output): add TLS/mTLS/SASL support to kafka output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,52 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [0.7.6] - 2026-06-21
 > syslog TLS folded into `syslog_tcp` on both sides (output: per-peer,
-> input: optional block); `otlp_http` gains TLS / mTLS
+> input: optional block); `otlp_http` gains TLS / mTLS; `output kafka`
+> gains TLS / mTLS / SASL
+
+### Added — `output kafka` `tls { ... }` and `sasl { ... }` blocks
+
+`output kafka` now accepts optional `tls { ca cert key }` and
+`sasl { mechanism username password_file }` blocks. The
+`security.protocol` is derived from which blocks are present
+(`plaintext` / `ssl` / `sasl_plaintext` / `sasl_ssl`), so the most
+common production setup (SASL/SCRAM over TLS) is a single config
+change away.
+
+`cert + key` in the `tls` block are both-or-neither: present them
+together for mTLS, omit both for one-way TLS. `ca` alone is fine for
+private-CA broker certs.
+
+Supported SASL mechanisms: `plain`, `scram_sha_256`, `scram_sha_512`.
+The DSL ident grammar forbids `-`, so the SCRAM mechanisms are spelled
+with underscores in the config and mapped to librdkafka's hyphen
+spelling (`SCRAM-SHA-256` / `SCRAM-SHA-512`) at parse time.
+
+SASL credentials are split intentionally: `username` is inline (not
+secret), `password_file` points to a separate file (chmod 600) — the
+same disposition limpid uses for TLS private keys. Inline `password`
+is **not** supported, so credentials never end up in config diffs,
+backups, or pretty-printed log output. Empty `password_file` is
+rejected as a misconfiguration.
+
+`brokers` is still a single comma-separated bootstrap list — librdkafka
+handles broker discovery / partition routing / leader failover
+internally, so unlike the syslog / http / otlp outputs there is no
+per-peer rotation layer to add here.
+
+```
+def output secure {
+    type kafka
+    brokers "kafka1.example.com:9094"
+    topic "syslog-events"
+    tls { ca "/etc/limpid/kafka-ca.pem" }
+    sasl {
+        mechanism scram-sha-512
+        username "limpid-producer"
+        password_file "/etc/limpid/kafka.pw"
+    }
+}
+```
 
 ### Added — `input otlp_http` optional `tls { ... }` block (HTTPS + mTLS)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "duct"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1419,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "opentelemetry"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1474,16 @@ dependencies = [
  "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1817,7 +1851,9 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
+ "sasl2-sys",
 ]
 
 [[package]]
@@ -2008,6 +2044,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "sasl2-sys"
+version = "0.1.22+2.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f2a7f7efd9fc98b3a9033272df10709f5ee3fa0eabbd61a527a3a1ed6bd3c6"
+dependencies = [
+ "cc",
+ "duct",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,10 +2198,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ installation, .deb packaging, and systemd integration.
 
 ### Outputs
 `syslog_udp` · `syslog_tcp` (with optional per-peer TLS) · `file` ·
-`http` · `kafka` · `unix_socket` · `stdout` · `otlp`
+`http` · `kafka` (with optional TLS / mTLS / SASL) · `unix_socket` ·
+`stdout` · `otlp`
 
 ### Upgrading from earlier versions
 
@@ -200,6 +201,18 @@ when TLS is configured, 514 otherwise. The standalone
 `input syslog_tls` module is removed in 0.7.6 — see `CHANGELOG.md`
 for migration. (`input otlp_http` gains the same `tls { ... }` block
 in the same release; `input otlp_grpc` already had it.)
+
+`output kafka` gains optional `tls { ca cert key }` and
+`sasl { mechanism username password_file }` blocks. With both
+configured the producer talks SASL/SCRAM (or PLAIN) over TLS — the
+standard production combination. `cert + key` in `tls` enables mTLS;
+`password_file` (not inline `password`) is the only supported way to
+pass SASL credentials, matching the on-disk-with-chmod-600 pattern
+already used for TLS private keys. No per-peer rotation: librdkafka's
+`brokers` bootstrap list already handles broker discovery and leader
+failover internally. Building with `--features kafka` now requires
+`libssl-dev` and `libsasl2-dev` on Debian/Ubuntu (the cmake-built
+librdkafka links against them at compile time).
 
 ### Snippets
 

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -57,7 +57,7 @@ bumpalo = { version = "3", features = ["collections"] }
 # strings, …) sit comfortably under the inline budget.
 compact_str = { version = "0.9", features = ["serde"] }
 systemd = { version = "0.10", optional = true }
-rdkafka = { version = "0.36", features = ["cmake-build"], optional = true }
+rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "sasl"], optional = true }
 
 # OTLP (OpenTelemetry Protocol). Pre-generated message types from the
 # official OpenTelemetry-rust ecosystem. `gen-tonic` pulls in tonic +

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -1,7 +1,10 @@
 //! Kafka output: produces event messages to an Apache Kafka topic.
 //!
 //! Uses librdkafka via the rdkafka crate. The producer handles batching,
-//! compression, retries, and connection management internally.
+//! compression, retries, and connection management internally — so unlike
+//! the syslog / http / otlp outputs there is no per-peer rotation layer
+//! on top: `brokers` is the bootstrap list and librdkafka resolves the
+//! cluster from there.
 //!
 //! Properties:
 //!   brokers   "kafka1:9092,kafka2:9092"   — required
@@ -9,7 +12,22 @@
 //!   compression  snappy                   — optional (none, gzip, snappy, lz4, zstd)
 //!   acks      all                         — optional (0, 1, all; default: all)
 //!   key       source                      — optional (event field to use as partition key)
-//!   queue_timeout "5s"                    — optional (max wait when internal queue is full; default: 5s)
+//!   queue_timeout "5s"                    — optional
+//!   tls  { ca; cert; key }                — optional (TLS to brokers; mTLS if cert+key)
+//!   sasl { mechanism; username; password_file }
+//!                                          — optional (SASL/PLAIN or SCRAM)
+//!
+//! `security.protocol` is derived from the blocks present:
+//! - neither      → plaintext (librdkafka default)
+//! - `tls` only   → ssl
+//! - `sasl` only  → sasl_plaintext
+//! - both         → sasl_ssl
+//!
+//! Secrets handling: `key` (PEM private key path) and `password_file`
+//! both point to **separate files** rather than inline strings, matching
+//! the mTLS convention used elsewhere in limpid. Use chmod 600 on those
+//! files; the daemon refuses to run as root, so the config user must
+//! own them.
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -27,6 +45,72 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::tls::ClientTlsConfig;
+
+/// All three fields are optional at the schema layer; the invariant
+/// (cert ↔ key paired) is enforced at parse time via
+/// [`ClientTlsConfig::validate`].
+const KAFKA_TLS_BLOCK_PROPERTIES: &[PropertySpec] = &[
+    PropertySpec {
+        name: "ca",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::String,
+    },
+    PropertySpec {
+        name: "cert",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::String,
+    },
+    PropertySpec {
+        name: "key",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::String,
+    },
+];
+
+/// Supported SASL mechanisms. The DSL spelling is underscore-separated
+/// (`scram_sha_256`) to fit the DSL's ident grammar — `-` would
+/// tokenise as subtraction. They're mapped to librdkafka's canonical
+/// hyphen-separated spelling (`SCRAM-SHA-256`) at parse time.
+const KAFKA_SASL_MECHANISMS: &[&str] = &["plain", "scram_sha_256", "scram_sha_512"];
+
+/// SASL block schema. All three keys are required when the block is
+/// present so a typo can't silently downgrade auth.
+///
+/// `password_file` (not `password`) is the only supported shape —
+/// inline `password` would put cleartext credentials in the config
+/// itself, which gets committed / backed up / logged. The file at
+/// `password_file` is read once at startup; rotate it and restart
+/// the daemon to refresh.
+const KAFKA_SASL_BLOCK_PROPERTIES: &[PropertySpec] = &[
+    PropertySpec {
+        name: "mechanism",
+        required: true,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::Enum(KAFKA_SASL_MECHANISMS),
+    },
+    PropertySpec {
+        name: "username",
+        required: true,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::String,
+    },
+    PropertySpec {
+        name: "password_file",
+        required: true,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::String,
+    },
+];
 
 const KAFKA_OUTPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
@@ -74,8 +158,110 @@ const KAFKA_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::Duration,
     },
+    PropertySpec {
+        name: "tls",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::Block(KAFKA_TLS_BLOCK_PROPERTIES),
+    },
+    PropertySpec {
+        name: "sasl",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::Block(KAFKA_SASL_BLOCK_PROPERTIES),
+    },
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
+
+struct SaslConfig {
+    /// rdkafka-spelled mechanism (`PLAIN` / `SCRAM-SHA-256` / …).
+    mechanism: String,
+    username: String,
+    password: String,
+}
+
+fn parse_tls_block(name: &str, properties: &[Property]) -> Result<Option<ClientTlsConfig>> {
+    let Some(block) = props::get_block(properties, "tls") else {
+        return Ok(None);
+    };
+    let tls = ClientTlsConfig {
+        ca_path: props::get_string(block, "ca"),
+        cert_path: props::get_string(block, "cert"),
+        key_path: props::get_string(block, "key"),
+    };
+    tls.validate(&format!("output '{}'", name))?;
+    Ok(Some(tls))
+}
+
+fn parse_sasl_block(name: &str, properties: &[Property]) -> Result<Option<SaslConfig>> {
+    let Some(block) = props::get_block(properties, "sasl") else {
+        return Ok(None);
+    };
+    let mechanism = props::get_ident(block, "mechanism").ok_or_else(|| {
+        anyhow::anyhow!("output '{}': sasl block requires 'mechanism'", name)
+    })?;
+    let username = props::get_string(block, "username").ok_or_else(|| {
+        anyhow::anyhow!("output '{}': sasl block requires 'username'", name)
+    })?;
+    let password_file = props::get_string(block, "password_file").ok_or_else(|| {
+        anyhow::anyhow!("output '{}': sasl block requires 'password_file'", name)
+    })?;
+
+    let raw = std::fs::read_to_string(&password_file).with_context(|| {
+        format!(
+            "output '{}': failed to read sasl password_file '{}'",
+            name, password_file
+        )
+    })?;
+    // Strip a single trailing newline (the common case for
+    // `echo "secret" > pw`). Empty file or whitespace-only file is
+    // probably a misconfigured secret, not a deliberate empty
+    // password, so reject it.
+    let password = raw.strip_suffix('\n').unwrap_or(&raw).to_string();
+    if password.trim().is_empty() {
+        anyhow::bail!(
+            "output '{}': sasl password_file '{}' is empty",
+            name,
+            password_file
+        );
+    }
+
+    // Map DSL underscore-spelling → librdkafka hyphen-spelling.
+    let mechanism_upper = match mechanism.as_str() {
+        "plain" => "PLAIN",
+        "scram_sha_256" => "SCRAM-SHA-256",
+        "scram_sha_512" => "SCRAM-SHA-512",
+        other => {
+            anyhow::bail!(
+                "output '{}': unsupported sasl mechanism '{}' (expected one of {:?})",
+                name,
+                other,
+                KAFKA_SASL_MECHANISMS
+            );
+        }
+    };
+
+    Ok(Some(SaslConfig {
+        mechanism: mechanism_upper.to_string(),
+        username,
+        password,
+    }))
+}
+
+/// Pick librdkafka's `security.protocol` from which of (tls, sasl)
+/// are configured. Returns `None` for the "no extra protocol layer"
+/// case so the caller can simply skip the setting (librdkafka
+/// defaults to plaintext).
+fn security_protocol(has_tls: bool, has_sasl: bool) -> Option<&'static str> {
+    match (has_tls, has_sasl) {
+        (false, false) => None,
+        (true, false) => Some("ssl"),
+        (false, true) => Some("sasl_plaintext"),
+        (true, true) => Some("sasl_ssl"),
+    }
+}
 
 struct KafkaPayload {
     egress: Bytes,
@@ -141,14 +327,39 @@ impl Module for KafkaOutput {
             other => KeyField::Field(other.to_string()),
         });
 
+        let tls = parse_tls_block(name, properties)?;
+        let sasl = parse_sasl_block(name, properties)?;
+
         // message.timeout.ms: rdkafka's internal delivery timeout (includes retries to broker).
         // Separate from queue_timeout which is the wait time when the internal queue is full.
         // If delivery fails after this timeout, limpid's queue retry mechanism handles re-delivery.
-        let producer: FutureProducer = ClientConfig::new()
+        let mut client = ClientConfig::new();
+        client
             .set("bootstrap.servers", &brokers)
             .set("compression.type", &compression)
             .set("acks", &acks)
-            .set("message.timeout.ms", "30000")
+            .set("message.timeout.ms", "30000");
+
+        if let Some(protocol) = security_protocol(tls.is_some(), sasl.is_some()) {
+            client.set("security.protocol", protocol);
+        }
+        if let Some(ref tls) = tls {
+            if let Some(ref ca) = tls.ca_path {
+                client.set("ssl.ca.location", ca);
+            }
+            if let (Some(cert), Some(key)) = (&tls.cert_path, &tls.key_path) {
+                client.set("ssl.certificate.location", cert);
+                client.set("ssl.key.location", key);
+            }
+        }
+        if let Some(ref sasl) = sasl {
+            client
+                .set("sasl.mechanism", &sasl.mechanism)
+                .set("sasl.username", &sasl.username)
+                .set("sasl.password", &sasl.password);
+        }
+
+        let producer: FutureProducer = client
             .create()
             .with_context(|| format!("output '{}': failed to create Kafka producer", name))?;
 
@@ -218,5 +429,177 @@ impl KafkaOutput {
                 .and_then(|v| v.as_str().map(|s| s.to_string()))?,
         };
         Some(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dsl::ast::{Expr, ExprKind, Property};
+    use tempfile::TempDir;
+
+    fn kv(key: &str, kind: ExprKind) -> Property {
+        Property::KeyValue {
+            key: key.into(),
+            key_span: None,
+            value: Expr::spanless(kind),
+            value_span: None,
+        }
+    }
+
+    fn block(key: &str, properties: Vec<Property>) -> Property {
+        Property::Block {
+            key: key.into(),
+            key_span: None,
+            properties,
+        }
+    }
+
+    fn str_prop(key: &str, val: &str) -> Property {
+        kv(key, ExprKind::StringLit(val.into()))
+    }
+
+    fn ident_prop(key: &str, val: &str) -> Property {
+        kv(key, ExprKind::Ident(vec![val.into()]))
+    }
+
+    // ---- security_protocol selector ----
+
+    #[test]
+    fn security_protocol_matrix() {
+        assert_eq!(security_protocol(false, false), None);
+        assert_eq!(security_protocol(true, false), Some("ssl"));
+        assert_eq!(security_protocol(false, true), Some("sasl_plaintext"));
+        assert_eq!(security_protocol(true, true), Some("sasl_ssl"));
+    }
+
+    // ---- parse_tls_block ----
+
+    #[test]
+    fn parse_tls_absent_returns_none() {
+        let result = parse_tls_block("k", &[]).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_tls_ca_only() {
+        let props = vec![block("tls", vec![str_prop("ca", "/etc/ca.pem")])];
+        let tls = parse_tls_block("k", &props).unwrap().unwrap();
+        assert_eq!(tls.ca_path.as_deref(), Some("/etc/ca.pem"));
+        assert!(tls.cert_path.is_none() && tls.key_path.is_none());
+    }
+
+    #[test]
+    fn parse_tls_mtls_full() {
+        let props = vec![block(
+            "tls",
+            vec![
+                str_prop("ca", "/ca.pem"),
+                str_prop("cert", "/c.pem"),
+                str_prop("key", "/k.pem"),
+            ],
+        )];
+        let tls = parse_tls_block("k", &props).unwrap().unwrap();
+        assert_eq!(tls.ca_path.as_deref(), Some("/ca.pem"));
+        assert_eq!(tls.cert_path.as_deref(), Some("/c.pem"));
+        assert_eq!(tls.key_path.as_deref(), Some("/k.pem"));
+    }
+
+    #[test]
+    fn parse_tls_cert_without_key_rejected() {
+        let props = vec![block("tls", vec![str_prop("cert", "/c.pem")])];
+        let err = parse_tls_block("k", &props).err().unwrap();
+        assert!(err.to_string().contains("cert and key"), "{}", err);
+    }
+
+    #[test]
+    fn parse_tls_key_without_cert_rejected() {
+        let props = vec![block("tls", vec![str_prop("key", "/k.pem")])];
+        let err = parse_tls_block("k", &props).err().unwrap();
+        assert!(err.to_string().contains("cert and key"), "{}", err);
+    }
+
+    // ---- parse_sasl_block ----
+
+    struct PasswordFile {
+        _dir: TempDir,
+        path: String,
+    }
+
+    fn make_password_file(contents: &[u8]) -> PasswordFile {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("kafka.pw");
+        std::fs::write(&path, contents).unwrap();
+        PasswordFile {
+            _dir: dir,
+            path: path.display().to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_sasl_absent_returns_none() {
+        assert!(parse_sasl_block("k", &[]).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_sasl_plain_reads_password_file() {
+        let pw = make_password_file(b"hunter2\n");
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "plain"),
+                str_prop("username", "limpid"),
+                str_prop("password_file", &pw.path),
+            ],
+        )];
+        let sasl = parse_sasl_block("k", &props).unwrap().unwrap();
+        assert_eq!(sasl.mechanism, "PLAIN");
+        assert_eq!(sasl.username, "limpid");
+        assert_eq!(sasl.password, "hunter2"); // trailing newline stripped
+    }
+
+    #[test]
+    fn parse_sasl_scram_uppercases_mechanism() {
+        let pw = make_password_file(b"secret");
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "scram_sha_512"),
+                str_prop("username", "u"),
+                str_prop("password_file", &pw.path),
+            ],
+        )];
+        let sasl = parse_sasl_block("k", &props).unwrap().unwrap();
+        // DSL underscore form → librdkafka hyphen form.
+        assert_eq!(sasl.mechanism, "SCRAM-SHA-512");
+    }
+
+    #[test]
+    fn parse_sasl_missing_password_file_errors() {
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "plain"),
+                str_prop("username", "u"),
+                str_prop("password_file", "/nonexistent/path/to/pw"),
+            ],
+        )];
+        let err = parse_sasl_block("k", &props).err().unwrap();
+        assert!(err.to_string().contains("password_file"), "{}", err);
+    }
+
+    #[test]
+    fn parse_sasl_empty_password_file_rejected() {
+        let pw = make_password_file(b"\n");
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "plain"),
+                str_prop("username", "u"),
+                str_prop("password_file", &pw.path),
+            ],
+        )];
+        let err = parse_sasl_block("k", &props).err().unwrap();
+        assert!(err.to_string().contains("empty"), "{}", err);
     }
 }

--- a/docs/src/outputs/kafka.md
+++ b/docs/src/outputs/kafka.md
@@ -22,16 +22,90 @@ def output events {
 }
 ```
 
+TLS to the brokers (with optional client cert for mTLS):
+
+```
+def output secure {
+    type kafka
+    brokers "kafka1.example.com:9093,kafka2.example.com:9093"
+    topic "syslog-events"
+    tls {
+        ca   "/etc/limpid/kafka-ca.pem"
+        cert "/etc/limpid/kafka-client.crt"   // optional; required only for mTLS
+        key  "/etc/limpid/kafka-client.key"   // optional; pairs with cert
+    }
+}
+```
+
+SASL/SCRAM (over TLS — the typical production combo):
+
+```
+def output authenticated {
+    type kafka
+    brokers "kafka1.example.com:9094"
+    topic "syslog-events"
+    tls { ca "/etc/limpid/kafka-ca.pem" }
+    sasl {
+        mechanism scram_sha_512
+        username "limpid-producer"
+        password_file "/etc/limpid/kafka.pw"   // chmod 600
+    }
+}
+```
+
 ## Properties
 
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `brokers` | yes | — | Comma-separated list of Kafka brokers |
+| `brokers` | yes | — | Comma-separated list of Kafka brokers (bootstrap list) |
 | `topic` | yes | — | Target topic name |
 | `compression` | no | `none` | `none`, `gzip`, `snappy`, `lz4`, `zstd` |
 | `acks` | no | `all` | `0` (fire-and-forget), `1` (leader only), `all` (all replicas) |
 | `key` | no | none | Event value to use as partition key |
 | `queue_timeout` | no | `5s` | Max wait when rdkafka's internal queue is full |
+| `tls` | no | — | TLS block (see [tls block](#tls-block)). Omit for plaintext. |
+| `sasl` | no | — | SASL block (see [sasl block](#sasl-block)). Omit for no auth. |
+
+`security.protocol` is derived from which blocks are present:
+
+| `tls` | `sasl` | result |
+|---|---|---|
+| absent | absent | `plaintext` (librdkafka default) |
+| present | absent | `ssl` |
+| absent | present | `sasl_plaintext` |
+| present | present | `sasl_ssl` (the recommended production combo) |
+
+### tls block
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `ca` | no | Path to PEM-encoded CA cert for broker verification. Omit to use the system root store. |
+| `cert` | no | Path to PEM-encoded client certificate (for mTLS). Pairs with `key`. |
+| `key` | no | Path to PEM-encoded client private key. Pairs with `cert`. |
+
+`cert` and `key` are both-or-neither: specify them together for mTLS, or
+omit both for one-way TLS.
+
+### sasl block
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `mechanism` | yes | One of `plain`, `scram_sha_256`, `scram_sha_512`. The DSL ident grammar forbids `-`, so the mechanism is spelled with underscores; limpid maps it to the librdkafka canonical spelling (`SCRAM-SHA-256` / `SCRAM-SHA-512`) internally. |
+| `username` | yes | SASL username (not a secret; goes in the config) |
+| `password_file` | yes | Path to a file containing the SASL password (the **only** way to set the password — inline `password` is intentionally not supported) |
+
+The `password_file` is read once at daemon start; rotate it and restart
+the daemon to refresh credentials. `chmod 600` it and ensure the file
+is owned by the limpid user. A trailing newline is stripped, so
+`echo "secret" > /etc/limpid/kafka.pw` works as expected. An empty file
+is rejected — that's almost always a misconfigured secret, not a
+deliberate empty password.
+
+Why no inline `password`: inline credentials end up in version-control
+diffs, backups, and log output of any tool that pretty-prints the config.
+Treating SASL passwords with the same disposition as TLS private keys
+(file on disk, restrictive perms) keeps both secrets on the same operational
+footing.
 
 ## Partition key
 


### PR DESCRIPTION
## Summary

- `output kafka` gains optional `tls { ca cert key }` and `sasl { mechanism username password_file }` blocks
- Supports the four `security.protocol` combinations librdkafka exposes: plaintext / `ssl` / `sasl_plaintext` / `sasl_ssl`
- SASL mechanisms: `plain`, `scram_sha_256`, `scram_sha_512` (DSL underscore form → librdkafka hyphen form at parse time)
- SASL credentials use `password_file` (not inline `password`) — matches the mTLS private-key disposition; secret never appears in config or backups
- rdkafka picks up `ssl` + `sasl` features (adds `libssl-dev` + `libsasl2-dev` build deps on Debian/Ubuntu)
- No per-peer rotation layer: librdkafka handles broker discovery internally from the `brokers` bootstrap list

## Test plan

- [x] 11 new unit tests in `kafka.rs` (security_protocol matrix, parse_tls_block all branches, parse_sasl_block incl. trailing newline strip + empty-file rejection + mechanism map)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end smoke test against redpanda (single-binary Kafka-compatible broker, docker) in Parallels VM:
  - plaintext → `ssl` (CA only) → `sasl_plaintext` (SCRAM/PLAIN) → `sasl_ssl` (SCRAM-over-TLS)
  - mTLS variant (cert + key + CA) verified to send through TLS handshake
  - syslog_tcp → kafka topic round-trip confirmed via `rpk topic consume`
- [x] uchgs push-gate: 7/7 audits passed (confidentiality / ci-precheck / cicd-pipeline / abstraction / readme-current / rust / security)