### PR TITLE
fix(output otlp): propagate 0.7.8 http.rs hardening to otlp_grpc + otlp_http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output otlp_http` no longer buffers unbounded error bodies into memory
+
+The peer-failure diagnostic path used `resp.text().await` and then trimmed the resulting `String` to 500 chars. Because `text()` buffers the entire response body before returning, a peer (or upstream proxy) emitting a multi-MB error body forced the daemon to allocate / decode the full payload on every failure — an availability footgun the matching fix in `output http` already closed. `output otlp_http` now reads via the shared `read_body_capped` helper with the same 4 KiB cap, so the cost of a failing peer is bounded regardless of how chatty its error responses are.
+
+
 ### Internal — `read_body_capped` extracted to a shared helper
 
 `output http` and the soon-to-be-aligned `output otlp_http` both need to bound how many bytes of an error response body they read into memory, so the helper moved from `modules/output/http.rs` to a new `modules/output/http_util.rs` module. No behaviour change for `output http`. The lingering misleading comment that claimed the connection "returns to the pool" after a mid-chunk break is also corrected: reqwest/hyper closes the underlying TCP connection when the `Response` is dropped without reaching EOF, and that's an accepted trade-off (bounded memory matters more on a failing peer than reusing its connection).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output otlp_grpc` rejects `tls { ... }` on plaintext `http://` endpoints
+
+Same trap `output otlp_http` already closes for itself in 0.7.8: tonic only engages the TLS layer when the URI scheme is `https`, so a `peer { endpoint "http://otel:4317"; tls { ca ...; cert ...; key ... } }` configuration silently dropped the entire TLS block and shipped gRPC in clear text — exactly the misconfiguration an operator who took the trouble to write a `tls` block was trying to avoid. The mismatch is now rejected at parse time with the same error wording as the `otlp_http` guard: switch the endpoint to `https://` or drop the `tls` block.
+
+
 ### Fixed — `output otlp_grpc` and `output otlp_http` now bound peer cooldown from failure time, not request start
 
 The peer-rotation cooldown timer was being measured from a pre-request `Instant::now()`, the same bug `output http` already fixed in 0.7.8 (commit `e0484e9`) and which was not propagated to the OTLP sinks. With the newly-introduced 30 s export timeout and a 5 s `PEER_COOLDOWN`, a peer that timed out wrote a cooldown that was already 25 s in the past, so the immediately-following batch reselected the same bad peer instead of rotating away. The cooldown timestamp now derives from a fresh `Instant::now()` captured on the failure branch in both `otlp/grpc.rs` and `otlp/http.rs`, matching the `output http` fix and giving the rotation budget the wall-clock distance it needs to actually shift load to a healthy peer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output otlp_grpc` and `output otlp_http` now bound peer cooldown from failure time, not request start
+
+The peer-rotation cooldown timer was being measured from a pre-request `Instant::now()`, the same bug `output http` already fixed in 0.7.8 (commit `e0484e9`) and which was not propagated to the OTLP sinks. With the newly-introduced 30 s export timeout and a 5 s `PEER_COOLDOWN`, a peer that timed out wrote a cooldown that was already 25 s in the past, so the immediately-following batch reselected the same bad peer instead of rotating away. The cooldown timestamp now derives from a fresh `Instant::now()` captured on the failure branch in both `otlp/grpc.rs` and `otlp/http.rs`, matching the `output http` fix and giving the rotation budget the wall-clock distance it needs to actually shift load to a healthy peer.
+
+
 ### Fixed — `output otlp_http` no longer buffers unbounded error bodies into memory
 
 The peer-failure diagnostic path used `resp.text().await` and then trimmed the resulting `String` to 500 chars. Because `text()` buffers the entire response body before returning, a peer (or upstream proxy) emitting a multi-MB error body forced the daemon to allocate / decode the full payload on every failure — an availability footgun the matching fix in `output http` already closed. `output otlp_http` now reads via the shared `read_body_capped` helper with the same 4 KiB cap, so the cost of a failing peer is bounded regardless of how chatty its error responses are.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output otlp_http` now warns loudly when `verify false` is paired with an https endpoint
