### PR TITLE
fix(output): flush batched buffer on shutdown

### DIFF
--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -368,6 +368,26 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     /// expressions at write time (e.g. `${...}` templates in a path)
     /// override this to stash the registry. Default: no-op.
     fn attach_funcs(&mut self, _funcs: Arc<FunctionRegistry>) {}
+
+    /// Drain any internal buffer before the queue consumer stops.
+    ///
+    /// `Drop` cannot do this because it is synchronous and the
+    /// sink-side I/O is async. Batched outputs (`http`, `otlp_http`,
+    /// `otlp_grpc`) collect events in an in-memory buffer between
+    /// flushes, and on a clean shutdown those events would otherwise
+    /// be dropped: the memory queue already counted them as
+    /// delivered when the per-event `write()` returned `Ok`, the
+    /// flush timer is aborted by `Drop`, and the daemon exits with
+    /// the buffer contents still resident in memory. Override to
+    /// flush before returning. Default impl is a no-op for unbatched
+    /// sinks.
+    ///
+    /// Errors are surfaced for logging but the consumer continues
+    /// the shutdown sequence regardless — there is no further retry
+    /// path available at this point.
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Helper for `Output::write_owned` overrides that ship a single Owned
@@ -721,6 +741,10 @@ impl OutputWriter for OutputWriterWrapper {
             SinkInput::Rendered(payload) => self.0.write(payload).await,
             SinkInput::Owned(event) => self.0.write_owned(&event).await,
         }
+    }
+
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        self.0.shutdown().await
     }
 }
 

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -482,6 +482,14 @@ impl Output for HttpOutput {
         })
         .await
     }
