### PR TITLE
fix(output): bypass batch for Owned events, add 30s export timeouts, reject tls on plaintext otlp_http endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output otlp_grpc` / `output otlp_http` / `output http`: Owned events no longer get silently merged into a batch
+
+Disk-queue replay and control-socket inject events (`SinkInput::Owned`)
+need a per-event ship verdict from the output module — `Ok` ⇒ drop from
+the queue, `Err` ⇒ retry / disk-replay / secondary. The batched outputs
+previously routed Owned events through the same buffer as the memory
+hot path and returned `Ok` after only enqueueing the event, so the
+caller never saw a per-event verdict. If the eventual flush failed the
+buffered events were silently lost (the queue had already dropped
+them).
+
+The three batched outputs now override `write_owned` to ship a single
+event inline, bypassing the batch, so the caller's queue retry / disk
+replay semantics work as designed. The memory hot path (Rendered)
+continues to batch as before.
+
+### Fixed — `output otlp_grpc`: per-export 30s timeout
+
+`client.export(request)` is now wrapped in `tokio::time::timeout(30s)`.
+A collector that accepted the connection but never returned a HEADERS
+frame would previously hold the flush future open indefinitely, blocking
+rotation and starving retry. Matches the existing per-call timeouts
+used elsewhere (syslog input, etc.).
+
+### Fixed — `output otlp_http`: per-export 30s timeout + reject `tls { ... }` on plaintext endpoints
+
+Two related corrections:
+
+- The reqwest client now carries a 30s `timeout(...)` so a peer that
+  accepts the connection but never replies counts as a failure and
+  yields to the next peer in the rotation. Without this, a stalled
+  collector blocked flush indefinitely.
+- A `tls { ... }` block paired with an `http://` endpoint is rejected
+  at config-load time. reqwest only negotiates TLS on `https://` URLs,
+  so the previous behaviour silently shipped in clear text while
+  pretending the tls block was active.
+
 ### Fixed — `output kafka`: reject `mechanism plain` without a `tls { ... }` block
 
 SASL/PLAIN puts the username and password in clear text on the wire —

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -370,6 +370,50 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     fn attach_funcs(&mut self, _funcs: Arc<FunctionRegistry>) {}
 }
 
