### PR TITLE
audit wrap-up: gzip body placeholder, timeout firing tests, kafka comment, 0.7.8 migration note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Internal — End-to-end timeout-firing tests for the 0.7.8 export and TLS-handshake timeouts
+
+The three timeout constants introduced in 0.7.8 — `GRPC_REQUEST_TIMEOUT` / `HTTP_REQUEST_TIMEOUT` (30 s, on the OTLP sinks) and `TLS_HANDSHAKE_TIMEOUT` (10 s, on `input syslog_tcp`) — previously had bound-check assertions only. A regression that removed the `tokio::time::timeout(…)` wrap, or pointed it at a much larger duration, would not have been caught by a constant-value check. Three new paused-time tests (`export_timeout_fires_against_stalled_peer` in each of `output/otlp/grpc.rs` and `output/otlp/http.rs`, plus `tls_handshake_timeout_fires_against_stalled_client` in `input/syslog_tcp.rs`) exercise the actual firing path against a stalled TCP peer / client. Each uses `tokio::time::advance` past the documented timeout and asserts the call surfaces a timeout-flavoured error rather than hanging. `tokio`'s `test-util` feature is added to `[dev-dependencies]` to enable virtual time control. No production code change.
+
+
 ### Fixed — `output http` / `otlp_http` render a placeholder when error bodies are gzip/brotli/deflate encoded
 
 limpid's `reqwest` build excludes the `gzip` / `brotli` / `deflate` decompression features, so when a peer (or upstream proxy) returns an error response with `Content-Encoding: gzip` the still-compressed bytes were running through `from_utf8_lossy` and ending up as replacement-char soup in the daemon log. The shared `error_snippet` helper in `modules/output/http_util.rs` now inspects `Content-Encoding` and substitutes `<gzip-encoded body, N bytes>` (or whatever the advertised encoding is) when it's not `identity`. The byte count is retained so an operator can still see the peer is returning *something*. `identity`, missing header, and the existing 4 KiB cap path all keep their previous behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Upgrading — configs that now fail-fast (action required if matched)
+
+0.7.8 turns three previously-tolerated misconfigurations into hard parse-time errors. If a 0.7.7 config matches any of the patterns below, the daemon will refuse to start on 0.7.8 and limpidctl check will reject it:
+
+- **`output kafka` with `mechanism plain` and no `tls { ... }` block.** SASL/PLAIN sends credentials in clear text, so 0.7.8 requires a TLS transport. Remediation: add a `tls { ... }` block (CA only is fine for a server-cert-validated peer) or switch to `mechanism scram_sha_256` / `scram_sha_512`, which use challenge-response and never put the password on the wire.
+- **`output otlp_http` with a `tls { ... }` block on an `http://` endpoint** (and now `output otlp_grpc` too, added in the 0.7.8 sibling-regression follow-up). reqwest and tonic only engage TLS when the URI scheme is `https`, so the previous behaviour silently dropped the TLS block and shipped in clear text. Remediation: change the endpoint to `https://...`, or drop the `tls { ... }` block if plaintext is intended.
+- **`output http` with a `method` other than POST / PUT / an extension token reqwest accepts.** 0.7.7 silently downgraded unknown methods to POST; 0.7.8 fails fast at parse time. Remediation: spell the method correctly. The set of accepted methods matches reqwest's `Method::from_bytes` — uppercase, ASCII.
+
+No CHANGELOG entry intentionally hides any of these; they are individually called out in the `Fixed —` entries below. This summary just gives operators upgrading from 0.7.7 a single place to scan before the upgrade.
+
+
 ### Internal — End-to-end timeout-firing tests for the 0.7.8 export and TLS-handshake timeouts
 
 The three timeout constants introduced in 0.7.8 — `GRPC_REQUEST_TIMEOUT` / `HTTP_REQUEST_TIMEOUT` (30 s, on the OTLP sinks) and `TLS_HANDSHAKE_TIMEOUT` (10 s, on `input syslog_tcp`) — previously had bound-check assertions only. A regression that removed the `tokio::time::timeout(…)` wrap, or pointed it at a much larger duration, would not have been caught by a constant-value check. Three new paused-time tests (`export_timeout_fires_against_stalled_peer` in each of `output/otlp/grpc.rs` and `output/otlp/http.rs`, plus `tls_handshake_timeout_fires_against_stalled_client` in `input/syslog_tcp.rs`) exercise the actual firing path against a stalled TCP peer / client. Each uses `tokio::time::advance` past the documented timeout and asserts the call surfaces a timeout-flavoured error rather than hanging. `tokio`'s `test-util` feature is added to `[dev-dependencies]` to enable virtual time control. No production code change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output http` / `otlp_http` render a placeholder when error bodies are gzip/brotli/deflate encoded
