### PR TITLE
test(tier1): fortifications for TLS / queue / pipeline / event boundary / file+socket security

### DIFF
--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -324,3 +324,92 @@ fn json_to_bytes(v: &JsonValue) -> Option<Bytes> {
     }
     None
 }
+
+#[cfg(test)]
+mod boundary_tests {
+    use super::*;
+
+    fn sample_event() -> OwnedEvent {
+        let mut ev = OwnedEvent::new(
+            Bytes::from_static(b"<13>hello world"),
+            "192.0.2.10:5140".parse::<SocketAddr>().unwrap(),
+        );
+        ev.egress = Bytes::from_static(b"rendered");
+        ev.workspace.insert("k_str".into(), OwnedValue::String("v".into()));
+        ev.workspace.insert("k_int".into(), OwnedValue::Int(42));
+        ev.workspace
+            .insert("k_bytes".into(), OwnedValue::Bytes(Bytes::from_static(&[0xff, 0x00, 0xab])));
+        ev
+    }
+
+    #[test]
+    fn view_in_then_to_owned_round_trips_event() {
+        // The pipeline runs against `BorrowedEvent<'bump>`; failure
+        // paths (errored / disk-queue / dlq / inject) need to recover
+        // the equivalent `OwnedEvent`. The round-trip through
+        // `view_in(arena) → to_owned()` must preserve every field
+        // including workspace order-insensitive equality of keys.
+        let original = sample_event();
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let borrowed = original.view_in(&arena);
+        let recovered: OwnedEvent = borrowed.to_owned();
+        assert_eq!(recovered.received_at, original.received_at);
+        assert_eq!(recovered.source, original.source);
+        assert_eq!(recovered.ingress, original.ingress);
+        assert_eq!(recovered.egress, original.egress);
+        assert_eq!(recovered.workspace.len(), original.workspace.len());
+        for (k, v) in &original.workspace {
+            assert_eq!(recovered.workspace.get(k), Some(v), "key {k} lost");
+        }
+    }
+
+    #[test]
+    fn to_json_value_then_from_json_round_trips_event() {
+        // This boundary is exercised every time a disk-queue replay /
+        // tap snapshot / error-log entry / inject command needs to
+        // serialise and re-hydrate an event. A regression in either
+        // direction would silently drop fields. We hit each
+        // representative value variant: String, Int, Bytes (which
+        // routes through the `$bytes_b64` escape pathway).
+        let original = sample_event();
+        let json = original.to_json_value();
+        let serialized = serde_json::to_string(&json).unwrap();
+        let recovered =
+            OwnedEvent::from_json(&serialized).expect("from_json must accept its own to_json");
+        assert_eq!(recovered.received_at, original.received_at);
+        assert_eq!(recovered.source, original.source);
+        assert_eq!(recovered.ingress, original.ingress);
+        assert_eq!(recovered.egress, original.egress);
+        assert_eq!(recovered.workspace.len(), original.workspace.len());
+        // Bytes round-trip: the value must come back as Bytes (not as
+        // a base64 String), otherwise downstream consumers that
+        // pattern-match on OwnedValue::Bytes would silently see
+        // String instead.
+        match recovered.workspace.get("k_bytes") {
+            Some(OwnedValue::Bytes(b)) => assert_eq!(&b[..], &[0xff, 0x00, 0xab]),
+            other => panic!("k_bytes round-tripped as wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_json_preserves_received_at_to_seconds_precision() {
+        // received_at is serialised as an i64 Unix-seconds in the v0.5.6+
+        // wire form. Recovery must reproduce the original timestamp to
+        // at least seconds precision (sub-second is intentionally
+        // dropped; pin it so a future "promote to ms" change is an
+        // explicit decision rather than a silent regression).
+        let mut original = OwnedEvent::new(
+            Bytes::from_static(b"x"),
+            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        );
+        original.received_at =
+            chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let json = serde_json::to_string(&original.to_json_value()).unwrap();
+        let recovered = OwnedEvent::from_json(&json).unwrap();
+        assert_eq!(
+            recovered.received_at.timestamp(),
+            original.received_at.timestamp()
+        );
+    }
+}

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -142,3 +142,132 @@ impl Input for UnixSocketInput {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+    use std::os::unix::net::UnixDatagram as StdUnixDatagram;
+
+    /// Tiny helper: build the input with a path and a shutdown channel,
+    /// spawn `run`, return the join handle + the shutdown sender. The
+    /// caller drives shutdown to terminate the listener cleanly.
+    fn spawn_with_path(
+        path: &std::path::Path,
+    ) -> (
+        tokio::task::JoinHandle<Result<()>>,
+        tokio::sync::watch::Sender<bool>,
+        tokio::sync::mpsc::Receiver<Event>,
+    ) {
+        let input = UnixSocketInput {
+            path: path.display().to_string(),
+            metrics: Arc::new(InputMetrics::default()),
+        };
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let (sd_tx, sd_rx) = tokio::sync::watch::channel(false);
+        let handle = tokio::spawn(async move { input.run(tx, sd_rx).await });
+        (handle, sd_tx, rx)
+    }
+
+    #[tokio::test]
+    async fn refuses_to_run_when_path_is_a_symlink() {
+        // The accept loop is supposed to refuse to remove a symlink at
+        // the configured socket path. A regression that followed the
+        // symlink (via `remove_file` directly, no symlink_metadata
+        // check) could let a malicious user pre-place a symlink and
+        // make limpid clobber the target file when binding. Pin the
+        // refusal behaviour: pre-create the path as a symlink, run
+        // the input, assert `run` returns an Err whose message
+        // mentions "symlink", and the symlink target is untouched.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, b"do not clobber").unwrap();
+        let socket_path = dir.path().join("sock");
+        std::os::unix::fs::symlink(&target, &socket_path).unwrap();
+
+        let (handle, _sd_tx, _rx) = spawn_with_path(&socket_path);
+        let result = handle.await.expect("task join");
+        let err = result.expect_err("run must error on symlink");
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected symlink-refusal error, got: {err}"
+        );
+        // Target must be unchanged.
+        let body = std::fs::read(&target).unwrap();
+        assert_eq!(body, b"do not clobber");
+    }
+
+    #[tokio::test]
+    async fn replaces_stale_regular_file_at_path() {
+        // Inverse case: a stale regular file at the configured path
+        // (e.g. left over from a previous run that didn't clean up
+        // gracefully) MUST be removed so the bind can proceed. A
+        // regression that conflated regular-file and symlink would
+        // either leave the daemon stuck on startup OR (worse) let
+        // symlinks through.
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("sock");
+        std::fs::write(&socket_path, b"stale").unwrap();
+
+        let (handle, sd_tx, _rx) = spawn_with_path(&socket_path);
+        // Give the listener a moment to bind.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Path should now be a socket, not a regular file.
+        let meta = std::fs::symlink_metadata(&socket_path).unwrap();
+        assert!(meta.file_type().is_socket(), "expected socket, got {:?}", meta.file_type());
+        let _ = sd_tx.send(true);
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn binds_with_world_writable_permissions() {
+        // Documented behaviour: the socket is set to 0o666 after bind
+        // so every local process can write (mirrors /dev/log). A
+        // regression that dropped the chmod would silently lock out
+        // unprivileged senders. The set_permissions call uses warn-
+        // -on-error rather than bail, so a missing chmod doesn't
+        // even surface as an Err — pin the bits explicitly.
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("sock");
+
+        let (handle, sd_tx, _rx) = spawn_with_path(&socket_path);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mode = std::fs::metadata(&socket_path).unwrap().permissions().mode();
+        // mode() returns the full st_mode including file-type bits;
+        // mask to the permission portion (0o7777).
+        assert_eq!(
+            mode & 0o7777,
+            0o666,
+            "expected 0o666, got 0o{:o} (full mode 0o{:o})",
+            mode & 0o7777,
+            mode
+        );
+        let _ = sd_tx.send(true);
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn receives_valid_syslog_datagram() {
+        // End-to-end sanity: a valid `<PRI>` syslog datagram sent to
+        // the bound socket arrives as an Event via the mpsc channel
+        // with events_received counted exactly once. Guards against
+        // a regression in the validate_pri / recv / events_received
+        // wiring.
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("sock");
+
+        let (handle, sd_tx, mut rx) = spawn_with_path(&socket_path);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let sender = StdUnixDatagram::unbound().unwrap();
+        sender.send_to(b"<13>test message", &socket_path).unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("recv timed out")
+            .expect("channel closed");
+        assert_eq!(&event.ingress[..], b"<13>test message");
+        let _ = sd_tx.send(true);
+        let _ = handle.await;
+    }
+}

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -601,6 +601,72 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_path_component_replaces_unix_separator() {
+        assert_eq!(sanitize_path_component("a/b/c"), "a_b_c");
+    }
+
+    #[test]
+    fn sanitize_path_component_replaces_windows_separator() {
+        // Backslash must be sanitised on every platform, not just
+        // Windows — a Windows-style path leaking into the limpid
+        // value pool would otherwise let an attacker (or a typo)
+        // smuggle in a path-component break on Linux too. Pre-fix
+        // audits flagged that the existing
+        // render_template_sanitises_every_interpolation case used a
+        // value with neither `/` nor `\` and so didn't actually pin
+        // the backslash branch; pin it here.
+        assert_eq!(sanitize_path_component("a\\b\\c"), "a_b_c");
+    }
+
+    #[test]
+    fn sanitize_path_component_replaces_mixed_separators() {
+        // A value containing both forward and back slashes (e.g. a
+        // raw vendor field that mixes Windows + Unix paths) must
+        // strip BOTH; a regression that narrowed replace() to a
+        // single character would let the unfiltered side through.
+        assert_eq!(sanitize_path_component("a/b\\c/d\\e"), "a_b_c_d_e");
+    }
+
+    #[test]
+    fn sanitize_path_component_leaves_dots_alone() {
+        // Operators rely on dots for FQDN-style filenames; the
+        // sanitiser must NOT eat them. Regression guard against an
+        // over-aggressive future "also strip `.`" change that would
+        // silently corrupt `web01.example.com.log` into `web01_example_com_log`.
+        assert_eq!(
+            sanitize_path_component("web01.example.com"),
+            "web01.example.com"
+        );
+    }
+
+    #[test]
+    fn render_template_sanitises_backslash_from_workspace() {
+        // End-to-end pin: a workspace value containing `\` (which a
+        // Windows-origin vendor field might carry) must be
+        // sanitised in the rendered template, not pass through. The
+        // existing workspace-reference test happens to use a value
+        // with `/` only; this one closes the backslash branch.
+        use crate::dsl::OwnedValue;
+        let out = make_output(ek(ExprKind::Template(vec![
+            TemplateFragment::Literal("/var/log/".into()),
+            TemplateFragment::Interp(ek(ExprKind::Ident(vec![
+                "workspace".into(),
+                "winpath".into(),
+            ]))),
+            TemplateFragment::Literal(".log".into()),
+        ])));
+        let mut event = Event::new(
+            Bytes::from("x"),
+            "192.168.1.10:514".parse::<SocketAddr>().unwrap(),
+        );
+        event
+            .workspace
+            .insert("winpath".into(), OwnedValue::String("C:\\Users\\bob".into()));
+        let (rendered, _) = render_path_owned(&out, &event).unwrap();
+        assert_eq!(rendered, "/var/log/C:_Users_bob.log");
+    }
+
+    #[test]
     fn render_template_errors_on_empty_interpolation() {
         // Template `/var/log/${workspace.empty}.log` with empty value would
         // produce `/var/log/.log` — almost never the operator's intent.

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -998,6 +998,102 @@ def pipeline p {
     }
 
     #[test]
+    fn render_failure_falls_back_to_owned_sink_input() {
+        // The memory-queue render path catches a sink's `render` Err
+        // and falls back to `SinkInput::Owned(event.to_owned())` so
+        // the pipeline never drops an event because of a renderer
+        // bug. Mock an Output whose render() always errors, dispatch
+        // through run_pipeline, and assert the output_sinks list
+        // contains an Owned variant — not Rendered, not empty.
+        use crate::event::{BorrowedEvent, Event, OwnedEvent};
+        use crate::functions::{FunctionRegistry, register_builtins, table::TableStore};
+        use crate::metrics::OutputMetrics;
+        use crate::modules::{HasMetrics, Output, RenderedPayload};
+        use bytes::Bytes;
+        use std::net::SocketAddr;
+
+        struct AlwaysFailRender {
+            metrics: Arc<OutputMetrics>,
+        }
+        impl HasMetrics for AlwaysFailRender {
+            type Stats = OutputMetrics;
+            fn metrics(&self) -> Arc<OutputMetrics> {
+                Arc::clone(&self.metrics)
+            }
+        }
+        #[async_trait::async_trait]
+        impl Output for AlwaysFailRender {
+            fn render(
+                &self,
+                _event: &BorrowedEvent<'_>,
+                _arena: &crate::dsl::arena::EventArena<'_>,
+            ) -> anyhow::Result<RenderedPayload> {
+                anyhow::bail!("intentional render failure")
+            }
+            async fn write(&self, _payload: RenderedPayload) -> anyhow::Result<()> {
+                unreachable!("write must not be called when render errored")
+            }
+        }
+
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    output o
+}
+"#;
+        let cfg = compile(src).unwrap();
+        let pipeline = cfg.pipelines.get("p").unwrap();
+        let mut funcs = FunctionRegistry::new();
+        let store = TableStore::from_configs(vec![]).unwrap();
+        register_builtins(&mut funcs, store);
+
+        // Replace `o`'s sink with the mock so render() errors.
+        let mut sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
+        sinks.insert(
+            "o".into(),
+            Arc::new(AlwaysFailRender {
+                metrics: Arc::new(OutputMetrics::default()),
+            }) as Arc<dyn Output>,
+        );
+
+        let event = OwnedEvent::new(
+            Bytes::from_static(b"payload"),
+            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        );
+        let result = run_pipeline(
+            pipeline,
+            &event,
+            &cfg,
+            &funcs,
+            None,
+            &sinks,
+            &mut bumpalo::Bump::new(),
+        )
+        .unwrap();
+        assert_eq!(result.termination, PipelineTermination::Finished);
+        assert_eq!(result.outputs.len(), 1, "expected 1 output, got {}", result.outputs.len());
+        let (name, sink_input) = &result.outputs[0];
+        assert_eq!(name, "o");
+        assert!(
+            matches!(sink_input, SinkInput::Owned(_)),
+            "render failure must fall back to Owned, got Rendered"
+        );
+        // Round-trip: the Owned event's ingress must equal what we fed.
+        if let SinkInput::Owned(ev) = sink_input {
+            assert_eq!(&ev.ingress[..], b"payload");
+        }
+        // Drop unused name to keep clippy happy in case the assert
+        // above doesn't reference it.
+        let _ = name;
+        let _: &Event = match sink_input {
+            SinkInput::Owned(e) => e,
+            SinkInput::Rendered(_) => unreachable!(),
+        };
+    }
+
+    #[test]
     fn validate_accepts_fan_in_when_all_inputs_exist() {
         let src = r#"
 def input a { type syslog_udp bind "0.0.0.0:5140" }

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -533,4 +533,138 @@ mod tests {
             });
         }
     }
+
+    // ---------- enforce_max_size unread-protection invariant ----------
+
+    fn make_segment(dir: &Path, seq: u64, byte_len: usize) {
+        let path = segment_path(dir, seq);
+        std::fs::write(&path, vec![b'x'; byte_len]).unwrap();
+    }
+
+    fn segment_exists(dir: &Path, seq: u64) -> bool {
+        segment_path(dir, seq).exists()
+    }
+
+    #[test]
+    fn enforce_max_size_deletes_oldest_consumed_segments_until_under_cap() {
+        // 5 segments seq=0..4, each 1024 bytes; cap = 2048, reader is
+        // sitting on seq=4 (everything before consumed). Caller must
+        // delete seq=0, 1, 2 to fit; seq=3 might or might not be
+        // removed depending on order, but seq=4 (== current_read_seq)
+        // must stay because it's the live read target.
+        let dir = tempfile::tempdir().unwrap();
+        for s in 0..5u64 {
+            make_segment(dir.path(), s, 1024);
+        }
+        enforce_max_size(dir.path(), 2048, /* current_read_seq */ 4, 4);
+        // seq < 4 may be deleted; seq=4 MUST stay (live read segment).
+        assert!(
+            segment_exists(dir.path(), 4),
+            "live read segment must not be deleted"
+        );
+    }
+
+    #[test]
+    fn enforce_max_size_never_deletes_unread_segments_even_when_over_cap() {
+        // 4 segments seq=0..3, each 1 MiB. Cap = 100 KiB, reader is
+        // ONLY at seq=0 (everything ahead is unread). enforce_max_size
+        // is forbidden from deleting unread data (= `seq >= current_read_seq`),
+        // so the function must STOP at seq=0 even though total is
+        // still over the cap. This is the data-loss invariant: an
+        // operator setting a too-small max_size must not silently lose
+        // events that haven't been processed yet.
+        let dir = tempfile::tempdir().unwrap();
+        for s in 0..4u64 {
+            make_segment(dir.path(), s, 1024 * 1024);
+        }
+        enforce_max_size(dir.path(), 100 * 1024, /* current_read_seq */ 0, 3);
+        // All 4 segments must still exist: seq=0 is current_read_seq
+        // (live), seq=1..3 are unread, NONE are deletable.
+        for s in 0..4u64 {
+            assert!(
+                segment_exists(dir.path(), s),
+                "seq={s} was deleted but is at or past the read cursor"
+            );
+        }
+    }
+
+    #[test]
+    fn enforce_max_size_no_op_when_total_under_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        for s in 0..3u64 {
+            make_segment(dir.path(), s, 1024);
+        }
+        enforce_max_size(dir.path(), 1024 * 1024, 0, 2);
+        for s in 0..3u64 {
+            assert!(segment_exists(dir.path(), s));
+        }
+    }
+
+    #[test]
+    fn enforce_max_size_zero_cap_disables_enforcement() {
+        // max_size = 0 is the "no cap" sentinel; enforce_max_size
+        // must early-return without scanning the dir. Documented via
+        // the early-return branch; pin it so a refactor that flips
+        // the predicate doesn't accidentally turn this into "cap at
+        // 0 bytes → delete everything".
+        let dir = tempfile::tempdir().unwrap();
+        for s in 0..3u64 {
+            make_segment(dir.path(), s, 1024 * 1024);
+        }
+        enforce_max_size(dir.path(), 0, 1, 2);
+        for s in 0..3u64 {
+            assert!(segment_exists(dir.path(), s));
+        }
+    }
+
+    // ---------- save_cursor / load_cursor ----------
+
+    #[test]
+    fn save_cursor_round_trips_through_load_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        save_cursor(dir.path(), 42, 12345);
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!((seq, off), (42, 12345));
+    }
+
+    #[test]
+    fn save_cursor_overwrites_previous_value_atomically() {
+        // The save_cursor path is "write tmp, rename atomically". A
+        // regression that, e.g., writes directly to the cursor file
+        // would leave the file truncated mid-write on a crash. We
+        // can't simulate a crash easily, but we can verify that
+        // repeated overwrites land cleanly and that no leftover .tmp
+        // remains after a successful save.
+        let dir = tempfile::tempdir().unwrap();
+        save_cursor(dir.path(), 1, 10);
+        save_cursor(dir.path(), 2, 20);
+        save_cursor(dir.path(), 3, 30);
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!((seq, off), (3, 30));
+        let tmp = cursor_path(dir.path()).with_extension("tmp");
+        assert!(
+            !tmp.exists(),
+            "leftover .tmp after successful save: {}",
+            tmp.display()
+        );
+    }
+
+    #[test]
+    fn load_cursor_returns_zero_zero_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!((seq, off), (0, 0));
+    }
+
+    #[test]
+    fn load_cursor_returns_zero_zero_for_malformed_file() {
+        // A cursor file from a future format, or one that got
+        // truncated, must NOT panic. The function falls back to (0,0)
+        // — pessimistic but safe (= replays everything since the
+        // start of the available segments).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(cursor_path(dir.path()), "not-a-cursor").unwrap();
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!((seq, off), (0, 0));
+    }
 }

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -585,3 +585,238 @@ async fn write_with_retry(
     }
     false
 }
