### PR TITLE
chore: bump version to 0.7.6 + tidy leftover doc references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ def output secure {
     topic "syslog-events"
     tls { ca "/etc/limpid/kafka-ca.pem" }
     sasl {
-        mechanism scram-sha-512
+        mechanism scram_sha_512
         username "limpid-producer"
         password_file "/etc/limpid/kafka.pw"
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -168,10 +168,11 @@ installation, .deb packaging, and systemd integration.
 `journal` · `unix_socket` · `otlp_http` · `otlp_grpc`
 
 ### Outputs
-`syslog_udp` · `syslog_tcp` (with optional per-peer TLS) · `file` ·
-`http` (with per-peer TLS / mTLS, round-robin across peers) ·
+`syslog_udp` · `syslog_tcp` (with optional per-peer TLS / mTLS) ·
+`file` · `http` (with per-peer TLS / mTLS, round-robin across peers) ·
 `kafka` (with optional TLS / mTLS / SASL) · `unix_socket` ·
-`stdout` · `otlp_http` · `otlp_grpc`
+`stdout` · `otlp_http` / `otlp_grpc` (with per-peer TLS / mTLS,
+round-robin across peers)
 
 ### Upgrading from earlier versions
 

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/docs/src/inputs/otlp-http.md
+++ b/docs/src/inputs/otlp-http.md
@@ -99,7 +99,7 @@ A decode failure returns HTTP 400 and increments `events_invalid`. Successful bu
 
 ## Pure pass-through
 
-If the pipeline has no process layer, an OTLP/HTTP → `otlp` output topology relays without re-encoding — `egress` is already valid singleton ResourceLogs proto bytes:
+If the pipeline has no process layer, an OTLP/HTTP → `otlp_http` (or `otlp_grpc`) output topology relays without re-encoding — `egress` is already valid singleton ResourceLogs proto bytes:
 
 ```
 def pipeline otlp_relay {
@@ -110,4 +110,9 @@ def pipeline otlp_relay {
 
 ## TLS
 
-Server-side TLS is **not** implemented for `otlp_http` as of v0.5.0. Front the input with a reverse proxy (envoy, nginx, traefik) for TLS termination, or use [`otlp_grpc`](./otlp-grpc.md) — its `tls { cert key ca }` block does ship in v0.5.0 and supports both plain TLS and mutual TLS. Native HTTPS support for `otlp_http` is queued for v0.5.x.
+Native HTTPS lands in v0.7.6 via the [`tls` block](#tls-block) at the
+top of this page — `tls { cert key }` for plain server TLS, plus
+optional `ca` for mTLS (client-cert verification at handshake). The
+same shape is shared with [`input syslog_tcp`](./syslog-tcp.md) and
+[`input otlp_grpc`](./otlp-grpc.md). Without the block, the listener
+serves plaintext HTTP on the configured port.

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -22,14 +22,14 @@ read that and explains the OTLP-specific reading on top.
 
 ---
 
-## 1. Scope of v0.5.0
+## 1. Scope
 
-| Aspect | v0.5.0 |
+| Aspect | Current (0.7.6) |
 |---|---|
 | Signal | **logs** only — no traces, no metrics, no profiles |
-| Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three) |
+| Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` as of 0.7.6) |
 | Direction | input *and* output (so collector-to-collector relay works) |
-| TLS | server-side TLS / mTLS on `otlp_grpc`; HTTP server TLS queued for v0.5.x |
+| TLS | server-side TLS / mTLS on every input (`otlp_http`, `otlp_grpc`); client-side TLS / mTLS on every output (per-peer `tls { ca cert key }` on both `output otlp_http` and `output otlp_grpc` as of 0.7.6) |
 | Versioning | OTLP 1.4 wire (the proto3 schema as of opentelemetry-proto 0.27) |
 
 Traces and metrics share the same wire envelope shape but use different
@@ -405,9 +405,10 @@ producer's "High" means OTLP 13 (WARN) for some vendors and OTLP 17
 (ERROR) for others. limpid does not bake any mapping into Rust;
 snippets carry the table.
 
-The reference snippet library (queued for v0.6.0) will ship
-opinionated mappings for common vendors. Until then, snippet authors
-write the table inline.
+The reference snippet library that landed in v0.7.0 (and expanded in
+v0.7.1) ships opinionated mappings for common vendors — see
+[Snippet Library](./snippets/README.md). Authors of new snippets
+follow the table conventions documented there.
 
 ### 5.6 Retry: transport-level only
 

--- a/docs/src/outputs/README.md
+++ b/docs/src/outputs/README.md
@@ -7,13 +7,14 @@ Output modules write processed events to external destinations.
 | Type | Description |
 |------|-------------|
 | [`file`](./file.md) | Local file with dynamic path templates |
-| [`http`](./http.md) | HTTP/HTTPS endpoint (Elasticsearch, Splunk HEC, etc.) |
-| [`kafka`](./kafka.md) | Apache Kafka topic (requires `--features kafka`) |
-| [`syslog_tcp`](./syslog-tcp.md) | Syslog TCP with persistent per-peer connections; per-peer TLS optional |
+| [`http`](./http.md) | HTTP/HTTPS endpoint (Elasticsearch, Splunk HEC, etc.); per-peer TLS / mTLS, round-robin across peers |
+| [`kafka`](./kafka.md) | Apache Kafka topic with optional TLS / mTLS / SASL (requires `--features kafka`) |
+| [`syslog_tcp`](./syslog-tcp.md) | Syslog TCP with persistent per-peer connections; per-peer TLS / mTLS optional |
 | [`syslog_udp`](./syslog-udp.md) | Syslog UDP datagrams |
 | [`unix_socket`](./unix-socket.md) | Unix stream socket |
 | [`stdout`](./stdout.md) | Standard output (debugging) |
-| [`otlp`](./otlp.md) | OTLP logs sender (HTTP/JSON, HTTP/protobuf, gRPC) |
+| [`otlp_http`](./otlp_http.md) | OTLP/HTTP logs sender (`http_protobuf` / `http_json`), per-peer TLS / mTLS |
+| [`otlp_grpc`](./otlp_grpc.md) | OTLP/gRPC logs sender, per-peer TLS / mTLS |
 
 ## Queue and retry
 

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -175,7 +175,7 @@ The question "function or process?" has a clean answer:
 | Recursive | A `def process` (`def function` rejects recursion at `--check` time) |
 | Operator-specific policy (facility rewrite, vendor filter, site-specific routing) | Always a `def process`, defined close to the pipeline that uses it |
 
-A snippet library (for example, the v0.6.0 `_common/*.limpid` + `parsers/*.limpid` + `composers/*.limpid` collection) mixes the three: `def function` for vendor-agnostic mappings (severity, proto, action), `def process` for the parser / composer bodies that consume Event state and write to `workspace.limpid`, and built-in primitives (`syslog.parse`, `cef.parse`, `to_json`, `regex_*`) as the building blocks underneath.
+A snippet library (for example, the v0.7.0 `_common/*.limpid` + `parsers/*.limpid` + `composers/*.limpid` collection that ships under `/usr/share/limpid/snippets/`) mixes the three: `def function` for vendor-agnostic mappings (severity, proto, action), `def process` for the parser / composer bodies that consume Event state and write to `workspace.limpid`, and built-in primitives (`syslog.parse`, `cef.parse`, `to_json`, `regex_*`) as the building blocks underneath.
 
 ## Writing for a snippet library
 

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -1,6 +1,6 @@
 # User-defined Processes
 
-limpid is preparing a [Snippet Library](../snippets/README.md) of pre-built processes for common parsing / mapping work (landing in v0.6.0). Even once it ships, sooner or later you'll hit a situation the library doesn't cover — a vendor format we haven't shipped, a one-off enrichment, a dedup or rate-limit shape that's specific to your environment — and want to write your own. This page covers how.
+limpid ships a [Snippet Library](../snippets/README.md) of pre-built processes for common parsing / mapping work (debuts in v0.7.0, expanded in v0.7.1). Sooner or later you'll hit a situation the library doesn't cover — a vendor format we haven't shipped, a one-off enrichment, a dedup or rate-limit shape that's specific to your environment — and want to write your own. This page covers how.
 
 You define a process with `def process <name> { ... }`. Inside the body you call functions, assign to event slots and workspace, branch with `if` / `switch` / `try`, transform arrays with the block-arg primitives (`map`, `filter`, `find`, `reduce`), and call other processes by name.
 


### PR DESCRIPTION
## Summary

Final release prep for 0.7.6 — bumps the three crate versions in lockstep and catches doc references left stale by the syslog_tls → syslog_tcp merge ([#17](https://github.com/naoto256/limpid/pull/17)/[#18](https://github.com/naoto256/limpid/pull/18)), kafka TLS/SASL ([#19](https://github.com/naoto256/limpid/pull/19)), otlp split + per-peer mTLS ([#20](https://github.com/naoto256/limpid/pull/20)) and http per-peer mTLS ([#21](https://github.com/naoto256/limpid/pull/21)).

### Version

- `crates/limpid` 0.7.5 → 0.7.6
- `crates/limpidctl` 0.7.5 → 0.7.6
- `crates/limpid-prometheus` 0.7.5 → 0.7.6
- `Cargo.lock` refreshed

### Doc tidy (8 findings from a thorough sweep)

- **CHANGELOG.md** — kafka example used `mechanism scram-sha-512` (hyphen). DSL ident grammar rejects `-`; the same paragraph 24 lines above documents the underscore convention. Fix to `scram_sha_512`.
- **README.md outputs row** — align per-module TLS annotations: `syslog_tcp` gains `/ mTLS`; `otlp_http` / `otlp_grpc` gain the same `(with per-peer TLS / mTLS, round-robin across peers)` annotation `http` / `kafka` already carry.
- **docs/src/inputs/otlp-http.md** — the "## TLS" paragraph claimed TLS was not implemented and recommended a reverse proxy; the `tls { cert key ca }` block now lands at the top of the same page. Rewrite to point at the block reference.
- **docs/src/inputs/otlp-http.md** — pass-through example referred to the removed `output otlp` module. Update to `otlp_http` / `otlp_grpc`.
- **docs/src/outputs/README.md** — available-types table still listed an `otlp` row pointing at a non-existent file. Split into `otlp_http` / `otlp_grpc` rows and add TLS / mTLS / SASL annotations to the `http` / `kafka` / `syslog_tcp` rows.
- **docs/src/otlp.md** — "Scope of v0.5.0" table rewritten as "Scope" with the current 0.7.6 state (HTTP server TLS landed; output split; per-peer client TLS landed).
- **docs/src/otlp.md** — snippet library "queued for v0.6.0" → actually debuted in v0.7.0 and expanded in v0.7.1.
- **docs/src/processing/{user-defined,design-guide}.md** — same snippet-library version drift, fixed in matching wording.

Substantive 0.7.6 entries already in CHANGELOG.md from the prior PRs are unchanged.

## Test plan

- [x] `cargo build --workspace` clean (the only code-relevant change is the version bump; everything compiles against 0.7.6 versions)
- [x] `cargo test --workspace` 510 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] uchgs push-gate: 7/7 audits (confidentiality / ci-precheck / cicd-pipeline / abstraction / readme-current / rust / security). 2 baseline-carry-over confirmations (cicd-pipeline release.yml `contents: write`; rust 7 dup-version warnings).