+
+limpid's `reqwest` build excludes the `gzip` / `brotli` / `deflate` decompression features, so when a peer (or upstream proxy) returns an error response with `Content-Encoding: gzip` the still-compressed bytes were running through `from_utf8_lossy` and ending up as replacement-char soup in the daemon log. The shared `error_snippet` helper in `modules/output/http_util.rs` now inspects `Content-Encoding` and substitutes `<gzip-encoded body, N bytes>` (or whatever the advertised encoding is) when it's not `identity`. The byte count is retained so an operator can still see the peer is returning *something*. `identity`, missing header, and the existing 4 KiB cap path all keep their previous behaviour.
+
+
 ### Fixed — `output syslog_udp` walks every resolved address on connect, restoring DNS-level failover
 
 The 0.7.8 family-aware bind rewrite kept v6-only destinations working but regressed DNS failover: `lookup_host(host:port).next()` committed to the first resolved `SocketAddr` and gave up if that one didn't connect. Pre-0.7.8 `socket.connect(host:port)` walked the whole resolution list internally and succeeded on the first reachable address — common during a partial v6 outage or a stale AAAA record on a dual-stack host. The connect path now iterates every resolved `SocketAddr`, binding a fresh ephemeral socket of the matching family per attempt and breaking on first success. On exhaustion the most recent error is returned with both the original hostname and the specific address that failed, so an operator can see which records were tried.

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -82,6 +82,7 @@ kafka = ["dep:rdkafka"]
 [dev-dependencies]
 rcgen = "0.13"
 tempfile = "3"
