### PR TITLE
fix(output syslog): IPv6 + parse-path correctness (+ refactor follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output syslog_tcp` / `output syslog_udp`: IPv6 + parse-path correctness
+
+Three fixes from the PR #9 (release 0.7.4) review that surfaced once
+this PR audit ran end-to-end on the current codebase:
+
+- **`Peer::address` now brackets IPv6 literals.** A peer configured
+  with `host "::1"` previously produced the address string `::1:514`,
+  which Rust's `SocketAddr` parser rejects (it reads the trailing
+  `:514` as part of the address). Both TCP `TcpStream::connect` and
+  UDP `UdpSocket::connect` hit this. The formatted address now reads
+  `[::1]:514`; IPv4 and hostnames are left unbracketed; an already-
+  bracketed literal is preserved.
+- **`output syslog_tcp` / `output syslog_udp` reject `peer` + `peers`
+  in `from_properties` too.** The schema-validating `Module::build`
+  path already caught this, but `from_properties` (called directly
+  from snippet expansion and inline test fixtures) silently took the
+  first `peer` block and discarded the `peers` block. The exclusivity
+  contract is now enforced on every entry point.
+- **`output syslog_udp` no longer forces an IPv4 ephemeral socket.**
+  The previous hard `UdpSocket::bind("0.0.0.0:0")` meant any peer
+  that resolved only to AAAA failed before the first datagram left.
+  The output now resolves the peer first, picks `0.0.0.0:0` or
+  `[::]:0` to match the resolved address family, then connects.
+
+
 ### Fixed — `input syslog_tcp`: TLS handshakes are now bounded at 10 s
 
 A client that opened TCP but never completed the TLS handshake would

--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -57,8 +57,22 @@ pub struct Peer {
 }
 
 impl Peer {
+    /// Formatted `host:port` suitable for `TcpStream::connect` /
+    /// `UdpSocket::connect`. Bare IPv6 literals (e.g. `::1`) must be
+    /// bracketed so the port parses correctly — `format!("{}:{}", "::1", 514)`
+    /// yields `::1:514` which Rust's `SocketAddr` parser rejects (it
+    /// reads the trailing `:514` as part of the address). Hostnames
+    /// and IPv4 literals don't need brackets; an already-bracketed
+    /// literal (`[::1]`) is left untouched.
     pub fn address(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+        if self.host.contains(':')
+            && !self.host.starts_with('[')
+            && !self.host.ends_with(']')
+        {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
     }
 }
 
@@ -288,6 +302,43 @@ mod tests {
         (0..n)
             .map(|idx| peer(&format!("peer-{idx}"), 514 + idx as u16))
             .collect()
+    }
+
+    #[test]
+    fn address_brackets_ipv6_literal() {
+        // `format!("{}:{}", "::1", 514)` yields `::1:514` which Rust's
+        // `SocketAddr::parse` rejects (it reads the trailing `:514` as
+        // part of the address itself). `Peer::address` is fed directly
+        // into `TcpStream::connect` / `UdpSocket::connect`, so the v6
+        // path must come out as `[::1]:514`.
+        let p = peer("::1", 514);
+        assert_eq!(p.address(), "[::1]:514");
+
+        // Full-form IPv6 literal.
+        let p = peer("2001:db8::1", 6514);
+        assert_eq!(p.address(), "[2001:db8::1]:6514");
+    }
+
+    #[test]
+    fn address_leaves_ipv4_unbracketed() {
+        let p = peer("127.0.0.1", 514);
+        assert_eq!(p.address(), "127.0.0.1:514");
+    }
+
+    #[test]
+    fn address_leaves_hostname_unbracketed() {
+        // Hostnames don't contain `:` so the no-bracket path applies.
+        let p = peer("relay.example.com", 514);
+        assert_eq!(p.address(), "relay.example.com:514");
+    }
+
+    #[test]
+    fn address_does_not_double_bracket_ipv6() {
+        // If the operator already wrote the literal with brackets in
+        // the config (some tools do), preserve that — adding another
+        // pair would produce `[[::1]]:514` which doesn't parse.
+        let p = peer("[::1]", 514);
+        assert_eq!(p.address(), "[::1]:514");
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -94,6 +94,48 @@ pub fn parse_host_port(
     Ok((host, port))
 }
 
+/// Single entry point that turns a syslog-style output's top-level
+/// `peer { ... }` / `peers { peer { ... } ... }` schema into a `Vec<Peer>`.
+///
+/// Enforces the contract every syslog output shares:
+/// - `peer` and `peers` are mutually exclusive — supplying both is an
+///   error (the schema marks them as an `exclusive_group`, but this
+///   function is also called from `from_properties` which bypasses
+///   schema validation, so we re-enforce here).
+/// - At least one must be present.
+/// - Both forms ultimately delegate to a caller-supplied `parse_peer`
+///   closure for the per-`peer { ... }` parsing — that part is per-
+///   output (TCP needs `profiles`, UDP doesn't), so it stays a
+///   closure rather than being baked into this helper.
+///
+/// The `label` passed to `parse_peer` distinguishes the two call
+/// shapes for error messages: `"peer"` for the single-shorthand,
+/// `"peers.peer"` for each inner `peer` of a `peers` block.
+pub fn parse_peer_or_peers<F>(
+    name: &str,
+    properties: &[Property],
+    mut parse_peer: F,
+) -> anyhow::Result<Vec<Peer>>
+where
+    F: FnMut(&str, &[Property]) -> anyhow::Result<Peer>,
+{
+    match (
+        props::get_block(properties, "peer"),
+        props::get_block(properties, "peers"),
+    ) {
+        (Some(_), Some(_)) => anyhow::bail!(
+            "output '{}': 'peer' and 'peers' are mutually exclusive",
+            name
+        ),
+        (Some(peer_block), None) => Ok(vec![parse_peer("peer", peer_block)?]),
+        (None, Some(peers_block)) => {
+            let label = format!("output '{}': peers", name);
+            iter_peers_block(peers_block, &label, |inner| parse_peer("peers.peer", inner))
+        }
+        (None, None) => anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name),
+    }
+}
+
 /// Iterate `peer` blocks inside a `peers` block, invoking the provided
 /// per-peer parser for each one.
 pub fn iter_peers_block<T, F>(

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -251,18 +251,28 @@ fn parse_peers(
     properties: &[Property],
     profiles: &HashMap<String, ClientTlsConfig>,
 ) -> Result<Vec<Peer>> {
-    if let Some(peer_block) = props::get_block(properties, "peer") {
-        return Ok(vec![parse_peer(name, "peer", peer_block, profiles)?]);
+    // The schema marks `peer` and `peers` as mutually exclusive via
+    // its `exclusive_group`, but `from_properties()` can also be
+    // called directly (e.g. from snippet expansion / inline test
+    // fixtures) before schema validation runs. Re-enforce the
+    // exclusivity here so the contract holds on every entry point.
+    match (
+        props::get_block(properties, "peer"),
+        props::get_block(properties, "peers"),
+    ) {
+        (Some(_), Some(_)) => anyhow::bail!(
+            "output '{}': 'peer' and 'peers' are mutually exclusive",
+            name
+        ),
+        (Some(peer_block), None) => Ok(vec![parse_peer(name, "peer", peer_block, profiles)?]),
+        (None, Some(peers_block)) => {
+            let label = format!("output '{}': peers", name);
+            iter_peers_block(peers_block, &label, |inner| {
+                parse_peer(name, "peers.peer", inner, profiles)
+            })
+        }
+        (None, None) => anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name),
     }
-
-    if let Some(peers_block) = props::get_block(properties, "peers") {
-        let label = format!("output '{}': peers", name);
-        return iter_peers_block(peers_block, &label, |inner| {
-            parse_peer(name, "peers.peer", inner, profiles)
-        });
-    }
-
-    anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name)
 }
 
 fn parse_peer(
@@ -644,6 +654,24 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("exclusive group"), "{}", msg);
         assert!(msg.contains("peer") && msg.contains("peers"), "{}", msg);
+    }
+
+    #[test]
+    fn from_properties_rejects_peer_and_peers_together() {
+        // `Module::build` validates the schema and catches this case,
+        // but callers that bypass schema validation (snippet
+        // expansion, inline test fixtures) reach `from_properties`
+        // directly. Without this check, `parse_peers` would silently
+        // take the first `peer` block and discard the `peers` block.
+        let props = vec![
+            peer_plain("a", 514),
+            block("peers", vec![peer_plain("b", 514)]),
+        ];
+        let err = SyslogTcpOutput::from_properties("relay", &mp(&props))
+            .err()
+            .expect("from_properties should reject both blocks");
+        let msg = err.to_string();
+        assert!(msg.contains("mutually exclusive"), "{}", msg);
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -34,7 +34,7 @@ use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
     PEER_CONNECT_TIMEOUT, PEER_HANDSHAKE_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList,
-    SyslogFraming, SyslogPayload, iter_peers_block, parse_host_port, write_framed,
+    SyslogFraming, SyslogPayload, parse_host_port, write_framed,
 };
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::tls::{ClientTlsConfig, build_client_config_sync};
@@ -251,28 +251,11 @@ fn parse_peers(
     properties: &[Property],
     profiles: &HashMap<String, ClientTlsConfig>,
 ) -> Result<Vec<Peer>> {
-    // The schema marks `peer` and `peers` as mutually exclusive via
-    // its `exclusive_group`, but `from_properties()` can also be
-    // called directly (e.g. from snippet expansion / inline test
-    // fixtures) before schema validation runs. Re-enforce the
-    // exclusivity here so the contract holds on every entry point.
-    match (
-        props::get_block(properties, "peer"),
-        props::get_block(properties, "peers"),
-    ) {
-        (Some(_), Some(_)) => anyhow::bail!(
-            "output '{}': 'peer' and 'peers' are mutually exclusive",
-            name
-        ),
-        (Some(peer_block), None) => Ok(vec![parse_peer(name, "peer", peer_block, profiles)?]),
-        (None, Some(peers_block)) => {
-            let label = format!("output '{}': peers", name);
-            iter_peers_block(peers_block, &label, |inner| {
-                parse_peer(name, "peers.peer", inner, profiles)
-            })
-        }
-        (None, None) => anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name),
-    }
+    crate::modules::output::syslog_peers::parse_peer_or_peers(
+        name,
+        properties,
+        |label, peer_props| parse_peer(name, label, peer_props, profiles),
+    )
 }
 
 fn parse_peer(

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -82,18 +82,28 @@ impl Module for SyslogUdpOutput {
 }
 
 fn parse_peers(name: &str, properties: &[Property]) -> Result<Vec<Peer>> {
-    if let Some(peer_block) = props::get_block(properties, "peer") {
-        return Ok(vec![parse_peer(name, "peer", peer_block)?]);
+    // The schema marks `peer` and `peers` as mutually exclusive via
+    // its `exclusive_group`, but `from_properties()` can also be
+    // called directly (e.g. from snippet expansion / inline test
+    // fixtures) before schema validation runs. Re-enforce the
+    // exclusivity here so the contract holds on every entry point.
+    match (
+        props::get_block(properties, "peer"),
+        props::get_block(properties, "peers"),
+    ) {
+        (Some(_), Some(_)) => anyhow::bail!(
+            "output '{}': 'peer' and 'peers' are mutually exclusive",
+            name
+        ),
+        (Some(peer_block), None) => Ok(vec![parse_peer(name, "peer", peer_block)?]),
+        (None, Some(peers_block)) => {
+            let label = format!("output '{}': peers", name);
+            iter_peers_block(peers_block, &label, |inner| {
+                parse_peer(name, "peers.peer", inner)
+            })
+        }
+        (None, None) => anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name),
     }
-
-    if let Some(peers_block) = props::get_block(properties, "peers") {
-        let label = format!("output '{}': peers", name);
-        return iter_peers_block(peers_block, &label, |inner| {
-            parse_peer(name, "peers.peer", inner)
-        });
-    }
-
-    anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name)
 }
 
 fn parse_peer(name: &str, label: &str, properties: &[Property]) -> Result<Peer> {
@@ -135,10 +145,43 @@ impl Output for SyslogUdpOutput {
                 let address = peer.address();
                 Box::pin(async move {
                     if state.conn.is_none() {
-                        let socket = UdpSocket::bind("0.0.0.0:0")
+                        // Resolve the peer address first and pick the
+                        // bind family from the resolved SocketAddr —
+                        // hard-binding to `0.0.0.0:0` would refuse to
+                        // connect any peer that resolves only to AAAA,
+                        // and `host` accepts hostnames that may do
+                        // exactly that. Hostnames are still typically
+                        // dual-stack, so this preserves the common
+                        // case while admitting v6-only destinations.
+                        let resolved = tokio::time::timeout(
+                            PEER_CONNECT_TIMEOUT,
+                            tokio::net::lookup_host(address.as_str()),
+                        )
+                        .await
+                        .with_context(|| {
+                            format!("syslog_udp lookup {} timed out", address)
+                        })?
+                        .with_context(|| format!("syslog_udp lookup {}", address))?
+                        .next()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "syslog_udp: name resolution for {} returned no addresses",
+                                address
+                            )
+                        })?;
+                        let bind_addr = match resolved {
+                            std::net::SocketAddr::V4(_) => "0.0.0.0:0",
+                            std::net::SocketAddr::V6(_) => "[::]:0",
+                        };
+                        let socket = UdpSocket::bind(bind_addr)
                             .await
-                            .context("syslog_udp output: failed to bind ephemeral socket")?;
-                        tokio::time::timeout(PEER_CONNECT_TIMEOUT, socket.connect(&address))
+                            .with_context(|| {
+                                format!(
+                                    "syslog_udp output: failed to bind ephemeral socket ({})",
+                                    bind_addr
+                                )
+                            })?;
+                        tokio::time::timeout(PEER_CONNECT_TIMEOUT, socket.connect(resolved))
                             .await
                             .with_context(|| {
                                 format!("syslog_udp connect to {} timed out", address)
@@ -180,6 +223,7 @@ mod tests {
     use super::*;
     use crate::dsl::ast::{Expr, ExprKind, Property};
     use crate::dsl::schema::SchemaErrorKind;
+    use std::time::Duration;
 
     /// Wrap a property list in a `ModuleProperties` shaped for this test module.
     /// Mirrors what the parser produces for `def input/output ... { type syslog_udp; ... }`
@@ -286,6 +330,23 @@ mod tests {
     }
 
     #[test]
+    fn from_properties_rejects_peer_and_peers_together() {
+        // `Module::build` validates the schema first and so always
+        // catches the exclusive_group violation before reaching
+        // `from_properties`. But callers that bypass schema validation
+        // (snippet expansion, inline test fixtures) hit
+        // `from_properties` directly — without this check it would
+        // silently take the first `peer` block and discard the
+        // `peers` block. Belt-and-braces.
+        let props = vec![peer("a", 1), block("peers", vec![peer("b", 2)])];
+        let err = SyslogUdpOutput::from_properties("u", &mp(&props))
+            .err()
+            .expect("from_properties should reject both blocks");
+        let msg = err.to_string();
+        assert!(msg.contains("mutually exclusive"), "{}", msg);
+    }
+
+    #[test]
     fn build_rejects_empty_peers_block() {
         let err = SyslogUdpOutput::from_properties("u", &mp(&[block("peers", vec![])]))
             .err()
@@ -313,5 +374,53 @@ mod tests {
             .err()
             .expect("should fail");
         assert!(err.to_string().contains("host"), "{}", err);
+    }
+
+    #[tokio::test]
+    async fn send_to_ipv6_loopback_peer() {
+        // Regression guard for the IPv4-forced bind. Listen on the
+        // IPv6 loopback, configure the output to send there, and
+        // verify the bytes arrive. Pre-fix, the output would bind a
+        // v4 socket and `connect()` to a v6 destination, which fails
+        // before the first datagram leaves.
+        use bytes::Bytes;
+        use std::net::SocketAddr;
+
+        let listener = UdpSocket::bind("[::1]:0")
+            .await
+            .expect("ipv6 loopback unavailable on this host");
+        let addr = listener.local_addr().unwrap();
+        let port = addr.port() as i64;
+
+        let output = SyslogUdpOutput::build(
+            "u6",
+            &mp(&[block(
+                "peer",
+                vec![
+                    kv("host", ExprKind::StringLit("::1".into())),
+                    kv("port", ExprKind::IntLit(port)),
+                ],
+            )]),
+        )
+        .expect("build");
+
+        // Hand-craft a RenderedPayload the way the runtime does.
+        let payload = RenderedPayload::new(SyslogPayload {
+            egress: Bytes::from_static(b"<134>hello-v6"),
+        });
+        output.write(payload).await.expect("write should succeed");
+
+        // Read one datagram off the listener.
+        let mut buf = [0u8; 64];
+        let (n, src) = tokio::time::timeout(Duration::from_secs(1), listener.recv_from(&mut buf))
+            .await
+            .expect("timed out waiting for datagram")
+            .expect("recv_from");
+        assert_eq!(&buf[..n], b"<134>hello-v6");
+        assert!(
+            matches!(src, SocketAddr::V6(_)),
+            "peer source must be v6, got {:?}",
+            src
+        );
     }
 }

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -8,12 +8,11 @@ use tokio::net::UdpSocket;
 
 use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
-use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
-    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogPayload, iter_peers_block,
+    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogPayload,
     parse_host_port,
 };
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
@@ -82,28 +81,11 @@ impl Module for SyslogUdpOutput {
 }
 
 fn parse_peers(name: &str, properties: &[Property]) -> Result<Vec<Peer>> {
-    // The schema marks `peer` and `peers` as mutually exclusive via
-    // its `exclusive_group`, but `from_properties()` can also be
-    // called directly (e.g. from snippet expansion / inline test
-    // fixtures) before schema validation runs. Re-enforce the
-    // exclusivity here so the contract holds on every entry point.
-    match (
-        props::get_block(properties, "peer"),
-        props::get_block(properties, "peers"),
-    ) {
-        (Some(_), Some(_)) => anyhow::bail!(
-            "output '{}': 'peer' and 'peers' are mutually exclusive",
-            name
-        ),
-        (Some(peer_block), None) => Ok(vec![parse_peer(name, "peer", peer_block)?]),
-        (None, Some(peers_block)) => {
-            let label = format!("output '{}': peers", name);
-            iter_peers_block(peers_block, &label, |inner| {
-                parse_peer(name, "peers.peer", inner)
-            })
-        }
-        (None, None) => anyhow::bail!("output '{}': either 'peer' or 'peers' is required", name),
-    }
+    crate::modules::output::syslog_peers::parse_peer_or_peers(
+        name,
+        properties,
+        |label, peer_props| parse_peer(name, label, peer_props),
+    )
 }
 
 fn parse_peer(name: &str, label: &str, properties: &[Property]) -> Result<Peer> {

--- a/docs/src/outputs/syslog-tcp.md
+++ b/docs/src/outputs/syslog-tcp.md
@@ -87,7 +87,7 @@ Exactly one of `peer` or `peers` must be specified.
 
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `host` | yes | - | Hostname or IP of the syslog receiver. Also used as the TLS SNI / certificate verification name when `tls` is set. |
+| `host` | yes | - | Hostname or IP of the syslog receiver. IPv4 literals, IPv6 literals (`::1` / `2001:db8::1`, bare or bracketed), and hostnames are all accepted. Also used as the TLS SNI / certificate verification name when `tls` is set. |
 | `port` | no | per-peer | TCP port. Defaults to `6514` when this peer has a `tls` block (RFC 5425) and `514` otherwise (RFC 6587). |
 | `tls` | no | - | Either an inline [tls block](#tls-block) or a bare identifier referencing a profile defined in the outer `tls { ... }` map. Omit to use plaintext TCP. |
 

--- a/docs/src/outputs/syslog-udp.md
+++ b/docs/src/outputs/syslog-udp.md
@@ -41,7 +41,7 @@ Exactly one of `peer` or `peers` must be specified.
 
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `host` | yes | - | Hostname or IP of the syslog receiver |
+| `host` | yes | - | Hostname or IP of the syslog receiver. IPv4 literals (`10.0.0.1`), IPv6 literals (`::1`, `2001:db8::1` — bare or bracketed), and hostnames are all accepted. Hostnames that resolve only to AAAA work as well; limpid binds the ephemeral local socket in the matching address family. |
 | `port` | no | `514` | UDP port |
 
 ## Multi-destination semantics


### PR DESCRIPTION
## Summary

Closes **three CodeRabbit Major findings** on [#9](https://github.com/naoto256/limpid/pull/9) (release 0.7.4 review), all 🟠.

### Commit 1: `fix(output syslog)` — three correctness fixes

- **`Peer::address` brackets IPv6 literals.** `format!("{}:{}", "::1", 514)` yielded `::1:514` which Rust's `SocketAddr` parser rejects (reads the trailing `:514` as part of the address). Both `TcpStream::connect` and `UdpSocket::connect` are fed `Peer::address()` directly. The formatted address now reads `[::1]:514`; IPv4 and hostnames are unbracketed; an already-bracketed literal is preserved.
- **`output syslog_tcp` / `output syslog_udp` reject `peer` + `peers` in `from_properties` too.** The schema-validating `Module::build` path already caught this, but `from_properties` (called from snippet expansion / inline test fixtures, bypassing schema) silently took the first `peer` block and discarded `peers`. The contract is now enforced on every entry point.
- **`output syslog_udp` no longer forces an IPv4 ephemeral socket.** The previous hard `UdpSocket::bind("0.0.0.0:0")` meant any peer that resolved only to AAAA failed before the first datagram left. The output now resolves the peer first via `tokio::net::lookup_host`, picks `0.0.0.0:0` or `[::]:0` to match the resolved address family, then connects.

### Commit 2: `refactor(syslog peers)` — close abstraction finding

Commit 1's `parse_peers` functions in `syslog_tcp` + `syslog_udp` landed literal copy-paste (same `match` arms, same error strings, same label format — differing only in the `parse_peer` callee signature). Extracted `parse_peer_or_peers` to `syslog_peers`, generic over a closure for the per-peer parse step. Each call site shrinks from ~25 lines to ~6.

## Test plan

- [x] `cargo clippy --features kafka --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --features kafka --workspace` — 553 passed (546 baseline + 7 new)
- [x] uchgs push gate: 7/7 scopes confirmed across both commits

New tests:
- `syslog_peers::tests::address_brackets_ipv6_literal`
- `syslog_peers::tests::address_leaves_ipv4_unbracketed`
- `syslog_peers::tests::address_leaves_hostname_unbracketed`
- `syslog_peers::tests::address_does_not_double_bracket_ipv6`
- `syslog_tcp::tests::from_properties_rejects_peer_and_peers_together`
- `syslog_udp::tests::from_properties_rejects_peer_and_peers_together`
- `syslog_udp::tests::send_to_ipv6_loopback_peer` (real round-trip through an `[::1]:0` UDP listener)