### PR TITLE
fix(output): OTLP batch retention symmetry + syslog cooldown anchor

### DIFF
--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -382,7 +382,10 @@ impl OtlpGrpcOutput {
             return Ok(());
         }
         let count = drained.len() as u64;
-        let result = send_batch(&self.inner, drained).await;
+        // Clone for the send so the original survives for retry
+        // restoration on transport error. `Bytes::clone` is a
+        // refcount bump, no payload copy.
+        let result = send_batch(&self.inner, drained.clone()).await;
         match result {
             Ok(outcome) => {
                 let rejected = outcome.rejected.min(count);
@@ -400,9 +403,16 @@ impl OtlpGrpcOutput {
                 Ok(())
             }
             Err(e) => {
-                self.metrics
-                    .events_failed
-                    .fetch_add(count, Ordering::Relaxed);
+                // Transport error: put the drained batch back into
+                // the buffer for retry instead of dropping it.
+                // Mirrors `output http` (PR limpid#33) and the
+                // sibling `otlp_http` write-flush path. Do NOT bump
+                // events_failed — the events are retained, not
+                // permanently rejected.
+                let mut batch = self.inner.batch.lock().await;
+                let new_events = std::mem::take(&mut *batch);
+                *batch = drained;
+                batch.extend(new_events);
                 Err(e)
             }
         }
@@ -428,7 +438,7 @@ impl OtlpGrpcOutput {
                 return;
             }
             let count = drained.len() as u64;
-            match send_batch(&inner, drained).await {
+            match send_batch(&inner, drained.clone()).await {
                 Ok(outcome) => {
                     let rejected = outcome.rejected.min(count);
                     let written = count - rejected;
@@ -440,8 +450,18 @@ impl OtlpGrpcOutput {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("otlp_grpc flush timer: send failed ({})", e);
-                    metrics.events_failed.fetch_add(count, Ordering::Relaxed);
+                    // Same retention contract as the write-triggered
+                    // flush: return the drained batch to the buffer
+                    // for the next write or timer firing to retry.
+                    tracing::warn!(
+                        "otlp_grpc flush timer: send failed ({}) — {} events returned to buffer",
+                        e,
+                        count
+                    );
+                    let mut buf = inner.batch.lock().await;
+                    let new_events = std::mem::take(&mut *buf);
+                    *buf = drained;
+                    buf.extend(new_events);
                 }
             }
         });
@@ -1147,5 +1167,58 @@ mod tests {
         assert_eq!(batch_len, 0, "Owned event must not land in the batch");
         let timer_armed = output.flush_handle.lock().await.is_some();
         assert!(!timer_armed, "Owned event must not arm the flush timer");
+    }
+
+    #[tokio::test]
+    async fn flush_failure_restores_batch_to_buffer() {
+        // Regression mirror of `otlp_http`'s same-named test: the
+        // batched flush path used to drain the batch and, on
+        // transport failure, bump events_failed and drop the events.
+        // `output http` retained them for retry; OTLP was the odd
+        // one out. The fix restores the drained batch so the next
+        // write or timer firing can re-attempt.
+        let mut props = one_peer_props("http://127.0.0.1:1");
+        props.push(prop_int("batch_size", 2));
+        props.push(prop_str("batch_timeout", "30s"));
+        // Single attempt, no backoff — keeps the test fast.
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+
+        let arena_bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&arena_bump);
+        let e1 = event_with_egress(singleton_bytes(1));
+        let p1 = output.render(&e1.view_in(&arena), &arena).unwrap();
+        output.write(p1).await.unwrap();
+        assert_eq!(output.inner.batch.lock().await.len(), 1);
+
+        let e2 = event_with_egress(singleton_bytes(2));
+        let p2 = output.render(&e2.view_in(&arena), &arena).unwrap();
+        let err = output
+            .write(p2)
+            .await
+            .expect_err("flush against unreachable peer must fail");
+        assert!(
+            err.to_string().contains("otlp_grpc"),
+            "expected ship error, got: {err}"
+        );
+
+        let batch_len = output.inner.batch.lock().await.len();
+        assert_eq!(
+            batch_len, 2,
+            "flush failure must put the drained batch back into the buffer",
+        );
+        let failed = output.metrics.events_failed.load(Ordering::Relaxed);
+        assert_eq!(
+            failed, 0,
+            "events retained for retry must NOT be counted as failed yet (got {failed})",
+        );
     }
 }

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -478,7 +478,11 @@ impl OtlpHttpOutput {
             return Ok(());
         }
         let count = drained.len() as u64;
