### PR TITLE
fix(input syslog_tcp): bound TLS handshakes at 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `input syslog_tcp`: TLS handshakes are now bounded at 10 s
+
+A client that opened TCP but never completed the TLS handshake would
+otherwise pin a task on `acceptor.accept().await` forever and consume
+one of the `max_connections` slots. With enough stalled handshakes an
+attacker (or a misbehaving client) could exhaust the slot pool and
+deny service to legitimate peers. Handshakes now have a hard 10 s
+ceiling; on timeout the connection is dropped with a `WARN` log
+naming the peer address and the timeout duration.
+
 ### Fixed — `output http`: four correctness fixes from the 0.7.6 review
 
 - **`verify false` no longer drops the client identity.** A `tls { cert

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -113,6 +113,15 @@ const MAX_MSG_LEN_DIGITS: usize = 7;
 /// the connection is dropped. Prevents resource leaks from dead peers.
 const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Upper bound on the TLS handshake. A client that opens TCP but never
+/// finishes the handshake (slow handshakes happen on real networks;
+/// hung-mid-handshake attempts happen on hostile ones) would otherwise
+/// pin a task on `acceptor.accept().await` forever and consume one of
+/// the `max_connections` slots. 10 s is loose enough for high-latency
+/// links + a slow CPU on the client and tight enough that a handful of
+/// stalled handshakes can't exhaust the slot pool.
+const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Syslog TCP framing method per RFC 6587.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TcpFraming {
@@ -265,15 +274,37 @@ impl Input for SyslogTcpInput {
                             conn_handles.push(tokio::spawn(async move {
                                 let accepted = match acceptor {
                                     Some(acceptor) => {
-                                        match acceptor.accept(stream).await {
-                                            Ok(s) => {
+                                        // Bound the TLS handshake: a client that
+                                        // opens TCP but never finishes the
+                                        // handshake (slow / malicious) would
+                                        // otherwise pin a task on this stalled
+                                        // future and burn one of the
+                                        // `max_connections` slots until something
+                                        // unrelated kills it. 10 s is loose
+                                        // enough for normal TLS over high-latency
+                                        // links and short enough that an attacker
+                                        // can't trivially exhaust the slot pool.
+                                        match tokio::time::timeout(
+                                            TLS_HANDSHAKE_TIMEOUT,
+                                            acceptor.accept(stream),
+                                        )
+                                        .await
+                                        {
+                                            Ok(Ok(s)) => {
                                                 debug!("syslog_tcp [{}]: TLS handshake complete", addr);
                                                 AcceptedStream::Tls(Box::new(s))
                                             }
-                                            Err(e) => {
+                                            Ok(Err(e)) => {
                                                 warn!(
                                                     "syslog_tcp [{}]: TLS handshake failed: {}",
                                                     addr, e
+                                                );
+                                                return;
+                                            }
+                                            Err(_) => {
+                                                warn!(
+                                                    "syslog_tcp [{}]: TLS handshake timed out after {:?}",
+                                                    addr, TLS_HANDSHAKE_TIMEOUT
                                                 );
                                                 return;
                                             }
@@ -951,6 +982,23 @@ mod tests {
             key_span: None,
             properties,
         }
+    }
+
+    #[test]
+    fn tls_handshake_timeout_is_sensible() {
+        // Regression guard: the constant exists, is non-zero, and sits
+        // in a band that doesn't trivially exhaust the connection pool
+        // (≤ 30 s) while still tolerating real-world high-latency
+        // links + slow client CPUs (≥ 1 s). A full timing test would
+        // require either a 10 s real-wait or a paused-time harness
+        // tangled around the runtime's task spawning; neither pays
+        // for itself given the change is a mechanical tokio::time::
+        // timeout wrap. Code review + this bound check catch the
+        // regression modes that matter (const removed, set to 0,
+        // set to a multi-minute value that lets attackers fill the
+        // slot pool with stalled handshakes).
+        assert!(TLS_HANDSHAKE_TIMEOUT >= Duration::from_secs(1));
+        assert!(TLS_HANDSHAKE_TIMEOUT <= Duration::from_secs(30));
     }
 
     #[test]

--- a/docs/src/inputs/syslog-tcp.md
+++ b/docs/src/inputs/syslog-tcp.md
@@ -87,3 +87,6 @@ Framing detection runs after the TLS handshake when `tls` is configured.
 - Connections exceeding `max_connections` are rejected immediately.
 - TLS server config (cert / key / CA loading + parsing) happens at
   daemon start — invalid files fail-fast before the listener binds.
+- TLS handshakes are bounded at 10 s. A client that opens TCP but
+  never completes the handshake is dropped after the timeout so it
+  cannot pin a connection slot indefinitely.


### PR DESCRIPTION
## Summary

Closes a 🟠 Major CodeRabbit finding on [#23](https://github.com/naoto256/limpid/pull/23) (release 0.7.6 review).

Previously `acceptor.accept(stream).await` had no upper bound. A client that opened TCP but never completed the handshake (slow on real networks, hung-mid-handshake on hostile ones) would pin a task on the stalled future forever and consume one of the `max_connections` slots. With enough stalled handshakes a misbehaving — or actively malicious — client could exhaust the slot pool and deny service to legitimate peers.

The handshake is now wrapped in `tokio::time::timeout` with a hard 10 s ceiling; on timeout the connection is dropped with a `WARN` log naming the peer address and the timeout duration. The new const `TLS_HANDSHAKE_TIMEOUT` documents the rationale (loose enough for high-latency links + slow client CPUs, tight enough that a small number of stalled handshakes can't exhaust the pool).

## Test note

A timing regression test would require either a 10 s real-wait or a paused-time harness threaded around the runtime's task spawning; neither pays for itself given the change is a mechanical `tokio::time::timeout` wrap. The new bound-check unit test catches the regression modes that matter (const removed, set to 0, set to a multi-minute value that lets attackers fill the slot pool).

## Test plan

- [x] `cargo clippy --features kafka --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --features kafka --workspace` — 546 passed (545 baseline + 1 bound-check)
- [x] uchgs push gate: 7/7 scopes confirmed