### PR TITLE
ci(release): drop softprops/action-gh-release, bump checkout to v6 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   build-deb:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # pin-audit:2026-05-21 34e1148 | v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # pin-audit:2026-06-03 de0fac2 | v6.0.2
         with:
           persist-credentials: false
 
@@ -67,8 +67,19 @@ jobs:
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # pin-audit:2026-05-21 3bb1273 | v2.6.2
-        with:
-          name: ${{ steps.notes.outputs.name }}
-          files: target/debian/*.deb
-          body_path: RELEASE_NOTES.md
+        env:
+          # Pre-installed gh CLI on the runner authenticates with the
+          # job's GITHUB_TOKEN; no third-party action in the trust path.
+          GH_TOKEN: ${{ github.token }}
+          # Pass the release title through an env var rather than
+          # interpolating `${{ ... }}` into `run:` — the value comes
+          # from CHANGELOG via awk, so it is repo-controlled rather
+          # than attacker-controlled, but expression substitution into
+          # a shell command would still be the wrong defense-in-depth
+          # shape if a future change ever lets non-repo data flow into
+          # `steps.notes.outputs.name`.
+          RELEASE_TITLE: ${{ steps.notes.outputs.name }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" target/debian/*.deb \
+            --title "$RELEASE_TITLE" \
+            --notes-file RELEASE_NOTES.md


### PR DESCRIPTION
## Summary

GitHub Actions deprecated the Node 20 runtime; the runners now force
any action targeting Node 20 to run on Node 24 anyway and emit a
deprecation warning. Two of release.yml's pins were affected during
the v0.7.6 release run: `actions/checkout@v4.3.1` and
`softprops/action-gh-release@v2.6.2`.

This PR brings release.yml to a fully-Node-24 trust profile.

### Changes

- **`actions/checkout` v4.3.1 → v6.0.2** — the pre-audited pin
  (\`de0fac2e4500dabe0009e67214ff5f5447ce83dd\`; targets Node 24). The
  matching bump on ci.yml had already landed earlier in the 0.7.7 line.
- **`softprops/action-gh-release` removed.** The action is
  single-maintainer; account-compromise-on-tag-pin is a real exposure
  that the cicd-pipeline audit explicitly flags. The v3.x line that
  targets Node 24 is not yet in the audited-pins cache. The same
  release upload is one `gh release create` invocation against the
  runner's pre-installed gh CLI, authenticated with the job's
  GITHUB_TOKEN — no third-party action remains in this step's trust
  path.
- **`gh release create` uses env-var indirection** for the title
  (`RELEASE_TITLE: \${{ steps.notes.outputs.name }}` → `--title "$RELEASE_TITLE"`)
  rather than interpolating the expression directly into the shell
  command. The value comes from CHANGELOG via awk, so it is
  repo-controlled rather than attacker-controlled, but expression
  substitution into `run:` would still be the wrong defense-in-depth
  shape if a future change ever lets non-repo data flow into
  `steps.notes.outputs.name`.

### Resulting trust surface for release.yml

- `actions/checkout` (official GitHub action, v6.0.2 audited)
- `dtolnay/rust-toolchain@29eef33` (composite shell, no Node runtime)
- Runner's pre-installed `gh` CLI for the release upload

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` 510 passed
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] uchgs push-gate: 7/7 audits passed (confidentiality / ci-precheck / cicd-pipeline / abstraction / readme-current / rust / security). 2 baseline-carry-over confirmations (cicd-pipeline release.yml \`contents: write\`; rust 7 dup-version warnings).

The release.yml change can only be exercised by pushing a tag, so end-to-end verification will happen on the next release. The deprecation warning that motivated this PR will be gone.