### PR TITLE
fix(queue): reject misconfigured secondary refs at startup

### DIFF
--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -100,11 +100,32 @@ impl Runtime {
             metrics_registry.register_output(name, created.metrics);
             tap.register(&format!("output {}", name)).await;
 
-            output_receivers.push((receiver, created.writer, retry_config, output_metrics));
+            output_receivers.push((
+                name.clone(),
+                receiver,
+                created.writer,
+                retry_config,
+                output_metrics,
+            ));
+        }
+
+        // Validate every output's `secondary` reference up front,
+        // before we spawn consumer tasks. See `validate_secondary_refs`
+        // for the two failure modes (typo, self-reference) that used
+        // to slip through silently.
+        {
+            let known: std::collections::HashSet<&str> =
+                output_senders.keys().map(String::as_str).collect();
+            validate_secondary_refs(
+                output_receivers
+                    .iter()
+                    .map(|(n, _, _, rc, _)| (n.as_str(), rc.secondary.as_deref())),
+                &known,
+            )?;
         }
 
         // Start queue consumers (no metrics counting here — output does it)
-        for (receiver, writer, retry_config, output_metrics) in output_receivers {
+        for (_name, receiver, writer, retry_config, output_metrics) in output_receivers {
             let secondary_sender = retry_config
                 .secondary
                 .as_ref()
@@ -326,6 +347,48 @@ impl Runtime {
             }
         }
     }
+}
+
+/// Reject misconfigured `secondary` references before any consumer task starts.
+///
+/// `secondary` lookup at queue-consumer spawn time was
+/// `output_senders.get(s).cloned()` — a `None` for either reason
+/// silently disabled the safety net. Two operator-visible failure
+/// modes:
+///
+/// - **typo** (`secondary foo_typo` where no `foo_typo` exists): the
+///   queue consumer just logs "no secondary" and drops the event.
+///   The operator configured a safety net and got nothing.
+/// - **self-reference** (`secondary <own_name>`): exhausted-retry
+///   events get routed back into the same queue, looping forever on
+///   any poison event. Worse on disk-backed queues (each loop
+///   re-persists to the tail).
+///
+/// Both are config errors. Surface them at startup so the daemon
+/// doesn't pretend to be healthy.
+fn validate_secondary_refs<'a>(
+    refs: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+    known_outputs: &std::collections::HashSet<&str>,
+) -> Result<()> {
+    for (name, secondary) in refs {
+        let Some(target) = secondary else { continue };
+        if target == name {
+            return Err(anyhow::anyhow!(
+                "output '{name}': secondary cannot reference itself; \
+                 a self-referential secondary would form an infinite \
+                 retry loop on a poison event"
+            ));
+        }
+        if !known_outputs.contains(target) {
+            let mut listed: Vec<&str> = known_outputs.iter().copied().collect();
+            listed.sort_unstable();
+            return Err(anyhow::anyhow!(
+                "output '{name}': secondary '{target}' is not a known output; \
+                 configured outputs: {listed:?}"
+            ));
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -751,5 +814,66 @@ mod tests {
         // All 8 events should have been attributed to the shared worker.
         assert_eq!(worker.metrics.events_received.load(Ordering::Relaxed), 8);
         assert_eq!(worker.metrics.events_dropped.load(Ordering::Relaxed), 8);
+    }
+
+    fn known<'a>(names: &[&'a str]) -> std::collections::HashSet<&'a str> {
+        names.iter().copied().collect()
+    }
+
+    #[test]
+    fn validate_secondary_refs_accepts_unset() {
+        // Baseline: outputs without a `secondary` configured pass
+        // through cleanly.
+        let refs = [("primary", None), ("backup", None)];
+        let known = known(&["primary", "backup"]);
+        validate_secondary_refs(refs.iter().copied(), &known).unwrap();
+    }
+
+    #[test]
+    fn validate_secondary_refs_accepts_resolved_target() {
+        // Baseline: a `secondary` that names a real, different
+        // output passes.
+        let refs = [("primary", Some("backup")), ("backup", None)];
+        let known = known(&["primary", "backup"]);
+        validate_secondary_refs(refs.iter().copied(), &known).unwrap();
+    }
+
+    #[test]
+    fn validate_secondary_refs_rejects_self_reference() {
+        // Regression: self-reference used to silently route
+        // exhausted-retry events back into the same queue, looping
+        // forever on a poison event (worse on disk-backed queues).
+        let refs = [("primary", Some("primary"))];
+        let known = known(&["primary"]);
+        let err = validate_secondary_refs(refs.iter().copied(), &known)
+            .expect_err("self-reference must fail validation");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("primary") && msg.contains("itself"),
+            "expected self-reference message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_secondary_refs_rejects_unknown_target() {
+        // Regression: a typo'd secondary name used to silently
+        // disable the safety net at queue-consumer spawn time —
+        // `output_senders.get(s).cloned()` returned None and the
+        // consumer dropped failed events with "no secondary".
+        let refs = [("primary", Some("backup_typo"))];
+        let known = known(&["primary", "backup"]);
+        let err = validate_secondary_refs(refs.iter().copied(), &known)
+            .expect_err("unknown secondary must fail validation");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("backup_typo") && msg.contains("not a known output"),
+            "expected unknown-target message, got: {msg}"
+        );
+        // Operator-friendly: surface the actual configured names so
+        // the typo is easy to spot.
+        assert!(
+            msg.contains("backup"),
+            "error must list known outputs to aid debugging; got: {msg}"
+        );
     }
 }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -370,6 +370,10 @@ fn validate_secondary_refs<'a>(
     refs: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
     known_outputs: &std::collections::HashSet<&str>,
 ) -> Result<()> {
+    // First pass: per-edge checks (typo + direct self-reference).
+    // Collect the edge map at the same time for the cycle pass below.
+    let mut edges: std::collections::HashMap<&str, &str> =
+        std::collections::HashMap::new();
     for (name, secondary) in refs {
         let Some(target) = secondary else { continue };
         if target == name {
@@ -387,7 +391,38 @@ fn validate_secondary_refs<'a>(
                  configured outputs: {listed:?}"
             ));
         }