+
+    async fn shutdown(&self) -> Result<()> {
+        // Cancel any pending timer first so it doesn't race with us
+        // for the buffer lock and end up double-flushing an
+        // already-empty buffer.
+        self.cancel_timer().await;
+        self.flush().await
+    }
 }
 
 impl HttpOutput {
@@ -1308,6 +1316,68 @@ mod tests {
         assert!(
             posted.contains("e1") && posted.contains("e2"),
             "retry must carry the same two events; got: {posted}"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_flushes_pending_batch_buffer() {
+        // Regression: under batch_size > 1 the queue-side `write()`
+        // returns Ok once the event is in the buffer, so the memory
+        // queue considers it delivered. If the daemon shuts down
+        // before the batch fills or the timer fires, Drop alone
+        // aborts the timer and leaks the buffered events. The fix
+        // gives Output a `shutdown()` method that the queue consumer
+        // calls once the consume loop exits, and HttpOutput
+        // overrides it to cancel the timer and run one final flush.
+        let (addr, received, server) = run_echo_collector().await;
+        let url = format!("http://{}/", addr);
+        let output = HttpOutput::from_properties(
+            "test",
+            &mp(&[
+                peer_block(&url),
+                // Large batch + long timer so the only thing that
+                // can drain this buffer is the explicit shutdown.
+                prop_int("batch_size", 100),
+                prop_str("batch_timeout", "30s"),
+            ]),
+        )
+        .unwrap();
+
+        let p1 = RenderedPayload::new(HttpPayload { msg: "ev1".into() });
+        output.write(p1).await.unwrap();
+        let p2 = RenderedPayload::new(HttpPayload { msg: "ev2".into() });
+        output.write(p2).await.unwrap();
+        assert_eq!(
+            output.inner.batch.lock().await.len(),
+            2,
+            "events must sit in the buffer (batch_size and timer both far away)"
+        );
+        // Server has nothing yet — neither write triggered a flush.
+        assert!(received.lock().await.is_empty());
+
+        output.shutdown().await.unwrap();
+
+        // Buffer drained.
+        assert_eq!(
+            output.inner.batch.lock().await.len(),
+            0,
+            "shutdown() must drain the buffer"
+        );
+
+        // And the request actually went out.
+        for _ in 0..50 {
+            if !received.lock().await.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        server.abort();
+        let got = received.lock().await.clone();
+        assert_eq!(got.len(), 1, "shutdown flush must POST exactly once");
+        let body = &got[0];
+        assert!(
+            body.contains("ev1") && body.contains("ev2"),
+            "shutdown POST must carry the buffered events; got: {body}"
         );
     }
 }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -370,6 +370,18 @@ impl Output for OtlpGrpcOutput {
         })
         .await
     }
+
+    async fn shutdown(&self) -> Result<()> {
+        // Same contract as `otlp_http::shutdown`: abort the timer to
+        // avoid a race for the buffer lock, then drain in one final
+        // send. Without this the queue consumer's shutdown call
+        // races the timer task, and either Drop's abort or the
+        // process exit can leave the in-flight buffer behind.
+        if let Some(h) = self.flush_handle.lock().await.take() {
+            h.abort();
+        }
+        self.flush().await
+    }
 }
 
 impl OtlpGrpcOutput {
@@ -1167,6 +1179,79 @@ mod tests {
         assert_eq!(batch_len, 0, "Owned event must not land in the batch");
         let timer_armed = output.flush_handle.lock().await.is_some();
         assert!(!timer_armed, "Owned event must not arm the flush timer");
+    }
+
+    #[tokio::test]
+    async fn shutdown_flushes_pending_batch_buffer() {
+        // Regression mirror of `output http` / `otlp_http`: when
+        // batch_size > 1 the queue-side `write()` returns Ok once
+        // the event is in the buffer, so the memory queue considers
+        // it delivered. If the daemon shuts down before the batch
+        // fills, Drop alone aborts the timer and leaks the buffer.
+        // `shutdown()` aborts the timer and runs one final flush.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let svc = RecordingLogs {
+            received: Arc::clone(&received),
+        };
+        let server = tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(LogsServiceServer::new(svc))
+                .serve_with_incoming(incoming)
+                .await;
+        });
+
+        let endpoint = format!("http://{}", addr);
+        let mut props = one_peer_props(&endpoint);
+        // Large batch + long timer: only shutdown drains the buffer.
+        props.push(prop_int("batch_size", 100));
+        props.push(prop_str("batch_timeout", "30s"));
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+
+        let arena_bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&arena_bump);
+        for ts in [1u64, 2u64] {
+            let ev = event_with_egress(singleton_bytes(ts));
+            let payload = output.render(&ev.view_in(&arena), &arena).unwrap();
+            output.write(payload).await.unwrap();
+        }
+        assert_eq!(
+            output.inner.batch.lock().await.len(),
+            2,
+            "writes must land in the buffer"
+        );
+
+        output.shutdown().await.unwrap();
+
+        assert_eq!(
+            output.inner.batch.lock().await.len(),
+            0,
+            "shutdown() must drain the buffer"
+        );
+
+        let probe = || {
+            let g = received.try_lock().ok()?;
+            if g.is_empty() { None } else { Some(g.clone()) }
+        };
+        let got = wait_for(probe).await;
+        server.abort();
+
+        assert_eq!(got.len(), 1, "shutdown flush must send exactly once");
+        let record_count: usize = got[0]
+            .resource_logs
+            .iter()
+            .flat_map(|rl| rl.scope_logs.iter())
+            .map(|sl| sl.log_records.len())
+            .sum();
+        assert_eq!(
+            record_count, 2,
+            "shutdown send must carry both buffered records"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -464,6 +464,19 @@ impl Output for OtlpHttpOutput {
         })
         .await
     }
