### PR TITLE
chore: bump version to 0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2608,7 +2608,7 @@ hot reload via `SIGHUP` with automatic rollback; per-output disk-backed
 queues.
 
 [0.7.7]: https://github.com/naoto256/limpid/compare/v0.7.6...v0.7.7
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.7.7...HEAD
 [0.4.0]: https://github.com/naoto256/limpid/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/naoto256/limpid/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/naoto256/limpid/compare/v0.2.1...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-1.0 releases may introduce breaking changes freely as the DSL and
 runtime shape converge. After 1.0, changes will follow semver strictly.
 
-## [Unreleased] - 0.7.7
+## [0.7.7] - 2026-06-22
 
 ### Fixed — `cef.parse` now emits the raw extension blob as `ext`
 
@@ -2607,6 +2607,7 @@ with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`);
 hot reload via `SIGHUP` with automatic rollback; per-output disk-backed
 queues.
 
+[0.7.7]: https://github.com/naoto256/limpid/compare/v0.7.6...v0.7.7
 [Unreleased]: https://github.com/naoto256/limpid/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/naoto256/limpid/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/naoto256/limpid/compare/v0.2.2...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2607,8 +2607,26 @@ with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`);
 hot reload via `SIGHUP` with automatic rollback; per-output disk-backed
 queues.
 
-[0.7.7]: https://github.com/naoto256/limpid/compare/v0.7.6...v0.7.7
 [Unreleased]: https://github.com/naoto256/limpid/compare/v0.7.7...HEAD
+[0.7.7]: https://github.com/naoto256/limpid/compare/v0.7.6...v0.7.7
+[0.7.6]: https://github.com/naoto256/limpid/compare/v0.7.5...v0.7.6
+[0.7.5]: https://github.com/naoto256/limpid/compare/v0.7.4...v0.7.5
+[0.7.4]: https://github.com/naoto256/limpid/compare/v0.7.3...v0.7.4
+[0.7.3]: https://github.com/naoto256/limpid/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/naoto256/limpid/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/naoto256/limpid/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/naoto256/limpid/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/naoto256/limpid/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/naoto256/limpid/compare/v0.5.8...v0.6.0
+[0.5.8]: https://github.com/naoto256/limpid/compare/v0.5.7...v0.5.8
+[0.5.7]: https://github.com/naoto256/limpid/compare/v0.5.6...v0.5.7
+[0.5.6]: https://github.com/naoto256/limpid/compare/v0.5.5...v0.5.6
+[0.5.5]: https://github.com/naoto256/limpid/compare/v0.5.4...v0.5.5
+[0.5.4]: https://github.com/naoto256/limpid/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/naoto256/limpid/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/naoto256/limpid/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/naoto256/limpid/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/naoto256/limpid/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/naoto256/limpid/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/naoto256/limpid/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/naoto256/limpid/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bump workspace crates (`limpid`, `limpidctl`, `limpid-prometheus`) from 0.7.6 → 0.7.7 and refresh `Cargo.lock`.
- Finalize CHANGELOG: rename `## [Unreleased] - 0.7.7` → `## [0.7.7] - 2026-06-22`.
- Backfill CHANGELOG link references — the `[Unreleased]` reference was stale since v0.4.0, and the 0.5.0–0.7.6 entries had never been added. Now every shipped version in the document has a working compare-link, and `[Unreleased]` is at the top of the reference block per keep-a-changelog convention.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 518 passed
- [x] uchgs push gate: 7/7 scopes confirmed