### PR TITLE
fix(output kafka): reject SASL/PLAIN without TLS + handle CRLF password files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-1.0 releases may introduce breaking changes freely as the DSL and
 runtime shape converge. After 1.0, changes will follow semver strictly.
 
+## [Unreleased] - 0.7.8
+
+### Fixed — `output kafka`: reject `mechanism plain` without a `tls { ... }` block
+
+SASL/PLAIN puts the username and password in clear text on the wire —
+the only safe transport for that mechanism is TLS. Previously
+`mechanism plain` paired with an absent `tls` block selected
+librdkafka's `sasl_plaintext`, sending credentials to the broker in
+clear text. limpid now refuses this combination at config-load time
+and the daemon will not start until either a `tls { ... }` block is
+added or the mechanism is switched to `scram_sha_256` / `scram_sha_512`
+(SCRAM uses challenge-response and never puts the password on the
+wire).
+
+### Fixed — `output kafka`: SASL `password_file` handles CRLF / bare CR
+
+Trailing-newline stripping now matches `\r\n` and bare `\r` in addition
+to bare `\n`, so password files written on Windows hosts (or with an
+editor that defaults to CRLF) authenticate correctly. Previously a
+CRLF-terminated file left a `\r` on the password and produced a
+`bad credentials`–shaped failure that looked like an operator typo.
+
 ## [0.7.7] - 2026-06-22
 
 ### Fixed — `cef.parse` now emits the raw extension blob as `ext`

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -186,10 +186,16 @@ fn parse_sasl_block(name: &str, properties: &[Property]) -> Result<Option<SaslCo
         )
     })?;
     // Strip a single trailing newline (the common case for
-    // `echo "secret" > pw`). Empty file or whitespace-only file is
-    // probably a misconfigured secret, not a deliberate empty
-    // password, so reject it.
-    let password = raw.strip_suffix('\n').unwrap_or(&raw).to_string();
+    // `echo "secret" > pw`), handling CRLF as well as bare LF so
+    // password files written on Windows hosts authenticate correctly.
+    // Empty file or whitespace-only file is probably a misconfigured
+    // secret, not a deliberate empty password, so reject it.
+    let password = raw
+        .strip_suffix("\r\n")
+        .or_else(|| raw.strip_suffix('\n'))
+        .or_else(|| raw.strip_suffix('\r'))
+        .unwrap_or(&raw)
+        .to_string();
     if password.trim().is_empty() {
         anyhow::bail!(
             "output '{}': sasl password_file '{}' is empty",
@@ -218,6 +224,30 @@ fn parse_sasl_block(name: &str, properties: &[Property]) -> Result<Option<SaslCo
         username,
         password,
     }))
+}
+
+/// Reject `mechanism plain` without a `tls { ... }` block — SASL/PLAIN
+/// transmits the username and password in clear text on the wire, so
+/// the only safe transport is TLS (Kafka and Confluent both document
+/// this requirement: "TLS/SSL encryption should always be used if SASL
+/// mechanism is PLAIN"). If the operator wants plain-text Kafka, the
+/// supported path is `scram_sha_256` / `scram_sha_512`, which use a
+/// challenge-response and never put the password on the wire.
+fn require_tls_for_plain(
+    name: &str,
+    sasl: Option<&SaslConfig>,
+    tls: Option<&ClientTlsConfig>,
+) -> Result<()> {
+    if let Some(s) = sasl
+        && s.mechanism == "PLAIN"
+        && tls.is_none()
+    {
+        anyhow::bail!(
+            "output '{}': sasl mechanism 'plain' requires a tls {{ ... }} block — PLAIN puts credentials in clear text on the wire and must run over TLS. Use scram_sha_256 or scram_sha_512 if TLS is not available.",
+            name
+        );
+    }
+    Ok(())
 }
 
 /// Pick librdkafka's `security.protocol` from which of (tls, sasl)
@@ -299,6 +329,7 @@ impl Module for KafkaOutput {
 
         let tls = parse_tls_block(name, properties)?;
         let sasl = parse_sasl_block(name, properties)?;
+        require_tls_for_plain(name, sasl.as_ref(), tls.as_ref())?;
 
         // message.timeout.ms: rdkafka's internal delivery timeout (includes retries to broker).
         // Separate from queue_timeout which is the wait time when the internal queue is full.
@@ -571,5 +602,87 @@ mod tests {
         )];
         let err = parse_sasl_block("k", &props).err().unwrap();
         assert!(err.to_string().contains("empty"), "{}", err);
