### PR TITLE
chore: clippy manual_contains fix + cargo fmt --all

### DIFF
--- a/crates/limpid/src/check/outputs.rs
+++ b/crates/limpid/src/check/outputs.rs
@@ -31,9 +31,7 @@ fn inner_block_schema(
     inner_block_schema_of(&spec.kind)
 }
 
-fn inner_block_schema_of(
-    kind: &PropertyValueKind,
-) -> Option<&'static [PropertySpec]> {
+fn inner_block_schema_of(kind: &PropertyValueKind) -> Option<&'static [PropertySpec]> {
     match kind {
         PropertyValueKind::Block(s) => Some(s),
         PropertyValueKind::BlockMap(s) => Some(s),
@@ -115,8 +113,7 @@ fn analyze_property(
     // block was schema-declared). Recomputing per-key against the
     // current schema level — and descending into the inner spec when
     // we enter a block — fixes that.
-    let schema_owned =
-        parent_schema.is_some_and(|s| schema_declares_key(s, property_key(prop)));
+    let schema_owned = parent_schema.is_some_and(|s| schema_declares_key(s, property_key(prop)));
 
     match prop {
         Property::KeyValue {
@@ -141,8 +138,7 @@ fn analyze_property(
             // FuncCall, etc.) still gets walked by `check_types` so
             // unknown-function / type-mismatch diagnostics inside
             // template bodies continue to surface.
-            let skip_expr_types =
-                schema_owned && matches!(expr.kind, ExprKind::Ident(_));
+            let skip_expr_types = schema_owned && matches!(expr.kind, ExprKind::Ident(_));
             if !skip_expr_types {
                 expr_types::check_types(
                     expr,
@@ -170,8 +166,8 @@ fn analyze_property(
             // at this level, we pass `None` so inner keys evaluate
             // against no schema (and therefore aren't "owned") —
             // expression-level diagnostics will run on them.
-            let inner_schema = parent_schema
-                .and_then(|s| inner_block_schema(s, property_key(prop)));
+            let inner_schema =
+                parent_schema.and_then(|s| inner_block_schema(s, property_key(prop)));
             for inner in properties {
                 analyze_property(
                     inner,

--- a/crates/limpid/src/config.rs
+++ b/crates/limpid/src/config.rs
@@ -532,11 +532,12 @@ mod tests {
             return None;
         }
         if let Some(parent) = sys.parent()
-            && !parent.exists() {
-                // /usr/share/limpid may not exist in CI; try to create
-                // the whole chain. Fall through on EACCES.
-                let _ = std::fs::create_dir_all(parent);
-            }
+            && !parent.exists()
+        {
+            // /usr/share/limpid may not exist in CI; try to create
+            // the whole chain. Fall through on EACCES.
+            let _ = std::fs::create_dir_all(parent);
+        }
         std::os::unix::fs::symlink(target, sys).ok()
     }
 

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -1112,8 +1112,8 @@ mod tests {
         assert_eq!(errs.len(), 1, "{errs:?}");
         match &errs[0].kind {
             SchemaErrorKind::OneOfMismatch { expected, actual } => {
-                assert!(expected.iter().any(|e| *e == "String"), "{expected:?}");
-                assert!(expected.iter().any(|e| *e == "Int"), "{expected:?}");
+                assert!(expected.contains(&"String"), "{expected:?}");
+                assert!(expected.contains(&"Int"), "{expected:?}");
                 assert!(actual.contains("Bool"), "{actual}");
             }
             other => panic!("expected OneOfMismatch, got {other:?}"),

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -1078,10 +1078,7 @@ mod tests {
         // specific error: "expects an identifier".
         let errs = validate(&[kv("tls", ExprKind::StringLit("profile_a".into()))], S);
         assert_eq!(errs.len(), 1, "{errs:?}");
-        assert!(matches!(
-            errs[0].kind,
-            SchemaErrorKind::TypeMismatch { .. }
-        ));
+        assert!(matches!(errs[0].kind, SchemaErrorKind::TypeMismatch { .. }));
         let rendered = errs[0].to_string();
         assert!(
             rendered.contains("identifier"),
@@ -1103,10 +1100,7 @@ mod tests {
             required: false,
             repeatable: false,
             exclusive_group: None,
-            kind: PropertyValueKind::OneOf(&[
-                PropertyValueKind::String,
-                PropertyValueKind::Int,
-            ]),
+            kind: PropertyValueKind::OneOf(&[PropertyValueKind::String, PropertyValueKind::Int]),
         }];
         let errs = validate(&[kv("x", ExprKind::BoolLit(true))], S);
         assert_eq!(errs.len(), 1, "{errs:?}");
@@ -1179,10 +1173,7 @@ mod tests {
             S,
         );
         assert_eq!(errs.len(), 1, "{errs:?}");
-        assert!(matches!(
-            errs[0].kind,
-            SchemaErrorKind::MissingRequired
-        ));
+        assert!(matches!(errs[0].kind, SchemaErrorKind::MissingRequired));
         assert_eq!(errs[0].key, "cert");
     }
 

--- a/crates/limpid/src/dsl/value.rs
+++ b/crates/limpid/src/dsl/value.rs
@@ -110,7 +110,8 @@ impl OwnedValue {
             OwnedValue::Bytes(b) => Value::Bytes(arena.alloc_bytes(b)),
             OwnedValue::Timestamp(dt) => Value::Timestamp(*dt),
             OwnedValue::Array(items) => {
-                let mut out = bumpalo::collections::Vec::with_capacity_in(items.len(), arena.bump());
+                let mut out =
+                    bumpalo::collections::Vec::with_capacity_in(items.len(), arena.bump());
                 for item in items {
                     out.push(item.view_in(arena));
                 }
@@ -352,9 +353,9 @@ impl<'bump> Value<'bump> {
             Value::String(s) => OwnedValue::String(CompactString::from(s)),
             Value::Bytes(b) => OwnedValue::Bytes(Bytes::copy_from_slice(b)),
             Value::Timestamp(dt) => OwnedValue::Timestamp(dt),
-            Value::Array(items) => OwnedValue::Array(
-                items.iter().map(|v| v.to_owned_value()).collect(),
-            ),
+            Value::Array(items) => {
+                OwnedValue::Array(items.iter().map(|v| v.to_owned_value()).collect())
+            }
             Value::Object(entries) => {
                 let mut map = Map::with_capacity(entries.len());
                 for (k, v) in entries {
@@ -507,10 +508,7 @@ impl<'bump> Value<'bump> {
     /// in insertion order).
     pub fn get(&self, key: &str) -> Option<Value<'bump>> {
         match self {
-            Value::Object(entries) => entries
-                .iter()
-                .find(|(k, _)| *k == key)
-                .map(|(_, v)| *v),
+            Value::Object(entries) => entries.iter().find(|(k, _)| *k == key).map(|(_, v)| *v),
             _ => None,
         }
     }

--- a/crates/limpid/src/dsl/value_json.rs
+++ b/crates/limpid/src/dsl/value_json.rs
@@ -161,10 +161,7 @@ pub fn json_to_value(v: &JsonValue) -> Result<OwnedValue> {
 /// start.
 ///
 /// Applies the same `$bytes_b64` marker recognition as [`json_to_value`].
-pub fn json_to_value_in<'bump>(
-    v: &JsonValue,
-    arena: &EventArena<'bump>,
-) -> Result<Value<'bump>> {
+pub fn json_to_value_in<'bump>(v: &JsonValue, arena: &EventArena<'bump>) -> Result<Value<'bump>> {
     match v {
         JsonValue::Null => Ok(Value::Null),
         JsonValue::Bool(b) => Ok(Value::Bool(*b)),
@@ -183,8 +180,7 @@ pub fn json_to_value_in<'bump>(
         }
         JsonValue::String(s) => Ok(Value::String(arena.alloc_str(s))),
         JsonValue::Array(a) => {
-            let mut out =
-                bumpalo::collections::Vec::with_capacity_in(a.len(), arena.bump());
+            let mut out = bumpalo::collections::Vec::with_capacity_in(a.len(), arena.bump());
             for item in a {
                 out.push(json_to_value_in(item, arena)?);
             }
@@ -461,7 +457,10 @@ mod tests {
     #[test]
     fn nested_object_with_bytes_inside() {
         let mut inner = Map::new();
-        inner.insert("blob".into(), OwnedValue::Bytes(Bytes::from_static(b"\x00\xff")));
+        inner.insert(
+            "blob".into(),
+            OwnedValue::Bytes(Bytes::from_static(b"\x00\xff")),
+        );
         let mut outer = Map::new();
         outer.insert("payload".into(), OwnedValue::Object(inner));
         let v = OwnedValue::Object(outer);
@@ -492,8 +491,7 @@ mod tests {
         // converting back to OwnedValue for comparison).
         let bump = bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
-        let json: JsonValue =
-            serde_json::from_str(r#"{"a":1,"b":"hi","c":[1,2,3]}"#).unwrap();
+        let json: JsonValue = serde_json::from_str(r#"{"a":1,"b":"hi","c":[1,2,3]}"#).unwrap();
         let view = json_to_value_in(&json, &arena).unwrap();
         let owned = view.to_owned_value();
         let from_owned = json_to_value(&json).unwrap();
@@ -512,14 +510,8 @@ mod tests {
     fn direct_serialize_scalar_shapes() {
         // Integers stay i64 (not "1234"-as-string); floats stay
         // numbers; booleans / null are JSON natives.
-        assert_eq!(
-            direct_to_json_string(&OwnedValue::Int(42)).unwrap(),
-            "42"
-        );
-        assert_eq!(
-            direct_to_json_string(&OwnedValue::Int(-1)).unwrap(),
-            "-1"
-        );
+        assert_eq!(direct_to_json_string(&OwnedValue::Int(42)).unwrap(), "42");
+        assert_eq!(direct_to_json_string(&OwnedValue::Int(-1)).unwrap(), "-1");
         assert_eq!(
             direct_to_json_string(&OwnedValue::Float(2.5)).unwrap(),
             "2.5"
@@ -528,10 +520,7 @@ mod tests {
             direct_to_json_string(&OwnedValue::Bool(true)).unwrap(),
             "true"
         );
-        assert_eq!(
-            direct_to_json_string(&OwnedValue::Null).unwrap(),
-            "null"
-        );
+        assert_eq!(direct_to_json_string(&OwnedValue::Null).unwrap(), "null");
         assert_eq!(
             direct_to_json_string(&OwnedValue::String("hi".into())).unwrap(),
             "\"hi\""
@@ -602,7 +591,10 @@ mod tests {
         // Bytes deep inside the tree must still surface via marker so
         // the wire form stays self-describing for the round-trip path.
         let mut inner = Map::new();
-        inner.insert("blob".into(), OwnedValue::Bytes(Bytes::from_static(b"\x00\xff")));
+        inner.insert(
+            "blob".into(),
+            OwnedValue::Bytes(Bytes::from_static(b"\x00\xff")),
+        );
         let mut outer = Map::new();
         outer.insert("payload".into(), OwnedValue::Object(inner));
         let v = OwnedValue::Object(outer);

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -261,11 +261,7 @@ impl<'bump> BorrowedEvent<'bump> {
     /// `String` should `arena.alloc_str(...)` first; for ergonomics
     /// see [`Self::workspace_set_str`].
     pub fn workspace_set(&mut self, key: &'bump str, value: Value<'bump>) {
-        if let Some(slot) = self
-            .workspace
-            .iter_mut()
-            .find(|(k, _)| *k == key)
-        {
+        if let Some(slot) = self.workspace.iter_mut().find(|(k, _)| *k == key) {
             slot.1 = value;
         } else {
             self.workspace.push((key, value));
@@ -274,12 +270,7 @@ impl<'bump> BorrowedEvent<'bump> {
 
     /// Insert or replace the workspace entry for `key`, copying the
     /// key into the arena first.
-    pub fn workspace_set_str(
-        &mut self,
-        arena: &EventArena<'bump>,
-        key: &str,
-        value: Value<'bump>,
-    ) {
+    pub fn workspace_set_str(&mut self, arena: &EventArena<'bump>, key: &str, value: Value<'bump>) {
         if let Some(slot) = self.workspace.iter_mut().find(|(k, _)| *k == key) {
             slot.1 = value;
         } else {
@@ -335,10 +326,13 @@ mod boundary_tests {
             "192.0.2.10:5140".parse::<SocketAddr>().unwrap(),
         );
         ev.egress = Bytes::from_static(b"rendered");
-        ev.workspace.insert("k_str".into(), OwnedValue::String("v".into()));
-        ev.workspace.insert("k_int".into(), OwnedValue::Int(42));
         ev.workspace
-            .insert("k_bytes".into(), OwnedValue::Bytes(Bytes::from_static(&[0xff, 0x00, 0xab])));
+            .insert("k_str".into(), OwnedValue::String("v".into()));
+        ev.workspace.insert("k_int".into(), OwnedValue::Int(42));
+        ev.workspace.insert(
+            "k_bytes".into(),
+            OwnedValue::Bytes(Bytes::from_static(&[0xff, 0x00, 0xab])),
+        );
         ev
     }
 

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -204,14 +204,8 @@ mod tests {
         arena: &'bump EventArena<'bump>,
         line: &'bump str,
     ) -> Value<'bump> {
-        reg.call(
-            Some("cef"),
-            "parse",
-            &[Value::String(line)],
-            bevent,
-            arena,
-        )
-        .expect("parse should succeed")
+        reg.call(Some("cef"), "parse", &[Value::String(line)], bevent, arena)
+            .expect("parse should succeed")
     }
 
     #[test]
@@ -227,9 +221,18 @@ mod tests {
             panic!("expected Object");
         };
         assert_eq!(lookup(entries, "version"), Some(Value::String("0")));
-        assert_eq!(lookup(entries, "device_vendor"), Some(Value::String("ArcSight")));
-        assert_eq!(lookup(entries, "device_product"), Some(Value::String("Console")));
-        assert_eq!(lookup(entries, "device_version"), Some(Value::String("6.9")));
+        assert_eq!(
+            lookup(entries, "device_vendor"),
+            Some(Value::String("ArcSight"))
+        );
+        assert_eq!(
+            lookup(entries, "device_product"),
+            Some(Value::String("Console"))
+        );
+        assert_eq!(
+            lookup(entries, "device_version"),
+            Some(Value::String("6.9"))
+        );
         assert_eq!(lookup(entries, "signature_id"), Some(Value::String("13")));
         assert_eq!(lookup(entries, "name"), Some(Value::String("alert raised")));
         assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
@@ -321,14 +324,16 @@ mod tests {
         let owned = dummy_event();
         let bevent = owned.view_in(&arena);
         let reg = make_registry();
-        let line = arena.alloc_str(
-            "CEF:0|V|P|1.0|sig|name|3|msg=Failed login attempt user=alice src=10.0.0.1",
-        );
+        let line = arena
+            .alloc_str("CEF:0|V|P|1.0|sig|name|3|msg=Failed login attempt user=alice src=10.0.0.1");
         let v = parse_into(&reg, &bevent, &arena, line);
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        assert_eq!(lookup(entries, "msg"), Some(Value::String("Failed login attempt")));
+        assert_eq!(
+            lookup(entries, "msg"),
+            Some(Value::String("Failed login attempt"))
+        );
         assert_eq!(lookup(entries, "user"), Some(Value::String("alice")));
         assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
     }
@@ -451,15 +456,17 @@ mod tests {
         let owned = dummy_event();
         let bevent = owned.view_in(&arena);
         let reg = make_registry();
-        let line = arena.alloc_str(
-            "CEF:0|V|P|1.0|sig|name|3|vendor_field=v1 cs1Label=Source IP cs1=10.0.0.1",
-        );
+        let line = arena
+            .alloc_str("CEF:0|V|P|1.0|sig|name|3|vendor_field=v1 cs1Label=Source IP cs1=10.0.0.1");
         let v = parse_into(&reg, &bevent, &arena, line);
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
         assert_eq!(lookup(entries, "vendor_field"), Some(Value::String("v1")));
-        assert_eq!(lookup(entries, "cs1Label"), Some(Value::String("Source IP")));
+        assert_eq!(
+            lookup(entries, "cs1Label"),
+            Some(Value::String("Source IP"))
+        );
         assert_eq!(lookup(entries, "cs1"), Some(Value::String("10.0.0.1")));
     }
 
@@ -482,9 +489,7 @@ mod tests {
         let bevent = owned.view_in(&arena);
         let reg = make_registry();
         // 7 fields; the `name` field contains an escaped pipe.
-        let line = arena.alloc_str(
-            "CEF:0|V|P|1.0|sig|deny\\|drop|3|act=block",
-        );
+        let line = arena.alloc_str("CEF:0|V|P|1.0|sig|deny\\|drop|3|act=block");
         let v = parse_into(&reg, &bevent, &arena, line);
         // Just verify parse succeeded and produced an Object — the
         // exact name value depends on whether the parser unescapes.
@@ -512,9 +517,8 @@ mod tests {
         let owned = dummy_event();
         let bevent = owned.view_in(&arena);
         let reg = make_registry();
-        let line = arena.alloc_str(
-            "CEF:0|V|P|1.0|sig|name|3|src=10.0.0.1 src=10.0.0.2 dst=8.8.8.8",
-        );
+        let line =
+            arena.alloc_str("CEF:0|V|P|1.0|sig|name|3|src=10.0.0.1 src=10.0.0.2 dst=8.8.8.8");
         let v = parse_into(&reg, &bevent, &arena, line);
         let Value::Object(entries) = v else {
             panic!("expected Object");

--- a/crates/limpid/src/functions/otlp/encode.rs
+++ b/crates/limpid/src/functions/otlp/encode.rs
@@ -245,15 +245,11 @@ fn expect_object<'a, 'bump: 'a>(v: &'a Value<'bump>, ctx: &str) -> Result<Entrie
 }
 
 fn lookup<'bump>(entries: Entries<'bump>, key: &str) -> Option<Value<'bump>> {
-    entries
-        .iter()
-        .find(|(k, _)| *k == key)
-        .map(|(_, v)| *v)
+    entries.iter().find(|(k, _)| *k == key).map(|(_, v)| *v)
 }
 
 fn string_field(entries: Entries<'_>, key: &str) -> Option<String> {
-    lookup(entries, key)
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
+    lookup(entries, key).and_then(|v| v.as_str().map(|s| s.to_string()))
 }
 
 fn u32_field(entries: Entries<'_>, key: &str) -> Option<u32> {
@@ -311,10 +307,7 @@ where
 // prost → HashLit (arena-backed)
 // ---------------------------------------------------------------------------
 
-fn resourcelog_to_hashlit<'bump>(
-    arena: &EventArena<'bump>,
-    rl: &ResourceLogs,
-) -> Value<'bump> {
+fn resourcelog_to_hashlit<'bump>(arena: &EventArena<'bump>, rl: &ResourceLogs) -> Value<'bump> {
     let mut b = ObjectBuilder::new(arena);
     if let Some(r) = &rl.resource {
         b.push("resource", resource_to_hashlit(arena, r));
@@ -362,10 +355,7 @@ fn scope_logs_to_hashlit<'bump>(arena: &EventArena<'bump>, sl: &ScopeLogs) -> Va
     b.finish()
 }
 
-fn scope_to_hashlit<'bump>(
-    arena: &EventArena<'bump>,
-    s: &InstrumentationScope,
-) -> Value<'bump> {
+fn scope_to_hashlit<'bump>(arena: &EventArena<'bump>, s: &InstrumentationScope) -> Value<'bump> {
     let mut b = ObjectBuilder::new(arena);
     if !s.name.is_empty() {
         b.push("name", Value::String(arena.alloc_str(&s.name)));

--- a/crates/limpid/src/functions/primitives/nest_dotted_keys.rs
+++ b/crates/limpid/src/functions/primitives/nest_dotted_keys.rs
@@ -165,7 +165,10 @@ fn insert_path<'bump>(
     }
 }
 
-fn materialise<'bump>(arena: &EventArena<'bump>, tree: BTreeMap<String, Node<'bump>>) -> Value<'bump> {
+fn materialise<'bump>(
+    arena: &EventArena<'bump>,
+    tree: BTreeMap<String, Node<'bump>>,
+) -> Value<'bump> {
     let mut builder = ObjectBuilder::with_capacity(arena, tree.len());
     for (k, v) in tree {
         let key_ref = arena.alloc_str(&k);
@@ -195,19 +198,28 @@ mod tests {
         Ok(value_to_json(&nested))
     }
 
-    fn json_to_value<'bump>(arena: &'bump EventArena<'bump>, v: &serde_json::Value) -> Value<'bump> {
+    fn json_to_value<'bump>(
+        arena: &'bump EventArena<'bump>,
+        v: &serde_json::Value,
+    ) -> Value<'bump> {
         match v {
             serde_json::Value::Null => Value::Null,
             serde_json::Value::Bool(b) => Value::Bool(*b),
             serde_json::Value::Number(n) => {
-                if let Some(i) = n.as_i64() { Value::Int(i) }
-                else if let Some(f) = n.as_f64() { Value::Float(f) }
-                else { Value::Null }
+                if let Some(i) = n.as_i64() {
+                    Value::Int(i)
+                } else if let Some(f) = n.as_f64() {
+                    Value::Float(f)
+                } else {
+                    Value::Null
+                }
             }
             serde_json::Value::String(s) => Value::String(arena.alloc_str(s)),
             serde_json::Value::Array(items) => {
                 let mut b = ArrayBuilder::with_capacity(arena, items.len());
-                for i in items { b.push(json_to_value(arena, i)); }
+                for i in items {
+                    b.push(json_to_value(arena, i));
+                }
                 b.finish()
             }
             serde_json::Value::Object(map) => {
@@ -235,7 +247,8 @@ mod tests {
                 format!("[{}]", parts.join(","))
             }
             Value::Object(entries) => {
-                let parts: Vec<String> = entries.iter()
+                let parts: Vec<String> = entries
+                    .iter()
                     .map(|(k, v)| format!("\"{}\":{}", k, value_to_json(v)))
                     .collect();
                 format!("{{{}}}", parts.join(","))
@@ -255,8 +268,9 @@ mod tests {
     fn merges_sibling_keys() {
         // Sibling dotted keys with a common prefix collapse together.
         let out = parse_and_nest(
-            r#"{"id.orig_h":"1.1.1.1","id.orig_p":80,"id.resp_h":"2.2.2.2","ts":123}"#
-        ).unwrap();
+            r#"{"id.orig_h":"1.1.1.1","id.orig_p":80,"id.resp_h":"2.2.2.2","ts":123}"#,
+        )
+        .unwrap();
         // BTreeMap orders keys lexicographically.
         assert_eq!(
             out,
@@ -308,12 +322,14 @@ mod tests {
         // Without the limit, this would recurse 100-deep into insert_path
         // and ultimately enable stack-overflow DoS for attacker-controlled
         // JSON. With the limit, we bail loud and fast.
-        let key: String = (0..100).map(|i| format!("a{i}")).collect::<Vec<_>>().join(".");
+        let key: String = (0..100)
+            .map(|i| format!("a{i}"))
+            .collect::<Vec<_>>()
+            .join(".");
         let json = format!(r#"{{"{}":1}}"#, key);
         let err = parse_and_nest(&json).unwrap_err();
         assert!(
-            err.to_string().contains("dotted segments")
-                && err.to_string().contains("limit"),
+            err.to_string().contains("dotted segments") && err.to_string().contains("limit"),
             "expected segment-depth error, got: {}",
             err
         );
@@ -338,7 +354,10 @@ mod tests {
     #[test]
     fn accepts_depth_at_segment_limit() {
         // Exactly 32 segments — at the limit but not over. Should succeed.
-        let key: String = (0..32).map(|i| format!("a{i}")).collect::<Vec<_>>().join(".");
+        let key: String = (0..32)
+            .map(|i| format!("a{i}"))
+            .collect::<Vec<_>>()
+            .join(".");
         let json = format!(r#"{{"{}":1}}"#, key);
         let out = parse_and_nest(&json).expect("32-segment key should be accepted");
         assert!(out.starts_with("{\"a0\":{"));

--- a/crates/limpid/src/functions/primitives/null_omit.rs
+++ b/crates/limpid/src/functions/primitives/null_omit.rs
@@ -33,10 +33,7 @@ pub fn register(reg: &mut FunctionRegistry) {
 /// Walk `value` and produce its null-stripped form. Returns `None` when
 /// the *whole* value is `Null` (the caller — an Object — drops the key).
 /// Otherwise returns `Some(stripped)`. Arrays preserve `Null` elements.
-fn strip<'bump>(
-    arena: &EventArena<'bump>,
-    value: &Value<'bump>,
-) -> Option<Value<'bump>> {
+fn strip<'bump>(arena: &EventArena<'bump>, value: &Value<'bump>) -> Option<Value<'bump>> {
     match value {
         Value::Null => None,
         Value::Object(entries) => {

--- a/crates/limpid/src/functions/primitives/parse_datetime_rfc3339.rs
+++ b/crates/limpid/src/functions/primitives/parse_datetime_rfc3339.rs
@@ -59,10 +59,7 @@ pub fn register(reg: &mut FunctionRegistry) {
             match chrono::DateTime::parse_from_rfc3339(&text) {
                 Ok(dt) => Ok(Value::Timestamp(dt.with_timezone(&Utc))),
                 Err(rfc_err) => {
-                    match chrono::DateTime::parse_from_str(
-                        &text,
-                        "%Y-%m-%dT%H:%M:%S%.f%z",
-                    ) {
+                    match chrono::DateTime::parse_from_str(&text, "%Y-%m-%dT%H:%M:%S%.f%z") {
                         Ok(dt) => Ok(Value::Timestamp(dt.with_timezone(&Utc))),
                         Err(_) => bail!(
                             "parse_datetime_rfc3339(): could not parse '{}': {}",
@@ -80,19 +77,16 @@ pub fn register(reg: &mut FunctionRegistry) {
 mod tests {
     use super::*;
     use anyhow::Result;
-    
 
     fn parse_one(s: &str) -> Result<Value<'static>> {
         // Mirrors the primitive's fallback chain so the unit tests
         // exercise the same surface operators rely on at runtime.
         match chrono::DateTime::parse_from_rfc3339(s) {
             Ok(dt) => Ok(Value::Timestamp(dt.with_timezone(&Utc))),
-            Err(rfc_err) => {
-                match chrono::DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z") {
-                    Ok(dt) => Ok(Value::Timestamp(dt.with_timezone(&Utc))),
-                    Err(_) => Err(rfc_err.into()),
-                }
-            }
+            Err(rfc_err) => match chrono::DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z") {
+                Ok(dt) => Ok(Value::Timestamp(dt.with_timezone(&Utc))),
+                Err(_) => Err(rfc_err.into()),
+            },
         }
     }
 
@@ -150,7 +144,10 @@ mod tests {
         let v = parse_one("2026-04-30T01:23:45.123456789Z").unwrap();
         match v {
             Value::Timestamp(dt) => {
-                assert_eq!(dt.timestamp_nanos_opt().unwrap() % 1_000_000_000, 123_456_789);
+                assert_eq!(
+                    dt.timestamp_nanos_opt().unwrap() % 1_000_000_000,
+                    123_456_789
+                );
             }
             _ => panic!("expected Timestamp"),
         }

--- a/crates/limpid/src/functions/primitives/parse_json.rs
+++ b/crates/limpid/src/functions/primitives/parse_json.rs
@@ -32,8 +32,8 @@ fn parse_json_impl<'bump>(
     let text = val_to_str(&args[0])?;
     let json: serde_json::Value = serde_json::from_str(&text)
         .map_err(|e| anyhow::anyhow!("parse_json(): JSON parse error: {}", e))?;
-    let parsed = json_to_value_in(&json, arena)
-        .map_err(|e| anyhow::anyhow!("parse_json(): {}", e))?;
+    let parsed =
+        json_to_value_in(&json, arena).map_err(|e| anyhow::anyhow!("parse_json(): {}", e))?;
 
     let result = match parsed {
         Value::Object(_) => parsed,

--- a/crates/limpid/src/functions/primitives/parse_kv.rs
+++ b/crates/limpid/src/functions/primitives/parse_kv.rs
@@ -231,7 +231,13 @@ mod tests {
         // boundary. Pin that the parse succeeds AND the value is
         // recoverable as the original string.
         let p = pairs("name=日本語 next=v", b' ');
-        assert_eq!(p, vec![("name".into(), "日本語".into()), ("next".into(), "v".into())]);
+        assert_eq!(
+            p,
+            vec![
+                ("name".into(), "日本語".into()),
+                ("next".into(), "v".into())
+            ]
+        );
     }
 
     #[test]

--- a/crates/limpid/src/functions/primitives/regex_parse.rs
+++ b/crates/limpid/src/functions/primitives/regex_parse.rs
@@ -89,11 +89,8 @@ fn insert_path(node: &mut Tree, path: &str, value: &str) {
                 if !current.order.iter().any(|s| s == part) {
                     current.order.push(part.to_string());
                 }
-                current
-                    .children
-                    .entry(part.to_string())
-                    .or_default()
-                    .leaf = Some(value.to_string());
+                current.children.entry(part.to_string()).or_default().leaf =
+                    Some(value.to_string());
             }
             return;
         }

--- a/crates/limpid/src/functions/primitives/sum.rs
+++ b/crates/limpid/src/functions/primitives/sum.rs
@@ -89,7 +89,11 @@ mod tests {
     #[test]
     fn sums_integers() {
         let bump = Bump::new();
-        let v = run(&bump, arr(&bump, &[Value::Int(1), Value::Int(2), Value::Int(3)])).unwrap();
+        let v = run(
+            &bump,
+            arr(&bump, &[Value::Int(1), Value::Int(2), Value::Int(3)]),
+        )
+        .unwrap();
         assert_eq!(v, Value::Int(6));
     }
 
@@ -129,7 +133,10 @@ mod tests {
         let bump = Bump::new();
         let v = arr(&bump, &[Value::Int(1), Value::String("nope")]);
         let err = run(&bump, v).err().unwrap();
-        assert!(err.to_string().contains("expects numeric elements"), "{err}");
+        assert!(
+            err.to_string().contains("expects numeric elements"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -168,7 +175,10 @@ mod tests {
         let bump = Bump::new();
         let v = run(
             &bump,
-            arr(&bump, &[Value::Float(1.5), Value::Float(2.25), Value::Float(0.25)]),
+            arr(
+                &bump,
+                &[Value::Float(1.5), Value::Float(2.25), Value::Float(0.25)],
+            ),
         )
         .unwrap();
         assert_eq!(v, Value::Float(4.0));
@@ -221,7 +231,10 @@ mod tests {
         // the input means the operator wants to know the input was
         // dirty, not that it should be silently dropped.
         let bump = Bump::new();
-        let v = arr(&bump, &[Value::Float(1.0), Value::Float(f64::NAN), Value::Float(2.0)]);
+        let v = arr(
+            &bump,
+            &[Value::Float(1.0), Value::Float(f64::NAN), Value::Float(2.0)],
+        );
         let result = run(&bump, v).unwrap();
         match result {
             Value::Float(f) => assert!(f.is_nan(), "got {f}"),
@@ -235,6 +248,9 @@ mod tests {
         let v = arr(&bump, &[Value::Int(i64::MAX), Value::Int(1)]);
         let err = run(&bump, v).err().unwrap();
         let msg = err.to_string();
-        assert!(msg.contains("multiply by 1.0"), "remediation hint missing: {msg}");
+        assert!(
+            msg.contains("multiply by 1.0"),
+            "remediation hint missing: {msg}"
+        );
     }
 }

--- a/crates/limpid/src/functions/primitives/to_json.rs
+++ b/crates/limpid/src/functions/primitives/to_json.rs
@@ -26,8 +26,8 @@ pub fn register(reg: &mut FunctionRegistry) {
         FunctionSig::fixed(&[FieldType::Any], FieldType::String),
         |arena, args, _event| {
             ensure_no_bytes(&args[0])?;
-            let s = serde_json::to_string(&args[0])
-                .map_err(|e| anyhow::anyhow!("to_json(): {e}"))?;
+            let s =
+                serde_json::to_string(&args[0]).map_err(|e| anyhow::anyhow!("to_json(): {e}"))?;
             Ok(Value::String(arena.alloc_str(&s)))
         },
     );

--- a/crates/limpid/src/functions/syslog/parse.rs
+++ b/crates/limpid/src/functions/syslog/parse.rs
@@ -83,7 +83,9 @@ fn parse_impl<'bump>(
 
     if let Some(v) = args.get(1) {
         match v {
-            Value::Object(_) | Value::Null => apply_defaults(arena, "syslog.parse", Some(v), parsed),
+            Value::Object(_) | Value::Null => {
+                apply_defaults(arena, "syslog.parse", Some(v), parsed)
+            }
             other => bail!(
                 "syslog.parse(): second argument must be a hash literal, got {}",
                 type_name(other)
@@ -261,7 +263,6 @@ fn nth_space(input: &str, n: usize) -> Option<usize> {
     None
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,9 +317,8 @@ mod tests {
         let owned = dummy_event();
         let bevent = owned.view_in(&arena);
         let reg = make_registry();
-        let line = arena.alloc_str(
-            "<134>1 2026-04-15T10:30:00Z firewall01 sshd 1234 - - Failed password",
-        );
+        let line =
+            arena.alloc_str("<134>1 2026-04-15T10:30:00Z firewall01 sshd 1234 - - Failed password");
         let v = parse_into(&reg, &bevent, &arena, line);
         let Value::Object(entries) = v else {
             panic!("expected Object");
@@ -331,10 +331,16 @@ mod tests {
             lookup(entries, "timestamp"),
             Some(Value::String("2026-04-15T10:30:00Z"))
         );
-        assert_eq!(lookup(entries, "hostname"), Some(Value::String("firewall01")));
+        assert_eq!(
+            lookup(entries, "hostname"),
+            Some(Value::String("firewall01"))
+        );
         assert_eq!(lookup(entries, "appname"), Some(Value::String("sshd")));
         assert_eq!(lookup(entries, "procid"), Some(Value::String("1234")));
-        assert_eq!(lookup(entries, "msg"), Some(Value::String("Failed password")));
+        assert_eq!(
+            lookup(entries, "msg"),
+            Some(Value::String("Failed password"))
+        );
     }
 
     #[test]
@@ -344,9 +350,7 @@ mod tests {
         let owned = dummy_event();
         let bevent = owned.view_in(&arena);
         let reg = make_registry();
-        let line = arena.alloc_str(
-            "<134>Apr 15 10:30:00 myhost sshd[1234]: Failed password",
-        );
+        let line = arena.alloc_str("<134>Apr 15 10:30:00 myhost sshd[1234]: Failed password");
         let v = parse_into(&reg, &bevent, &arena, line);
         let Value::Object(entries) = v else {
             panic!("expected Object");
@@ -371,19 +375,14 @@ mod tests {
         let owned = dummy_event();
         let bevent = owned.view_in(&arena);
         let reg = make_registry();
-        let line = arena.alloc_str(
-            "<134>Apr 15 10:30:00 myhost kernel: Out of memory",
-        );
+        let line = arena.alloc_str("<134>Apr 15 10:30:00 myhost kernel: Out of memory");
         let v = parse_into(&reg, &bevent, &arena, line);
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
         assert_eq!(lookup(entries, "hostname"), Some(Value::String("myhost")));
         assert_eq!(lookup(entries, "appname"), Some(Value::String("kernel")));
-        assert_eq!(
-            lookup(entries, "msg"),
-            Some(Value::String("Out of memory"))
-        );
+        assert_eq!(lookup(entries, "msg"), Some(Value::String("Out of memory")));
     }
 
     #[test]

--- a/crates/limpid/src/functions/syslog/set_pri.rs
+++ b/crates/limpid/src/functions/syslog/set_pri.rs
@@ -28,10 +28,7 @@ pub fn register(reg: &mut FunctionRegistry) {
     );
 }
 
-fn set_pri_impl<'bump>(
-    arena: &EventArena<'bump>,
-    args: &[Value<'bump>],
-) -> Result<Value<'bump>> {
+fn set_pri_impl<'bump>(arena: &EventArena<'bump>, args: &[Value<'bump>]) -> Result<Value<'bump>> {
     let text = val_to_str(&args[0])?;
     let facility = arg_as_u8(&args[1], "facility", 23)?;
     let severity = arg_as_u8(&args[2], "severity", 7)?;

--- a/crates/limpid/src/functions/table.rs
+++ b/crates/limpid/src/functions/table.rs
@@ -256,13 +256,7 @@ impl TableStore {
     }
 
     /// Upsert with an explicit TTL override (None = no expiry).
-    pub fn upsert(
-        &self,
-        table_name: &str,
-        key: &str,
-        value: OwnedValue,
-        expire: Option<Duration>,
-    ) {
+    pub fn upsert(&self, table_name: &str, key: &str, value: OwnedValue, expire: Option<Duration>) {
         let table_lock = match self.tables.get(table_name) {
             Some(t) => t,
             None => {

--- a/crates/limpid/src/modules/input/otlp/http.rs
+++ b/crates/limpid/src/modules/input/otlp/http.rs
@@ -169,7 +169,8 @@ impl Module for OtlpHttpInput {
 
     fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
         let properties = properties.user_properties();
-        let tls_config = TlsConfig::from_properties_block(&format!("input '{}'", name), properties)?;
+        let tls_config =
+            TlsConfig::from_properties_block(&format!("input '{}'", name), properties)?;
         // Install the rustls crypto provider before we ever assemble a
         // ServerConfig. Only paid when TLS is actually configured.
         if tls_config.is_some() {
@@ -580,10 +581,7 @@ mod tests {
             "o",
             &mp(&[prop_block(
                 "tls",
-                vec![
-                    prop_str("cert", &files.cert),
-                    prop_str("key", &files.key),
-                ],
+                vec![prop_str("cert", &files.cert), prop_str("key", &files.key)],
             )]),
         )
         .unwrap();

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -166,7 +166,8 @@ impl Module for SyslogTcpInput {
         properties: &crate::modules::ModuleProperties,
     ) -> anyhow::Result<Self> {
         let properties = properties.user_properties();
-        let tls_config = TlsConfig::from_properties_block(&format!("input '{}'", name), properties)?;
+        let tls_config =
+            TlsConfig::from_properties_block(&format!("input '{}'", name), properties)?;
         // The crypto provider must be installed before rustls server
         // config assembly. Only pay the cost when TLS is actually
         // configured for this input.
@@ -230,7 +231,11 @@ impl Input for SyslogTcpInput {
         info!(
             "syslog_tcp listening on {} ({})",
             self.bind_addr,
-            if acceptor.is_some() { "TLS" } else { "plaintext" }
+            if acceptor.is_some() {
+                "TLS"
+            } else {
+                "plaintext"
+            }
         );
 
         let limiter: Option<Arc<RateLimiter>> = self.rate_limit.map(|r| {

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -214,7 +214,11 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         // Path should now be a socket, not a regular file.
         let meta = std::fs::symlink_metadata(&socket_path).unwrap();
-        assert!(meta.file_type().is_socket(), "expected socket, got {:?}", meta.file_type());
+        assert!(
+            meta.file_type().is_socket(),
+            "expected socket, got {:?}",
+            meta.file_type()
+        );
         let _ = sd_tx.send(true);
         let _ = handle.await;
     }
@@ -232,7 +236,10 @@ mod tests {
 
         let (handle, sd_tx, _rx) = spawn_with_path(&socket_path);
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        let mode = std::fs::metadata(&socket_path).unwrap().permissions().mode();
+        let mode = std::fs::metadata(&socket_path)
+            .unwrap()
+            .permissions()
+            .mode();
         // mode() returns the full st_mode including file-type bits;
         // mask to the permission portion (0o7777).
         assert_eq!(

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -659,9 +659,10 @@ mod tests {
             Bytes::from("x"),
             "192.168.1.10:514".parse::<SocketAddr>().unwrap(),
         );
-        event
-            .workspace
-            .insert("winpath".into(), OwnedValue::String("C:\\Users\\bob".into()));
+        event.workspace.insert(
+            "winpath".into(),
+            OwnedValue::String("C:\\Users\\bob".into()),
+        );
         let (rendered, _) = render_path_owned(&out, &event).unwrap();
         assert_eq!(rendered, "/var/log/C:_Users_bob.log");
     }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -634,7 +634,12 @@ async fn send_once(peer: &HttpPeer, inner: &Inner, body: &[u8]) -> Result<()> {
         // bytes>` placeholder so the daemon log doesn't fill with
         // replacement-char soup.
         let snippet = error_snippet(response, ERROR_BODY_BYTE_CAP, 200).await;
-        anyhow::bail!("http output: {} returned {} — {}", peer.url, status, snippet);
+        anyhow::bail!(
+            "http output: {} returned {} — {}",
+            peer.url,
+            status,
+            snippet
+        );
     }
 
     Ok(())
@@ -983,7 +988,9 @@ mod tests {
     async fn honors_configured_method() {
         // Method other than POST/PUT used to silently degrade to POST.
         // Now PATCH should reach the server as PATCH.
-        use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::any};
+        use axum::{
+            Router, extract::State, http::StatusCode, response::IntoResponse, routing::any,
+        };
 
         #[derive(Clone)]
         struct AppState {

--- a/crates/limpid/src/modules/output/http_util.rs
+++ b/crates/limpid/src/modules/output/http_util.rs
@@ -68,6 +68,9 @@ pub(crate) async fn error_snippet(
         Some(enc) if !enc.is_empty() && enc != "identity" => {
             format!("<{}-encoded body, {} bytes>", enc, raw.len())
         }
-        _ => String::from_utf8_lossy(&raw).chars().take(max_chars).collect(),
+        _ => String::from_utf8_lossy(&raw)
+            .chars()
+            .take(max_chars)
+            .collect(),
     }
 }

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -759,7 +759,10 @@ mod tests {
             .unwrap();
         let msg = err.to_string();
         assert!(msg.contains("plain") && msg.contains("tls"), "{msg}");
-        assert!(!msg.contains("password_file"), "must not leak file-path: {msg}");
+        assert!(
+            !msg.contains("password_file"),
+            "must not leak file-path: {msg}"
+        );
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -433,21 +433,15 @@ impl OtlpGrpcOutput {
                     let rejected = outcome.rejected.min(count);
                     let written = count - rejected;
                     if written > 0 {
-                        metrics
-                            .events_written
-                            .fetch_add(written, Ordering::Relaxed);
+                        metrics.events_written.fetch_add(written, Ordering::Relaxed);
                     }
                     if rejected > 0 {
-                        metrics
-                            .events_failed
-                            .fetch_add(rejected, Ordering::Relaxed);
+                        metrics.events_failed.fetch_add(rejected, Ordering::Relaxed);
                     }
                 }
                 Err(e) => {
                     tracing::warn!("otlp_grpc flush timer: send failed ({})", e);
-                    metrics
-                        .events_failed
-                        .fetch_add(count, Ordering::Relaxed);
+                    metrics.events_failed.fetch_add(count, Ordering::Relaxed);
                 }
             }
         });
@@ -971,7 +965,9 @@ mod tests {
         let listener = tokio::net::TcpListener::from_std(listener).unwrap();
         let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
 
-        let svc = PartialSuccessLogs { rejected_per_call: 2 };
+        let svc = PartialSuccessLogs {
+            rejected_per_call: 2,
+        };
         let server = tokio::spawn(async move {
             let _ = tonic::transport::Server::builder()
                 .add_service(LogsServiceServer::new(svc))
@@ -1015,8 +1011,14 @@ mod tests {
         // 3 events total: 2 rejected → events_failed, 1 accepted → events_written.
         let written = output.metrics.events_written.load(Ordering::Relaxed);
         let failed = output.metrics.events_failed.load(Ordering::Relaxed);
-        assert_eq!(written, 1, "expected 1 written, got {written} (failed={failed})");
-        assert_eq!(failed, 2, "expected 2 failed, got {failed} (written={written})");
+        assert_eq!(
+            written, 1,
+            "expected 1 written, got {written} (failed={failed})"
+        );
+        assert_eq!(
+            failed, 2,
+            "expected 2 failed, got {failed} (written={written})"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -531,21 +531,15 @@ impl OtlpHttpOutput {
                     let rejected = outcome.rejected.min(count);
                     let written = count - rejected;
                     if written > 0 {
-                        metrics
-                            .events_written
-                            .fetch_add(written, Ordering::Relaxed);
+                        metrics.events_written.fetch_add(written, Ordering::Relaxed);
                     }
                     if rejected > 0 {
-                        metrics
-                            .events_failed
-                            .fetch_add(rejected, Ordering::Relaxed);
+                        metrics.events_failed.fetch_add(rejected, Ordering::Relaxed);
                     }
                 }
                 Err(e) => {
                     tracing::warn!("otlp_http flush timer: send failed ({})", e);
-                    metrics
-                        .events_failed
-                        .fetch_add(count, Ordering::Relaxed);
+                    metrics.events_failed.fetch_add(count, Ordering::Relaxed);
                 }
             }
         });
@@ -1262,10 +1256,7 @@ mod tests {
             received_count: Arc<AtomicUsize>,
         }
 
-        async fn handle(
-            State(state): State<AppState>,
-            body: AxumBytes,
-        ) -> impl IntoResponse {
+        async fn handle(State(state): State<AppState>, body: AxumBytes) -> impl IntoResponse {
             // Decode the request only to confirm it parsed; the test
             // exercise is the response body, not the request.
             let _ = ExportLogsServiceRequest::decode(&body[..]);
@@ -1332,8 +1323,14 @@ mod tests {
 
         let written = output.metrics.events_written.load(Ordering::Relaxed);
         let failed = output.metrics.events_failed.load(Ordering::Relaxed);
-        assert_eq!(written, 1, "expected 1 written, got {written} (failed={failed})");
-        assert_eq!(failed, 2, "expected 2 failed, got {failed} (written={written})");
+        assert_eq!(
+            written, 1,
+            "expected 1 written, got {written} (failed={failed})"
+        );
+        assert_eq!(
+            failed, 2,
+            "expected 2 failed, got {failed} (written={written})"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/mod.rs
+++ b/crates/limpid/src/modules/output/otlp/mod.rs
@@ -336,7 +336,12 @@ mod tests {
 
     /// Helper: same-resource singleton with an explicit Resource-level
     /// schema_url so the schema-url merge rule can be exercised.
-    fn singleton_with_schema(svc: &str, scope: &str, t: u64, resource_schema: &str) -> ResourceLogs {
+    fn singleton_with_schema(
+        svc: &str,
+        scope: &str,
+        t: u64,
+        resource_schema: &str,
+    ) -> ResourceLogs {
         let mut rl = singleton(svc, scope, t);
         rl.schema_url = resource_schema.to_string();
         rl
@@ -353,7 +358,11 @@ mod tests {
             singleton_with_schema("svc-a", "scope-1", 2, "https://schemas.example.com/v2"),
         ];
         let req = merge_by_resource(input);
-        assert_eq!(req.resource_logs.len(), 2, "different schema_urls must stay distinct");
+        assert_eq!(
+            req.resource_logs.len(),
+            2,
+            "different schema_urls must stay distinct"
+        );
         let urls: Vec<&str> = req
             .resource_logs
             .iter()
@@ -375,7 +384,10 @@ mod tests {
         ];
         let req = merge_by_resource(input);
         assert_eq!(req.resource_logs.len(), 1);
-        assert_eq!(req.resource_logs[0].schema_url, "https://schemas.example.com/v1");
+        assert_eq!(
+            req.resource_logs[0].schema_url,
+            "https://schemas.example.com/v1"
+        );
         assert_eq!(req.resource_logs[0].scope_logs.len(), 2);
     }
 
@@ -388,7 +400,10 @@ mod tests {
         ];
         let req = merge_by_resource(input);
         assert_eq!(req.resource_logs.len(), 1);
-        assert_eq!(req.resource_logs[0].schema_url, "https://schemas.example.com/v1");
+        assert_eq!(
+            req.resource_logs[0].schema_url,
+            "https://schemas.example.com/v1"
+        );
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -30,7 +30,10 @@ impl Module for StdoutOutput {
         Some(STDOUT_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(_name: &str, _properties: &crate::modules::ModuleProperties) -> Result<Self> {
+    fn from_properties(
+        _name: &str,
+        _properties: &crate::modules::ModuleProperties,
+    ) -> Result<Self> {
         Ok(Self {
             metrics: Arc::new(OutputMetrics::default()),
         })

--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -65,10 +65,7 @@ impl Peer {
     /// and IPv4 literals don't need brackets; an already-bracketed
     /// literal (`[::1]`) is left untouched.
     pub fn address(&self) -> String {
-        if self.host.contains(':')
-            && !self.host.starts_with('[')
-            && !self.host.ends_with(']')
-        {
+        if self.host.contains(':') && !self.host.starts_with('[') && !self.host.ends_with(']') {
             format!("[{}]:{}", self.host, self.port)
         } else {
             format!("{}:{}", self.host, self.port)

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -12,8 +12,7 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
-    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogPayload,
-    parse_host_port,
+    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogPayload, parse_host_port,
 };
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 
@@ -147,9 +146,7 @@ impl Output for SyslogUdpOutput {
                             tokio::net::lookup_host(address.as_str()),
                         )
                         .await
-                        .with_context(|| {
-                            format!("syslog_udp lookup {} timed out", address)
-                        })?
+                        .with_context(|| format!("syslog_udp lookup {} timed out", address))?
                         .with_context(|| format!("syslog_udp lookup {}", address))?
                         .collect();
                         if resolved.is_empty() {

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -579,20 +579,15 @@ fn exec_pipeline_stmt<'bump>(
                         for a in args {
                             evaluated_args.push(eval_expr(a, &current, ctx.funcs, ctx.arena)?);
                         }
-                        let arg_repr: Vec<String> = evaluated_args
-                            .iter()
-                            .map(|v| v.to_string())
-                            .collect();
+                        let arg_repr: Vec<String> =
+                            evaluated_args.iter().map(|v| v.to_string()).collect();
 
                         // Snapshot the heap-owned form before the
                         // registry consumes the borrowed event — the
                         // Err arm needs a stable, arena-independent
                         // event for the DLQ context.
                         let backup_owned = current.to_owned();
-                        match ctx
-                            .registry
-                            .call(name, &evaluated_args, current, ctx.arena)
-                        {
+                        match ctx.registry.call(name, &evaluated_args, current, ctx.arena) {
                             Ok(Some(e)) => {
                                 out.trace.push(TraceEntry {
                                     stage: "process".into(),
@@ -749,12 +744,8 @@ fn exec_pipeline_stmt<'bump>(
                 if arm.pattern.is_none() {
                     return exec_pipeline_branch_body(&arm.body, event, ctx, out);
                 }
-                let pattern_val = eval_expr(
-                    arm.pattern.as_ref().unwrap(),
-                    &event,
-                    ctx.funcs,
-                    ctx.arena,
-                )?;
+                let pattern_val =
+                    eval_expr(arm.pattern.as_ref().unwrap(), &event, ctx.funcs, ctx.arena)?;
                 if values_match(&disc_val, &pattern_val) {
                     return exec_pipeline_branch_body(&arm.body, event, ctx, out);
                 }
@@ -890,7 +881,16 @@ def pipeline p {
             "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
         );
         let sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
-        let result = run_pipeline(pipeline, &event, &cfg, &funcs, None, &sinks, &mut bumpalo::Bump::new()).unwrap();
+        let result = run_pipeline(
+            pipeline,
+            &event,
+            &cfg,
+            &funcs,
+            None,
+            &sinks,
+            &mut bumpalo::Bump::new(),
+        )
+        .unwrap();
         assert_eq!(result.termination, PipelineTermination::Errored);
         let ctx = result.errored.expect("errored context must be populated");
         assert_eq!(ctx.pipeline, "p");
@@ -941,7 +941,16 @@ def pipeline p {
             "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
         );
         let sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
-        let result = run_pipeline(pipeline, &event, &cfg, &funcs, None, &sinks, &mut bumpalo::Bump::new()).unwrap();
+        let result = run_pipeline(
+            pipeline,
+            &event,
+            &cfg,
+            &funcs,
+            None,
+            &sinks,
+            &mut bumpalo::Bump::new(),
+        )
+        .unwrap();
         assert_eq!(result.termination, PipelineTermination::Errored);
         let ctx = result.errored.expect("errored context must be populated");
         assert_eq!(ctx.pipeline, "p");
@@ -984,7 +993,16 @@ def pipeline p {
             "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
         );
         let sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
-        let result = run_pipeline(pipeline, &event, &cfg, &funcs, None, &sinks, &mut bumpalo::Bump::new()).unwrap();
+        let result = run_pipeline(
+            pipeline,
+            &event,
+            &cfg,
+            &funcs,
+            None,
+            &sinks,
+            &mut bumpalo::Bump::new(),
+        )
+        .unwrap();
         assert_eq!(result.termination, PipelineTermination::Errored);
         let ctx = result.errored.expect("errored context must be populated");
         assert_eq!(ctx.pipeline, "p");
@@ -1073,7 +1091,12 @@ def pipeline p {
         )
         .unwrap();
         assert_eq!(result.termination, PipelineTermination::Finished);
-        assert_eq!(result.outputs.len(), 1, "expected 1 output, got {}", result.outputs.len());
+        assert_eq!(
+            result.outputs.len(),
+            1,
+            "expected 1 output, got {}",
+            result.outputs.len()
+        );
         let (name, sink_input) = &result.outputs[0];
         assert_eq!(name, "o");
         assert!(

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -619,11 +619,7 @@ mod write_with_retry_tests {
         async fn consume(&self, _input: SinkInput) -> anyhow::Result<()> {
             self.calls.fetch_add(1, Ordering::Relaxed);
             let mut s = self.script.lock().unwrap();
-            if s.is_empty() {
-                Ok(())
-            } else {
-                s.remove(0)
-            }
+            if s.is_empty() { Ok(()) } else { s.remove(0) }
         }
     }
 
@@ -742,7 +738,12 @@ mod write_with_retry_tests {
         )
         .await;
         assert!(!ok);
-        assert_eq!(w.calls(), 1, "Rendered must NOT retry, got {} calls", w.calls());
+        assert_eq!(
+            w.calls(),
+            1,
+            "Rendered must NOT retry, got {} calls",
+            w.calls()
+        );
         assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
     }
 
@@ -752,10 +753,7 @@ mod write_with_retry_tests {
         // secondary queue. A regression that dropped the secondary
         // routing or swapped the secondary->primary direction would
         // make the secondary silently dead.
-        let w = ScriptedWriter::new(vec![
-            Err(anyhow::anyhow!("e1")),
-            Err(anyhow::anyhow!("e2")),
-        ]);
+        let w = ScriptedWriter::new(vec![Err(anyhow::anyhow!("e1")), Err(anyhow::anyhow!("e2"))]);
         let m = fresh_metrics();
         let (sec_tx, mut sec_rx) = create_queue(
             "secondary".into(),

--- a/crates/limpid/src/tls.rs
+++ b/crates/limpid/src/tls.rs
@@ -380,7 +380,9 @@ mod tests {
         };
         let err = build_server_config(&cfg).await.expect_err("must fail");
         assert!(
-            err.to_string().to_ascii_lowercase().contains("server config")
+            err.to_string()
+                .to_ascii_lowercase()
+                .contains("server config")
                 || err.to_string().to_ascii_lowercase().contains("key"),
             "expected pairing-rejection error, got: {err}"
         );
@@ -429,10 +431,7 @@ mod tests {
             key_path: None,
         };
         let err = build_client_config_sync(&cfg).expect_err("must fail");
-        assert!(
-            err.to_string().contains("cert and key"),
-            "got: {err}"
-        );
+        assert!(err.to_string().contains("cert and key"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

CI hygiene bundle from the latest external audit of \`release/0.7.8\` — findings #4 (\`cargo fmt --all -- --check\` failing) and #5 (clippy \`manual_contains\` on schema tests). Both are mechanical; landing them as the **A** companion to PR-B ([limpid#44](https://github.com/naoto256/limpid/pull/44)) keeps the branch lint-clean.

Two commits, kept separate for rebase-merge clarity.

## Commits

- [\`2cecf94 chore(test): use slice contains in schema OneOfMismatch assertion\`](crates/limpid/src/dsl/schema.rs#L1115) — replaces \`expected.iter().any(|e| *e == "...")\` with \`expected.contains(&"...")\` in two test assertions. Satisfies clippy \`manual_contains\` (Rust 1.96.0+) when run with \`--all-targets\`. Current CI clippy step doesn't pass \`--all-targets\`, so this was invisible at gate time.
- \`7c388fe chore: cargo fmt --all\` — applies pending rustfmt diffs across 35 files in \`crates/limpid\`. Pure whitespace / line-break / argument re-flow; no behavioural change. Brings the tree to a state where \`cargo fmt --all -- --check\` is green, so a fmt CI step (or pre-commit hook) can be added without churn.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` (637 tests pass)
- [x] \`cargo clippy --workspace -- -D warnings\` clean (current CI form)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean (broader form, was failing before)
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)