### PR TITLE
fix(sum): guard integer accumulator against i64 overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `sum()` now reports i64 overflow as a typed error
+
+The integer accumulator used unchecked `+=` and depended on the
+build profile for overflow behaviour: debug builds panicked,
+release builds wrapped silently and produced bogus (often
+negative) totals for large arrays. The accumulator now uses
+`checked_add` and surfaces a typed error
+`sum() overflowed i64 (accumulator …, element …)` regardless of
+build mode, catching the bug in tests / `--check` instead of
+production. Nine new unit tests cover the function (no inline
+tests existed before): integer / mixed-numeric / empty-array
+happy paths, type-error rejections (non-array input, null
+input, non-numeric element), and the overflow boundaries at
+`i64::MAX` + 1 and `i64::MIN` − 1.
+
+
 ### Fixed — `limpidctl check`: nested-block expression diagnostics + OneOf branch-specific errors
 
 Two diagnostic-quality fixes from the PR #9 (release 0.7.4) review:

--- a/crates/limpid/src/functions/primitives/sum.rs
+++ b/crates/limpid/src/functions/primitives/sum.rs
@@ -30,7 +30,21 @@ fn add<'bump>(v: &Value<'bump>) -> anyhow::Result<Value<'bump>> {
     let mut saw_float = false;
     for item in items {
         match item {
-            Value::Int(n) => int_acc += *n,
+            // `checked_add` so an i64 overflow surfaces as a typed
+            // error instead of either silently wrapping (release
+            // builds, with no explicit `[profile]` overflow-checks
+            // pin in any Cargo.toml) or panicking on the
+            // accumulator step (debug builds). Pipelines summing
+            // big integer arrays would otherwise emit nonsense
+            // negative totals in release, and the bug would only
+            // appear in production.
+            Value::Int(n) => {
+                int_acc = int_acc.checked_add(*n).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "sum() overflowed i64 (accumulator {int_acc}, element {n})"
+                    )
+                })?;
+            }
             Value::Float(n) => {
                 saw_float = true;
                 float_acc += *n;
@@ -42,5 +56,98 @@ fn add<'bump>(v: &Value<'bump>) -> anyhow::Result<Value<'bump>> {
         Ok(Value::Float(int_acc as f64 + float_acc))
     } else {
         Ok(Value::Int(int_acc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bumpalo::Bump;
+
+    fn run<'b>(_bump: &'b Bump, input: Value<'b>) -> anyhow::Result<Value<'b>> {
+        // The `_bump` parameter keeps the arena alive for the lifetime
+        // of `Value<'b>`; `add` itself doesn't need to allocate.
+        add(&input)
+    }
+
+    fn arr<'b>(bump: &'b Bump, items: &[Value<'b>]) -> Value<'b> {
+        Value::Array(bump.alloc_slice_copy(items))
+    }
+
+    #[test]
+    fn sums_integers() {
+        let bump = Bump::new();
+        let v = run(&bump, arr(&bump, &[Value::Int(1), Value::Int(2), Value::Int(3)])).unwrap();
+        assert_eq!(v, Value::Int(6));
+    }
+
+    #[test]
+    fn empty_array_returns_int_zero() {
+        let bump = Bump::new();
+        let v = run(&bump, arr(&bump, &[])).unwrap();
+        assert_eq!(v, Value::Int(0));
+    }
+
+    #[test]
+    fn mixed_int_float_promotes_to_float() {
+        let bump = Bump::new();
+        let v = run(&bump, arr(&bump, &[Value::Int(1), Value::Float(2.5)])).unwrap();
+        assert_eq!(v, Value::Float(3.5));
+    }
+
+    #[test]
+    fn rejects_non_array_input() {
+        let bump = Bump::new();
+        let err = run(&bump, Value::Int(42)).err().unwrap();
+        assert!(err.to_string().contains("expects an Array"), "{err}");
+    }
+
+    #[test]
+    fn rejects_null_input_with_array_error() {
+        // Earlier shape silently treated Null as Int(0); the current
+        // contract is "schema says Array, anything else is a type
+        // error". Regression guard for that contract.
+        let bump = Bump::new();
+        let err = run(&bump, Value::Null).err().unwrap();
+        assert!(err.to_string().contains("expects an Array"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_numeric_element() {
+        let bump = Bump::new();
+        let v = arr(&bump, &[Value::Int(1), Value::String("nope")]);
+        let err = run(&bump, v).err().unwrap();
+        assert!(err.to_string().contains("expects numeric elements"), "{err}");
+    }
+
+    #[test]
+    fn integer_overflow_returns_typed_error() {
+        // Regression guard: `int_acc += *n` would wrap silently in
+        // release builds and panic in debug. `checked_add` produces
+        // a typed error so pipelines surface the bug instead of
+        // shipping bogus negative totals.
+        let bump = Bump::new();
+        let v = arr(&bump, &[Value::Int(i64::MAX), Value::Int(1)]);
+        let err = run(&bump, v).err().unwrap();
+        let msg = err.to_string();
+        assert!(msg.contains("overflowed"), "{msg}");
+        assert!(msg.contains("i64"), "{msg}");
+    }
+
+    #[test]
+    fn integer_overflow_works_at_min_too() {
+        let bump = Bump::new();
+        let v = arr(&bump, &[Value::Int(i64::MIN), Value::Int(-1)]);
+        let err = run(&bump, v).err().unwrap();
+        assert!(err.to_string().contains("overflowed"), "{err}");
+    }
+
+    #[test]
+    fn sum_at_i64_max_without_overflow_succeeds() {
+        // Boundary case — adding 0 to MAX should not trip the check.
+        let bump = Bump::new();
+        let v = arr(&bump, &[Value::Int(i64::MAX), Value::Int(0)]);
+        let result = run(&bump, v).unwrap();
+        assert_eq!(result, Value::Int(i64::MAX));
     }
 }

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -735,7 +735,7 @@ workspace.distinct_users = distinct(map(workspace.events) { |e| e.user })
 
 Reduce a numeric array to a scalar.
 
-- `sum` — all-Int stays Int; any Float participant promotes the result to Float. Empty array → `Int(0)`.
+- `sum` — all-Int stays Int; any Float participant promotes the result to Float. Empty array → `Int(0)`. Integer-only sums that exceed the `i64` range surface a typed error (`sum() overflowed i64 …`) rather than silently wrapping in release builds — wrap the input in `map(...) { |x| x as f64 }` if you genuinely need to sum past `i64::MAX`.
 - `max` / `min` — compare through `f64`; empty array → `null`.
 
 Non-numeric elements bail rather than silently coerce. Mixed numeric / null arrays also bail, because "skip the nulls" is a per-pipeline policy decision; use `filter(arr) { |x| x != null } |> sum` to opt in.


### PR DESCRIPTION
## Summary

Closes the **🟠 Major** CodeRabbit finding on [#14](https://github.com/naoto256/limpid/pull/14) (release 0.7.5 review) about `sum()`'s integer accumulator.

The accumulator used unchecked `int_acc += *n`, so overflow behaviour depended on the build profile: debug panicked, release wrapped silently and emitted bogus (often negative) totals for large integer arrays. With no `[profile]` / overflow-checks pin in any Cargo.toml, the wrapping path is what production builds got.

Now switches to `checked_add` and surfaces a typed error:

```
sum() overflowed i64 (accumulator …, element …)
```

The two **Minor** findings on PR #12 from the same review group are already addressed in current code and need no work: `first.rs` already declares `FieldType::Any` (not `FieldType::Array` as the comment reported), and `sum.rs` no longer special-cases `Null → Int(0)`.

## Test plan

- [x] `cargo clippy --features kafka --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --features kafka --workspace` — 565 passed (556 baseline + 9 new)
- [x] uchgs push gate: 7/7 scopes confirmed across both commits

Nine new unit tests cover `sum()` (no inline tests existed before):
- integer / mixed-numeric / empty-array happy paths
- rejects non-array input, null input, and non-numeric elements with the documented messages
- overflow boundaries at `i64::MAX + 1` and `i64::MIN − 1`
- boundary test: sum at exactly `i64::MAX` (with +0) still succeeds

Two commits — rebase merge keeps both:
1. `fix(sum): guard integer accumulator against i64 overflow` — production fix + tests
2. `docs(sum): note i64 overflow now surfaces a typed error` — one-line update in `expression-functions.md` so users know to wrap in `map { |x| x as f64 }` if they genuinely need to sum past `i64::MAX`