-        let result = send_batch(&self.inner, drained).await;
+        // Clone for the send so the original is available for
+        // restoration on transport error. `Bytes::clone` is a cheap
+        // refcount bump (no payload copy), so this scales linearly
+        // with batch length rather than with batch byte size.
+        let result = send_batch(&self.inner, drained.clone()).await;
         match result {
             Ok(outcome) => {
                 let rejected = outcome.rejected.min(count);
@@ -496,9 +500,18 @@ impl OtlpHttpOutput {
                 Ok(())
             }
             Err(e) => {
-                self.metrics
-                    .events_failed
-                    .fetch_add(count, Ordering::Relaxed);
+                // Transport error: put the drained batch back into
+                // the buffer for retry instead of dropping it. The
+                // queue layer counts Rendered payloads as failed and
+                // does not replay them (see queue/mod.rs), so this
+                // is the only chance these events have. `output
+                // http` does the same (PR limpid#33); OTLP was the
+                // odd one out. Do NOT bump events_failed here — the
+                // events are retained, not permanently rejected.
+                let mut batch = self.inner.batch.lock().await;
+                let new_events = std::mem::take(&mut *batch);
+                *batch = drained;
+                batch.extend(new_events);
                 Err(e)
             }
         }
@@ -526,7 +539,7 @@ impl OtlpHttpOutput {
                 return;
             }
             let count = drained.len() as u64;
-            match send_batch(&inner, drained).await {
+            match send_batch(&inner, drained.clone()).await {
                 Ok(outcome) => {
                     let rejected = outcome.rejected.min(count);
                     let written = count - rejected;
@@ -538,8 +551,19 @@ impl OtlpHttpOutput {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("otlp_http flush timer: send failed ({})", e);
-                    metrics.events_failed.fetch_add(count, Ordering::Relaxed);
+                    // Same retention contract as the write-triggered
+                    // flush above: put the drained batch back so the
+                    // next write or timer firing can retry, instead
+                    // of silently dropping events here.
+                    tracing::warn!(
+                        "otlp_http flush timer: send failed ({}) — {} events returned to buffer",
+                        e,
+                        count
+                    );
+                    let mut buf = inner.batch.lock().await;
+                    let new_events = std::mem::take(&mut *buf);
+                    *buf = drained;
+                    buf.extend(new_events);
                 }
             }
         });
@@ -1383,6 +1407,66 @@ mod tests {
         assert_eq!(batch_len, 0, "Owned event must not land in the batch");
         let timer_armed = output.flush_handle.lock().await.is_some();
         assert!(!timer_armed, "Owned event must not arm the flush timer");
+    }
+
+    #[tokio::test]
+    async fn flush_failure_restores_batch_to_buffer() {
+        // Regression: `flush()` used to drain the batch and, on
+        // transport failure, just bump events_failed and drop the
+        // drained events. `output http` retained them for retry; OTLP
+        // was the odd one out. The fix restores the drained batch
+        // into the buffer so the next write or timer firing has a
+        // chance to ship them.
+        let mut props = one_peer_props("http://127.0.0.1:1");
+        props.push(prop_int("batch_size", 2));
+        props.push(prop_str("batch_timeout", "30s"));
+        // Single attempt against the unreachable peer so the test
+        // doesn't sit through the default retry backoff.
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+
+        // First write fills the buffer below batch_size — no flush.
+        let arena_bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&arena_bump);
+        let e1 = event_with_egress(singleton_bytes(1));
+        let p1 = output.render(&e1.view_in(&arena), &arena).unwrap();
+        output.write(p1).await.unwrap();
+        assert_eq!(output.inner.batch.lock().await.len(), 1);
+
+        // Second write tips the batch over batch_size, triggers
+        // flush() against the unreachable peer, which must Err.
+        let e2 = event_with_egress(singleton_bytes(2));
+        let p2 = output.render(&e2.view_in(&arena), &arena).unwrap();
+        let err = output
+            .write(p2)
+            .await
+            .expect_err("flush against unreachable peer must fail");
+        assert!(
+            err.to_string().contains("otlp_http"),
+            "expected ship error, got: {err}"
+        );
+
+        // Regression assertion: both events must still be in the
+        // buffer (old code dropped them; the events_failed counter
+        // would have been bumped to 2).
+        let batch_len = output.inner.batch.lock().await.len();
+        assert_eq!(
+            batch_len, 2,
+            "flush failure must put the drained batch back into the buffer",
+        );
+        let failed = output.metrics.events_failed.load(Ordering::Relaxed);
+        assert_eq!(
+            failed, 0,
+            "events retained for retry must NOT be counted as failed yet (got {failed})",
+        );
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -300,7 +300,18 @@ impl<C> PeerList<C> {
                     return Ok(());
                 }
                 Err(_) => {
-                    state.cooldown_until = Some(now + PEER_COOLDOWN);
+                    // Capture the timestamp AFTER the attempt failed,
+                    // not the `now` we were called with — that was
+                    // snapshot at the START of the rotation pass.
+                    // `attempt` may take up to PEER_WRITE_TIMEOUT
+                    // (10s, see § const above), which is longer than
+                    // PEER_COOLDOWN (5s); using `now + PEER_COOLDOWN`
+                    // would set a cooldown that has already expired
+                    // and immediately re-select the bad peer on the
+                    // next write. HTTP/OTLP fixed the same shape
+                    // earlier (`output http` PR limpid#33); align
+                    // the shared helper.
+                    state.cooldown_until = Some(Instant::now() + PEER_COOLDOWN);
                     self.metrics[idx]
                         .connect_failures
                         .fetch_add(1, Ordering::Relaxed);
@@ -579,6 +590,53 @@ mod tests {
                 .events_written
                 .load(Ordering::Relaxed),
             2
+        );
+    }
+
+    #[tokio::test]
+    async fn cooldown_measured_from_failure_time_not_attempt_start() {
+        // Regression: cooldown_until used to be set to
+        // `now + PEER_COOLDOWN` where `now` was the snapshot taken
+        // at the START of the rotation pass. If `attempt` actually
+        // took longer than PEER_COOLDOWN (which is realistic:
+        // PEER_WRITE_TIMEOUT is 10 s, PEER_COOLDOWN is 5 s), the
+        // cooldown's expiry would already be in the past by the
+        // time it was written, so the very next write would
+        // immediately re-select the same broken peer. HTTP/OTLP
+        // sinks were fixed earlier; this pins the syslog-shared
+        // helper to the same contract: cooldown is anchored on
+        // failure-completion time.
+        let list = PeerList::<()>::new(peers(1));
+        let pre_call = Instant::now();
+        let delay = Duration::from_millis(300);
+
+        let _ = list
+            .write_with_rotation_now(move |_, _, _| {
+                Box::pin(async move {
+                    tokio::time::sleep(delay).await;
+                    Err(anyhow!("slow failure"))
+                })
+            })
+            .await
+            .expect_err("attempt errors → peer cools down");
+
+        let cooldown_until = list.state[0]
+            .lock()
+            .await
+            .cooldown_until
+            .expect("failure must set cooldown_until");
+
+        // Anchored on failure-completion: cooldown_until > pre_call
+        // + PEER_COOLDOWN + most of the delay. Allow generous slack
+        // for scheduling jitter. With the old code,
+        // cooldown_until == pre_call + PEER_COOLDOWN (no delay
+        // contribution).
+        let expected_floor = pre_call + PEER_COOLDOWN + Duration::from_millis(200);
+        assert!(
+            cooldown_until > expected_floor,
+            "cooldown_until ({:?}) must exceed pre_call + PEER_COOLDOWN + delay ({:?})",
+            cooldown_until,
+            expected_floor
         );
     }
 }


