### PR TITLE
fix(queue): commit disk cursor on consumer ack, not on recv

### DIFF
--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -72,10 +72,22 @@ pub struct DiskQueueReceiver {
     state: Arc<Mutex<DiskQueueState>>,
     notify: Arc<tokio::sync::Notify>,
     closed: Arc<AtomicBool>,
-    /// Current read segment sequence.
+    /// In-memory read cursor — the next byte to read. Advances as
+    /// `recv()` returns events; NOT persisted on disk between recv
+    /// and ack. A crash between recv and ack rolls back to the
+    /// acked cursor below, so the unacked event replays on restart
+    /// (at-least-once contract — matches Kafka/RabbitMQ).
     read_seq: u64,
-    /// Current byte offset within the read segment.
     read_offset: u64,
+    /// Persisted cursor — the last byte the consumer has explicitly
+    /// acknowledged as processed. `save_cursor` is only called after
+    /// `ack()` advances this; segment files below `acked_seq` are
+    /// also deleted by `ack()`. The pre-fix code saved the read
+    /// cursor immediately on each `recv()`, which made the disk
+    /// queue at-most-once: a crash mid-write lost the in-flight
+    /// event because the cursor said it had been consumed.
+    acked_seq: u64,
+    acked_offset: u64,
     dir: PathBuf,
 }
 
@@ -115,6 +127,11 @@ pub fn create_disk_queue(
             closed,
             read_seq,
             read_offset,
+            // Boot up with acked == read: anything before
+            // `read_offset` was acked by a previous run (that's
+            // what `recover_state` returned).
+            acked_seq: read_seq,
+            acked_offset: read_offset,
             dir,
         },
     ))
@@ -175,6 +192,57 @@ impl DiskQueueReceiver {
         self.try_read_next()
     }
 