+
+`output http` already emits a one-line, greppable `tracing::warn!` when `verify false` is paired with an https URL, so operators can audit the daemon log for MITM-vulnerable peers. `output otlp_http` exposes the identical `verify` knob but had no such warning — `verify false` toggled `danger_accept_invalid_certs(true)` silently, so the same security-relevant misconfiguration was visible in one output and invisible in the other. The warn now fires once per https peer at startup with the same wording as the `output http` message.
+
+
 ### Fixed — `output otlp_grpc` rejects `tls { ... }` on plaintext `http://` endpoints
 
 Same trap `output otlp_http` already closes for itself in 0.7.8: tonic only engages the TLS layer when the URI scheme is `https`, so a `peer { endpoint "http://otel:4317"; tls { ca ...; cert ...; key ... } }` configuration silently dropped the entire TLS block and shipped gRPC in clear text — exactly the misconfiguration an operator who took the trouble to write a `tls` block was trying to avoid. The mismatch is now rejected at parse time with the same error wording as the `otlp_http` guard: switch the endpoint to `https://` or drop the `tls` block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Internal — `read_body_capped` extracted to a shared helper
+
+`output http` and the soon-to-be-aligned `output otlp_http` both need to bound how many bytes of an error response body they read into memory, so the helper moved from `modules/output/http.rs` to a new `modules/output/http_util.rs` module. No behaviour change for `output http`. The lingering misleading comment that claimed the connection "returns to the pool" after a mid-chunk break is also corrected: reqwest/hyper closes the underlying TCP connection when the `Response` is dropped without reaching EOF, and that's an accepted trade-off (bounded memory matters more on a failing peer than reusing its connection).
+
+
 ### Fixed — Docs: fenced code blocks now tagged for markdownlint MD040 compliance
 
 `docs/src/{dsl-syntax,functions/expression-functions,processing/user-defined,inputs/syslog-tcp,outputs/syslog-udp}.md` had unannotated fenced code blocks. mdbook-style consumers tolerate this, but markdownlint MD040 flags them and standard syntax-highlighting falls back to "no language". All 93 bare fences across these 5 files are now tagged `limpid` (the contents are uniformly limpid DSL — `def input/output/process { … }`, `workspace.x = …`, expression-function call sites). The accompanying `tls.rs` doc comment on `TLS_CLIENT_BLOCK_PROPERTIES` is also corrected: it claimed "empty `tls {}` block is rejected by callers", but the actual contract is module-specific (`output otlp_http` rejects on plaintext endpoints; other callers accept empty blocks as "use system CA roots"). Doc-only — no code path touched.

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -64,6 +64,7 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::{BorrowedEvent, Event};
 use crate::metrics::OutputMetrics;
+use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, read_body_capped};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::tls::ClientTlsConfig;
@@ -600,39 +601,6 @@ impl Inner {
             }
         }
     }
