### PR TITLE
fix(check): nested-block expression diagnostics + OneOf branch-specific errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `limpidctl check`: nested-block expression diagnostics + OneOf branch-specific errors
+
+Two diagnostic-quality fixes from the PR #9 (release 0.7.4) review:
+
+- **Expression-level diagnostics inside nested output blocks no longer
+  silenced.** A typo like `peer { host "${upperr(workspace.msg)}" }`
+  used to skip `expr_types::check_types` for `host` — the analyzer
+  inherited the parent block's `schema_owned=true` flag through every
+  recursion level and silenced every inner key, masking unknown
+  functions, type mismatches, and similar expression errors inside
+  any schema-declared nested block. The skip is now narrowed to the
+  only case it actually targets — a bare top-level `ExprKind::Ident`
+  value like `framing non_transparent` (= an enum-shaped value the
+  schema validator owns) — so template interpolations inside nested
+  output properties get checked again.
+- **`OneOf` schema mismatches now surface the specific inner error
+  when exactly one variant matched structurally.** Previously, when
+  no variant matched cleanly, every failure collapsed to
+  `OneOfMismatch` ("expected Block | Ident, got Block") — actively
+  misleading when the user wrote the right outer shape and the real
+  problem was one missing inner key. If exactly one variant matches
+  the outer shape (no `ExpectedBlock` / `ExpectedValue` failure),
+  the analyzer now surfaces that variant's specific inner error
+  (e.g. `MissingRequired` for the missing `cert`). When zero or
+  multiple variants structurally match, the generic `OneOfMismatch`
+  still fires so the operator sees the full variant list.
+
+
 ### Fixed — `output syslog_tcp` / `output syslog_udp`: IPv6 + parse-path correctness
 
 Three fixes from the PR #9 (release 0.7.4) review that surfaced once

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -1651,6 +1651,38 @@ def pipeline p {
     }
 
     #[test]