+/// Helper for `Output::write_owned` overrides that ship a single Owned
+/// event inline, bypassing any internal buffer. Renders the event in a
+/// transient arena (same scope discipline as the default impl), awaits
+/// the caller-supplied `ship` closure, then updates the
+/// `events_written` / `events_failed` counters on the metrics handle.
+///
+/// The batched outputs (`otlp_grpc`, `otlp_http`, `output http`)
+/// each need to override `write_owned` so the queue consumer's
+/// per-event `Ok`/`Err` contract is honored (disk-replay events
+/// would otherwise be merged into a batched flush and the verdict
+/// would be lost). They differ only in the `ship` body — payload
+/// downcast and the per-module `send_batch` shape — so the
+/// scaffolding lives here once.
+pub async fn ship_owned_inline<O, F, Fut>(
+    output: &O,
+    event: &Event,
+    metrics: &OutputMetrics,
+    ship: F,
+) -> Result<()>
+where
+    O: Output + ?Sized,
+    F: FnOnce(RenderedPayload) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    use std::sync::atomic::Ordering;
+
+    let payload = {
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let bevent = event.view_in(&arena);
+        output.render(&bevent, &arena)?
+    };
+    match ship(payload).await {
+        Ok(()) => {
+            metrics.events_written.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+        Err(e) => {
+            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            Err(e)
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Factory return types
 // ---------------------------------------------------------------------------

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -436,23 +436,11 @@ impl Output for HttpOutput {
     /// here, bypassing the batch (same disposition as the
     /// `batch_size <= 1` short-circuit in `write`).
     async fn write_owned(&self, event: &Event) -> Result<()> {
-        let payload = {
-            let bump = bumpalo::Bump::new();
-            let arena = EventArena::new(&bump);
-            let bevent = event.view_in(&arena);
-            self.render(&bevent, &arena)?
-        };
-        let payload: HttpPayload = payload.downcast()?;
-        match self.inner.send_batch(&[payload.msg]).await {
-            Ok(()) => {
-                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
-            Err(e) => {
-                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                Err(e)
-            }
-        }
+        crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
+            let payload: HttpPayload = payload.downcast()?;
+            self.inner.send_batch(&[payload.msg]).await
+        })
+        .await
     }
 }
 

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -62,7 +62,7 @@ use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::{BorrowedEvent, Event};
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
@@ -427,6 +427,32 @@ impl Output for HttpOutput {
         }
 
         Ok(())
+    }
+
+    /// Owned-event path (disk-queue replay, control-socket inject). The
+    /// queue consumer needs a per-event ship verdict; routing Owned
+    /// events through the batched buffer would silently merge them into
+    /// a later flush and the caller would lose the verdict. Ship inline
+    /// here, bypassing the batch (same disposition as the
+    /// `batch_size <= 1` short-circuit in `write`).
+    async fn write_owned(&self, event: &Event) -> Result<()> {
+        let payload = {
+            let bump = bumpalo::Bump::new();
+            let arena = EventArena::new(&bump);
+            let bevent = event.view_in(&arena);
+            self.render(&bevent, &arena)?
+        };
+        let payload: HttpPayload = payload.downcast()?;
+        match self.inner.send_batch(&[payload.msg]).await {
+            Ok(()) => {
+                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(e) => {
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 }
 
@@ -860,5 +886,26 @@ mod tests {
         output.write_owned(&event_with("rr-ok")).await.unwrap();
         s_a.abort();
         s_b.abort();
+    }
+
+    #[tokio::test]
+    async fn write_owned_bypasses_batch_buffer() {
+        // Owned events ship inline rather than landing in the batch
+        // buffer, so the queue consumer's per-event Ok/Err contract is
+        // honored. Verify the buffer stays empty and no flush timer is
+        // armed even with batch_size > 1.
+        let mut props = vec![peer_block("http://127.0.0.1:1/")];
+        props.push(prop_int("batch_size", 1024));
+        props.push(prop_str("batch_timeout", "30s"));
+        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let err = output
+            .write_owned(&event_with("bypass"))
+            .await
+            .expect_err("send must fail against unreachable peer");
+        assert!(err.to_string().contains("http"), "got: {err}");
+        let batch_len = output.inner.batch.lock().await.len();
+        assert_eq!(batch_len, 0, "Owned event must not land in the batch");
+        let timer_armed = output.flush_handle.lock().await.is_some();
+        assert!(!timer_armed, "Owned event must not arm the flush timer");
     }
 }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -348,23 +348,11 @@ impl Output for OtlpGrpcOutput {
     /// into a later flush and the caller would lose the verdict. Ship
     /// inline here, bypassing the batch.
     async fn write_owned(&self, event: &Event) -> Result<()> {
-        let payload = {
-            let bump = bumpalo::Bump::new();
-            let arena = EventArena::new(&bump);
-            let bevent = event.view_in(&arena);
-            self.render(&bevent, &arena)?
-        };
-        let payload: OtlpPayload = payload.downcast()?;
-        match send_batch(&self.inner, vec![payload.egress]).await {
-            Ok(()) => {
-                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
-            Err(e) => {
-                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                Err(e)
-            }
-        }
+        crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
+            let payload: OtlpPayload = payload.downcast()?;
+            send_batch(&self.inner, vec![payload.egress]).await
+        })
+        .await
     }
 }
 

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -61,13 +61,21 @@ use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::{BorrowedEvent, Event};
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::queue::{BackoffStrategy, RetryConfig};
 
 use super::{BatchLevel, OTLP_RETRY_BLOCK_PROPERTIES, OtlpPayload, decode_drained_to_request};
+
+/// Upper bound on a single gRPC export. A stalled collector (TCP
+/// connection accepted but no HEADERS frame returned) would otherwise
+/// hold the flush future open indefinitely and starve the
+/// rotation/retry path. 30s is loose enough for normal collector
+/// latency including TLS handshake; flushes that take longer are
+/// almost certainly hung.
+const GRPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct GrpcPeer {
     endpoint: String,
@@ -332,6 +340,32 @@ impl Output for OtlpGrpcOutput {
         }
         Ok(())
     }
+
+    /// Owned-event path (disk-queue replay, control-socket inject). The
+    /// queue consumer needs a per-event ship verdict — Ok ⇒ drop from
+    /// the queue, Err ⇒ retry / disk-replay / secondary — so routing
+    /// Owned events through the batched buffer would silently merge them
+    /// into a later flush and the caller would lose the verdict. Ship
+    /// inline here, bypassing the batch.
+    async fn write_owned(&self, event: &Event) -> Result<()> {
+        let payload = {
+            let bump = bumpalo::Bump::new();
+            let arena = EventArena::new(&bump);
+            let bevent = event.view_in(&arena);
+            self.render(&bevent, &arena)?
+        };
+        let payload: OtlpPayload = payload.downcast()?;
+        match send_batch(&self.inner, vec![payload.egress]).await {
+            Ok(()) => {
+                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(e) => {
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
+    }
 }
 
 impl OtlpGrpcOutput {
@@ -494,9 +528,15 @@ async fn send_once(peer: &GrpcPeer, inner: &Inner, req: &ExportLogsServiceReques
             }
         }
     }
-    let response = client
-        .export(request)
+    let response = tokio::time::timeout(GRPC_REQUEST_TIMEOUT, client.export(request))
         .await
+        .map_err(|_| {
+            anyhow!(
+                "output otlp_grpc: export to {} timed out after {:?}",
+                peer.endpoint,
+                GRPC_REQUEST_TIMEOUT
+            )
+        })?
         .with_context(|| format!("output otlp_grpc: export to {} failed", peer.endpoint))?;
     // The receiver may report `partial_success.rejected_log_records`.
     // Currently logged as a warning; selective re-send of *only* the
@@ -802,16 +842,60 @@ mod tests {
 
     #[tokio::test]
     async fn drop_aborts_pending_flush_timer() {
+        // The flush timer is only armed by the Rendered (memory hot
+        // path) buffer write — Owned events bypass the batch entirely
+        // (see `write_owned`) so they never arm the timer. Drive the
+        // timer via the Rendered path here.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
-        output
+        let ev = event_with_egress(singleton_bytes(1));
+        let payload = {
+            let bump = bumpalo::Bump::new();
+            let arena = EventArena::new(&bump);
+            let bev = ev.view_in(&arena);
+            output.render(&bev, &arena).unwrap()
+        };
+        output.write(payload).await.unwrap();
+        let handle_before = output.flush_handle.lock().await.is_some();
+        assert!(handle_before, "Rendered write must arm the flush timer");
+        drop(output);
+    }
+
+    #[tokio::test]
+    async fn write_owned_bypasses_batch_buffer() {
+        // Owned events ship inline rather than landing in the batch
+        // buffer, so the queue consumer's per-event Ok/Err contract is
+        // honored (Err → disk-replay / retry / secondary). Use an
+        // unreachable endpoint and large batch_size so the only way
+        // the assertion can fail is if write_owned routed through the
+        // batch instead of bypassing it.
+        let mut props = one_peer_props("http://127.0.0.1:1");
+        props.push(prop_int("batch_size", 1024));
+        props.push(prop_str("batch_timeout", "30s"));
+        // Single attempt with no backoff so the test finishes fast.
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let err = output
             .write_owned(&event_with_egress(singleton_bytes(1)))
             .await
-            .unwrap();
-        let handle_before = output.flush_handle.lock().await.is_some();
-        assert!(handle_before, "write must arm the flush timer");
-        drop(output);
+            .expect_err("send must fail against unreachable peer");
+        assert!(
+            err.to_string().contains("otlp_grpc"),
+            "expected ship error, got: {err}"
+        );
+        let batch_len = output.inner.batch.lock().await.len();
+        assert_eq!(batch_len, 0, "Owned event must not land in the batch");
+        let timer_armed = output.flush_handle.lock().await.is_some();
+        assert!(!timer_armed, "Owned event must not arm the flush timer");
     }
 }

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -58,7 +58,7 @@ use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::{BorrowedEvent, Event};
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
@@ -66,6 +66,13 @@ use crate::queue::{BackoffStrategy, RetryConfig};
 use crate::tls::ClientTlsConfig;
 
 use super::{BatchLevel, OTLP_RETRY_BLOCK_PROPERTIES, OtlpPayload, decode_drained_to_request};
+
+/// Upper bound on a single HTTP export — connect, TLS handshake,
+/// request body send, response headers, response body. A peer that
+/// accepts the connection but never replies would otherwise hold the
+/// flush future open indefinitely and starve the rotation/retry path.
+/// Matches the gRPC side.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HttpProtocol {
@@ -252,6 +259,19 @@ fn parse_peer(name: &str, peer_props: &[Property], verify: bool) -> Result<HttpP
     let endpoint = props::get_string(peer_props, "endpoint")
         .ok_or_else(|| anyhow!("output '{}': otlp_http peer requires 'endpoint'", name))?;
     let tls_block = props::get_block(peer_props, "tls");
+    if tls_block.is_some() && !endpoint.to_ascii_lowercase().starts_with("https://") {
+        // A `tls { ... }` block on a plaintext `http://` endpoint is
+        // almost always an operator error: reqwest would silently
+        // ignore the CA / client-cert settings (TLS only kicks in on
+        // an https scheme) and the daemon would happily ship in clear
+        // text. Refuse at parse time so the misconfiguration is
+        // visible.
+        bail!(
+            "output '{}': otlp_http peer endpoint '{}' uses a plaintext scheme but a tls {{ ... }} block was supplied — switch the endpoint to https:// or drop the tls block",
+            name,
+            endpoint
+        );
+    }
     let tls_config = tls_block
         .map(|block| {
             let cfg = ClientTlsConfig {
@@ -264,7 +284,7 @@ fn parse_peer(name: &str, peer_props: &[Property], verify: bool) -> Result<HttpP
         })
         .transpose()?;
 
-    let mut builder = reqwest::Client::builder();
+    let mut builder = reqwest::Client::builder().timeout(HTTP_REQUEST_TIMEOUT);
     if !verify {
         builder = builder.danger_accept_invalid_certs(true);
     }
@@ -413,6 +433,30 @@ impl Output for OtlpHttpOutput {
             self.ensure_flush_timer().await;
         }
         Ok(())
+    }
+
+    /// Owned-event path (disk-queue replay, control-socket inject). See
+    /// the rationale on `OtlpGrpcOutput::write_owned`: the queue
+    /// consumer needs a per-event ship verdict, and the batched buffer
+    /// would lose it. Ship inline here, bypassing the batch.
+    async fn write_owned(&self, event: &Event) -> Result<()> {
+        let payload = {
+            let bump = bumpalo::Bump::new();
+            let arena = EventArena::new(&bump);
+            let bevent = event.view_in(&arena);
+            self.render(&bevent, &arena)?
+        };
+        let payload: OtlpPayload = payload.downcast()?;
+        match send_batch(&self.inner, vec![payload.egress]).await {
+            Ok(()) => {
+                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(e) => {
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 }
 
@@ -1120,16 +1164,105 @@ mod tests {
 
     #[tokio::test]
     async fn drop_aborts_pending_flush_timer() {
+        // The flush timer is only armed by the Rendered (memory hot
+        // path) buffer write — Owned events bypass the batch entirely
+        // (see `write_owned`) so they never arm the timer. Drive the
+        // timer via the Rendered path here.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
-        output
+        let ev = event_with_egress(singleton_bytes(1));
+        let payload = {
+            let bump = bumpalo::Bump::new();
+            let arena = EventArena::new(&bump);
+            let bev = ev.view_in(&arena);
+            output.render(&bev, &arena).unwrap()
+        };
+        output.write(payload).await.unwrap();
+        let handle_before = output.flush_handle.lock().await.is_some();
+        assert!(handle_before, "Rendered write must arm the flush timer");
+        drop(output);
+    }
+
+    #[tokio::test]
+    async fn write_owned_bypasses_batch_buffer() {
+        let mut props = one_peer_props("http://127.0.0.1:1");
+        props.push(prop_int("batch_size", 1024));
+        props.push(prop_str("batch_timeout", "30s"));
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let err = output
             .write_owned(&event_with_egress(singleton_bytes(1)))
             .await
+            .expect_err("send must fail against unreachable peer");
+        assert!(
+            err.to_string().contains("otlp_http"),
+            "expected ship error, got: {err}"
+        );
+        let batch_len = output.inner.batch.lock().await.len();
+        assert_eq!(batch_len, 0, "Owned event must not land in the batch");
+        let timer_armed = output.flush_handle.lock().await.is_some();
+        assert!(!timer_armed, "Owned event must not arm the flush timer");
+    }
+
+    #[test]
+    fn rejects_tls_block_on_plaintext_endpoint() {
+        // `tls { ... }` on an `http://` endpoint is almost always an
+        // operator error — reqwest silently ignores the CA / client
+        // cert when the URL is plaintext, so the daemon would ship in
+        // clear text without any indication that the tls block did
+        // nothing. Fail fast at parse time.
+        let props = vec![peers_block_with(vec![Property::Block {
+            key: "peer".into(),
+            key_span: None,
+            properties: vec![
+                prop_str("endpoint", "http://collector.example.com:4318/v1/logs"),
+                Property::Block {
+                    key: "tls".into(),
+                    key_span: None,
+                    properties: vec![prop_str("ca", "/etc/ca.pem")],
+                },
+            ],
+        }])];
+        let err = OtlpHttpOutput::from_properties("o", &mp(&props))
+            .err()
             .unwrap();
-        let handle_before = output.flush_handle.lock().await.is_some();
-        assert!(handle_before, "write must arm the flush timer");
-        drop(output);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("plaintext") && msg.contains("https://"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[test]
+    fn accepts_empty_tls_block_on_https_endpoint() {
+        // Regression guard for the plaintext-rejection check: https://
+        // endpoints must still accept a (here empty) tls block. We use
+        // an empty block so the test doesn't try to read a CA pem off
+        // disk; the validation we care about (scheme check) runs
+        // before the file read.
+        let props = vec![peers_block_with(vec![Property::Block {
+            key: "peer".into(),
+            key_span: None,
+            properties: vec![
+                prop_str("endpoint", "https://collector.example.com:4318/v1/logs"),
+                Property::Block {
+                    key: "tls".into(),
+                    key_span: None,
+                    properties: vec![],
+                },
+            ],
+        }])];
+        let output = OtlpHttpOutput::from_properties("o", &mp(&props)).unwrap();
+        assert_eq!(output.inner.peers.len(), 1);
     }
 }

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -440,23 +440,11 @@ impl Output for OtlpHttpOutput {
     /// consumer needs a per-event ship verdict, and the batched buffer
     /// would lose it. Ship inline here, bypassing the batch.
     async fn write_owned(&self, event: &Event) -> Result<()> {
-        let payload = {
-            let bump = bumpalo::Bump::new();
-            let arena = EventArena::new(&bump);
-            let bevent = event.view_in(&arena);
-            self.render(&bevent, &arena)?
-        };
-        let payload: OtlpPayload = payload.downcast()?;
-        match send_batch(&self.inner, vec![payload.egress]).await {
-            Ok(()) => {
-                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
-            Err(e) => {
-                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                Err(e)
-            }
-        }
+        crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
+            let payload: OtlpPayload = payload.downcast()?;
+            send_batch(&self.inner, vec![payload.egress]).await
+        })
+        .await
     }
 }
 

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -70,6 +70,8 @@ Each `peer` block configures one collector endpoint:
 
 On each flush, peers are tried in round-robin order. A peer that fails the request is marked cooled-down for ~5s and skipped on subsequent flushes until the cooldown expires. The cursor advances per flush so successive flushes start at successive peers; within one flush the `retry` budget protects against transient failures by rotating to the next available peer.
 
+Every gRPC `Export` call is bounded by a 30s timeout. A peer that accepts the connection but never returns a HEADERS frame counts as a failure and yields to the next peer in the rotation.
+
 > `verify false` is intentionally not exposed. tonic does not support insecure-skip-verify the way reqwest does; use an `http://` endpoint for plaintext development setups or terminate TLS at a sidecar.
 
 ## Pipeline contract

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -67,11 +67,13 @@ Each `peer` block configures one collector endpoint:
 
 | Per-peer property | Required | Description |
 |-------------------|----------|-------------|
-| `endpoint` | yes | Full OTLP/HTTP URL including `/v1/logs` (limpid does not append it). |
+| `endpoint` | yes | Full OTLP/HTTP URL including `/v1/logs` (limpid does not append it). A `tls { ... }` block is rejected at config-load time if this is not an `https://` URL — reqwest only negotiates TLS on https URLs, so a tls block on a plaintext endpoint would silently ship in clear text. |
 | `tls.ca` | no | Custom CA certificate file (PEM) for this peer. Falls back to the system root store if omitted. |
 | `tls.cert`, `tls.key` | no (paired) | Client certificate and private key for mTLS, as separate PEM files (chmod 600 the key). Both must be present together. |
 
 On each flush, peers are tried in round-robin order. A peer that fails the request is marked cooled-down for ~5s and skipped on subsequent flushes until the cooldown expires. The cursor advances per flush so successive flushes start at successive peers; within one flush the `retry` budget protects against transient failures by rotating to the next available peer.
+
+Every HTTP export is bounded by a 30s timeout (connect, TLS handshake, request send, response body). A peer that accepts the connection but never replies counts as a failure and yields to the next peer in the rotation.
 
 ## Pipeline contract
 


### PR DESCRIPTION
## Summary

Closes **five CodeRabbit findings** on [#23](https://github.com/naoto256/limpid/pull/23) (release 0.7.6 review):

### 🔴 Critical — Owned-event ownership (2 findings)

`otlp_grpc` / `otlp_http` previously routed disk-queue replay and control-socket inject events (`SinkInput::Owned`) through the same buffer as the memory hot path. `write()` returned Ok after only enqueueing the event, so the queue consumer treated the event as delivered. If the eventual flush failed, the buffered Owned events were silently lost — the queue had already dropped them, and no `Err` ever surfaced to trigger the retry / disk-replay / secondary path.

Both batched OTLP outputs (and `output/http` preemptively, since it shares the architectural pattern) now override `write_owned` to ship a single event inline via `send_batch`, bypassing the batch. The memory hot path (Rendered) continues to batch as before.

### 🟠 Major — Per-export timeouts (2 findings)

- `otlp_grpc`: `client.export(request).await` was unbounded. A stalled collector that accepted the connection but never returned a HEADERS frame held the flush future open indefinitely, blocked rotation, and starved the retry budget. Now wrapped in `tokio::time::timeout(30s)`.
- `otlp_http`: the `reqwest::Client` lacked a request timeout. Same failure mode. Now carries `.timeout(30s)` on the builder.

### 🟠 Major — Reject `tls { ... }` on plaintext OTLP/HTTP endpoints

`otlp_http` previously accepted a `tls { ... }` block paired with an `http://` endpoint. reqwest only negotiates TLS on `https://` URLs, so CA / client-cert settings were silently dropped and the daemon shipped in clear text while pretending the tls block was active. Now rejected at config-load time with a clear error.

### Refactor — `ship_owned_inline` helper (follow-up commit)

The three batched outputs all landed the same `write_owned` override shape (render → downcast → send_batch → metric match). After the parent commit, the abstraction audit flagged the duplication; a follow-up commit extracts a free helper `ship_owned_inline` in `modules/mod.rs` so each override is a 5-line call site. Open/Closed satisfied for the next batched output.

## Test plan

- [x] `cargo clean` + clean rebuild from scratch
- [x] `cargo clippy --features kafka --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --features kafka --workspace` — 540 passed (+5 new vs PR #28 baseline)
- [x] uchgs push gate: 7/7 scopes confirmed

New tests:
- `otlp::grpc::tests::write_owned_bypasses_batch_buffer`
- `otlp::http::tests::write_owned_bypasses_batch_buffer`
- `otlp::http::tests::rejects_tls_block_on_plaintext_endpoint`
- `otlp::http::tests::accepts_empty_tls_block_on_https_endpoint`
- `http::tests::write_owned_bypasses_batch_buffer`

Two existing `drop_aborts_pending_flush_timer` tests reworked to drive the timer via the Rendered path (Owned events no longer arm the flush timer with the new bypass).