-}
-
-/// Hard cap on how many bytes of an error response body we read into
-/// memory for the failure diagnostic. A malicious or misconfigured
-/// peer can otherwise return an unbounded body and `response.text()`
-/// would buffer the whole thing before we trim it. 4 KiB is plenty
-/// for the typical "what went wrong" snippet a downstream operator
-/// needs to see in the daemon log.
-const ERROR_BODY_BYTE_CAP: usize = 4096;
-
-/// Drain at most `cap` bytes from the response, then stop. Uses
-/// `Response::chunk()` (available without the `stream` reqwest
-/// feature) so we don't have to pull in `futures-util` for one
-/// streaming consumer.
-async fn read_body_capped(mut response: reqwest::Response, cap: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(cap.min(1024));
-    while buf.len() < cap {
-        match response.chunk().await {
-            Ok(Some(chunk)) => {
-                let remaining = cap - buf.len();
-                let take = chunk.len().min(remaining);
-                buf.extend_from_slice(&chunk[..take]);
-                if chunk.len() > take {
-                    // We hit the cap mid-chunk; stop reading so the
-                    // peer's connection can be returned to the pool
-                    // and we don't keep streaming bytes we discard.
-                    break;
-                }
-            }
-            Ok(None) | Err(_) => break,
-        }
-    }
-    buf
 }
 
 async fn send_once(peer: &HttpPeer, inner: &Inner, body: &[u8]) -> Result<()> {

--- a/crates/limpid/src/modules/output/http_util.rs
+++ b/crates/limpid/src/modules/output/http_util.rs
@@ -1,0 +1,43 @@
+//! Shared helpers for HTTP-based outputs (`output http`, `output
+//! otlp_http`). Lives here rather than in each module so the
+//! invariants stay consistent across them — every place that buffers
+//! a peer's response body for an error diagnostic must apply the same
+//! byte cap, and adding a third HTTP sink shouldn't require
+//! rediscovering this.
+
+/// Hard cap on how many bytes of an error response body we read into
+/// memory for the failure diagnostic. A malicious or misconfigured
+/// peer can otherwise return an unbounded body and `response.text()`
+/// would buffer the whole thing before we trim it. 4 KiB is plenty
+/// for the typical "what went wrong" snippet a downstream operator
+/// needs to see in the daemon log.
+pub(crate) const ERROR_BODY_BYTE_CAP: usize = 4096;
+
+/// Drain at most `cap` bytes from the response, then stop. Uses
+/// `Response::chunk()` (available without the `stream` reqwest
+/// feature) so we don't have to pull in `futures-util` for one
+/// streaming consumer.
+///
+/// Note: when we break mid-chunk after hitting `cap`, the `Response`
+/// is dropped without reaching EOF. reqwest/hyper closes the
+/// underlying connection in that case rather than returning it to
+/// the keep-alive pool — that's an accepted trade-off here, the
+/// error path is rare and bounded memory matters more than reusing
+/// a connection to a peer that just failed.
+pub(crate) async fn read_body_capped(mut response: reqwest::Response, cap: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(cap.min(1024));
+    while buf.len() < cap {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                let remaining = cap - buf.len();
+                let take = chunk.len().min(remaining);
+                buf.extend_from_slice(&chunk[..take]);
+                if chunk.len() > take {
+                    break;
+                }
+            }
+            Ok(None) | Err(_) => break,
+        }
+    }
+    buf
+}

--- a/crates/limpid/src/modules/output/mod.rs
+++ b/crates/limpid/src/modules/output/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod file;
 pub mod http;
+pub(crate) mod http_util;
 #[cfg(feature = "kafka")]
 pub mod kafka;
 pub mod otlp;

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -49,7 +49,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use bytes::Bytes;
 use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsServiceRequest, logs_service_client::LogsServiceClient,