+    fn unknown_function_inside_nested_output_block_is_flagged() {
+        // Regression guard: `peer { host "${upperr(...)}" }` —
+        // `upperr` is a typo for `upper`. The unknown-function
+        // diagnostic must surface even though `host` lives inside a
+        // schema-owned `peer` block. The previous implementation
+        // forwarded the parent's `schema_owned=true` flag down through
+        // every nested property and silently skipped `expr_types::
+        // check_types` for the inner key. Now `schema_owned` is
+        // recomputed against the nested inner schema at each level —
+        // `host` is declared as `String`, not `Block`, so it's a
+        // value-shaped key whose expression body must still be type-
+        // checked.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type syslog_tcp peer { host "${upperr(workspace.msg)}" port 1 } }
+def pipeline p {
+    input i
+    process { syslog.parse(ingress) }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.message.contains("upperr") && d.message.contains("unknown function")),
+            "expected unknown-function diagnostic for `upperr` inside nested block, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
     fn error_keyword_in_function_body_fails_to_parse() {
         // Function body grammar is `process_let* ~ expr` — `error` is a
         // statement, not an expression, so it can't appear there.

--- a/crates/limpid/src/check/outputs.rs
+++ b/crates/limpid/src/check/outputs.rs
@@ -8,6 +8,7 @@
 //! mean" hints are attached when a near match exists.
 
 use crate::dsl::ast::{Expr, ExprKind, OutputDef, Property, walk_children};
+use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::dsl::span::Span;
 use crate::functions::FunctionRegistry;
 use crate::modules::ModuleRegistry;
@@ -15,6 +16,33 @@ use crate::modules::ModuleRegistry;
 use super::bindings::Bindings;
 use super::module_props::schema_declares_key;
 use super::{DiagKind, Diagnostic, expr_types, suggestions};
+
+/// When descending into a `Property::Block`, look up the inner schema
+/// for that block's key in the parent schema (if any). Returns the
+/// inner spec so the recursion can re-evaluate `schema_owned` for each
+/// nested key on its own merits rather than inheriting the parent's
+/// flag. Supports `Block`, `BlockMap`, and `OneOf` (the last by
+/// preferring the first block-shaped variant).
+fn inner_block_schema(
+    parent: &'static [PropertySpec],
+    key: &str,
+) -> Option<&'static [PropertySpec]> {
+    let spec = parent.iter().find(|p| p.name == key)?;
+    inner_block_schema_of(&spec.kind)
+}
+
+fn inner_block_schema_of(
+    kind: &PropertyValueKind,
+) -> Option<&'static [PropertySpec]> {
+    match kind {
+        PropertyValueKind::Block(s) => Some(s),
+        PropertyValueKind::BlockMap(s) => Some(s),
+        PropertyValueKind::OneOf(variants) => {
+            variants.iter().find_map(inner_block_schema_of)
+        }
+        _ => None,
+    }
+}
 
 pub(super) fn analyze_output(
     output: &OutputDef,
@@ -32,7 +60,7 @@ pub(super) fn analyze_output(
     for prop in output.properties.user_properties() {
         analyze_property(
             prop,
-            schema.is_some_and(|s| schema_declares_key(s, property_key(prop))),
+            schema,
             &output.name,
             pipeline_name,
             registry,
@@ -50,28 +78,51 @@ fn property_key(prop: &Property) -> &str {
 
 fn analyze_property(
     prop: &Property,
-    schema_owned: bool,
+    parent_schema: Option<&'static [PropertySpec]>,
     output_name: &str,
     pipeline_name: &str,
     registry: &FunctionRegistry,
     bindings: &Bindings,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    // Whether *this* key is declared in the *parent* schema. The
+    // previous shape carried a single `schema_owned` flag down through
+    // every recursion level, which silently silenced expression-level
+    // diagnostics inside any nested block whose outer key was
+    // schema-declared (e.g. `peer { host "${upperr(...)}" }` skipped
+    // `expr_types::check_types` on `host` because the parent `peer`
+    // block was schema-declared). Recomputing per-key against the
+    // current schema level — and descending into the inner spec when
+    // we enter a block — fixes that.
+    let schema_owned =
+        parent_schema.is_some_and(|s| schema_declares_key(s, property_key(prop)));
+
     match prop {
         Property::KeyValue {
             value: expr,
             value_span,
             ..
         } => {
-            // If this key is declared in the Module's property schema,
-            // the schema validator (see `module_props::analyze_all`)
-            // owns the value's *shape* — bare-ident enum values like
-            // `framing non_transparent` are no longer flagged as
-            // unresolved idents. Workspace references inside template
-            // values remain a dataflow concern, so the
-            // `collect_workspace_refs` walk still runs regardless of
-            // whether the schema covers the key.
-            if !schema_owned {
+            // The schema validator (see `module_props::analyze_all`)
+            // owns the *shape* of schema-declared values — that's why
+            // `framing non_transparent` (a bare-ident enum value)
+            // doesn't surface as "unresolved ident". The previous
+            // implementation skipped `expr_types::check_types` for
+            // every schema-declared key, which over-applied the
+            // silencing: an unknown function inside a template
+            // interpolation like `host "${upperr(...)}"` was silenced
+            // too because `host` is schema-declared (as `String`).
+            //
+            // Restrict the skip to the only case it actually targets:
+            // a bare top-level `ExprKind::Ident` value, i.e. the form
+            // `framing non_transparent`. Every other value shape
+            // (StringLit with interpolations, IntLit, BoolLit,
+            // FuncCall, etc.) still gets walked by `check_types` so
+            // unknown-function / type-mismatch diagnostics inside
+            // template bodies continue to surface.
+            let skip_expr_types =
+                schema_owned && matches!(expr.kind, ExprKind::Ident(_));
+            if !skip_expr_types {
                 expr_types::check_types(
                     expr,
                     pipeline_name,
@@ -93,10 +144,17 @@ fn analyze_property(
             });
         }
         Property::Block { properties, .. } => {
+            // Descend into the inner schema for this block's key if
+            // the parent declares one. If the key isn't schema-owned
+            // at this level, we pass `None` so inner keys evaluate
+            // against no schema (and therefore aren't "owned") —
+            // expression-level diagnostics will run on them.
+            let inner_schema = parent_schema
+                .and_then(|s| inner_block_schema(s, property_key(prop)));
             for inner in properties {
                 analyze_property(
                     inner,
-                    schema_owned,
+                    inner_schema,
                     output_name,
                     pipeline_name,
                     registry,

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -398,11 +398,46 @@ fn check_one_of(
         "nested PropertyValueKind::OneOf is not supported"
     );
 
-    if variants
+    // Try every variant; cache the per-variant error set so we can
+    // make a smarter pick than "first error wins".
+    let per_variant: Vec<Vec<SchemaError>> = variants
         .iter()
-        .any(|kind| check_property(key, *kind, prop, key_span).is_empty())
-    {
+        .map(|kind| check_property(key, *kind, prop, key_span))
+        .collect();
+
+    // Happy path — at least one variant accepted the property.
+    if per_variant.iter().any(Vec::is_empty) {
         return Vec::new();
+    }
+
+    // None accepted, but a variant may have *structurally* matched
+    // (the property's outer shape — Block vs. KeyValue — fit) and only
+    // failed on inner content (e.g. an inline `tls { ... }` block
+    // missing a required key inside). When exactly one variant matches
+    // structurally, surface its inner errors instead of collapsing to
+    // a generic `OneOfMismatch` — the latter says "expected Block |
+    // Ident, got Block" which is actively misleading when the user
+    // wrote a Block and the real problem is one missing inner key.
+    //
+    // A structural failure shows up as `ExpectedBlock` (variant wanted
+    // a block, got a scalar) or `ExpectedValue` (variant wanted a
+    // scalar, got a block). Any other error kind means the variant
+    // recognised the outer shape and is reporting a content-level
+    // problem.
+    let structural_matches: Vec<&Vec<SchemaError>> = per_variant
+        .iter()
+        .filter(|errs| {
+            !errs.iter().any(|e| {
+                matches!(
+                    e.kind,
+                    SchemaErrorKind::ExpectedBlock | SchemaErrorKind::ExpectedValue
+                )
+            })
+        })
+        .collect();
+
+    if let [only] = structural_matches.as_slice() {
+        return (*only).clone();
     }
 
     vec![SchemaError {
@@ -1006,6 +1041,11 @@ mod tests {
 
     #[test]
     fn one_of_rejects_neither_variant() {
+        // OneOf[Block, Ident] with a string value: the user's input
+        // didn't match either outer shape (Block needs `{ ... }`,
+        // Ident needs a bare word). Both branches failed *structurally*,
+        // so the error collapses to `OneOfMismatch` which lists every
+        // variant so the operator can pick a direction.
         const S: &[PropertySpec] = &[PropertySpec {
             name: "tls",
             required: false,
@@ -1016,12 +1056,89 @@ mod tests {
                 PropertyValueKind::Enum(&["profile_a"]),
             ]),
         }];
+        // Wait — the Ident branch *can* take a KeyValue (just with the
+        // wrong value kind), so it actually matches structurally and
+        // emits TypeMismatch. The collapse to OneOfMismatch only
+        // happens when **multiple or zero** variants structurally
+        // match. Here exactly one (Enum) does, so we surface its
+        // specific error: "expects an identifier".
         let errs = validate(&[kv("tls", ExprKind::StringLit("profile_a".into()))], S);
-        assert_eq!(errs.len(), 1);
+        assert_eq!(errs.len(), 1, "{errs:?}");
+        assert!(matches!(
+            errs[0].kind,
+            SchemaErrorKind::TypeMismatch { .. }
+        ));
         let rendered = errs[0].to_string();
-        assert!(rendered.contains("Block"), "{rendered}");
-        assert!(rendered.contains("Ident"), "{rendered}");
-        assert!(rendered.contains("String"), "{rendered}");
+        assert!(
+            rendered.contains("identifier"),
+            "expected the Enum branch's specific error, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn one_of_falls_back_to_mismatch_when_zero_variants_structurally_match() {
+        // OneOf[Block, Block-with-other-shape] — two block variants,
+        // user wrote a KeyValue. Both fail with ExpectedBlock; neither
+        // structurally matches; the error collapses to OneOfMismatch.
+        const S: &[PropertySpec] = &[PropertySpec {
+            name: "x",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::OneOf(&[
+                PropertyValueKind::Block(&[]),
+                PropertyValueKind::BlockMap(&[]),
+            ]),
+        }];
+        let errs = validate(&[kv("x", ExprKind::IntLit(5))], S);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(
+            errs[0].kind,
+            SchemaErrorKind::OneOfMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn one_of_surfaces_inner_block_error_when_block_variant_matches() {
+        // The motivating CodeRabbit case: OneOf[Block(inner_schema),
+        // Ident]. The user wrote a Block but forgot a required inner
+        // key. The Block variant matches structurally and reports
+        // MissingRequired; the Ident variant fails with ExpectedValue
+        // (structural). Exactly one structural match → return the
+        // Block variant's inner error rather than a vague
+        // "expected Block | Ident, got Block".
+        const INNER: &[PropertySpec] = &[PropertySpec {
+            name: "cert",
+            required: true,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::String,
+        }];
+        const S: &[PropertySpec] = &[PropertySpec {
+            name: "tls",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::OneOf(&[
+                PropertyValueKind::Block(INNER),
+                PropertyValueKind::Enum(&["profile_a"]),
+            ]),
+        }];
+        // Inline block with `cert` missing.
+        let errs = validate(
+            &[Property::Block {
+                key: "tls".into(),
+                key_span: None,
+                properties: vec![],
+            }],
+            S,
+        );
+        assert_eq!(errs.len(), 1, "{errs:?}");
+        assert!(matches!(
+            errs[0].kind,
+            SchemaErrorKind::MissingRequired
+        ));
+        assert_eq!(errs[0].key, "cert");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes **two CodeRabbit Major findings** on [#9](https://github.com/naoto256/limpid/pull/9) (release 0.7.4 review), both about the quality of `limpidctl check` diagnostics:

### Expression-level diagnostics inside nested output blocks no longer silenced

A typo like `peer { host "${upperr(workspace.msg)}" }` used to skip `expr_types::check_types` for `host` — the analyzer forwarded the parent block's `schema_owned=true` flag through every recursion level and silenced every inner key, masking unknown functions and similar expression errors inside any schema-declared nested block.

Two changes fix this end to end:

1. `analyze_property` now threads the **parent schema** (`Option<&[PropertySpec]>`) instead of a single derived boolean, so each nested level recomputes ownership against its own inner spec rather than inheriting the parent's flag.
2. The expression-types skip is narrowed to the **only case it actually targets** — a bare top-level `ExprKind::Ident` value like `framing non_transparent`. Every other value shape (StringLit with interpolations, IntLit, BoolLit, FuncCall, …) still gets walked, so unknown-function / type-mismatch diagnostics inside template bodies continue to surface.

### `OneOf` schema mismatches now surface the specific inner error when exactly one variant matched structurally

Previously, when no variant matched cleanly, every failure collapsed to `OneOfMismatch` ("expected Block | Ident, got Block") — actively misleading when the user wrote the right outer shape and the real problem was one missing inner key.

`check_one_of` now classifies per-variant failures as **structural** (`ExpectedBlock` / `ExpectedValue` — the variant wanted a different outer shape) vs. **content** (everything else — the variant accepted the shape but found a problem inside). When **exactly one** variant matches structurally, that variant's specific inner error is surfaced (e.g. `MissingRequired` for the missing inner key). When zero or multiple variants structurally match, the generic `OneOfMismatch` still fires so the operator sees the full variant list.

## Test plan

- [x] `cargo clippy --features kafka --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --features kafka --workspace` — 556 passed (553 baseline + 3 new)
- [x] uchgs push gate: 7/7 scopes confirmed

New tests:
- `check::tests::unknown_function_inside_nested_output_block_is_flagged` (regression for the CodeRabbit example exactly)
- `dsl::schema::tests::one_of_falls_back_to_mismatch_when_zero_variants_structurally_match`
- `dsl::schema::tests::one_of_surfaces_inner_block_error_when_block_variant_matches`

The pre-existing `one_of_rejects_neither_variant` test was updated to reflect the more specific `TypeMismatch` error the new logic surfaces when exactly one variant matches structurally.