+        edges.insert(name, target);
     }
+
+    // Second pass: indirect cycle detection (A→B→A, A→B→C→A, …).
+    // Same poison-event ping-pong as the direct self-reference case;
+    // on disk-backed queues each loop iteration also re-persists the
+    // event, so the cycle grows the queue files unboundedly. With at
+    // most one outgoing edge per node (each output has a single
+    // `secondary`), the chain from any node is deterministic and
+    // either terminates at a node without a secondary or revisits a
+    // node — visit each starting node in turn and break on the first
+    // repeat.
+    for &start in edges.keys() {
+        let mut visited: Vec<&str> = vec![start];
+        let mut cursor = start;
+        while let Some(&next) = edges.get(cursor) {
+            if let Some(repeat_idx) = visited.iter().position(|n| *n == next) {
+                // Build the cycle path for an operator-friendly error.
+                let mut cycle: Vec<&str> = visited[repeat_idx..].to_vec();
+                cycle.push(next);
+                return Err(anyhow::anyhow!(
+                    "secondary cycle detected ({path}); a cycle would form an \
+                     infinite retry loop on a poison event, and on disk-backed \
+                     queues each iteration re-persists the event",
+                    path = cycle.join(" -> "),
+                ));
+            }
+            visited.push(next);
+            cursor = next;
+        }
+    }
+
     Ok(())
 }
 
@@ -852,6 +887,63 @@ mod tests {
             msg.contains("primary") && msg.contains("itself"),
             "expected self-reference message, got: {msg}"
         );