@@ -201,6 +201,20 @@ fn parse_peer(name: &str, peer_props: &[Property]) -> Result<GrpcPeer> {
         .ok_or_else(|| anyhow!("output '{}': otlp_grpc peer requires 'endpoint'", name))?;
 
     let tls_block = props::get_block(peer_props, "tls");
+    if tls_block.is_some() && !endpoint.to_ascii_lowercase().starts_with("https://") {
+        // A `tls { ... }` block on a plaintext (http:// or
+        // scheme-less) endpoint is almost always an operator
+        // error: tonic only engages the TLS layer when the URI
+        // scheme is https, so the configured CA / client identity
+        // is silently dropped and the daemon ships gRPC in clear
+        // text. Refuse at parse time so the misconfiguration is
+        // visible. Mirrors the matching guard in `output otlp_http`.
+        bail!(
+            "output '{}': otlp_grpc peer endpoint '{}' uses a plaintext scheme but a tls {{ ... }} block was supplied — switch the endpoint to https:// or drop the tls block",
+            name,
+            endpoint
+        );
+    }
     let tls_cfg = tls_block
         .map(|block| {
             let cfg = crate::tls::ClientTlsConfig {
@@ -655,6 +669,57 @@ mod tests {
         let output =
             OtlpGrpcOutput::from_properties("o", &mp(&one_peer_props("http://localhost:4317")))
                 .unwrap();
+        assert_eq!(output.inner.peers.len(), 1);
+    }
+
+    #[test]
+    fn rejects_tls_block_on_plaintext_endpoint() {
+        // `tls { ... }` on an `http://` endpoint is almost always an
+        // operator error — tonic only engages TLS when the URI scheme
+        // is https, so the configured CA / client identity would be
+        // silently dropped and the daemon would ship gRPC in clear
+        // text. Fail fast at parse time. Mirrors the matching guard
+        // in `output otlp_http`.
+        let props = vec![peers_block_with(vec![Property::Block {
+            key: "peer".into(),
+            key_span: None,
+            properties: vec![
+                prop_str("endpoint", "http://collector.example.com:4317"),
+                Property::Block {
+                    key: "tls".into(),
+                    key_span: None,
+                    properties: vec![prop_str("ca", "/etc/ca.pem")],
+                },
+            ],
+        }])];
+        let err = OtlpGrpcOutput::from_properties("o", &mp(&props))
+            .err()
+            .unwrap();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("plaintext") && msg.contains("https://"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_empty_tls_block_on_https_endpoint() {
+        // Regression guard for the plaintext-rejection check: https://
+        // endpoints must still accept a (here empty) tls block. Empty
+        // block keeps the test off-disk; the scheme check runs first.
+        let props = vec![peers_block_with(vec![Property::Block {
+            key: "peer".into(),
+            key_span: None,
+            properties: vec![
+                prop_str("endpoint", "https://collector.example.com:4317"),
+                Property::Block {
+                    key: "tls".into(),
+                    key_span: None,
+                    properties: vec![],
+                },
+            ],
+        }])];
+        let output = OtlpGrpcOutput::from_properties("o", &mp(&props)).unwrap();
         assert_eq!(output.inner.peers.len(), 1);
     }
 

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -465,7 +465,13 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
                 return Ok(());
             }
             Err(e) => {
-                *inner.peer_state[idx].cooldown_until.lock().await = Some(now + PEER_COOLDOWN);
+                // Measure cooldown from failure time, not request start:
+                // `now` was captured before `send_once`, so for any non-
+                // trivial request latency (and especially after a 30s
+                // GRPC_REQUEST_TIMEOUT firing) `now + PEER_COOLDOWN`
+                // can already be in the past, defeating the rotation.
+                *inner.peer_state[idx].cooldown_until.lock().await =
+                    Some(Instant::now() + PEER_COOLDOWN);
                 e
             }
         };

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -60,6 +60,7 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::{BorrowedEvent, Event};
 use crate::metrics::OutputMetrics;
+use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, read_body_capped};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::queue::{BackoffStrategy, RetryConfig};
@@ -624,12 +625,17 @@ async fn send_once(peer: &HttpPeer, inner: &Inner, req: &ExportLogsServiceReques
         .with_context(|| format!("output otlp_http: POST {} failed", peer.endpoint))?;
     let status = resp.status();
     if !status.is_success() {
-        let text = resp.text().await.unwrap_or_default();
+        let raw = read_body_capped(resp, ERROR_BODY_BYTE_CAP).await;
+        // The cap is in bytes; UTF-8 boundary handling falls out of
+        // `from_utf8_lossy`. We then trim to 500 chars for the log
+        // line so the message stays readable even when the peer
+        // returned the full 4 KiB of diagnostic.
+        let snippet: String = String::from_utf8_lossy(&raw).chars().take(500).collect();
         bail!(
             "output otlp_http: {} returned HTTP {} — {}",
             peer.endpoint,
             status.as_u16(),
-            text.chars().take(500).collect::<String>()
+            snippet
         );
     }
     Ok(())

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -288,6 +288,19 @@ fn parse_peer(name: &str, peer_props: &[Property], verify: bool) -> Result<HttpP
     let mut builder = reqwest::Client::builder().timeout(HTTP_REQUEST_TIMEOUT);
     if !verify {
         builder = builder.danger_accept_invalid_certs(true);
+        if endpoint.to_ascii_lowercase().starts_with("https://") {
+            // Loud, unconditional warning when TLS verification is
+            // disabled on an https endpoint. `verify false` is a
+            // config-level footgun — one line opens MITM. Emit the
+            // warning once per peer at startup so ops can grep for
+            // it. Mirrors the matching warn in `output http`.
+            tracing::warn!(
+                "output '{}': TLS certificate verification is DISABLED (verify false) — \
+                 connections to {} are vulnerable to MITM. Debugging only; never use in production.",
+                name,
+                endpoint
+            );
+        }
     }
     if let Some(tls) = &tls_config {
         if let Some(ca_path) = &tls.ca_path {

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -572,7 +572,13 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
                 return Ok(());
             }
             Err(e) => {
-                *inner.peer_state[idx].cooldown_until.lock().await = Some(now + PEER_COOLDOWN);
+                // Measure cooldown from failure time, not request start:
+                // `now` was captured before `send_once`, so for any non-
+                // trivial request latency (and especially after a 30s
+                // HTTP_REQUEST_TIMEOUT firing) `now + PEER_COOLDOWN`
+                // can already be in the past, defeating the rotation.
+                *inner.peer_state[idx].cooldown_until.lock().await =
+                    Some(Instant::now() + PEER_COOLDOWN);
                 e
             }
         };

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -64,7 +64,7 @@ Each `peer` block configures one collector endpoint:
 
 | Per-peer property | Required | Description |
 |-------------------|----------|-------------|
-| `endpoint` | yes | gRPC server URL. `https://` selects TLS, `http://` selects plaintext. The `LogsService.Export` path is implicit. |
+| `endpoint` | yes | gRPC server URL. `https://` selects TLS, `http://` selects plaintext. The `LogsService.Export` path is implicit. A `tls { ... }` block is rejected at config-load time if this is not an `https://` URL — tonic only negotiates TLS on https endpoints, so a tls block on a plaintext endpoint would silently ship in clear text. |
 | `tls.ca` | no | Custom CA certificate file (PEM) for this peer. Falls back to the system root store if omitted. |
 | `tls.cert`, `tls.key` | no (paired) | Client certificate and private key for mTLS, as separate PEM files (chmod 600 the key). Both must be present together. |
 

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -137,5 +137,5 @@ The merging modes are wire-efficiency optimisations; if your batch sizes are mod
 ## Notes
 
 - `http_protobuf` is the canonical OTLP wire form; `http_json` serializes per the OTLP/JSON canonical mapping (camelCase, u64-as-string, bytes-as-hex).
-- `verify false` skips certificate verification — development only.
+- `verify false` skips certificate verification — development only. limpid emits a `tracing::warn!` once per `https://` peer at startup when `verify false` is in effect so the misconfiguration is greppable in the daemon log. Has no effect on `http://` endpoints (no TLS to verify).
 - For gRPC transport see [otlp_grpc](./otlp_grpc.md).


### PR DESCRIPTION
## Summary

CodeRabbit-style review of release/0.7.8 caught a recurring pattern: several correctness / security fixes that landed in \`output http\` during 0.7.8 were not propagated to the OTLP sinks. This PR closes the four sibling regressions plus one inconsistency, and corrects a doc-comment drift along the way.

| commit | finding | what changed |
|---|---|---|
| \`ffdef62\` refactor | (prep) | \`read_body_capped\` + \`ERROR_BODY_BYTE_CAP\` extracted from http.rs to new \`modules/output/http_util.rs\` so both sinks share the same 4 KiB cap. Misleading "returns to the pool" comment corrected. |
| \`6ec42d1\` fix(otlp_http) | **M4** | error response body capped at 4 KiB via shared helper (previously \`resp.text().await\` buffered unbounded) |
| \`8a20dd5\` fix(otlp grpc+http) | **M2 + M3** | cooldown timer derived from \`Instant::now()\` at failure time, not request start (with 30 s timeout + 5 s cooldown, old code wrote already-expired cooldown so rotation never engaged) |
| \`3dada07\` fix(otlp_grpc) | **M1** | \`tls { ... }\` on a plaintext \`http://\` endpoint rejected at config-load time (tonic silently drops the tls block and ships gRPC in clear text otherwise). Mirrors the otlp_http guard. +2 tests. |
| \`3edbd6b\` fix(otlp_http) | **C4** | loud \`tracing::warn!\` when \`verify false\` is paired with an https endpoint — matches the \`output http\` warn so MITM-vulnerable peers are greppable in the daemon log |
| \`d178365\` docs | (drift) | otlp_grpc.md/otlp_http.md updated to describe the two new user-visible behaviours |

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 550 pass (+2 new otlp_grpc tests covering the plaintext-rejection guard)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] uchgs push-gate: 7 scopes confirmed (confidentiality / ci-precheck / cicd-pipeline / abstraction / readme-current / rust / security)