### PR TITLE
fix(output syslog_udp + kafka): restore DNS failover + pre-check PLAIN before password file read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output syslog_udp` walks every resolved address on connect, restoring DNS-level failover
+
+The 0.7.8 family-aware bind rewrite kept v6-only destinations working but regressed DNS failover: `lookup_host(host:port).next()` committed to the first resolved `SocketAddr` and gave up if that one didn't connect. Pre-0.7.8 `socket.connect(host:port)` walked the whole resolution list internally and succeeded on the first reachable address — common during a partial v6 outage or a stale AAAA record on a dual-stack host. The connect path now iterates every resolved `SocketAddr`, binding a fresh ephemeral socket of the matching family per attempt and breaking on first success. On exhaustion the most recent error is returned with both the original hostname and the specific address that failed, so an operator can see which records were tried.
+
+
+### Fixed — `output kafka` reports PLAIN-without-TLS before reading the password file
+
+A misconfiguration with both a broken `password_file` path and `mechanism plain` without a `tls { ... }` block surfaced the file-read error first, masking the more important credentials-on-the-wire problem. The operator would fix the file path, get the daemon to start, and only then discover their PLAIN config was unsafe. `kafka.rs` now does a cheap pre-check on the mechanism ident before `parse_sasl_block` touches the filesystem, so the PLAIN-without-TLS diagnostic always fires first. The post-parse `require_tls_for_plain` guard stays as a belt-and-braces check, and the new pre-check explicitly avoids leaking the password-file path into the error wording. Two new tests cover both branches.
+
+
 ### Internal — `limpidctl check`: OneOf schema edge cases documented + multi-block guard
 
 Two follow-ups on the OneOf branch-picking logic that landed in 0.7.8. (1) `check_one_of` now documents — with a regression test — the deliberate fallback to `OneOfMismatch` when 0 or 2+ variants structurally match. Two-scalar-variant OneOf given a wrong-type literal (e.g. `OneOf[String, Int]` with a Bool) keeps the "expected String | Int, got Bool" wording, which is more useful than picking one variant's TypeMismatch and hiding that the other shape was also allowed. (2) `inner_block_schema_of` in `check/outputs.rs` previously returned the first block-shaped OneOf variant via `find_map`. Today only `OneOf[Block(TLS_CLIENT_BLOCK_PROPERTIES), String]` exists, so "first block wins" is unambiguous — but a future `OneOf[Block(A), Block(B)]` (e.g. inline tls vs inline mTLS configs) would silently validate against the wrong schema. The function now returns `None` when more than one block-shaped variant exists, falling back to expression-level checks until a per-OneOf resolution rule is encoded explicitly. No user-visible behaviour change today.

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -226,13 +226,47 @@ fn parse_sasl_block(name: &str, properties: &[Property]) -> Result<Option<SaslCo
     }))
 }
 
-/// Reject `mechanism plain` without a `tls { ... }` block — SASL/PLAIN
-/// transmits the username and password in clear text on the wire, so
-/// the only safe transport is TLS (Kafka and Confluent both document
-/// this requirement: "TLS/SSL encryption should always be used if SASL
-/// mechanism is PLAIN"). If the operator wants plain-text Kafka, the
-/// supported path is `scram_sha_256` / `scram_sha_512`, which use a
-/// challenge-response and never put the password on the wire.
+fn plain_without_tls_error(name: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "output '{}': sasl mechanism 'plain' requires a tls {{ ... }} block — PLAIN puts credentials in clear text on the wire and must run over TLS. Use scram_sha_256 or scram_sha_512 if TLS is not available.",
+        name
+    )
+}
+
+/// Cheap pre-check that fires BEFORE `parse_sasl_block` reads the
+/// password file from disk. If the operator has both a broken
+/// `password_file` path and `mechanism plain` without TLS, the file
+/// I/O error masks the more important diagnostic (the
+/// credentials-on-the-wire problem), and fixing the path only
+/// exposes the second error after the fact. Surfacing the TLS
+/// requirement first lets the operator see the deeper issue without
+/// guessing which fix to apply first.
+fn pre_check_plain_requires_tls(
+    name: &str,
+    properties: &[Property],
+    tls: Option<&ClientTlsConfig>,
+) -> Result<()> {
+    let Some(sasl_block) = props::get_block(properties, "sasl") else {
+        return Ok(());
+    };
+    let Some(mechanism) = props::get_ident(sasl_block, "mechanism") else {
+        return Ok(());
+    };
+    if mechanism == "plain" && tls.is_none() {
+        return Err(plain_without_tls_error(name));
+    }
+    Ok(())
+}
+
+/// Post-parse guard: reject `mechanism plain` without a `tls { ... }`
+/// block. SASL/PLAIN transmits the username and password in clear text
+/// on the wire, so the only safe transport is TLS (Kafka and Confluent
+/// both document this requirement: "TLS/SSL encryption should always be
+/// used if SASL mechanism is PLAIN"). If the operator wants plain-text
+/// Kafka, the supported path is `scram_sha_256` / `scram_sha_512`,
+/// which use a challenge-response and never put the password on the
+/// wire. Kept as a belt-and-braces check after `pre_check_plain_requires_tls`
+/// in case future refactors reorder or skip the pre-check.
 fn require_tls_for_plain(
     name: &str,
     sasl: Option<&SaslConfig>,
@@ -242,10 +276,7 @@ fn require_tls_for_plain(
         && s.mechanism == "PLAIN"
         && tls.is_none()
     {
-        anyhow::bail!(
-            "output '{}': sasl mechanism 'plain' requires a tls {{ ... }} block — PLAIN puts credentials in clear text on the wire and must run over TLS. Use scram_sha_256 or scram_sha_512 if TLS is not available.",
-            name
-        );
+        return Err(plain_without_tls_error(name));
     }
     Ok(())
 }
@@ -328,6 +359,10 @@ impl Module for KafkaOutput {
         });
 
         let tls = parse_tls_block(name, properties)?;
+        // Pre-check before reading the password file so a broken
+        // `password_file` path doesn't mask the more important
+        // PLAIN-without-TLS error.
+        pre_check_plain_requires_tls(name, properties, tls.as_ref())?;
         let sasl = parse_sasl_block(name, properties)?;
         require_tls_for_plain(name, sasl.as_ref(), tls.as_ref())?;
 
@@ -684,5 +719,60 @@ mod tests {
     #[test]
     fn require_tls_for_plain_accepts_no_sasl() {
         require_tls_for_plain("k", None, None).unwrap();
+    }
+
+    // ---- pre_check_plain_requires_tls (ordering guard) ----
+
+    #[test]
+    fn pre_check_plain_requires_tls_fires_before_password_file_read() {
+        // Regression guard for the audit finding A2: if both the
+        // password_file path is broken AND the operator wrote
+        // `mechanism plain` without a tls block, the pre-check
+        // surfaces the TLS requirement *first*. Without the pre-
+        // check the file-read error from parse_sasl_block would mask
+        // the more important credentials-on-the-wire problem.
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "plain"),
+                str_prop("username", "u"),
+                str_prop("password_file", "/nonexistent/does/not/exist.txt"),
+            ],
+        )];
+        // No TLS block, plain mechanism: pre-check must fire here
+        // and we must NEVER hit the file-read in parse_sasl_block.
+        let err = pre_check_plain_requires_tls("k", &props, None)
+            .err()
+            .unwrap();
+        let msg = err.to_string();
+        assert!(msg.contains("plain") && msg.contains("tls"), "{msg}");
+        assert!(!msg.contains("password_file"), "must not leak file-path: {msg}");
+    }
+
+    #[test]
+    fn pre_check_plain_passes_when_tls_block_present() {
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "plain"),
+                str_prop("username", "u"),
+                str_prop("password_file", "/nonexistent/does/not/exist.txt"),
+            ],
+        )];
+        let tls = empty_tls();
+        pre_check_plain_requires_tls("k", &props, Some(&tls)).unwrap();
+    }
+
+    #[test]
+    fn pre_check_plain_passes_for_scram_without_tls() {
+        let props = vec![block(
+            "sasl",
+            vec![
+                ident_prop("mechanism", "scram_sha_512"),
+                str_prop("username", "u"),
+                str_prop("password_file", "/nonexistent/does/not/exist.txt"),
+            ],
+        )];
+        pre_check_plain_requires_tls("k", &props, None).unwrap();
     }
 }

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -127,15 +127,22 @@ impl Output for SyslogUdpOutput {
                 let address = peer.address();
                 Box::pin(async move {
                     if state.conn.is_none() {
-                        // Resolve the peer address first and pick the
-                        // bind family from the resolved SocketAddr —
-                        // hard-binding to `0.0.0.0:0` would refuse to
-                        // connect any peer that resolves only to AAAA,
-                        // and `host` accepts hostnames that may do
-                        // exactly that. Hostnames are still typically
-                        // dual-stack, so this preserves the common
-                        // case while admitting v6-only destinations.
-                        let resolved = tokio::time::timeout(
+                        // Resolve the peer address and walk every
+                        // result, picking the bind family per address
+                        // — hostnames are typically dual-stack and a
+                        // partial v6 outage (or a misconfigured AAAA)
+                        // would otherwise leave us stuck on the first
+                        // record. Pre-0.7.8 `socket.connect(host:port)`
+                        // walked the resolution list internally; the
+                        // 0.7.8 family-aware rewrite kept the v6-only
+                        // destination working but regressed the
+                        // failover by committing to `lookup_host().next()`.
+                        // Now we explicitly retry each resolved
+                        // SocketAddr (binding a fresh ephemeral socket
+                        // of the matching family) and break on first
+                        // success, mirroring the standard library's
+                        // `TcpStream::connect` walking semantics.
+                        let resolved: Vec<std::net::SocketAddr> = tokio::time::timeout(
                             PEER_CONNECT_TIMEOUT,
                             tokio::net::lookup_host(address.as_str()),
                         )
@@ -144,31 +151,63 @@ impl Output for SyslogUdpOutput {
                             format!("syslog_udp lookup {} timed out", address)
                         })?
                         .with_context(|| format!("syslog_udp lookup {}", address))?
-                        .next()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
+                        .collect();
+                        if resolved.is_empty() {
+                            anyhow::bail!(
                                 "syslog_udp: name resolution for {} returned no addresses",
                                 address
+                            );
+                        }
+                        let mut socket: Option<UdpSocket> = None;
+                        let mut last_err: Option<anyhow::Error> = None;
+                        for addr in &resolved {
+                            let bind_addr = match addr {
+                                std::net::SocketAddr::V4(_) => "0.0.0.0:0",
+                                std::net::SocketAddr::V6(_) => "[::]:0",
+                            };
+                            let candidate = match UdpSocket::bind(bind_addr).await {
+                                Ok(s) => s,
+                                Err(e) => {
+                                    last_err = Some(anyhow::Error::from(e).context(format!(
+                                        "syslog_udp output: failed to bind ephemeral socket ({})",
+                                        bind_addr
+                                    )));
+                                    continue;
+                                }
+                            };
+                            let connect_res = tokio::time::timeout(
+                                PEER_CONNECT_TIMEOUT,
+                                candidate.connect(*addr),
                             )
-                        })?;
-                        let bind_addr = match resolved {
-                            std::net::SocketAddr::V4(_) => "0.0.0.0:0",
-                            std::net::SocketAddr::V6(_) => "[::]:0",
-                        };
-                        let socket = UdpSocket::bind(bind_addr)
                             .await
-                            .with_context(|| {
-                                format!(
-                                    "syslog_udp output: failed to bind ephemeral socket ({})",
-                                    bind_addr
+                            .map_err(|_| {
+                                anyhow::anyhow!(
+                                    "syslog_udp connect to {} ({}) timed out",
+                                    address,
+                                    addr
                                 )
-                            })?;
-                        tokio::time::timeout(PEER_CONNECT_TIMEOUT, socket.connect(resolved))
-                            .await
-                            .with_context(|| {
-                                format!("syslog_udp connect to {} timed out", address)
-                            })?
-                            .with_context(|| format!("syslog_udp connect to {}", address))?;
+                            })
+                            .and_then(|res| {
+                                res.with_context(|| {
+                                    format!("syslog_udp connect to {} ({})", address, addr)
+                                })
+                            });
+                            match connect_res {
+                                Ok(()) => {
+                                    socket = Some(candidate);
+                                    break;
+                                }
+                                Err(e) => last_err = Some(e),
+                            }
+                        }
+                        let socket = socket.ok_or_else(|| {
+                            last_err.unwrap_or_else(|| {
+                                anyhow::anyhow!(
+                                    "syslog_udp: no resolved address for {} could be connected",
+                                    address
+                                )
+                            })
+                        })?;
                         state.conn = Some(socket);
                     }
 


### PR DESCRIPTION
## Summary

Two CodeRabbit-style review findings on the 0.7.8 line:

- **A3** — \`output syslog_udp\` lost A/AAAA failover when the 0.7.8 family-aware bind rewrite changed \`socket.connect(host:port)\` (which walks all resolved addresses) into \`lookup_host(host:port).next()\` + connect to the single first result. On a dual-stack host where the first record isn't reachable (partial v6 outage, stale AAAA), UDP sends fail where they used to succeed. The connect path now iterates every resolved \`SocketAddr\`, binds an ephemeral socket of the matching family per attempt, and breaks on first success — mirroring \`TcpStream::connect\` walking semantics. Last error wins on exhaustion, with both the hostname and the specific address recorded.
- **A2** — \`output kafka\` PLAIN-without-TLS guard ran AFTER \`parse_sasl_block\` had already tried to read the \`password_file\` from disk. A broken file path masked the credentials-on-the-wire problem. New \`pre_check_plain_requires_tls\` runs before \`parse_sasl_block\`, inspecting just the SASL block's \`mechanism\` ident. Shared error wording (\`plain_without_tls_error\`) keeps the pre-check and the existing post-parse guard in lockstep. The pre-check explicitly avoids leaking the \`password_file\` path into its error wording — regression-guarded by the new test.

## Test plan

- [x] \`cargo build --workspace\` (CI mirror) clean
- [x] \`cargo test --workspace\` — 556 pass
- [x] \`cargo build --workspace --features kafka\` clean
- [x] \`cargo test --workspace --features kafka\` — 559 pass (+3 new kafka pre-check tests)
- [x] \`cargo clippy --workspace -- -D warnings\` clean (both configs)
- [x] uchgs push-gate: 7 scopes confirmed