### PR TITLE
fix(input): tail offset persistence + journal blocking-reader shutdown

### DIFF
--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -30,7 +30,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -132,8 +132,24 @@ impl Input for JournalInput {
         // Channel payload: (entry-as-JSON-bytes, cursor)
         let (entry_tx, mut entry_rx) = tokio::sync::mpsc::channel::<(Vec<u8>, String)>(1024);
 
+        // The reader is parked inside `spawn_blocking`, so `abort()`
+        // on the handle below is effectively a no-op once execution
+        // begins (tokio only cancels not-yet-started blocking tasks).
+        // Signal shutdown explicitly via an atomic flag the reader
+        // polls between journal reads, so an idle reader exits within
+        // bounded latency instead of leaking until the next entry —
+        // which may never arrive on a quiet system.
+        let reader_shutdown = Arc::new(AtomicBool::new(false));
+        let reader_shutdown_for_thread = Arc::clone(&reader_shutdown);
+
         let journal_handle = tokio::task::spawn_blocking(move || {
-            run_journal_reader(matches, state_file, poll_interval, entry_tx)
+            run_journal_reader(
+                matches,
+                state_file,
+                poll_interval,
+                entry_tx,
+                reader_shutdown_for_thread,
+            )
         });
 
         loop {
@@ -143,6 +159,10 @@ impl Input for JournalInput {
                 _ = shutdown.changed() => {
                     if *shutdown.borrow() {
                         info!("journal: shutting down");
+                        // Tell the blocking reader to exit; `abort()`
+                        // alone would not (the reader is already
+                        // running on a blocking thread).
+                        reader_shutdown.store(true, Ordering::Relaxed);
                         journal_handle.abort();
                         break;
                     }
@@ -248,12 +268,35 @@ fn collect_entry_fields(journal: &mut Journal) -> Result<JsonMap<String, JsonVal
     Ok(map)
 }
 
+/// Sleep up to `total` but wake early when `shutdown` is set.
+///
+/// The journal reader's idle path used to be a plain
+/// `std::thread::sleep(poll_interval)`, which on a quiet system
+/// could nap for the full poll interval — and crucially could not
+/// see the orchestrator's shutdown signal during that nap, because
+/// `spawn_blocking` tasks can't be aborted once running. Sleeping
+/// in small quanta and re-checking the flag bounds shutdown latency
+/// to roughly one quantum regardless of `poll_interval`.
+fn interruptible_sleep(shutdown: &AtomicBool, total: Duration) {
+    const QUANTUM: Duration = Duration::from_millis(100);
+    let mut remaining = total;
+    while remaining > Duration::ZERO {
+        if shutdown.load(Ordering::Relaxed) {
+            return;
+        }
+        let nap = remaining.min(QUANTUM);
+        std::thread::sleep(nap);
+        remaining = remaining.saturating_sub(nap);
+    }
+}
+
 /// Synchronous journal reader running in a blocking thread.
 fn run_journal_reader(
     matches: Vec<String>,
     state_file: Option<PathBuf>,
     poll_interval: Duration,
     tx: tokio::sync::mpsc::Sender<(Vec<u8>, String)>,
+    shutdown: Arc<AtomicBool>,
 ) {
     let mut journal = match OpenOptions::default().open() {
         Ok(j) => j,
@@ -296,6 +339,9 @@ fn run_journal_reader(
     }
 
     loop {
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
         match journal.next() {
             Ok(n) if n > 0 => {
                 let map = match collect_entry_fields(&mut journal) {
@@ -327,13 +373,92 @@ fn run_journal_reader(
             }
             Ok(_) => {
                 // No more entries, wait
-                std::thread::sleep(poll_interval);
+                interruptible_sleep(&shutdown, poll_interval);
             }
             Err(e) => {
                 warn!("journal: read error: {}", e);
-                std::thread::sleep(poll_interval);
+                interruptible_sleep(&shutdown, poll_interval);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn interruptible_sleep_returns_promptly_when_flag_set_before_call() {
+        // Defensive baseline: if the flag is already set before the
+        // sleep starts, the loop never naps. Latency must be near
+        // zero.
+        let shutdown = AtomicBool::new(true);
+        let started = Instant::now();
+        interruptible_sleep(&shutdown, Duration::from_secs(60));
+        assert!(
+            started.elapsed() < Duration::from_millis(50),
+            "pre-set flag must short-circuit immediately; took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn interruptible_sleep_wakes_within_one_quantum_when_flag_flips() {
+        // Regression: the previous reader used plain
+        // `std::thread::sleep(poll_interval)`, so on an idle host the
+        // shutdown signal couldn't preempt the nap. With chunked
+        // sleeps re-checking the flag, the wake-up latency is bounded
+        // by one QUANTUM (~100ms) regardless of how long the caller
+        // asked us to sleep.
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let flip = Arc::clone(&shutdown);
+
+        // Flip the flag from another thread mid-sleep.
+        let flipper = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            flip.store(true, Ordering::Relaxed);
+        });
+
+        let started = Instant::now();
+        // Ask for a 30 s sleep that we'd never tolerate in shutdown.
+        interruptible_sleep(&shutdown, Duration::from_secs(30));
+        let elapsed = started.elapsed();
+        flipper.join().unwrap();
+
+        // Wake-up must happen well under one second: at most one
+        // QUANTUM (100 ms) after the flip at 150 ms = ~250 ms upper
+        // bound. Allow generous slack for CI scheduling jitter.
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "flag flip must interrupt the sleep; took {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "should not return before the first quantum elapses; took {:?}",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn interruptible_sleep_completes_full_duration_without_signal() {
+        // Sanity: when the flag never flips, the helper actually
+        // sleeps roughly the requested time.
+        let shutdown = AtomicBool::new(false);
+        let started = Instant::now();
+        interruptible_sleep(&shutdown, Duration::from_millis(250));
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(240),
+            "should sleep close to requested duration; took {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_millis(600),
+            "should not over-sleep wildly; took {:?}",
+            elapsed
+        );
     }
 }
 

--- a/crates/limpid/src/modules/input/tail.rs
+++ b/crates/limpid/src/modules/input/tail.rs
@@ -105,16 +105,8 @@ impl Input for TailInput {
 
         let source_addr = TAIL_SOURCE.parse().unwrap();
 
-        // Load saved position or start from end of file
-        let mut offset = self.load_position().unwrap_or(0);
+        let mut offset = self.initial_offset().await;
         let mut last_inode = get_inode(&self.path);
-
-        // If no state file or first run, start from end of file
-        if (self.state_file.is_none() || offset == 0)
-            && let Ok(meta) = tokio::fs::metadata(&self.path).await
-        {
-            offset = meta.len();
-        }
 
         loop {
             // Check for shutdown
@@ -218,11 +210,36 @@ impl TailInput {
 
             let event = Event::new(Bytes::copy_from_slice(trimmed.as_bytes()), source_addr);
             if tx.send(event).await.is_err() {
+                // Downstream closed. Rewind so this line is re-read
+                // on the next poll instead of being saved as already
+                // consumed; otherwise `run()` persists the advanced
+                // offset and the unsent line gets silently dropped.
+                current_offset -= bytes_read as u64;
                 break;
             }
         }
 
         Ok(current_offset)
+    }
+
+    /// Where to start the very first read for this `run()`.
+    ///
+    /// - `Some(n)` from the state file → resume from `n`, including
+    ///   the legitimate `Some(0)` case (e.g. we shut down right after
+    ///   a rotate/truncate). Treating `Some(0)` as "no state" used
+    ///   to send the cursor to EOF and silently skip every line
+    ///   appended between save and restart.
+    /// - `None` (no state file configured, missing, or unparseable)
+    ///   → start at EOF so a fresh daemon doesn't replay the entire
+    ///   historical log.
+    async fn initial_offset(&self) -> u64 {
+        match self.load_position() {
+            Some(n) => n,
+            None => tokio::fs::metadata(&self.path)
+                .await
+                .map(|m| m.len())
+                .unwrap_or(0),
+        }
     }
 
     fn load_position(&self) -> Option<u64> {
@@ -385,6 +402,77 @@ mod tests {
         std::fs::write(&log, b"").unwrap();
         let input = make_input(&log, Some(&state));
         assert_eq!(input.load_position(), None);
+    }
+
+    #[tokio::test]
+    async fn initial_offset_resumes_from_saved_zero_not_eof() {
+        // Regression: `save_position(0)` used to be indistinguishable
+        // from "no state file" because `load_position().unwrap_or(0)`
+        // collapsed both into the same `0`, and the follow-up `if
+        // offset == 0` then bumped the cursor to EOF. That silently
+        // dropped any data appended between a rotation-time save (=
+        // offset 0) and the next start — the typical recovery shape
+        // for `tail`.
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("log");
+        let state = dir.path().join("state");
+        std::fs::write(&log, b"appended-since-shutdown\n").unwrap();
+        let input = make_input(&log, Some(&state));
+        input.save_position(0);
+
+        assert_eq!(
+            input.initial_offset().await,
+            0,
+            "Some(0) from the state file must resume at 0, not EOF",
+        );
+    }
+
+    #[tokio::test]
+    async fn initial_offset_starts_at_eof_without_state_file() {
+        // First-run / no-state-file behaviour is preserved: don't
+        // replay the entire historical log, start at EOF.
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("log");
+        std::fs::write(&log, b"existing-content\n").unwrap();
+        let input = make_input(&log, None);
+
+        assert_eq!(input.initial_offset().await, 17);
+    }
+
+    #[tokio::test]
+    async fn initial_offset_starts_at_eof_when_state_file_missing() {
+        // State file configured but absent (= first start) — same
+        // contract as "no state file at all": start at EOF.
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("log");
+        let state = dir.path().join("does-not-exist");
+        std::fs::write(&log, b"existing\n").unwrap();
+        let input = make_input(&log, Some(&state));
+
+        assert_eq!(input.initial_offset().await, 9);
+    }
+
+    #[tokio::test]
+    async fn read_new_lines_rewinds_on_downstream_send_failure() {
+        // Regression: when the consumer is gone and `tx.send().await`
+        // fails, `read_new_lines` used to break out with
+        // `current_offset` already advanced past the un-sent line.
+        // `run()` then saved that offset and the next poll skipped
+        // the line entirely — silent data loss. The fix rewinds by
+        // `bytes_read` so the line is retried.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log");
+        std::fs::write(&path, b"line1\nline2\n").unwrap();
+        let input = make_input(&path, None);
+        let (tx, rx) = tokio::sync::mpsc::channel::<Event>(1);
+        // Close the receiver so the first send fails.
+        drop(rx);
+
+        let next_off = input.read_new_lines(0, &tx, dummy_addr()).await.unwrap();
+        assert_eq!(
+            next_off, 0,
+            "send failure must rewind so the un-sent line is retried",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three Medium audit findings against \`release/0.7.8\`, all on the input side, all silent data-loss / liveness bugs. Bundled in one PR because they share a theme (cursor persistence + shutdown contract) and don't conflict.

## Commits

### \`fix(input tail): preserve saved offset zero and rewind on send failure\`

Two tail findings together:

1. \`load_position().unwrap_or(0)\` plus a follow-up \`if offset == 0\` collapsed "no state file" and "saved \`Some(0)\`" into the same path, sending the cursor to EOF and skipping every line appended between the save and the next start — the typical recovery shape after rotate/truncate. Replaced with an \`initial_offset()\` helper that keeps the \`Option<u64>\`: \`Some(n)\` resumes from \`n\` (including 0), \`None\` falls back to EOF.

2. \`read_new_lines\` advanced \`current_offset\` past each line before sending it to the downstream channel. If \`tx.send()\` failed (consumer gone) the loop broke out and returned the already-advanced offset, which \`run()\` then persisted — silently dropping the un-sent line. Mirror the incomplete-line rewind: subtract \`bytes_read\` on send failure.

4 regression tests cover all three offset paths (\`Some(0)\` resume, no state file, missing state file) and the send-failure rewind.

### \`fix(input journal): exit blocking reader on shutdown while idle\`

The journal input runs its libsystemd-backed reader inside \`tokio::task::spawn_blocking\`, and on shutdown the orchestrator called \`journal_handle.abort()\`. tokio's abort cannot cancel a spawn_blocking task that has already started — it only prevents not-yet-started ones — so the reader stayed alive. Its only escape was the next \`tx.blocking_send()\` returning \`Err\` after the channel closed, which requires a fresh journal entry. On a quiet host that may not happen for a long time, leaving the blocking thread (and its journald file handle) parked indefinitely past daemon shutdown.

Signal shutdown explicitly via an \`Arc<AtomicBool>\` flag the reader polls between iterations, and replace \`std::thread::sleep(poll_interval)\` with \`interruptible_sleep\` that naps in 100 ms quanta re-checking the same flag. Shutdown latency is now bounded by one quantum regardless of how long \`poll_interval\` is.

3 unit tests cover the helper: pre-set flag short-circuits, mid-sleep flip wakes within bounded time, no flip completes near the requested duration.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` (643 tests pass, +4 new tail regression tests; journal helper tests require \`--features journal\` build environment, covered by release.yml CI which installs \`libsystemd-dev\`)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] Each tail fix individually verified: temporarily reverting either makes its regression test fail with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)