### PR DESCRIPTION
## Summary

Two High/Medium audit findings against \`release/0.7.8\`, both on the output side, both silent-failure shapes that \`output http\` already had the right contract for. Bundled because they're cohesive: each brings a sibling sink (\`otlp_http\`, \`otlp_grpc\`) or the shared \`syslog_peers\` helper into alignment with the existing pattern.

## Commits

### \`fix(output otlp): retain drained batch on flush failure\` (High)

\`otlp_http\` and \`otlp_grpc\` batched flush would \`std::mem::take\` the buffer, send, and on transport error bump \`events_failed\` by the batch count and drop the drained events. \`output http\` was fixed to retain the batch for retry in PR limpid#33; OTLP was the odd sink out. The asymmetry was load-bearing — the queue layer counts Rendered payloads as failed and does not replay them (see \`queue/mod.rs\`), so anything dropped at the sink boundary is gone for good.

Mirror http's contract for both OTLP sinks, in both flush paths (write-triggered and timer-spawned): put the drained batch back into the buffer on transport error, do NOT bump \`events_failed\` (the events are retained, not permanently rejected). \`send_batch\` consumes \`Vec<Bytes>\` by value, so the call site now clones for the send — \`Bytes::clone\` is a refcount bump, no payload copy.

Regression tests on both sinks: fill batch to \`batch_size - 1\`, then trip \`should_flush\` against an unreachable peer, and assert \`batch.len() == batch_size && events_failed == 0\`.

### \`fix(output syslog peers): anchor cooldown on failure-completion time\` (Medium)

The shared peer-rotation helper captured \`now = Instant::now()\` at the START of the rotation pass and, on a failed attempt, set \`cooldown_until = now + PEER_COOLDOWN\`. PEER_COOLDOWN is 5 s and \`attempt\` can legitimately take up to PEER_WRITE_TIMEOUT (10 s), so a timeout-flavoured failure would write a cooldown that has already expired by the time it lands. The next \`write\` would then immediately re-select the same broken peer. HTTP/OTLP sinks were fixed earlier; this aligns the shared helper.

Fix: capture \`Instant::now()\` AFTER the attempt fails. The pass-in \`now\` is still correct for the cooldown-expiry check at the top of the rotation loop (consistent snapshot for the pass), just not for the deadline being written.

Regression test sleeps \`attempt\` for 300 ms, then asserts \`cooldown_until > pre_call + PEER_COOLDOWN + 200 ms\`.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` (646 tests pass, +3 new regression tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)