+
+    async fn shutdown(&self) -> Result<()> {
+        // Abort any pending timer so it cannot race with us for the
+        // buffer lock. Then drain whatever is left in one final
+        // send. Without this the queue consumer's `shutdown()` call
+        // would race the timer and the in-flight events could be
+        // dropped between the timer's abort (via `Drop`) and the
+        // process exit.
+        if let Some(h) = self.flush_handle.lock().await.take() {
+            h.abort();
+        }
+        self.flush().await
+    }
 }
 
 impl OtlpHttpOutput {
@@ -1466,6 +1479,68 @@ mod tests {
         assert_eq!(
             failed, 0,
             "events retained for retry must NOT be counted as failed yet (got {failed})",
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_flushes_pending_batch_buffer() {
+        // Regression mirror of `output http`: when batch_size > 1 the
+        // queue-side `write()` returns Ok once the event is in the
+        // buffer, so the memory queue considers it delivered. If the
+        // daemon shuts down before the batch fills, Drop alone aborts
+        // the timer and leaks the buffer. `shutdown()` aborts the
+        // timer and runs one final flush.
+        let (addr, received, server) = run_http_collector("http_protobuf").await;
+        let endpoint = format!("http://{}/v1/logs", addr);
+        let mut props = one_peer_props(&endpoint);
+        props.push(prop_str("protocol", "http_protobuf"));
+        // Large batch + long timer: nothing but `shutdown()` can
+        // drain this buffer.
+        props.push(prop_int("batch_size", 100));
+        props.push(prop_str("batch_timeout", "30s"));
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+
+        // Drive the batched path with two render→write round trips.
+        let arena_bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&arena_bump);
+        for ts in [1u64, 2u64] {
+            let ev = event_with_egress(singleton_bytes(ts));
+            let payload = output.render(&ev.view_in(&arena), &arena).unwrap();
+            output.write(payload).await.unwrap();
+        }
+        assert_eq!(
+            output.inner.batch.lock().await.len(),
+            2,
+            "writes must land in the buffer (batch_size and timer both far away)"
+        );
+        assert!(received.lock().await.is_empty());
+
+        output.shutdown().await.unwrap();
+
+        assert_eq!(
+            output.inner.batch.lock().await.len(),
+            0,
+            "shutdown() must drain the buffer"
+        );
+
+        for _ in 0..50 {
+            if !received.lock().await.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        server.abort();
+        let got = received.lock().await.clone();
+        assert_eq!(got.len(), 1, "shutdown flush must POST exactly once");
+        let record_count: usize = got[0]
+            .resource_logs
+            .iter()
+            .flat_map(|rl| rl.scope_logs.iter())
+            .map(|sl| sl.log_records.len())
+            .sum();
+        assert_eq!(
+            record_count, 2,
+            "shutdown POST must carry both buffered records",
         );
     }
 

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -409,6 +409,14 @@ pub enum BackoffStrategy {
 #[async_trait::async_trait]
 pub trait OutputWriter: Send + Sync + 'static {
     async fn consume(&self, input: SinkInput) -> anyhow::Result<()>;
+
+    /// Drain any buffered events before the consumer stops. Forwarded
+    /// to the underlying `Output::shutdown` for `OutputWriterWrapper`;
+    /// default no-op for any future writer kind that holds no
+    /// internal buffer.
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 /// Run a queue consumer that drains events and writes them to an output.
@@ -448,6 +456,15 @@ pub async fn run_queue_consumer(
                 }
             }
         }
+    }
+
+    // Batched sinks hold an in-memory buffer that queue-side `write()`
+    // has already counted as delivered. Drop alone would abort the
+    // flush timer and leak those events; tell the output to drain
+    // itself before we exit. Both break paths above (shutdown signal
+    // and queue-closed) come through here so the contract is uniform.
+    if let Err(e) = writer.shutdown().await {
+        warn!("output '{}': shutdown flush failed: {}", name, e);
     }
 
     info!("output '{}': queue consumer stopped", name);


### PR DESCRIPTION
## Summary

High-severity audit finding against \`release/0.7.8\`: \`http\`, \`otlp_http\`, and \`otlp_grpc\` are batched sinks — the queue-side \`write()\` returns Ok once the event lands in their in-memory buffer (so the memory queue counts it as delivered), and the actual flush happens when \`batch_size\` is hit or when the per-output timer fires. On daemon shutdown those sinks' \`Drop\` impl aborts the timer and the process exits with the buffer contents still resident; the log line claiming events "will be re-delivered from queue" is not true for the memory queue.

\`Drop\` cannot fix this because it is synchronous and the sink I/O is async. This PR gives \`Output\` an async \`shutdown()\` hook with a default no-op, overrides it on the three batched sinks (abort the timer to dodge the buffer-lock race, then run one final flush), and calls it from \`run_queue_consumer\` once the consume loop exits — both shutdown-signal and queue-closed break paths fall through the same shutdown call so the contract is uniform. \`OutputWriter\` gets a matching default-no-op shutdown so the trait stays object-safe for the queue's dyn storage.

This makes the implementation match what [\`docs/src/operations/systemd.md\`](docs/src/operations/systemd.md#L60) already promises as step 3 of "Graceful shutdown" (Output queues flush), and brings http/OTLP in line with kafka's existing shutdown-flush behaviour ([\`docs/src/outputs/kafka.md:153\`](docs/src/outputs/kafka.md#L153)).

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` (649 tests pass, including 3 new shutdown-flush regression tests — one per batched sink)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Regression tests configure a large \`batch_size\` and long \`batch_timeout\` so nothing but the explicit \`shutdown()\` can drain the buffer, write two events, call \`shutdown()\`, and assert (a) the buffer is empty and (b) the receiver got exactly one POST/request carrying both events

🤖 Generated with [Claude Code](https://claude.com/claude-code)