+    /// Commit progress to disk: persist the cursor and reclaim fully-
+    /// consumed segments. Called by the queue consumer after each
+    /// event's disposition is decided (delivered, routed to secondary,
+    /// or dropped — all three are "done from this queue's POV").
+    ///
+    /// Before this hook existed the disk queue was at-most-once on
+    /// crashes: `recv()` advanced and persisted the cursor in one
+    /// shot, so a crash between the event being read and the consumer
+    /// actually writing it downstream lost the event. The contract is
+    /// now at-least-once — a crash mid-write replays the un-acked
+    /// event on restart (matches Kafka/RabbitMQ). Downstreams that
+    /// can't tolerate duplicates need idempotent ingestion; the
+    /// queue documents this.
+    pub fn ack(&mut self) {
+        if self.acked_seq == self.read_seq && self.acked_offset == self.read_offset {
+            // Idempotent ack — nothing new to commit. Cheap no-op
+            // path so callers can ack defensively after every event
+            // even if a prior ack already covered the position
+            // (e.g. drain-loop polling the empty tail).
+            return;
+        }
+
+        // Delete every fully-consumed segment whose seq is strictly
+        // below the new acked seq. We held them through recv() so
+        // crash-replay could find the in-flight event; once ack
+        // advances past them they're permanently consumed.
+        for stale_seq in self.acked_seq..self.read_seq {
+            let seg_path = segment_path(&self.dir, stale_seq);
+            if let Err(e) = fs::remove_file(&seg_path) {
+                // Missing file is acceptable (segment may have been
+                // GC'd already); other errors are operator-visible
+                // but non-fatal — leaving the segment around just
+                // wastes disk, not correctness.
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    warn!(
+                        "disk queue: failed to remove consumed segment {}: {}",
+                        stale_seq, e
+                    );
+                } else {
+                    debug!("disk queue: removed consumed segment {}", stale_seq);
+                }
+            } else {
+                debug!("disk queue: removed consumed segment {}", stale_seq);
+            }
+        }
+
+        self.acked_seq = self.read_seq;
+        self.acked_offset = self.read_offset;
+        save_cursor(&self.dir, self.acked_seq, self.acked_offset);
+    }
+
     fn try_read_next(&mut self) -> Option<Event> {
         loop {
             let seg_path = segment_path(&self.dir, self.read_seq);
@@ -227,7 +295,14 @@ impl DiskQueueReceiver {
                 }
 
                 self.read_offset += bytes_read as u64;
-                save_cursor(&self.dir, self.read_seq, self.read_offset);
+                // Do NOT save_cursor here. The cursor on disk only
+                // advances when the consumer calls `ack()`, after the
+                // event has been successfully handed off downstream.
+                // Returning here with the in-memory `read_offset`
+                // already moved gives the recv side an in-flight
+                // position; if the process crashes before `ack()`,
+                // restart re-reads from `acked_offset` and replays
+                // this event.
 
                 if let Some(event) = Event::from_json(trimmed) {
                     return Some(event);
@@ -246,19 +321,16 @@ impl DiskQueueReceiver {
             };
 
             if self.read_seq < write_seq {
-                // Delete consumed segment
-                if let Err(e) = fs::remove_file(&seg_path) {
-                    warn!(
-                        "disk queue: failed to remove consumed segment {}: {}",
-                        self.read_seq, e
-                    );
-                } else {
-                    debug!("disk queue: removed consumed segment {}", self.read_seq);
-                }
+                // Advance the in-memory read cursor to the next
+                // segment, but do NOT delete the current one or save
+                // the cursor yet — both are tied to `ack()`. The
+                // current segment may still hold the in-flight event
+                // (the one most recently returned by `recv()` but not
+                // yet acked); deleting it now would lose that event
+                // on crash-and-replay.
                 self.read_seq += 1;
                 self.read_offset = 0;
                 self.sync_read_seq();
-                save_cursor(&self.dir, self.read_seq, self.read_offset);
                 continue; // loop instead of recurse
             }
 
@@ -666,5 +738,91 @@ mod tests {
         std::fs::write(cursor_path(dir.path()), "not-a-cursor").unwrap();
         let (seq, off) = load_cursor(dir.path());
         assert_eq!((seq, off), (0, 0));
+    }
+
+    // ---------- ack / replay invariants ----------
+
+    #[tokio::test]
+    async fn unacked_recv_replays_on_reopen() {
+        // Regression: pre-fix the disk queue saved the cursor inside
+        // `recv()` immediately on each event, so the queue claimed
+        // events as consumed before the consumer had a chance to
+        // ship them downstream. A crash between recv and write lost
+        // the event because the on-disk cursor was already past it.
+        // The fix delays cursor persistence until `ack()`, so the
+        // un-acked event is replayed on the next open.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        {
+            let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
+            tx.send(make_event("<134>e1")).await;
+            tx.send(make_event("<134>e2")).await;
+            // Receive e1 but don't ack — simulates a process that
+            // started shipping it and crashed before completing.
+            let e1 = rx.recv().await.unwrap();
+            assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>e1");
+            // rx is dropped here without `ack()`.
+        }
+
+        {
+            let (_tx, mut rx) = create_disk_queue(path, 0).unwrap();
+            let e1 = rx.recv().await.unwrap();
+            assert_eq!(
+                String::from_utf8_lossy(&e1.ingress),
+                "<134>e1",
+                "unacked event must replay on reopen (at-least-once contract)",
+            );
+            // And e2 follows in order.
+            let e2 = rx.recv().await.unwrap();
+            assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>e2");
+        }
+    }
+
+    #[tokio::test]
+    async fn ack_persists_cursor_so_acked_event_does_not_replay() {
+        // Baseline of the contract above: once ack runs, the
+        // persisted cursor is past the acked event, so reopen
+        // resumes from the next un-acked event.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        {
+            let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
+            tx.send(make_event("<134>e1")).await;
+            tx.send(make_event("<134>e2")).await;
+            let e1 = rx.recv().await.unwrap();
+            assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>e1");
+            rx.ack();
+            // Now drop without acking e2.
+        }
+
+        {
+            let (_tx, mut rx) = create_disk_queue(path, 0).unwrap();
+            // Cursor is past e1, so the next recv starts at e2.
+            let next = rx.recv().await.unwrap();
+            assert_eq!(
+                String::from_utf8_lossy(&next.ingress),
+                "<134>e2",
+                "ack must persist the cursor; acked event must not replay",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn ack_is_idempotent_when_nothing_new_to_commit() {
+        // ack() is a no-op when acked == read. The drain loop and
+        // any defensive consumer-side double-ack should incur no
+        // disk write and no error.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
+        tx.send(make_event("<134>only")).await;
+        let _ = rx.recv().await.unwrap();
+        rx.ack();
+        // Second ack with nothing new to commit must be a clean
+        // no-op (no double-delete attempts, no panic).
+        rx.ack();
+        rx.ack();
     }
 }

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -289,6 +289,24 @@ impl QueueReceiver {
             ReceiverInner::Disk(rx) => rx.try_recv().map(SinkInput::Owned),
         }
     }
+
+    /// Commit the most recent `recv()` as processed. For the disk
+    /// backend this advances the persisted cursor and reclaims
+    /// fully-consumed segments — the actual durability hook. For the
+    /// memory backend this is a no-op (mpsc removes events on
+    /// `recv()`; there is no separate persistent cursor to advance).
+    ///
+    /// The consumer is expected to call `ack()` after every event's
+    /// final disposition is decided — delivered, routed to secondary,
+    /// or given up on (= "dropped" with retries exhausted). All three
+    /// dispositions mean the event no longer needs to live in the
+    /// queue. Skipping the call is safe (= the next call's progress
+    /// covers it) but unnecessarily defers cursor commits.
+    pub fn ack(&mut self) {
+        if let ReceiverInner::Disk(rx) = &mut self.inner {
+            rx.ack();
+        }
+    }
 }
 
 /// Create a sender/receiver pair.
@@ -448,6 +466,17 @@ pub async fn run_queue_consumer(
                 match input {
                     Some(input) => {
                         write_with_retry(writer.as_ref(), input, &retry_config, &secondary_sender, &name, &metrics, tap.as_ref()).await;
+                        // Acknowledge the event regardless of
+                        // disposition (delivered, routed to
+                        // secondary, or retries exhausted): from
+                        // this queue's POV the event has been
+                        // processed. For disk queues this is the
+                        // durability commit — `recv()` returned the
+                        // event with an in-memory cursor only, the
+                        // persisted cursor advances here. Skipping
+                        // the call on a crash gives at-least-once
+                        // replay on restart.
+                        receiver.ack();
                     }
                     None => {
                         info!("output '{}': queue closed", name);
@@ -491,6 +520,10 @@ async fn drain_remaining(
             tap,
         )
         .await;
+        // Mirror the steady-state ack contract: each event's
+        // disposition is committed to disk before we move on, so a
+        // crash mid-drain still replays exactly the un-acked tail.
+        receiver.ack();
         count += 1;
     }
     if count > 0 {

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -372,8 +372,7 @@ fn validate_secondary_refs<'a>(
 ) -> Result<()> {
     // First pass: per-edge checks (typo + direct self-reference).
     // Collect the edge map at the same time for the cycle pass below.
-    let mut edges: std::collections::HashMap<&str, &str> =
-        std::collections::HashMap::new();
+    let mut edges: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
     for (name, secondary) in refs {
         let Some(target) = secondary else { continue };
         if target == name {
@@ -901,10 +900,7 @@ mod tests {
         let err = validate_secondary_refs(refs.iter().copied(), &known)
             .expect_err("two-node secondary cycle must fail validation");
         let msg = err.to_string();
-        assert!(
-            msg.contains("cycle"),
-            "expected cycle error, got: {msg}"
-        );
+        assert!(msg.contains("cycle"), "expected cycle error, got: {msg}");
         // Operator-friendly: the cycle path must be shown so the
         // operator can see which secondary edge to remove.
         assert!(
@@ -917,11 +913,7 @@ mod tests {
     fn validate_secondary_refs_rejects_indirect_cycle_three_node() {
         // A→B→C→A — same shape with one more hop. Pin that the
         // cycle detector follows the chain beyond two nodes.
-        let refs = [
-            ("a", Some("b")),
-            ("b", Some("c")),
-            ("c", Some("a")),
-        ];
+        let refs = [("a", Some("b")), ("b", Some("c")), ("c", Some("a"))];
         let known = known(&["a", "b", "c"]);
         let err = validate_secondary_refs(refs.iter().copied(), &known)
             .expect_err("three-node secondary cycle must fail validation");
@@ -937,11 +929,7 @@ mod tests {
         // exhausted on A spills to B, anything exhausted on B
         // spills to C, and C has no secondary so events that
         // exhaust on C are dropped). No cycle, must pass.
-        let refs = [
-            ("a", Some("b")),
-            ("b", Some("c")),
-            ("c", None),
-        ];
+        let refs = [("a", Some("b")), ("b", Some("c")), ("c", None)];
         let known = known(&["a", "b", "c"]);
         validate_secondary_refs(refs.iter().copied(), &known).unwrap();
     }


### PR DESCRIPTION
## Summary

High-severity audit finding on \`release/0.7.8\`: the disk queue saved its read cursor inside \`recv()\` immediately after each event was returned. From the queue's POV the event was already consumed before the queue consumer even had a chance to hand it off downstream. A crash between recv and the output write lost the event: on restart the persisted cursor sat past the un-shipped record, so it was never replayed — defeating the "retry / restart re-delivers" contract the disk queue exists for.

Move to the standard durable-queue contract (Kafka/RabbitMQ shape): \`recv()\` only advances an in-memory cursor, and a new \`ack()\` hook persists progress + reclaims consumed segments. The queue consumer calls \`ack()\` after every event's disposition is decided — delivered, routed to secondary, or retries exhausted — so the on-disk cursor only moves once the event has reached a terminal state. A process kill anywhere before \`ack()\` replays the un-acked event on next start.

## Contract change

The disk queue shifts from **at-most-once** (= silent loss on crash) to **at-least-once** (= duplicates possible on crash-replay). This is the standard durable-queue tradeoff and matches the existing [\`docs/src/design-principles.md:76\`](docs/src/design-principles.md#L76) promise ("optionally persist to disk so a crash does not lose events in flight"). Downstream sinks that can't tolerate duplicates need idempotent ingestion; an explicit operator note belongs in the 0.7.8 CHANGELOG release entry.

Memory queue's \`ack()\` is a no-op (mpsc removes events on \`recv()\` already; no separate persistent cursor to advance).

## Commits

- [\`53b73e1 fix(queue): commit disk cursor on consumer ack, not on recv\`](crates/limpid/src/queue/disk.rs) — split read cursor (\`read_seq\`/\`read_offset\`, in-memory) from acked cursor (\`acked_seq\`/\`acked_offset\`, persisted). \`recv()\` no longer calls \`save_cursor\` or deletes segments. New \`pub fn ack()\` does both atomically; idempotent when nothing new. \`run_queue_consumer\` and \`drain_remaining\` call \`receiver.ack()\` after each \`write_with_retry\`. Regression tests cover unacked-replay-on-reopen (the bug), ack-persists-cursor, and ack-idempotency.
- \`f0a831a chore: cargo fmt --all\` — picks up runtime.rs fmt drift left over from PR limpid#50.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` (659 tests pass, +3 disk-ack regression)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)