### PR TITLE
fix(sum): decide accumulator type by pre-scan; add remediation hint + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `sum()` decides accumulator type from the whole array, not the first Float
+
+The 0.7.8 i64-overflow fix tripped on `[i64::MAX, 1, 0.5]`: the second integer overflowed the i64 accumulator before the third element (a Float) had a chance to promote the result. The eventual return type was clearly going to be `Float`, but the operator got a hard error instead of the float total they were summing toward. `sum()` now pre-scans the array for any Float and picks the accumulator type up front — Int-only arrays still use a checked `i64` accumulator (overflow surfaces a typed error with a remediation hint suggesting `* 1.0` promotion); any-Float arrays use a single `f64` accumulator and follow IEEE 754 semantics (overflow saturates to ±Infinity, NaN propagates). The expression-functions doc note is corrected at the same time — the prior `map(...) { |x| x as f64 }` suggestion referenced an `as` cast operator the limpid DSL does not implement; the working idiom is `map(...) { |x| x * 1.0 }`. Five new tests cover the boundary (mixed int+float past i64::MAX, float-only, float overflow → +Inf, NaN propagation, and the remediation hint in the overflow error).
+
+
 ### Fixed — `output otlp_http` now warns loudly when `verify false` is paired with an https endpoint
 
 `output http` already emits a one-line, greppable `tracing::warn!` when `verify false` is paired with an https URL, so operators can audit the daemon log for MITM-vulnerable peers. `output otlp_http` exposes the identical `verify` knob but had no such warning — `verify false` toggled `danger_accept_invalid_certs(true)` silently, so the same security-relevant misconfiguration was visible in one output and invisible in the other. The warn now fires once per https peer at startup with the same wording as the `output http` message.

--- a/crates/limpid/src/functions/primitives/sum.rs
+++ b/crates/limpid/src/functions/primitives/sum.rs
@@ -25,37 +25,49 @@ fn add<'bump>(v: &Value<'bump>) -> anyhow::Result<Value<'bump>> {
         Value::Array(items) => *items,
         other => bail!("sum() expects an Array, got {}", other.type_name()),
     };
-    let mut int_acc: i64 = 0;
-    let mut float_acc: f64 = 0.0;
-    let mut saw_float = false;
-    for item in items {
-        match item {
-            // `checked_add` so an i64 overflow surfaces as a typed
-            // error instead of either silently wrapping (release
-            // builds, with no explicit `[profile]` overflow-checks
-            // pin in any Cargo.toml) or panicking on the
-            // accumulator step (debug builds). Pipelines summing
-            // big integer arrays would otherwise emit nonsense
-            // negative totals in release, and the bug would only
-            // appear in production.
-            Value::Int(n) => {
-                int_acc = int_acc.checked_add(*n).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "sum() overflowed i64 (accumulator {int_acc}, element {n})"
-                    )
-                })?;
+    // Decide the accumulator type up front by scanning for any Float.
+    // Otherwise `[i64::MAX, 1, 0.5]` would overflow the i64 accumulator
+    // on element 2 before discovering that the result type is float
+    // anyway. The pre-scan is one extra pass over the slice (cheap;
+    // no per-element work besides the variant tag check) and avoids
+    // surprising the operator with a spurious overflow error when
+    // their intent was clearly a float total.
+    let has_float = items.iter().any(|i| matches!(i, Value::Float(_)));
+    if has_float {
+        let mut acc: f64 = 0.0;
+        for item in items {
+            match item {
+                Value::Int(n) => acc += *n as f64,
+                Value::Float(n) => acc += *n,
+                other => bail!("sum() expects numeric elements, got {}", other.type_name()),
             }
-            Value::Float(n) => {
-                saw_float = true;
-                float_acc += *n;
-            }
-            other => bail!("sum() expects numeric elements, got {}", other.type_name()),
         }
-    }
-    if saw_float {
-        Ok(Value::Float(int_acc as f64 + float_acc))
+        Ok(Value::Float(acc))
     } else {
-        Ok(Value::Int(int_acc))
+        // All-Int path: `checked_add` so overflow surfaces as a typed
+        // error instead of either silently wrapping (release builds,
+        // with no explicit `[profile]` overflow-checks pin in any
+        // Cargo.toml) or panicking on the accumulator step (debug
+        // builds). Pipelines summing big integer arrays would
+        // otherwise emit nonsense negative totals in release, and
+        // the bug would only appear in production.
+        let mut acc: i64 = 0;
+        for item in items {
+            match item {
+                Value::Int(n) => {
+                    acc = acc.checked_add(*n).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "sum() overflowed i64 (accumulator {acc}, element {n}); \
+                             if inputs may exceed i64::MAX, promote one element to \
+                             float first (e.g. multiply by 1.0) so the accumulator \
+                             becomes f64"
+                        )
+                    })?;
+                }
+                other => bail!("sum() expects numeric elements, got {}", other.type_name()),
+            }
+        }
+        Ok(Value::Int(acc))
     }
 }
 