+    }
+
+    #[test]
+    fn validate_secondary_refs_rejects_indirect_cycle_two_node() {
+        // Horizontal expansion of the self-reference finding: A→B→A
+        // is the same poison-event ping-pong as A→A, just with one
+        // hop in between. Per-edge check passes (each target is
+        // valid + not self), but the cycle still grows disk-backed
+        // queues unboundedly under repeated retry exhaustion.
+        let refs = [("primary", Some("backup")), ("backup", Some("primary"))];
+        let known = known(&["primary", "backup"]);
+        let err = validate_secondary_refs(refs.iter().copied(), &known)
+            .expect_err("two-node secondary cycle must fail validation");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cycle"),
+            "expected cycle error, got: {msg}"
+        );
+        // Operator-friendly: the cycle path must be shown so the
+        // operator can see which secondary edge to remove.
+        assert!(
+            msg.contains("primary") && msg.contains("backup"),
+            "cycle error must name involved outputs; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_secondary_refs_rejects_indirect_cycle_three_node() {
+        // A→B→C→A — same shape with one more hop. Pin that the
+        // cycle detector follows the chain beyond two nodes.
+        let refs = [
+            ("a", Some("b")),
+            ("b", Some("c")),
+            ("c", Some("a")),
+        ];
+        let known = known(&["a", "b", "c"]);
+        let err = validate_secondary_refs(refs.iter().copied(), &known)
+            .expect_err("three-node secondary cycle must fail validation");
+        assert!(
+            err.to_string().contains("cycle"),
+            "expected cycle error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_secondary_refs_accepts_acyclic_chain() {
+        // Baseline: A→B→C is a valid dead-letter chain (anything
+        // exhausted on A spills to B, anything exhausted on B
+        // spills to C, and C has no secondary so events that
+        // exhaust on C are dropped). No cycle, must pass.
+        let refs = [
+            ("a", Some("b")),
+            ("b", Some("c")),
+            ("c", None),
+        ];
+        let known = known(&["a", "b", "c"]);
+        validate_secondary_refs(refs.iter().copied(), &known).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two Medium audit findings against \`release/0.7.8\` on the same site (queue-consumer spawn), plus a third — indirect cycle — caught during horizontal-expansion review of the second.

Pre-fix the secondary lookup was

\`\`\`rust
retry_config.secondary
    .as_ref()
    .and_then(|s| output_senders.get(s).cloned())
\`\`\`

so three failure modes slipped through silently:

1. **typo** — \`secondary foo_typo\` where no \`foo_typo\` output exists. Lookup returned \`None\`, the queue consumer just logged "no secondary" on exhausted retries, and the operator never knew the safety net they configured was disconnected.
2. **direct self-reference** — \`secondary <own_name>\`. Lookup succeeded, and exhausted-retry events were routed back into the same queue. A single poison event then looped forever on retry-exhaust-route; on disk-backed queues each loop also re-persisted to the tail, growing the queue file unboundedly.
3. **indirect cycle** — A→B→A, A→B→C→A, …. Same poison-event ping-pong shape as (2), just with hops between, same disk-queue unbounded-growth pathology. Surfaced as a horizontal-expansion check during PR review.

## Commits

- [\`4ffcea9 fix(queue): reject misconfigured secondary refs at startup\`](crates/limpid/src/runtime.rs) — per-edge checks: typo (target not in \`output_senders\`) and direct self-reference. Extracted as a free fn \`validate_secondary_refs\` so the policy is unit-testable in isolation; called once before any consumer task spawns. Unknown-target errors list the configured output names to make the operator's typo easy to spot.
- [\`4500daa fix(queue): also reject indirect secondary cycles\`](crates/limpid/src/runtime.rs#L350) — same fn gets a second pass: walk the secondary chain from every starting node and break on the first repeat. With at most one outgoing edge per node (each output has a single \`secondary\`) the chain is deterministic, so this is a simple walk, not a full graph traversal. Cycle errors include the full cycle path so the operator can see which edge to remove.

## Horizontal-expansion review

Cycle detection (3) came out of asking "what other shapes of the self-reference finding exist?". The wider sweep also checked: pipeline output/process refs (already validated recursively in \`pipeline.rs:167-216\`), cooldown timing (already fixed across http/otlp/syslog in earlier PRs), batched-output shutdown drop (already fixed in PR limpid#49), table refs (runtime function dispatch raises an error, not silent). \`secondary\` was the remaining unaudited name-ref site.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` (656 tests pass, +7 new validate tests: accepts unset / accepts resolved target / rejects self / rejects 2-node cycle / rejects 3-node cycle / accepts acyclic chain / rejects unknown target)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)