+    }
+
+    #[test]
+    fn parse_sasl_plain_strips_crlf_password_file() {
+        // Windows hosts (or any editor that uses CRLF) write the
+        // trailing newline as `\r\n`; stripping only `\n` leaves a
+        // bare `\r` on the password and Kafka authentication fails
+        // with a "bad credentials" error that looks like a wrong
+        // password.
+        let pw = make_password_file(b"hunter2\r\n");
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "plain"),
+                str_prop("username", "limpid"),
+                str_prop("password_file", &pw.path),
+            ],
+        )];
+        let sasl = parse_sasl_block("k", &props).unwrap().unwrap();
+        assert_eq!(sasl.password, "hunter2");
+    }
+
+    #[test]
+    fn parse_sasl_plain_strips_bare_cr_password_file() {
+        let pw = make_password_file(b"hunter2\r");
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "plain"),
+                str_prop("username", "u"),
+                str_prop("password_file", &pw.path),
+            ],
+        )];
+        let sasl = parse_sasl_block("k", &props).unwrap().unwrap();
+        assert_eq!(sasl.password, "hunter2");
+    }
+
+    // ---- require_tls_for_plain ----
+
+    fn sasl(mechanism: &str) -> SaslConfig {
+        SaslConfig {
+            mechanism: mechanism.to_string(),
+            username: "u".into(),
+            password: "p".into(),
+        }
+    }
+
+    fn empty_tls() -> ClientTlsConfig {
+        ClientTlsConfig {
+            ca_path: None,
+            cert_path: None,
+            key_path: None,
+        }
+    }
+
+    #[test]
+    fn require_tls_for_plain_rejects_plain_without_tls() {
+        let s = sasl("PLAIN");
+        let err = require_tls_for_plain("k", Some(&s), None).err().unwrap();
+        assert!(err.to_string().contains("tls"), "{}", err);
+        assert!(err.to_string().contains("plain"), "{}", err);
+    }
+
+    #[test]
+    fn require_tls_for_plain_accepts_plain_with_tls() {
+        let s = sasl("PLAIN");
+        let t = empty_tls();
+        require_tls_for_plain("k", Some(&s), Some(&t)).unwrap();
+    }
+
+    #[test]
+    fn require_tls_for_plain_accepts_scram_without_tls() {
+        // SCRAM uses challenge-response; the password never goes on
+        // the wire, so plaintext transport is acceptable (though
+        // typically still paired with TLS in production).
+        let s = sasl("SCRAM-SHA-512");
+        require_tls_for_plain("k", Some(&s), None).unwrap();
+    }
+
+    #[test]
+    fn require_tls_for_plain_accepts_no_sasl() {
+        require_tls_for_plain("k", None, None).unwrap();
     }
 }

--- a/docs/src/outputs/kafka.md
+++ b/docs/src/outputs/kafka.md
@@ -72,7 +72,7 @@ def output authenticated {
 |---|---|---|
 | absent | absent | `plaintext` (librdkafka default) |
 | present | absent | `ssl` |
-| absent | present | `sasl_plaintext` |
+| absent | present | `sasl_plaintext` (rejected when `mechanism` is `plain` — see [SASL/PLAIN requires TLS](#saslplain-requires-tls)) |
 | present | present | `sasl_ssl` (the recommended production combo) |
 
 ### tls block
@@ -96,10 +96,39 @@ omit both for one-way TLS.
 
 The `password_file` is read once at daemon start; rotate it and restart
 the daemon to refresh credentials. `chmod 600` it and ensure the file
-is owned by the limpid user. A trailing newline is stripped, so
-`echo "secret" > /etc/limpid/kafka.pw` works as expected. An empty file
-is rejected — that's almost always a misconfigured secret, not a
-deliberate empty password.
+is owned by the limpid user. A trailing newline is stripped (`\r\n`,
+bare `\n`, and bare `\r` are all handled), so `echo "secret" >
+/etc/limpid/kafka.pw` works as expected and a CRLF-terminated file from
+a Windows host authenticates correctly. An empty file is rejected —
+that's almost always a misconfigured secret, not a deliberate empty
+password.
+
+### SASL/PLAIN requires TLS
+
+`mechanism plain` transmits the username and password in clear text on
+the wire — the only safe transport is TLS. limpid rejects this
+combination at config-load time:
+
+```
+output kafka {
+    name "lake"
+    brokers "..."
+    topic "events"
+    sasl {
+        mechanism plain        # ← plain on its own is rejected
+        username "limpid"
+        password_file "/etc/limpid/kafka.pw"
+    }
+    # NO tls block → daemon refuses to start
+}
+```
+
+Add a `tls { ... }` block (server CA, optionally `cert` / `key` for
+mTLS) to permit `plain`, or switch the mechanism to `scram_sha_256` /
+`scram_sha_512` — SCRAM uses a challenge-response so the password is
+never sent on the wire and runs safely without TLS. The Kafka project
+and Confluent both require TLS for `PLAIN`; limpid enforces this at
+config-load rather than letting the daemon start and leak credentials.
 
 Why no inline `password`: inline credentials end up in version-control
 diffs, backups, and log output of any tool that pretty-prints the config.


### PR DESCRIPTION
## Summary

Closes two CodeRabbit findings on [#23](https://github.com/naoto256/limpid/pull/23) (release 0.7.6 review):

- **🔴 Critical — reject `mechanism plain` without a `tls { ... }` block.** SASL/PLAIN puts the username and password in clear text on the wire; the only safe transport is TLS. Previously `mechanism plain` paired with an absent `tls` block selected librdkafka's `sasl_plaintext`, sending credentials in clear text. limpid now refuses this combination at config-load time. Operators can pair `plain` with TLS, or switch to `scram_sha_256` / `scram_sha_512` which use challenge-response and never put the password on the wire.
- **🟡 Minor — SASL `password_file` handles CRLF / bare CR.** Trailing-newline stripping now matches `\r\n` and bare `\r` in addition to bare `\n`. Password files written on Windows hosts (or with editors defaulting to CRLF) had a stray `\r` left on the password.

Six new unit tests cover both fixes: CRLF strip, bare CR strip, PLAIN-without-TLS rejection, PLAIN-with-TLS acceptance, SCRAM-without-TLS acceptance (regression), and the no-SASL case.

## Test plan

- [x] `cargo clippy --features kafka --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --features kafka --workspace` — 535 passed
- [x] uchgs push gate: 7/7 scopes confirmed