@@ -149,5 +161,80 @@ mod tests {
         let v = arr(&bump, &[Value::Int(i64::MAX), Value::Int(0)]);
         let result = run(&bump, v).unwrap();
         assert_eq!(result, Value::Int(i64::MAX));
+    }
+
+    #[test]
+    fn float_only_sum() {
+        let bump = Bump::new();
+        let v = run(
+            &bump,
+            arr(&bump, &[Value::Float(1.5), Value::Float(2.25), Value::Float(0.25)]),
+        )
+        .unwrap();
+        assert_eq!(v, Value::Float(4.0));
+    }
+
+    #[test]
+    fn mixed_int_float_does_not_spuriously_overflow_i64() {
+        // Regression guard: an earlier shape used a single i64
+        // accumulator that fell back to float only after seeing a
+        // Float, so `[i64::MAX, 1, 0.5]` errored with an i64
+        // overflow before reaching the Float that should have
+        // promoted the result. Pre-scanning the array for any Float
+        // means the accumulator type is decided up front; this array
+        // now returns a (lossy) f64 total instead of failing.
+        let bump = Bump::new();
+        let v = arr(
+            &bump,
+            &[Value::Int(i64::MAX), Value::Int(1), Value::Float(0.5)],
+        );
+        let result = run(&bump, v).unwrap();
+        // f64 cannot represent i64::MAX + 1 exactly, but the call
+        // succeeds and the magnitude is right (~9.22e18).
+        match result {
+            Value::Float(f) => assert!(f.is_finite() && f > 9.0e18, "got {f}"),
+            other => panic!("expected Float, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn float_overflow_returns_infinity_not_error() {
+        // Float accumulation is intentionally unchecked — IEEE 754
+        // saturates to ±Infinity on overflow, which is well-defined
+        // behaviour and what callers doing scientific-style sums
+        // expect. Documenting the contract via test so a future
+        // "make floats checked too" change has to override an
+        // explicit expectation.
+        let bump = Bump::new();
+        let v = arr(&bump, &[Value::Float(f64::MAX), Value::Float(f64::MAX)]);
+        let result = run(&bump, v).unwrap();
+        match result {
+            Value::Float(f) => assert!(f.is_infinite() && f > 0.0, "got {f}"),
+            other => panic!("expected Float, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nan_propagates() {
+        // NaN is a poison value in IEEE 754: any arithmetic touching
+        // a NaN yields NaN. limpid does not filter it out — a NaN in
+        // the input means the operator wants to know the input was
+        // dirty, not that it should be silently dropped.
+        let bump = Bump::new();
+        let v = arr(&bump, &[Value::Float(1.0), Value::Float(f64::NAN), Value::Float(2.0)]);
+        let result = run(&bump, v).unwrap();
+        match result {
+            Value::Float(f) => assert!(f.is_nan(), "got {f}"),
+            other => panic!("expected Float (NaN), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn overflow_error_includes_remediation_hint() {
+        let bump = Bump::new();
+        let v = arr(&bump, &[Value::Int(i64::MAX), Value::Int(1)]);
+        let err = run(&bump, v).err().unwrap();
+        let msg = err.to_string();
+        assert!(msg.contains("multiply by 1.0"), "remediation hint missing: {msg}");
     }
 }

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -735,7 +735,7 @@ workspace.distinct_users = distinct(map(workspace.events) { |e| e.user })
 
 Reduce a numeric array to a scalar.
 
-- `sum` — all-Int stays Int; any Float participant promotes the result to Float. Empty array → `Int(0)`. Integer-only sums that exceed the `i64` range surface a typed error (`sum() overflowed i64 …`) rather than silently wrapping in release builds — wrap the input in `map(...) { |x| x as f64 }` if you genuinely need to sum past `i64::MAX`.
+- `sum` — all-Int stays Int; any Float participant promotes the result to Float (decided up front by scanning the array, so `[i64::MAX, 1, 0.5]` returns a float total instead of spuriously overflowing on the second integer). Empty array → `Int(0)`. Integer-only sums that exceed the `i64` range surface a typed error (`sum() overflowed i64 …`) rather than silently wrapping in release builds — promote one element to float (e.g. wrap the input in `map(...) { |x| x * 1.0 }`) if you genuinely need to sum past `i64::MAX`. Float sums use IEEE 754 saturation (overflow yields ±Infinity) and propagate NaN unchanged.
 - `max` / `min` — compare through `f64`; empty array → `null`.
 
 Non-numeric elements bail rather than silently coerce. Mixed numeric / null arrays also bail, because "skip the nulls" is a per-pipeline policy decision; use `filter(arr) { |x| x != null } |> sum` to opt in.


### PR DESCRIPTION
## Summary

Three CodeRabbit-style review findings on \`sum()\` rolled into one commit because they sit on the same code path:

- **B1** — \`[i64::MAX, 1, 0.5]\` errored with \`sum() overflowed i64\` even though the result type was clearly Float. \`sum()\` now pre-scans the array for any Float and picks the accumulator type up front. Int-only path keeps the checked-add; any-Float path uses a single f64 accumulator with IEEE 754 semantics (overflow → ±Infinity, NaN propagates).
- **B4** — overflow error message had no remediation hint; now suggests \`multiply by 1.0\` to promote one element so the accumulator becomes f64.
- **C5** — doc note in \`docs/src/functions/expression-functions.md\` recommended \`map(...) { |x| x as f64 }\` as the workaround, but the limpid DSL has no \`as\` cast operator (parse error). Fixed to \`map(...) { |x| x * 1.0 }\`.

Five new tests (\`float_only_sum\`, \`mixed_int_float_does_not_spuriously_overflow_i64\`, \`float_overflow_returns_infinity_not_error\`, \`nan_propagates\`, \`overflow_error_includes_remediation_hint\`) — together they close finding **B5** (no float-only / NaN tests for \`sum()\`).

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 555 pass (14 sum tests including the 5 new)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] uchgs push-gate: 7 scopes confirmed