### PR TITLE
fix(output otlp): split partial_success into events_failed; preserve distinct schema_urls in merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ runtime shape converge. After 1.0, changes will follow semver strictly.
 
 ## [Unreleased] - 0.7.8
 
+### Fixed — `output otlp_grpc` / `output otlp_http`: route `partial_success.rejected_log_records` to `events_failed`
+
+When the OTLP receiver returned 2xx-equivalent with `partial_success.rejected_log_records > 0`, both transports counted the entire batch as `events_written`, hiding server-side data loss from operator dashboards. `otlp_grpc` parsed the response and logged a warning but did not split the metric; `otlp_http` did not parse the response body at all. The OTLP transport-success path now splits the batch's events between `events_written` (accepted) and `events_failed` (rejected) using the receiver's `partial_success.rejected_log_records`. `otlp_http` learned to decode the response body in both protobuf and JSON forms — peers returning empty bodies or undecodable bodies are still treated as fully accepted (the lenient default). Selective re-send of *only* the rejected records remains queued for a later release, as documented in the existing `send_once` doc comments; this change is purely metrics accuracy.
+
+
+### Fixed — `output otlp_grpc` / `output otlp_http`: stop silently dropping distinct `schema_url`s when merging by Resource / Scope
+
+`merge_by_resource` (and the inner Scope-level pass in `merge_by_scope`) keyed merges only on Resource (or Resource + InstrumentationScope) equality. Two entries sharing a Resource but declaring *different non-empty* `schema_url`s — semantically: "the same resource described under two different schemas" — collapsed into a single bucket and the second `schema_url` was dropped on the floor. Per OTLP semantics they should remain distinct. The merge key now also requires `schema_url` compatibility (equal, or at least one side empty), so different non-empty `schema_url`s keep their own bucket. The existing "promote empty acc → take incoming schema_url" behaviour is preserved (and now regression-guarded).
+
+
 ### Upgrading — configs that now fail-fast (action required if matched)
 
 0.7.8 turns three previously-tolerated misconfigurations into hard parse-time errors. If a 0.7.7 config matches any of the patterns below, the daemon will refuse to start on 0.7.8 and limpidctl check will reject it:

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -376,6 +376,15 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
 /// the caller-supplied `ship` closure, then updates the
 /// `events_written` / `events_failed` counters on the metrics handle.
 ///
+/// The closure returns `Result<u64>` where the `u64` is the number of
+/// records the server acknowledged as rejected (OTLP's
+/// `partial_success.rejected_log_records`; always 0 for outputs that
+/// have no equivalent concept, like `output http`). For a single Owned
+/// event a non-zero rejection means the server processed the request
+/// but refused our one record — transport-success, data-loss — so
+/// we count it as `events_failed` even though the call returns Ok
+/// (the queue layer must not retry; the server already said no).
+///
 /// The batched outputs (`otlp_grpc`, `otlp_http`, `output http`)
 /// each need to override `write_owned` so the queue consumer's
 /// per-event `Ok`/`Err` contract is honored (disk-replay events