+
+#[cfg(test)]
+mod write_with_retry_tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::net::SocketAddr;
+    use std::sync::Mutex;
+    use std::sync::atomic::Ordering;
+
+    /// Programmable mock: each call to `consume` pops the next result
+    /// from `script`; if the script is empty, returns Ok. Records the
+    /// number of consume invocations for assertions.
+    struct ScriptedWriter {
+        script: Mutex<Vec<anyhow::Result<()>>>,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ScriptedWriter {
+        fn new(script: Vec<anyhow::Result<()>>) -> Self {
+            Self {
+                script: Mutex::new(script),
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl OutputWriter for ScriptedWriter {
+        async fn consume(&self, _input: SinkInput) -> anyhow::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            let mut s = self.script.lock().unwrap();
+            if s.is_empty() {
+                Ok(())
+            } else {
+                s.remove(0)
+            }
+        }
+    }
+
+    fn fast_cfg(max_attempts: u32) -> RetryConfig {
+        RetryConfig {
+            max_attempts,
+            initial_wait: std::time::Duration::from_millis(1),
+            max_wait: std::time::Duration::from_millis(1),
+            backoff: BackoffStrategy::Fixed,
+            secondary: None,
+        }
+    }
+
+    fn owned_event() -> Event {
+        Event::new(
+            Bytes::from_static(b"x"),
+            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        )
+    }
+
+    fn rendered_event() -> SinkInput {
+        SinkInput::Rendered(RenderedPayload::new(()))
+    }
+
+    fn fresh_metrics() -> crate::metrics::OutputMetrics {
+        crate::metrics::OutputMetrics::default()
+    }
+
+    #[tokio::test]
+    async fn owned_succeeds_on_first_attempt_counts_no_retries() {
+        let w = ScriptedWriter::new(vec![Ok(())]);
+        let m = fresh_metrics();
+        let ok = write_with_retry(
+            &w,
+            SinkInput::Owned(owned_event()),
+            &fast_cfg(3),
+            &None,
+            "test",
+            &m,
+            None,
+        )
+        .await;
+        assert!(ok);
+        assert_eq!(w.calls(), 1);
+        assert_eq!(m.retries.load(Ordering::Relaxed), 0);
+        assert_eq!(m.events_failed.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn owned_retries_then_succeeds() {
+        let w = ScriptedWriter::new(vec![
+            Err(anyhow::anyhow!("transient 1")),
+            Err(anyhow::anyhow!("transient 2")),
+            Ok(()),
+        ]);
+        let m = fresh_metrics();
+        let ok = write_with_retry(
+            &w,
+            SinkInput::Owned(owned_event()),
+            &fast_cfg(5),
+            &None,
+            "test",
+            &m,
+            None,
+        )
+        .await;
+        assert!(ok);
+        assert_eq!(w.calls(), 3, "expected 1 + 2 retries");
+        assert_eq!(m.retries.load(Ordering::Relaxed), 2);
+        assert_eq!(m.events_failed.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn owned_exhausts_retries_bumps_events_failed() {
+        let w = ScriptedWriter::new(vec![
+            Err(anyhow::anyhow!("permanent")),
+            Err(anyhow::anyhow!("permanent")),
+            Err(anyhow::anyhow!("permanent")),
+        ]);
+        let m = fresh_metrics();
+        let ok = write_with_retry(
+            &w,
+            SinkInput::Owned(owned_event()),
+            &fast_cfg(3),
+            &None,
+            "test",
+            &m,
+            None,
+        )
+        .await;
+        assert!(!ok);
+        assert_eq!(w.calls(), 3);
+        assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
+        assert_eq!(m.retries.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn rendered_failure_skips_retries_and_logs() {
+        // Rendered payloads cannot be retried (the Box<dyn Any>
+        // payload was consumed by the first consume call). The
+        // retry-loop must take exactly one shot and then bump
+        // events_failed once with the "rendered payload, no retry"
+        // warn — never loop. A regression that mistakenly retries a
+        // Rendered would panic or silently no-op since the closure
+        // has nothing left to consume.
+        let w = ScriptedWriter::new(vec![Err(anyhow::anyhow!("nope"))]);
+        let m = fresh_metrics();
+        let ok = write_with_retry(
+            &w,
+            rendered_event(),
+            &fast_cfg(5), // 5 allowed but only 1 attempt should happen
+            &None,
+            "test",
+            &m,
+            None,
+        )
+        .await;
+        assert!(!ok);
+        assert_eq!(w.calls(), 1, "Rendered must NOT retry, got {} calls", w.calls());
+        assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn owned_exhausted_routes_to_secondary() {
+        // After retries exhaust, the Owned event must reach the
+        // secondary queue. A regression that dropped the secondary
+        // routing or swapped the secondary->primary direction would
+        // make the secondary silently dead.
+        let w = ScriptedWriter::new(vec![
+            Err(anyhow::anyhow!("e1")),
+            Err(anyhow::anyhow!("e2")),
+        ]);
+        let m = fresh_metrics();
+        let (sec_tx, mut sec_rx) = create_queue(
+            "secondary".into(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 8,
+                overflow: OverflowStrategy::Block,
+            },
+        )
+        .unwrap();
+        let secondary = Some(sec_tx);
+        let ok = write_with_retry(
+            &w,
+            SinkInput::Owned(owned_event()),
+            &fast_cfg(2),
+            &secondary,
+            "primary",
+            &m,
+            None,
+        )
+        .await;
+        assert!(!ok);
+        let routed = sec_rx.try_recv();
+        assert!(
+            matches!(routed, Some(SinkInput::Owned(_))),
+            "secondary did not receive the routed event"
+        );
+    }
+
+    #[tokio::test]
+    async fn rendered_exhausted_does_not_route_to_secondary() {
+        // A Rendered failure with a configured secondary must NOT
+        // route — there's no owned event to forward. The function
+        // logs the "cannot route" error and drops. A regression that
+        // sent SinkInput::Rendered to the secondary would corrupt the
+        // secondary's invariants (only Owned is serialisable on disk
+        // queues, and a Rendered on a memory secondary would still be
+        // an orphan since the original payload was consumed).
+        let w = ScriptedWriter::new(vec![Err(anyhow::anyhow!("rendered fail"))]);
+        let m = fresh_metrics();
+        let (sec_tx, mut sec_rx) = create_queue(
+            "secondary".into(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 8,
+                overflow: OverflowStrategy::Block,
+            },
+        )
+        .unwrap();
+        let secondary = Some(sec_tx);
+        let _ = write_with_retry(
+            &w,
+            rendered_event(),
+            &fast_cfg(5),
+            &secondary,
+            "primary",
+            &m,
+            None,
+        )
+        .await;
+        assert!(sec_rx.try_recv().is_none(), "Rendered must NOT route");
+        assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
+    }
+}

--- a/crates/limpid/src/tls.rs
+++ b/crates/limpid/src/tls.rs
@@ -265,3 +265,199 @@ fn load_private_key(path: &str) -> Result<PrivateKeyDer<'static>> {
         .with_context(|| format!("failed to parse key from: {}", path))?;
     Ok(key)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    struct PemSet {
+        _dir: TempDir,
+        cert: String,
+        key: String,
+        ca_cert: String,
+        // Independent cert that does NOT match `key` — used to force
+        // rustls's cert↔key consistency check to reject.
+        mismatched_cert: String,
+    }
+
+    fn gen_pems() -> PemSet {
+        let dir = TempDir::new().unwrap();
+        // Primary cert + key + CA.
+        let key_pair = rcgen::KeyPair::generate().expect("key gen");
+        let mut params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+        params.is_ca = rcgen::IsCa::ExplicitNoCa;
+        let cert = params.self_signed(&key_pair).unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(&cert_path, cert.pem()).unwrap();
+        std::fs::write(&key_path, key_pair.serialize_pem()).unwrap();
+
+        // Separate self-signed cert used both as the CA root and as a
+        // mismatched-cert source for the consistency-check test. The
+        // path is the same file; consumers pick whichever role.
+        let ca_kp = rcgen::KeyPair::generate().unwrap();
+        let ca_params = rcgen::CertificateParams::new(vec!["alt".to_string()]).unwrap();
+        let ca_cert = ca_params.self_signed(&ca_kp).unwrap();
+        let ca_path = dir.path().join("ca.pem");
+        std::fs::write(&ca_path, ca_cert.pem()).unwrap();
+
+        PemSet {
+            cert: cert_path.display().to_string(),
+            key: key_path.display().to_string(),
+            ca_cert: ca_path.display().to_string(),
+            mismatched_cert: ca_path.display().to_string(),
+            _dir: dir,
+        }
+    }
+
+    // ---------- build_server_config ----------
+
+    #[tokio::test]
+    async fn server_config_without_ca_skips_client_auth() {
+        let p = gen_pems();
+        let cfg = TlsConfig {
+            cert_path: p.cert.clone(),
+            key_path: p.key.clone(),
+            ca_path: None,
+        };
+        let server_cfg = build_server_config(&cfg).await.expect("build ok");
+        assert!(Arc::strong_count(&server_cfg) >= 1);
+    }
+
+    #[tokio::test]
+    async fn server_config_with_ca_enables_client_auth() {
+        let p = gen_pems();
+        let cfg = TlsConfig {
+            cert_path: p.cert.clone(),
+            key_path: p.key.clone(),
+            ca_path: Some(p.ca_cert.clone()),
+        };
+        let server_cfg = build_server_config(&cfg).await.expect("build ok");
+        assert!(Arc::strong_count(&server_cfg) >= 1);
+    }
+
+    #[tokio::test]
+    async fn server_config_rejects_missing_cert_file() {
+        let p = gen_pems();
+        let cfg = TlsConfig {
+            cert_path: "/nonexistent/cert.pem".into(),
+            key_path: p.key.clone(),
+            ca_path: None,
+        };
+        let err = build_server_config(&cfg).await.expect_err("must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cert") || msg.contains("read"),
+            "expected cert-read error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_config_rejects_missing_key_file() {
+        let p = gen_pems();
+        let cfg = TlsConfig {
+            cert_path: p.cert.clone(),
+            key_path: "/nonexistent/key.pem".into(),
+            ca_path: None,
+        };
+        let err = build_server_config(&cfg).await.expect_err("must fail");
+        assert!(err.to_string().contains("key") || err.to_string().contains("read"));
+    }
+
+    #[tokio::test]
+    async fn server_config_rejects_mismatched_cert_and_key() {
+        // Hand rustls a cert whose subject public key does NOT match
+        // the configured private key. rustls's `with_single_cert` is
+        // documented to verify this pairing; a regression that swapped
+        // it for a non-checking variant would let TLS handshake fail
+        // at runtime instead of config-load.
+        let p = gen_pems();
+        let cfg = TlsConfig {
+            cert_path: p.mismatched_cert.clone(),
+            key_path: p.key.clone(),
+            ca_path: None,
+        };
+        let err = build_server_config(&cfg).await.expect_err("must fail");
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("server config")
+                || err.to_string().to_ascii_lowercase().contains("key"),
+            "expected pairing-rejection error, got: {err}"
+        );
+    }
+
+    // ---------- build_client_config_sync ----------
+
+    #[test]
+    fn client_config_no_ca_no_identity_uses_webpki_roots() {
+        let cfg = ClientTlsConfig {
+            ca_path: None,
+            cert_path: None,
+            key_path: None,
+        };
+        let _ = build_client_config_sync(&cfg).expect("build ok");
+    }
+
+    #[test]
+    fn client_config_with_custom_ca() {
+        let p = gen_pems();
+        let cfg = ClientTlsConfig {
+            ca_path: Some(p.ca_cert.clone()),
+            cert_path: None,
+            key_path: None,
+        };
+        let _ = build_client_config_sync(&cfg).expect("build ok");
+    }
+
+    #[test]
+    fn client_config_with_mtls_identity() {
+        let p = gen_pems();
+        let cfg = ClientTlsConfig {
+            ca_path: Some(p.ca_cert.clone()),
+            cert_path: Some(p.cert.clone()),
+            key_path: Some(p.key.clone()),
+        };
+        let _ = build_client_config_sync(&cfg).expect("build ok");
+    }
+
+    #[test]
+    fn client_config_rejects_cert_without_key() {
+        let p = gen_pems();
+        let cfg = ClientTlsConfig {
+            ca_path: None,
+            cert_path: Some(p.cert.clone()),
+            key_path: None,
+        };
+        let err = build_client_config_sync(&cfg).expect_err("must fail");
+        assert!(
+            err.to_string().contains("cert and key"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn client_config_rejects_key_without_cert() {
+        let p = gen_pems();
+        let cfg = ClientTlsConfig {
+            ca_path: None,
+            cert_path: None,
+            key_path: Some(p.key.clone()),
+        };
+        let err = build_client_config_sync(&cfg).expect_err("must fail");
+        assert!(err.to_string().contains("cert and key"));
+    }
+
+    #[test]
+    fn client_config_rejects_unreadable_ca() {
+        let cfg = ClientTlsConfig {
+            ca_path: Some("/nonexistent/ca.pem".into()),
+            cert_path: None,
+            key_path: None,
+        };
+        let err = build_client_config_sync(&cfg).expect_err("must fail");
+        assert!(
+            err.to_string().contains("read") || err.to_string().contains("cert"),
+            "got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Tier 1 from the recent coverage-gap audit — silent-failure-risk areas that were untested. **+33 tests, +945 lines, zero production code change.** Each commit is one logical fortification unit.

### What's covered

- **TLS builders** (`build_server_config` / `build_client_config_sync` in \`tls.rs\`) — zero direct tests previously; every output module depends on these and a refactor would land in production unchecked. 11 new tests cover no-CA vs CA, cert+key consistency, mTLS identity, and the diagnostic-quality of missing-file errors.
- **\`queue/mod.rs::write_with_retry\`** state machine — the per-event retry/secondary/drop branches govern whether events are correctly retried, failed-over, or dropped. 6 new tests pin Owned success / Owned retry then success / Owned exhaustion → secondary / Rendered single-shot / Rendered → no secondary route.
- **\`queue/disk.rs::enforce_max_size\` + \`save_cursor\`** durability — the unread-protection invariant (never delete \`seq >= current_read_seq\`) was untested and is the data-loss guard for disk queues over the size cap. 8 new tests cover cap-enforcement, never-delete-unread, no-op-under-cap, the \`max_size == 0\` sentinel, plus cursor round-trip + atomicity + missing/malformed-file fallback.
- **\`pipeline.rs\` render-error fallback** — when an Output's \`render()\` errors, the memory path falls back to \`SinkInput::Owned(event.to_owned())\` so no event is dropped on a renderer bug. New test installs a mock Output whose render always errors and asserts the recovery.
- **\`event.rs\` boundary round-trips** — \`view_in(arena)\` ↔ \`to_owned()\` and \`to_json_value()\` ↔ \`from_json()\`. These are exercised by every disk-queue replay / tap / DLQ / inject path. 3 new tests pin all-field equality plus the Bytes-as-bytes \`\$bytes_b64\` invariant.
- **Security-tinted invariants** — \`output file\` path-component sanitisation now pins the backslash branch (the existing test happened to use a value with no slashes) plus 4 more variants; \`input unix_socket\` symlink-refusal is pinned end-to-end against a pre-placed symlink target.

### What's NOT covered (deferred to Tier 2 / skipped per triage)

Per the triage decision: 15 medium-leverage Tier 2 items (CEF / parse_kv / parse_json / syslog_udp / syslog_tcp limits / tail rotation) await user judgement; 27 low-leverage Tier 3 items (33 trivial primitive zero-test files, DSL parser Unicode edge cases, regex internal mangling, chrono DST, transitively-covered check/*.rs whole-file) are skipped as not worth the test cost.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 604 pass (+33 new)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] uchgs push-gate: 7 scopes confirmed