+tokio = { version = "1", features = ["full", "test-util"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 
 [package.metadata.deb]

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -1001,6 +1001,63 @@ mod tests {
         assert!(TLS_HANDSHAKE_TIMEOUT <= Duration::from_secs(30));
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn tls_handshake_timeout_fires_against_stalled_client() {
+        // The motivating slot-exhaustion vector for this timeout is
+        // a TCP-only client that connects (consuming a slot) but
+        // never sends the TLS ClientHello. Without the
+        // `tokio::time::timeout(TLS_HANDSHAKE_TIMEOUT, …)` wrap, the
+        // accept future stays pending forever and the slot is held
+        // until something unrelated kills the task. The existing
+        // bound-check test guards against the constant being removed
+        // or set to a nonsensical value; this test exercises the
+        // firing path directly, using the same `TlsAcceptor` +
+        // `tokio::time::timeout` pair the production accept loop
+        // calls.
+        crate::tls::install_default_crypto_provider();
+        let files = pem_files();
+        let tls_cfg = crate::tls::TlsConfig {
+            cert_path: files.cert.clone(),
+            key_path: files.key.clone(),
+            ca_path: None,
+        };
+        let server_config = crate::tls::build_server_config(&tls_cfg)
+            .await
+            .expect("build server config");
+        let acceptor = TlsAcceptor::from(server_config);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let accept_task = tokio::spawn(async move {
+            let (stream, _peer) = listener.accept().await.expect("accept");
+            // Same wrap as the production accept loop in `run`:
+            // bound the handshake at TLS_HANDSHAKE_TIMEOUT so a
+            // stalled client cannot pin the slot indefinitely.
+            tokio::time::timeout(TLS_HANDSHAKE_TIMEOUT, acceptor.accept(stream)).await
+        });
+
+        // Bare TCP connect — never speaks TLS. The acceptor sits
+        // waiting for the ClientHello forever; the timeout wrap is
+        // the only thing that releases the slot.
+        let _stalled_client = TcpStream::connect(addr).await.expect("tcp connect");
+
+        // Let the spawned accept task make progress (real-time
+        // TCP connect already returned), then jump virtual time
+        // past the handshake timeout so the wrap fires.
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(TLS_HANDSHAKE_TIMEOUT + Duration::from_secs(1)).await;
+
+        let result = accept_task.await.expect("task join");
+        assert!(
+            result.is_err(),
+            "expected timeout Err, got Ok({:?})",
+            result.is_ok()
+        );
+    }
+
     #[test]
     fn build_plaintext_defaults_to_port_514() {
         let i = SyslogTcpInput::build("relay", &mp(&[])).expect("should build");

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -64,7 +64,7 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::{BorrowedEvent, Event};
 use crate::metrics::OutputMetrics;
-use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, read_body_capped};
+use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::tls::ClientTlsConfig;
@@ -624,12 +624,14 @@ async fn send_once(peer: &HttpPeer, inner: &Inner, body: &[u8]) -> Result<()> {
 
     let status = response.status();
     if !status.is_success() {
-        let raw = read_body_capped(response, ERROR_BODY_BYTE_CAP).await;
-        // The cap is in bytes; UTF-8 boundary handling falls out of
-        // `from_utf8_lossy`. We then trim to 200 chars for the log
-        // line so the message stays readable even when the peer
-        // returned the full 4 KiB of diagnostic.
-        let snippet: String = String::from_utf8_lossy(&raw).chars().take(200).collect();
+        // `error_snippet` byte-caps the body via `read_body_capped`,
+        // then trims to 200 chars on the lossy decode for a readable
+        // log line; if the peer advertises a Content-Encoding limpid
+        // doesn't decode (gzip / brotli / deflate are all off in our
+        // reqwest build), it substitutes a `<gzip-encoded body, N
+        // bytes>` placeholder so the daemon log doesn't fill with
+        // replacement-char soup.
+        let snippet = error_snippet(response, ERROR_BODY_BYTE_CAP, 200).await;
         anyhow::bail!("http output: {} returned {} — {}", peer.url, status, snippet);
     }
 
@@ -1066,6 +1068,55 @@ mod tests {
             &msg[..msg.len().min(80)]
         );
         assert!(msg.contains("returned 500"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn error_body_with_unsupported_content_encoding_renders_placeholder() {
+        // limpid's reqwest is built without gzip/brotli/deflate
+        // decompression, so a peer that advertises Content-Encoding:
+        // gzip on its error body returns still-compressed bytes from
+        // `Response::chunk()`. Running `from_utf8_lossy` over that
+        // produces a daemon log line full of � replacement chars.
+        // `error_snippet` substitutes a placeholder noting the
+        // encoding + byte count so the log stays readable.
+        use axum::{
+            Router,
+            http::{HeaderValue, StatusCode, header::CONTENT_ENCODING},
+            response::IntoResponse,
+            routing::post,
+        };
+
+        async fn handle() -> impl IntoResponse {
+            // Bytes that look superficially binary; the exact contents
+            // don't matter, we're asserting on the rendering path.
+            let body: Vec<u8> = (0u8..=200).collect();
+            let mut resp = (StatusCode::BAD_GATEWAY, body).into_response();
+            resp.headers_mut()
+                .insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+            resp
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new().route("/", post(handle));
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let url = format!("http://{}/", addr);
+        let props = vec![peer_block(&url), prop_int("batch_size", 1)];
+        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let err = output
+            .write_owned(&event_with("hello"))
+            .await
+            .expect_err("502 must surface as Err");
+        server.abort();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("gzip-encoded body"),
+            "must show placeholder, got: {msg}"
+        );
+        assert!(msg.contains("returned 502"), "got: {msg}");
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/http_util.rs
+++ b/crates/limpid/src/modules/output/http_util.rs
@@ -41,3 +41,33 @@ pub(crate) async fn read_body_capped(mut response: reqwest::Response, cap: usize
     }
     buf
 }
+
+/// Build a human-readable snippet of an error response body for the
+/// failure diagnostic, capped at `cap` bytes of input and
+/// `max_chars` characters of output. When the peer (or an upstream
+/// proxy) advertises a Content-Encoding limpid doesn't decode —
+/// limpid's `reqwest` is built without the `gzip` / `brotli` /
+/// `deflate` features, so `Response::chunk()` returns the still-
+/// encoded raw bytes — surface a placeholder instead of running
+/// `from_utf8_lossy` over compressed gibberish that ends up as
+/// �replacement-char soup in the daemon log. The raw byte count is
+/// kept in the placeholder so an operator can tell "the peer is
+/// returning something, just not something we can render".
+pub(crate) async fn error_snippet(
+    response: reqwest::Response,
+    cap: usize,
+    max_chars: usize,
+) -> String {
+    let encoding = response
+        .headers()
+        .get(reqwest::header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_ascii_lowercase());
+    let raw = read_body_capped(response, cap).await;
+    match encoding.as_deref() {
+        Some(enc) if !enc.is_empty() && enc != "identity" => {
+            format!("<{}-encoded body, {} bytes>", enc, raw.len())
+        }
+        _ => String::from_utf8_lossy(&raw).chars().take(max_chars).collect(),
+    }
+}

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -267,6 +267,19 @@ fn pre_check_plain_requires_tls(
 /// which use a challenge-response and never put the password on the
 /// wire. Kept as a belt-and-braces check after `pre_check_plain_requires_tls`
 /// in case future refactors reorder or skip the pre-check.
+///
+/// Note on semantics: this checks `tls.is_none()` — i.e. *presence*
+/// of any `tls { ... }` block — not its validity. A tls block whose
+/// `ca` / `cert` / `key` paths point at non-existent files satisfies
+/// the guard at config-load time and is only rejected later when
+/// rdkafka tries to load the PEM bytes. Today that's fine because
+/// the kafka schema doesn't expose a `verify` toggle, so the only
+/// way to "have a tls block but no real TLS" is via a path typo,
+/// and the operator sees the file error a moment later. If a future
+/// `verify false` knob lands here (matching `output http` /
+/// `output otlp_http`), this guard would need to additionally
+/// reject `mechanism plain` + `verify false` since that combination
+/// would also put PLAIN credentials on a non-verified wire.
 fn require_tls_for_plain(
     name: &str,
     sasl: Option<&SaslConfig>,

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -922,6 +922,75 @@ mod tests {
         drop(output);
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn export_timeout_fires_against_stalled_peer() {
+        // A peer that accepts the TCP connection but never returns a
+        // gRPC HEADERS frame must surface as a timeout failure within
+        // GRPC_REQUEST_TIMEOUT (30 s). Without the
+        // `tokio::time::timeout(GRPC_REQUEST_TIMEOUT, …)` wrapper a
+        // single stalled collector would block the rotation forever.
+        // The constant-value assertion in another test catches the
+        // case where the constant gets renamed, but it would not catch
+        // a regression where the wrapper itself was removed or
+        // pointed at a different (e.g. much larger) duration. This
+        // test exercises the firing path end-to-end.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+        // Stalled "server": accept the TCP connection and hold the
+        // socket open without ever sending HTTP/2 SETTINGS or a gRPC
+        // response. tonic's client preface goes out, then it waits
+        // forever for the server preface — exactly the case the
+        // GRPC_REQUEST_TIMEOUT exists to bound.
+        let stall = tokio::spawn(async move {
+            let mut held = Vec::new();
+            loop {
+                if let Ok((sock, _)) = listener.accept().await {
+                    held.push(sock);
+                }
+            }
+        });
+
+        let endpoint = format!("http://{}", addr);
+        let mut props = one_peer_props(&endpoint);
+        props.push(prop_int("batch_size", 1));
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let send = tokio::spawn(async move {
+            output
+                .write_owned(&event_with_egress(singleton_bytes(1)))
+                .await
+        });
+
+        // Let the spawned future reach the timeout-wrapped await,
+        // then advance virtual time past GRPC_REQUEST_TIMEOUT so the
+        // timeout fires. The TCP connect happens on real I/O; a short
+        // wall-clock yield keeps the test from racing the connect.
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(GRPC_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
+
+        let result = send.await.unwrap();
+        stall.abort();
+
+        let err = result.expect_err("stalled peer must surface as Err");
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(
+            msg.contains("timed out") || msg.contains("timeout"),
+            "expected timeout-flavoured error, got: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn write_owned_bypasses_batch_buffer() {
         // Owned events ship inline rather than landing in the batch

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -1255,6 +1255,82 @@ mod tests {
         );
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn export_timeout_fires_against_stalled_peer() {
+        // A peer that accepts the TCP connection but never sends a
+        // response must surface as a timeout failure within
+        // HTTP_REQUEST_TIMEOUT (30 s). Without `reqwest::Client::
+        // builder().timeout(HTTP_REQUEST_TIMEOUT)` a single stalled
+        // collector would block the rotation forever. Constant-value
+        // checks (or a non-existent constant rename) wouldn't catch a
+        // regression that removed the builder call or pointed it at
+        // a much larger duration — this test exercises the firing
+        // path end-to-end.
+        use std::sync::Arc;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+        // Stalled "server": accept the TCP connection and hold the
+        // socket open without ever writing a response line, so reqwest
+        // hangs waiting for HTTP status bytes.
+        let stall = tokio::spawn(async move {
+            let held = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            loop {
+                if let Ok((sock, _)) = listener.accept().await {
+                    held.lock().await.push(sock);
+                }
+            }
+        });
+
+        let endpoint = format!("http://{}/v1/logs", addr);
+        let mut props = one_peer_props(&endpoint);
+        props.push(prop_int("batch_size", 1));
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let send = tokio::spawn(async move {
+            output
+                .write_owned(&event_with_egress(singleton_bytes(1)))
+                .await
+        });
+
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(HTTP_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
+
+        let result = send.await.unwrap();
+        stall.abort();
+
+        let err = result.expect_err("stalled peer must surface as Err");
+        // Walk the anyhow chain; reqwest's timeout shows up as
+        // `error sending request for url (...): operation timed out`
+        // in the underlying reqwest::Error, while the top-level
+        // anyhow context says "POST ... failed".
+        let mut chain_text = String::new();
+        let mut current: &dyn std::error::Error = err.as_ref();
+        chain_text.push_str(&current.to_string());
+        while let Some(src) = current.source() {
+            chain_text.push_str(" -> ");
+            chain_text.push_str(&src.to_string());
+            current = src;
+        }
+        let chain_lower = chain_text.to_ascii_lowercase();
+        assert!(
+            chain_lower.contains("timed out") || chain_lower.contains("timeout"),
+            "expected timeout-flavoured error somewhere in the chain, got: {chain_text}"
+        );
+    }
+
     #[test]
     fn accepts_empty_tls_block_on_https_endpoint() {
         // Regression guard for the plaintext-rejection check: https://

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -60,7 +60,7 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::{BorrowedEvent, Event};
 use crate::metrics::OutputMetrics;
-use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, read_body_capped};
+use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::queue::{BackoffStrategy, RetryConfig};
@@ -644,12 +644,11 @@ async fn send_once(peer: &HttpPeer, inner: &Inner, req: &ExportLogsServiceReques
         .with_context(|| format!("output otlp_http: POST {} failed", peer.endpoint))?;
     let status = resp.status();
     if !status.is_success() {
-        let raw = read_body_capped(resp, ERROR_BODY_BYTE_CAP).await;
-        // The cap is in bytes; UTF-8 boundary handling falls out of
-        // `from_utf8_lossy`. We then trim to 500 chars for the log
-        // line so the message stays readable even when the peer
-        // returned the full 4 KiB of diagnostic.
-        let snippet: String = String::from_utf8_lossy(&raw).chars().take(500).collect();
+        // 4 KiB byte cap, 500 chars on the lossy decode for the log
+        // line; gzip / brotli / deflate get a placeholder so the
+        // daemon log doesn't fill with replacement-char soup (limpid's
+        // reqwest is built without those decompression features).
+        let snippet = error_snippet(resp, ERROR_BODY_BYTE_CAP, 500).await;
         bail!(
             "output otlp_http: {} returned HTTP {} — {}",
             peer.endpoint,


### PR DESCRIPTION
## Summary

Final batch from the CodeRabbit-style review of release/0.7.8 — six remaining items rolled into three commits:

- **A6 (Nit)** — \`output http\` / \`output otlp_http\` now render a placeholder \`<gzip-encoded body, N bytes>\` when a peer (or upstream proxy) returns an error response with a Content-Encoding limpid's \`reqwest\` build doesn't decode (gzip / brotli / deflate). New shared \`error_snippet\` helper in \`http_util\` keeps both sinks consistent.
- **C6 / C7 / C8** — three paused-time tests that exercise the actual firing path of the 30 s OTLP export timeouts and the 10 s syslog_tcp TLS handshake timeout. Previously these constants were guarded by bound-check assertions only, so a regression that removed the \`tokio::time::timeout(...)\` wrap or pointed it at a much larger duration would have shipped undetected.
- **C9** — \`require_tls_for_plain\` in \`output kafka\` checks for the *presence* of a \`tls { ... }\` block, not its validity. Today that's correct because the kafka schema doesn't expose a \`verify\` toggle. Documented the assumption + the condition under which the guard would need to be extended (future \`verify false\` knob matching \`output http\` / \`output otlp_http\`).
- **C10** — added an "Upgrading — configs that now fail-fast" subsection at the top of the 0.7.8 CHANGELOG entry. Names the four config patterns that 0.7.7 loaded but 0.7.8 rejects (kafka PLAIN-without-TLS; otlp_http and otlp_grpc tls-on-http; http unknown-method-silent-downgrade), each with a one-line remediation, so an operator upgrading from 0.7.7 doesn't have to scan every Fixed entry to find the breaking patterns.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 560 pass (+3 new timeout tests + 1 new gzip-placeholder test)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] uchgs push-gate: 7 scopes confirmed

## Notes

\`tokio\`'s \`test-util\` feature is added to \`[dev-dependencies]\` to enable \`tokio::time::advance\` and \`#[tokio::test(start_paused = true)]\` for the new timeout tests. No production code change from that.