@@ -392,7 +401,7 @@ pub async fn ship_owned_inline<O, F, Fut>(
 where
     O: Output + ?Sized,
     F: FnOnce(RenderedPayload) -> Fut,
-    Fut: std::future::Future<Output = Result<()>>,
+    Fut: std::future::Future<Output = Result<u64>>,
 {
     use std::sync::atomic::Ordering;
 
@@ -403,8 +412,16 @@ where
         output.render(&bevent, &arena)?
     };
     match ship(payload).await {
-        Ok(()) => {
+        Ok(0) => {
             metrics.events_written.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+        Ok(_rejected) => {
+            // Transport said OK, server rejected the single record we
+            // sent. Count as failed so dashboards reflect the data
+            // loss; return Ok so the queue does not retry — the
+            // server already refused this exact bytes.
+            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
             Ok(())
         }
         Err(e) => {

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -461,7 +461,9 @@ impl Output for HttpOutput {
     async fn write_owned(&self, event: &Event) -> Result<()> {
         crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
             let payload: HttpPayload = payload.downcast()?;
-            self.inner.send_batch(&[payload.msg]).await
+            // Plain HTTP has no partial-success concept; either the
+            // POST succeeds end-to-end or it errors. Always Ok(0).
+            self.inner.send_batch(&[payload.msg]).await.map(|()| 0)
         })
         .await
     }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -364,7 +364,9 @@ impl Output for OtlpGrpcOutput {
     async fn write_owned(&self, event: &Event) -> Result<()> {
         crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
             let payload: OtlpPayload = payload.downcast()?;
-            send_batch(&self.inner, vec![payload.egress]).await
+            send_batch(&self.inner, vec![payload.egress])
+                .await
+                .map(|o| o.rejected)
         })
         .await
     }
@@ -379,19 +381,28 @@ impl OtlpGrpcOutput {
         if drained.is_empty() {
             return Ok(());
         }
-        let count = drained.len();
+        let count = drained.len() as u64;
         let result = send_batch(&self.inner, drained).await;
         match result {
-            Ok(()) => {
-                self.metrics
-                    .events_written
-                    .fetch_add(count as u64, Ordering::Relaxed);
+            Ok(outcome) => {
+                let rejected = outcome.rejected.min(count);
+                let written = count - rejected;
+                if written > 0 {
+                    self.metrics
+                        .events_written
+                        .fetch_add(written, Ordering::Relaxed);
+                }
+                if rejected > 0 {
+                    self.metrics
+                        .events_failed
+                        .fetch_add(rejected, Ordering::Relaxed);
+                }
                 Ok(())
             }
             Err(e) => {
                 self.metrics
                     .events_failed
-                    .fetch_add(count as u64, Ordering::Relaxed);
+                    .fetch_add(count, Ordering::Relaxed);
                 Err(e)
             }
         }
@@ -416,18 +427,27 @@ impl OtlpGrpcOutput {
             if drained.is_empty() {
                 return;
             }
-            let count = drained.len();
+            let count = drained.len() as u64;
             match send_batch(&inner, drained).await {
-                Ok(()) => {
-                    metrics
-                        .events_written
-                        .fetch_add(count as u64, Ordering::Relaxed);
+                Ok(outcome) => {
+                    let rejected = outcome.rejected.min(count);
+                    let written = count - rejected;
+                    if written > 0 {
+                        metrics
+                            .events_written
+                            .fetch_add(written, Ordering::Relaxed);
+                    }
+                    if rejected > 0 {
+                        metrics
+                            .events_failed
+                            .fetch_add(rejected, Ordering::Relaxed);
+                    }
                 }
                 Err(e) => {
                     tracing::warn!("otlp_grpc flush timer: send failed ({})", e);
                     metrics
                         .events_failed
-                        .fetch_add(count as u64, Ordering::Relaxed);
+                        .fetch_add(count, Ordering::Relaxed);
                 }
             }
         });
@@ -451,7 +471,7 @@ impl Drop for OtlpGrpcOutput {
     }
 }
 
-async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
+async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOutcome> {
     let req = decode_drained_to_request(drained, inner.batch_level)?;
     let n = inner.peers.len();
 
@@ -474,9 +494,9 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
         }
 
         let err = match send_once(&inner.peers[idx], inner, &req).await {
-            Ok(()) => {
+            Ok(outcome) => {
                 *inner.peer_state[idx].cooldown_until.lock().await = None;
-                return Ok(());
+                return Ok(outcome);
             }
             Err(e) => {
                 // Measure cooldown from failure time, not request start:
@@ -508,7 +528,11 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
     Err(final_err)
 }
 
-async fn send_once(peer: &GrpcPeer, inner: &Inner, req: &ExportLogsServiceRequest) -> Result<()> {
+async fn send_once(
+    peer: &GrpcPeer,
+    inner: &Inner,
+    req: &ExportLogsServiceRequest,
+) -> Result<super::SendOutcome> {
     let mut client = LogsServiceClient::new(peer.channel.clone());
     let mut request = tonic::Request::new(req.clone());
     let metadata = request.metadata_mut();
@@ -547,13 +571,21 @@ async fn send_once(peer: &GrpcPeer, inner: &Inner, req: &ExportLogsServiceReques
         })?
         .with_context(|| format!("output otlp_grpc: export to {} failed", peer.endpoint))?;
     // The receiver may report `partial_success.rejected_log_records`.
-    // Currently logged as a warning; selective re-send of *only* the
-    // rejected records is queued for a later release. The retry loop
+    // Logged here as a warning AND propagated to the caller via
+    // `SendOutcome.rejected` so the flush path can split the batch's
+    // events between `events_written` (accepted) and `events_failed`
+    // (rejected by the server). Selective re-send of *only* the
+    // rejected records is queued for a later release; the retry loop
     // in `send_batch` handles hard failures (connection refused, 5xx,
     // …) but not partial-success deltas, since the rejected set is a
     // strict subset of what already shipped.
     let inner_resp = response.into_inner();
-    if let Some(partial) = inner_resp.partial_success
+    let rejected = inner_resp
+        .partial_success
+        .as_ref()
+        .map(|p| p.rejected_log_records.max(0) as u64)
+        .unwrap_or(0);
+    if let Some(partial) = inner_resp.partial_success.as_ref()
         && partial.rejected_log_records > 0
     {
         tracing::warn!(
@@ -567,7 +599,7 @@ async fn send_once(peer: &GrpcPeer, inner: &Inner, req: &ExportLogsServiceReques
             }
         );
     }
-    Ok(())
+    Ok(super::SendOutcome { rejected })
 }
 
 // Note: `verify false` is intentionally not a property on `otlp_grpc`.
@@ -897,6 +929,94 @@ mod tests {
         assert_eq!(got.len(), 1);
         let lr = &got[0].resource_logs[0].scope_logs[0].log_records[0];
         assert_eq!(lr.time_unix_nano, 1_700_000_000_000_000_000);
+    }
+
+    /// Test-only LogsService that ALWAYS reports `partial_success.
+    /// rejected_log_records = rejected_count`. Used to pin the
+    /// behaviour of `events_written` / `events_failed` when the
+    /// receiver advertises a partial-success rejection.
+    struct PartialSuccessLogs {
+        rejected_per_call: i64,
+    }
+
+    #[tonic::async_trait]
+    impl LogsService for PartialSuccessLogs {
+        async fn export(
+            &self,
+            _request: tonic::Request<ExportLogsServiceRequest>,
+        ) -> std::result::Result<tonic::Response<ExportLogsServiceResponse>, tonic::Status>
+        {
+            Ok(tonic::Response::new(ExportLogsServiceResponse {
+                partial_success: Some(
+                    opentelemetry_proto::tonic::collector::logs::v1::ExportLogsPartialSuccess {
+                        rejected_log_records: self.rejected_per_call,
+                        error_message: "test rejection".into(),
+                    },
+                ),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn partial_success_rejected_log_records_routes_to_events_failed() {
+        // Regression guard: when the receiver returns 2xx-equivalent
+        // (gRPC OK) with `partial_success.rejected_log_records = N`,
+        // events_written must NOT cover the N rejected records.
+        // Previously the entire batch was counted as written and
+        // operators saw zero events_failed for server-side rejections,
+        // making partial-success outages invisible on dashboards.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+        let svc = PartialSuccessLogs { rejected_per_call: 2 };
+        let server = tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(LogsServiceServer::new(svc))
+                .serve_with_incoming(incoming)
+                .await;
+        });
+
+        let endpoint = format!("http://{}", addr);
+        // batch_size=3 so the single Rendered write triggers flush at
+        // exactly 3 events; receiver rejects 2 of them.
+        let mut props = one_peer_props(&endpoint);
+        props.push(prop_int("batch_size", 3));
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+
+        let mut payloads: Vec<RenderedPayload> = Vec::new();
+        for i in 0..3 {
+            let ev = event_with_egress(singleton_bytes(1_000_000_000 + i));
+            let payload = {
+                let bump = bumpalo::Bump::new();
+                let arena = EventArena::new(&bump);
+                let bev = ev.view_in(&arena);
+                output.render(&bev, &arena).unwrap()
+            };
+            payloads.push(payload);
+        }
+        for p in payloads {
+            output.write(p).await.unwrap();
+        }
+        // Give the inline flush a moment.
+        for _ in 0..50 {
+            if output.metrics.events_written.load(Ordering::Relaxed)
+                + output.metrics.events_failed.load(Ordering::Relaxed)
+                >= 3
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        server.abort();
+
+        // 3 events total: 2 rejected → events_failed, 1 accepted → events_written.
+        let written = output.metrics.events_written.load(Ordering::Relaxed);
+        let failed = output.metrics.events_failed.load(Ordering::Relaxed);
+        assert_eq!(written, 1, "expected 1 written, got {written} (failed={failed})");
+        assert_eq!(failed, 2, "expected 2 failed, got {failed} (written={written})");
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -50,7 +50,9 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use bytes::Bytes;
-use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+};
 use prost::Message;
 use tokio::sync::Mutex;
 
@@ -456,7 +458,9 @@ impl Output for OtlpHttpOutput {
     async fn write_owned(&self, event: &Event) -> Result<()> {
         crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
             let payload: OtlpPayload = payload.downcast()?;
-            send_batch(&self.inner, vec![payload.egress]).await
+            send_batch(&self.inner, vec![payload.egress])
+                .await
+                .map(|o| o.rejected)
         })
         .await
     }
@@ -473,19 +477,28 @@ impl OtlpHttpOutput {
         if drained.is_empty() {
             return Ok(());
         }
-        let count = drained.len();
+        let count = drained.len() as u64;
         let result = send_batch(&self.inner, drained).await;
         match result {
-            Ok(()) => {
-                self.metrics
-                    .events_written
-                    .fetch_add(count as u64, Ordering::Relaxed);
+            Ok(outcome) => {
+                let rejected = outcome.rejected.min(count);
+                let written = count - rejected;
+                if written > 0 {
+                    self.metrics
+                        .events_written
+                        .fetch_add(written, Ordering::Relaxed);
+                }
+                if rejected > 0 {
+                    self.metrics
+                        .events_failed
+                        .fetch_add(rejected, Ordering::Relaxed);
+                }
                 Ok(())
             }
             Err(e) => {
                 self.metrics
                     .events_failed
-                    .fetch_add(count as u64, Ordering::Relaxed);
+                    .fetch_add(count, Ordering::Relaxed);
                 Err(e)
             }
         }
@@ -512,18 +525,27 @@ impl OtlpHttpOutput {
             if drained.is_empty() {
                 return;
             }
-            let count = drained.len();
+            let count = drained.len() as u64;
             match send_batch(&inner, drained).await {
-                Ok(()) => {
-                    metrics
-                        .events_written
-                        .fetch_add(count as u64, Ordering::Relaxed);
+                Ok(outcome) => {
+                    let rejected = outcome.rejected.min(count);
+                    let written = count - rejected;
+                    if written > 0 {
+                        metrics
+                            .events_written
+                            .fetch_add(written, Ordering::Relaxed);
+                    }
+                    if rejected > 0 {
+                        metrics
+                            .events_failed
+                            .fetch_add(rejected, Ordering::Relaxed);
+                    }
                 }
                 Err(e) => {
                     tracing::warn!("otlp_http flush timer: send failed ({})", e);
                     metrics
                         .events_failed
-                        .fetch_add(count as u64, Ordering::Relaxed);
+                        .fetch_add(count, Ordering::Relaxed);
                 }
             }
         });
@@ -547,7 +569,7 @@ impl Drop for OtlpHttpOutput {
     }
 }
 
-async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
+async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOutcome> {
     let req = decode_drained_to_request(drained, inner.batch_level)?;
     let n = inner.peers.len();
 
@@ -578,11 +600,11 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
         }
 
         let err = match send_once(&inner.peers[idx], inner, &req).await {
-            Ok(()) => {
+            Ok(outcome) => {
                 // Reset cooldown on success so future flushes pick
                 // this peer freely.
                 *inner.peer_state[idx].cooldown_until.lock().await = None;
-                return Ok(());
+                return Ok(outcome);
             }
             Err(e) => {
                 // Measure cooldown from failure time, not request start:
@@ -619,7 +641,11 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<()> {
     Err(final_err)
 }
 
-async fn send_once(peer: &HttpPeer, inner: &Inner, req: &ExportLogsServiceRequest) -> Result<()> {
+async fn send_once(
+    peer: &HttpPeer,
+    inner: &Inner,
+    req: &ExportLogsServiceRequest,
+) -> Result<super::SendOutcome> {
     let body = match inner.protocol {
         HttpProtocol::Protobuf => {
             let mut buf = Vec::with_capacity(req.encoded_len());
@@ -656,7 +682,47 @@ async fn send_once(peer: &HttpPeer, inner: &Inner, req: &ExportLogsServiceReques
             snippet
         );
     }
-    Ok(())
+    // Parse the response body for `partial_success.rejected_log_records`.
+    // The OTLP/HTTP spec guarantees the body is an
+    // `ExportLogsServiceResponse` in the same wire form (protobuf or
+    // JSON) as the request. A peer that returns 2xx with an empty body,
+    // or with a body we can't decode, is treated as fully accepted —
+    // the alternative (failing the call) would convert lenient
+    // collectors into ship errors. Same semantics as
+    // `otlp_grpc::send_once` so the two transports report identical
+    // metrics for identical receiver behaviour.
+    let body_bytes = resp.bytes().await.unwrap_or_default();
+    let rejected = if body_bytes.is_empty() {
+        0
+    } else {
+        let parsed = match inner.protocol {
+            HttpProtocol::Protobuf => ExportLogsServiceResponse::decode(&*body_bytes).ok(),
+            HttpProtocol::Json => {
+                serde_json::from_slice::<ExportLogsServiceResponse>(&body_bytes).ok()
+            }
+        };
+        let r = parsed
+            .as_ref()
+            .and_then(|r| r.partial_success.as_ref())
+            .map(|p| p.rejected_log_records.max(0) as u64)
+            .unwrap_or(0);
+        if r > 0
+            && let Some(partial) = parsed.as_ref().and_then(|r| r.partial_success.as_ref())
+        {
+            tracing::warn!(
+                "otlp_http: {} rejected {} log record(s){}",
+                peer.endpoint,
+                partial.rejected_log_records,
+                if partial.error_message.is_empty() {
+                    String::new()
+                } else {
+                    format!(" — {}", partial.error_message)
+                }
+            );
+        }
+        r
+    };
+    Ok(super::SendOutcome { rejected })
 }
 
 #[cfg(test)]
@@ -1172,6 +1238,102 @@ mod tests {
             got[0].resource_logs[0].scope_logs[0].log_records[0].time_unix_nano,
             456
         );
+    }
+
+    #[tokio::test]
+    async fn partial_success_rejected_log_records_routes_to_events_failed() {
+        // Regression guard: when the receiver returns 2xx with a body
+        // containing `partial_success.rejected_log_records = N`,
+        // events_written must NOT cover the N rejected records. The
+        // pre-fix code did not parse the response body at all, so
+        // operators saw zero events_failed for server-side rejections.
+        // Mirror of the equivalent test in otlp_grpc — both transports
+        // must report identical metrics for identical receiver
+        // behaviour.
+        use axum::{
+            Router, body::Bytes as AxumBytes, extract::State, http::StatusCode,
+            response::IntoResponse, routing::post,
+        };
+        use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsPartialSuccess;
+        use std::sync::atomic::Ordering as AtomicOrdering;
+
+        #[derive(Clone)]
+        struct AppState {
+            received_count: Arc<AtomicUsize>,
+        }
+
+        async fn handle(
+            State(state): State<AppState>,
+            body: AxumBytes,
+        ) -> impl IntoResponse {
+            // Decode the request only to confirm it parsed; the test
+            // exercise is the response body, not the request.
+            let _ = ExportLogsServiceRequest::decode(&body[..]);
+            state.received_count.fetch_add(1, AtomicOrdering::SeqCst);
+            // Always claim 2 records were rejected.
+            let resp = ExportLogsServiceResponse {
+                partial_success: Some(ExportLogsPartialSuccess {
+                    rejected_log_records: 2,
+                    error_message: "test partial-success".into(),
+                }),
+            };
+            let mut buf = Vec::with_capacity(resp.encoded_len());
+            resp.encode(&mut buf).unwrap();
+            (
+                StatusCode::OK,
+                [("content-type", "application/x-protobuf")],
+                buf,
+            )
+                .into_response()
+        }
+
+        let received_count = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/v1/logs", post(handle))
+            .with_state(AppState {
+                received_count: Arc::clone(&received_count),
+            });
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let endpoint = format!("http://{}/v1/logs", addr);
+        let mut props = one_peer_props(&endpoint);
+        props.push(prop_str("protocol", "http_protobuf"));
+        props.push(prop_int("batch_size", 3));
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+
+        let mut payloads: Vec<RenderedPayload> = Vec::new();
+        for i in 0..3 {
+            let ev = event_with_egress(singleton_bytes(900_000_000 + i));
+            let payload = {
+                let bump = bumpalo::Bump::new();
+                let arena = EventArena::new(&bump);
+                let bev = ev.view_in(&arena);
+                output.render(&bev, &arena).unwrap()
+            };
+            payloads.push(payload);
+        }
+        for p in payloads {
+            output.write(p).await.unwrap();
+        }
+        for _ in 0..50 {
+            if output.metrics.events_written.load(Ordering::Relaxed)
+                + output.metrics.events_failed.load(Ordering::Relaxed)
+                >= 3
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        server.abort();
+
+        let written = output.metrics.events_written.load(Ordering::Relaxed);
+        let failed = output.metrics.events_failed.load(Ordering::Relaxed);
+        assert_eq!(written, 1, "expected 1 written, got {written} (failed={failed})");
+        assert_eq!(failed, 2, "expected 2 failed, got {failed} (written={written})");
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/mod.rs
+++ b/crates/limpid/src/modules/output/otlp/mod.rs
@@ -47,6 +47,21 @@ use prost::Message;
 
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 
+/// Transport-success outcome from a single OTLP export call.
+///
+/// `rejected` is the number of LogRecords the receiver acknowledged
+/// as not-stored via OTLP's `partial_success.rejected_log_records`.
+/// The HTTP 2xx / gRPC OK is still a transport success — the receiver
+/// processed the request, it just refused some records (typically
+/// quota / schema / size violations). limpid does not retry rejected
+/// records (selective re-send is queued for a later release); the
+/// counter split lets `events_failed` reflect the data loss so
+/// operator dashboards stay accurate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct SendOutcome {
+    pub rejected: u64,
+}
+
 pub(crate) struct OtlpPayload {
     pub(crate) egress: Bytes,
 }
@@ -142,10 +157,17 @@ pub(crate) fn decode_drained_to_request(
 pub(crate) fn merge_by_resource(decoded: Vec<ResourceLogs>) -> ExportLogsServiceRequest {
     let mut out: Vec<ResourceLogs> = Vec::new();
     for rl in decoded {
-        if let Some(idx) = out
-            .iter()
-            .position(|existing| resources_eq(&existing.resource, &rl.resource))
-        {
+        // Match only on (Resource, schema_url-compat). Two ResourceLogs
+        // entries with identical Resource but *different non-empty*
+        // schema_urls describe the same resource under different
+        // schemas, and OTLP semantics say these are distinct — merging
+        // them would silently drop one schema_url and conflate two
+        // semantically different declarations into one bucket. Keep
+        // them separate.
+        if let Some(idx) = out.iter().position(|existing| {
+            resources_eq(&existing.resource, &rl.resource)
+                && schema_urls_compatible(&existing.schema_url, &rl.schema_url)
+        }) {
             // Promote schema_url if the accumulator was empty and the
             // incoming entry has one (rare but spec-allowed).
             if out[idx].schema_url.is_empty() && !rl.schema_url.is_empty() {
@@ -159,6 +181,14 @@ pub(crate) fn merge_by_resource(decoded: Vec<ResourceLogs>) -> ExportLogsService
     ExportLogsServiceRequest { resource_logs: out }
 }
 
+/// Two schema_urls are merge-compatible when they're equal OR at least
+/// one side is empty (= unspecified, can take the other's). Different
+/// non-empty schema_urls are NOT compatible — keeping them in separate
+/// buckets prevents the silent drop of one of the two declarations.
+fn schema_urls_compatible(a: &str, b: &str) -> bool {
+    a.is_empty() || b.is_empty() || a == b
+}
+
 /// `merge_by_resource` plus an inner pass: within each Resource bucket,
 /// ScopeLogs sharing an InstrumentationScope (name + version +
 /// attributes + dropped_attributes_count) collapse into a single
@@ -169,10 +199,15 @@ pub(crate) fn merge_by_scope(decoded: Vec<ResourceLogs>) -> ExportLogsServiceReq
         let scope_logs = std::mem::take(&mut rl.scope_logs);
         let mut grouped: Vec<ScopeLogs> = Vec::new();
         for sl in scope_logs {
-            if let Some(idx) = grouped
-                .iter()
-                .position(|existing| scopes_eq(&existing.scope, &sl.scope))
-            {
+            // Same logic as the Resource-level merge above: only merge
+            // ScopeLogs that share an InstrumentationScope AND have
+            // compatible schema_urls. Different non-empty schema_urls
+            // describe the same scope under different schemas and must
+            // stay separate to avoid silently dropping one.
+            if let Some(idx) = grouped.iter().position(|existing| {
+                scopes_eq(&existing.scope, &sl.scope)
+                    && schema_urls_compatible(&existing.schema_url, &sl.schema_url)
+            }) {
                 if grouped[idx].schema_url.is_empty() && !sl.schema_url.is_empty() {
                     grouped[idx].schema_url = sl.schema_url;
                 }
@@ -297,6 +332,88 @@ mod tests {
         ];
         let req = merge_by_resource(input);
         assert_eq!(req.resource_logs.len(), 2);
+    }
+
+    /// Helper: same-resource singleton with an explicit Resource-level
+    /// schema_url so the schema-url merge rule can be exercised.
+    fn singleton_with_schema(svc: &str, scope: &str, t: u64, resource_schema: &str) -> ResourceLogs {
+        let mut rl = singleton(svc, scope, t);
+        rl.schema_url = resource_schema.to_string();
+        rl
+    }
+
+    #[test]
+    fn merge_by_resource_does_not_drop_distinct_schema_urls() {
+        // Same Resource, two different non-empty schema_urls. The
+        // pre-fix code silently dropped one schema_url and conflated
+        // the two declarations into a single bucket. They MUST stay
+        // in separate buckets so neither schema_url is lost.
+        let input = vec![
+            singleton_with_schema("svc-a", "scope-1", 1, "https://schemas.example.com/v1"),
+            singleton_with_schema("svc-a", "scope-1", 2, "https://schemas.example.com/v2"),
+        ];
+        let req = merge_by_resource(input);
+        assert_eq!(req.resource_logs.len(), 2, "different schema_urls must stay distinct");
+        let urls: Vec<&str> = req
+            .resource_logs
+            .iter()
+            .map(|rl| rl.schema_url.as_str())
+            .collect();
+        assert!(urls.contains(&"https://schemas.example.com/v1"));
+        assert!(urls.contains(&"https://schemas.example.com/v2"));
+    }
+
+    #[test]
+    fn merge_by_resource_merges_empty_into_existing_schema_url() {
+        // Same Resource, one with schema_url, one without. The empty
+        // side is unspecified — taking the populated side's schema_url
+        // is the existing 'rare but spec-allowed' promotion behaviour
+        // and must not regress.
+        let input = vec![
+            singleton_with_schema("svc-a", "scope-1", 1, "https://schemas.example.com/v1"),
+            singleton_with_schema("svc-a", "scope-2", 2, ""),
+        ];
+        let req = merge_by_resource(input);
+        assert_eq!(req.resource_logs.len(), 1);
+        assert_eq!(req.resource_logs[0].schema_url, "https://schemas.example.com/v1");
+        assert_eq!(req.resource_logs[0].scope_logs.len(), 2);
+    }
+
+    #[test]
+    fn merge_by_resource_promotes_empty_acc_with_incoming_schema_url() {
+        // Reverse order: empty schema_url first, then populated.
+        let input = vec![
+            singleton_with_schema("svc-a", "scope-1", 1, ""),
+            singleton_with_schema("svc-a", "scope-2", 2, "https://schemas.example.com/v1"),
+        ];
+        let req = merge_by_resource(input);
+        assert_eq!(req.resource_logs.len(), 1);
+        assert_eq!(req.resource_logs[0].schema_url, "https://schemas.example.com/v1");
+    }
+
+    #[test]
+    fn merge_by_scope_does_not_drop_distinct_scope_schema_urls() {
+        // Same Resource, same Scope, two different non-empty Scope-
+        // level schema_urls. Like the Resource-level test, the
+        // pre-fix code silently dropped one of the two.
+        let mut a = singleton("svc-a", "scope-1", 1);
+        a.scope_logs[0].schema_url = "https://schemas.example.com/scope/v1".into();
+        let mut b = singleton("svc-a", "scope-1", 2);
+        b.scope_logs[0].schema_url = "https://schemas.example.com/scope/v2".into();
+        let req = merge_by_scope(vec![a, b]);
+        // Same Resource bucket (only the resource matches; schema_urls
+        // at the Resource level are empty so they're compatible) ...
+        assert_eq!(req.resource_logs.len(), 1);
+        // ... but two distinct ScopeLogs entries inside, one per
+        // schema_url, with their log_records intact.
+        assert_eq!(req.resource_logs[0].scope_logs.len(), 2);
+        let scope_urls: Vec<&str> = req.resource_logs[0]
+            .scope_logs
+            .iter()
+            .map(|sl| sl.schema_url.as_str())
+            .collect();
+        assert!(scope_urls.contains(&"https://schemas.example.com/scope/v1"));
+        assert!(scope_urls.contains(&"https://schemas.example.com/scope/v2"));
     }
 
     #[test]

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -36,7 +36,7 @@ The split between `received` and `injected` keeps "real" traffic distinguishable
 | `received` | Total events that entered this output's queue (from pipelines + injects) |
 | `injected` | Events pushed into this output's queue via `limpidctl inject` |
 | `written` | Events successfully written to the destination |
-| `failed` | Events that failed after all retry attempts |
+| `failed` | Events that failed after all retry attempts. For the OTLP outputs (`otlp_grpc` / `otlp_http`), the receiver's `partial_success.rejected_log_records` is also routed here — those are events the server *accepted at the transport layer* but refused at the validation layer, dropped per the [`partial_success` policy](../otlp.md#56-retry-transport-level-only), and surfaced via this counter so dashboards see the loss. |
 | `retries` | Total retry attempts across all events |
 
 `received - injected` = events delivered via pipelines. `received - written - failed` ≈ events pending in the queue (useful for disk queues).

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -130,7 +130,7 @@ OTLP receivers accept an `ExportLogsServiceRequest` with multiple `ResourceLogs`
 | `resource` | merge same-Resource Events into one ResourceLogs | + linear Resource scan | smaller |
 | `scope` | merge same-(Resource, Scope) into one ScopeLogs | + Scope scan inside each Resource | smallest |
 
-Resource / Scope equality is order-insensitive on attributes — proto3 does not promise a canonical attribute order on the wire, so attribute lists are sorted by key before comparison.
+Resource / Scope equality is order-insensitive on attributes — proto3 does not promise a canonical attribute order on the wire, so attribute lists are sorted by key before comparison. Two entries that share a Resource but declare *different non-empty* `schema_url`s are kept in separate ResourceLogs buckets (same rule for ScopeLogs): they describe the same resource under different schemas, and merging them would silently drop one declaration.
 
 The merging modes are wire-efficiency optimisations; if your batch sizes are modest (hundreds of Events), `none` is fine. For collector → SaaS hops where every byte counts, `scope` is usually the right choice.
 


### PR DESCRIPTION
## Summary

Two production-side bugs surfaced by the coverage-gap audit (verified against the actual code — the other three claimed gaps in that audit were either correct-by-design or agent misreads):

- **OTLP partial_success ignored by metrics.** When the receiver returned 2xx-equivalent with \`partial_success.rejected_log_records > 0\`, both transports counted the entire batch as \`events_written\`, hiding server-side data loss from operator dashboards. \`otlp_grpc\` already parsed the response but only logged a warning; \`otlp_http\` did not parse the response body at all. Both now split the batch between \`events_written\` (accepted) and \`events_failed\` (rejected). \`otlp_http\` learned to decode the response body in both protobuf and JSON; empty / undecodable bodies are still treated as fully accepted (the lenient default — a malformed server can never bump our failure counters). Selective re-send of only the rejected records remains queued for a later release; this change is purely metrics accuracy.
- **\`merge_by_resource\` / \`merge_by_scope\` silently dropped distinct schema_urls.** Two entries that share a Resource (or Resource + InstrumentationScope) but declare different non-empty \`schema_url\`s used to collapse into one bucket, dropping the second \`schema_url\`. Per OTLP these are distinct (the same resource under different schemas). Merge key now includes \`schema_url\` compatibility; the existing 'promote empty acc → take incoming schema_url' behaviour is preserved and newly regression-guarded.

Both fixes ship with the surrounding doc updates that the readme-current audit caught: \`metrics.md\` cross-links to the OTLP design § on \`partial_success\` retry policy, and \`otlp_http.md\`'s \`batch_level\` equality note mentions the schema_url distinction (otlp_grpc inherits via 'Identical semantics to otlp_http').

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 566 pass (+6 new tests)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] uchgs push-gate: 7 scopes confirmed

New tests:
- \`otlp::grpc::partial_success_rejected_log_records_routes_to_events_failed\` (gRPC: 3 events, server rejects 2 → 1 written, 2 failed)
- \`otlp::http::partial_success_rejected_log_records_routes_to_events_failed\` (HTTP: same scenario, protobuf body)
- \`otlp::merge_by_resource_does_not_drop_distinct_schema_urls\`
- \`otlp::merge_by_resource_merges_empty_into_existing_schema_url\` (regression guard for existing promote behaviour)
- \`otlp::merge_by_resource_promotes_empty_acc_with_incoming_schema_url\` (reverse order)
- \`otlp::merge_by_scope_does_not_drop_distinct_scope_schema_urls\` (Scope-level schema_url)