### PR TITLE
fix(check): reject misplaced and duplicate switch default arms

### DIFF
--- a/crates/limpid/src/check/control_flow.rs
+++ b/crates/limpid/src/check/control_flow.rs
@@ -10,7 +10,7 @@
 //! Catch bodies pre-bind `workspace._error` as `String` to mirror the
 //! runtime convention.
 
-use crate::dsl::ast::{BranchBody, IfChain, ProcessStatement, SwitchArm};
+use crate::dsl::ast::{BranchBody, IfChain, ProcessStatement, SwitchStmtArm};
 use crate::functions::FunctionRegistry;
 use crate::modules::schema::FieldType;
 use crate::pipeline::CompiledConfig;
@@ -89,7 +89,7 @@ pub(super) fn analyze_if_chain(
 /// every input; without one we add the starting bindings as the implicit
 /// "fell through" branch.
 pub(super) fn analyze_switch(
-    arms: &[SwitchArm],
+    arms: &[SwitchStmtArm],
     pipeline_name: &str,
     config: &CompiledConfig,
     registry: &FunctionRegistry,
@@ -175,7 +175,7 @@ pub(super) fn analyze_inline_if(
 
 /// `switch` inside a process body — process-statement bodies only.
 pub(super) fn analyze_inline_switch(
-    arms: &[SwitchArm],
+    arms: &[SwitchStmtArm],
     pipeline_name: &str,
     registry: &FunctionRegistry,
     bindings: &mut Bindings,

--- a/crates/limpid/src/check/control_flow.rs
+++ b/crates/limpid/src/check/control_flow.rs
@@ -10,14 +10,79 @@
 //! Catch bodies pre-bind `workspace._error` as `String` to mirror the
 //! runtime convention.
 
-use crate::dsl::ast::{BranchBody, IfChain, ProcessStatement, SwitchStmtArm};
+use crate::dsl::ast::{BranchBody, IfChain, ProcessStatement, SwitchArm, SwitchStmtArm};
 use crate::functions::FunctionRegistry;
 use crate::modules::schema::FieldType;
 use crate::pipeline::CompiledConfig;
 
 use super::bindings::{Bindings, intersect_branches};
 use super::expr_types;
-use super::{Diagnostic, analyze_pipeline_stmt, analyze_process_stmt};
+use super::{DiagKind, Diagnostic, analyze_pipeline_stmt, analyze_process_stmt};
+
+/// Reject `switch` constructs whose `default` arm isn't last or
+/// appears more than once.
+///
+/// The runtime walks arms in source order and dispatches at the first
+/// match — `default` matches everything, so any arm after a `default`
+/// is unreachable. Two failure modes:
+///
+/// - **default not last** (e.g. `default { … } case 1 { … }`): every
+///   event hits the `default` arm and the trailing arms never run.
+///   Operators reading the source see "case 1 is configured" and
+///   reasonably expect it to fire; silent unreachability misleads.
+/// - **multiple defaults**: ambiguous, only the first runs. Almost
+///   certainly an operator typo (intended one `default` plus a pattern
+///   arm).
+///
+/// Both surface as `DiagKind::Dataflow` errors so `--check` blocks the
+/// deploy. The runtime behaviour is unchanged — this is a pre-load
+/// gate, not a behavioural fix.
+///
+/// Generic over the arm body type so the same helper covers both
+/// statement-form (`SwitchStmtArm`, called from this file) and
+/// expression-form (`SwitchExprArm`, called from `expr_types` and
+/// `function`) switches; the check looks at `pattern.is_some()` only
+/// and never touches the body.
+pub(super) fn validate_switch_default_position<B>(
+    arms: &[SwitchArm<B>],
+    pipeline_name: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut first_default: Option<usize> = None;
+    for (i, arm) in arms.iter().enumerate() {
+        if arm.pattern.is_some() {
+            continue;
+        }
+        match first_default {
+            None => {
+                first_default = Some(i);
+                if i + 1 < arms.len() {
+                    diagnostics.push(Diagnostic::error_kind(
+                        DiagKind::Dataflow,
+                        format!(
+                            "`switch` in pipeline '{pipeline_name}': `default` arm \
+                             is at position {i} of {n} but must be the last arm; \
+                             the {trailing} arm(s) after `default` are unreachable \
+                             (the runtime dispatches at the first match)",
+                            n = arms.len(),
+                            trailing = arms.len() - i - 1,
+                        ),
+                    ));
+                }
+            }
+            Some(prev) => {
+                diagnostics.push(Diagnostic::error_kind(
+                    DiagKind::Dataflow,
+                    format!(
+                        "`switch` in pipeline '{pipeline_name}': multiple `default` \
+                         arms (positions {prev} and {i}); only one is allowed and \
+                         only the first runs"
+                    ),
+                ));
+            }
+        }
+    }
+}
 
 /// `if`/`else if`/`else` chain at *pipeline* statement level — branches
 /// can contain pipeline statements (`output o`, `process p`, etc.) as
@@ -97,6 +162,7 @@ pub(super) fn analyze_switch(
     bindings: &mut Bindings,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    validate_switch_default_position(arms, pipeline_name, diagnostics);
     let starting = bindings.clone();
     let mut results: Vec<Bindings> = Vec::with_capacity(arms.len() + 1);
     let mut has_default = false;
@@ -181,6 +247,7 @@ pub(super) fn analyze_inline_switch(
     bindings: &mut Bindings,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    validate_switch_default_position(arms, pipeline_name, diagnostics);
     let starting = bindings.clone();
     let mut results: Vec<Bindings> = Vec::with_capacity(arms.len() + 1);
     let mut has_default = false;

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -261,6 +261,27 @@ pub fn check_types(
                 diagnostics,
             );
         }
+        ExprKind::SwitchExpr { arms, .. } => {
+            // Recurse into the scrutinee and each arm's pattern/body
+            // via the generic walker, then run the default-position
+            // check at this node. Sibling pipeline/process `switch`
+            // statements get the same check in
+            // `check::control_flow::analyze_switch` /
+            // `analyze_inline_switch`, and function bodies route
+            // through `check::function::walk_for_purity` which calls
+            // the same helper.
+            walk_children(expr, |child| {
+                check_types(
+                    child,
+                    pipeline_name,
+                    bindings,
+                    registry,
+                    fallback_span,
+                    diagnostics,
+                )
+            });
+            super::control_flow::validate_switch_default_position(arms, pipeline_name, diagnostics);
+        }
         // Everything else is plain recursion — no node-local check
         // beyond visiting children.
         _ => walk_children(expr, |child| {
@@ -577,3 +598,4 @@ fn warning(pipeline: &str, message: String, span: Option<Span>) -> Diagnostic {
         help: None,
     }
 }
+

--- a/crates/limpid/src/check/function.rs
+++ b/crates/limpid/src/check/function.rs
@@ -259,6 +259,18 @@ fn walk_for_purity(
                 );
             }
         }
+        ExprKind::SwitchExpr { arms, .. } => {
+            // Walk children first so any unknown idents / cross-scope
+            // refs inside arm patterns / bodies still surface. Then
+            // run the default-position check at this node — function
+            // bodies frequently *are* a switch expression so a
+            // misplaced `default` here would otherwise sail through
+            // `--check`.
+            walk_children(expr, |child| {
+                walk_for_purity(child, fn_name, params, config, registry, diagnostics)
+            });
+            super::control_flow::validate_switch_default_position(arms, fn_name, diagnostics);
+        }
         // All other variants delegate recursion to `walk_children`;
         // their own structure carries no purity-relevant signal.
         _ => walk_children(expr, |child| {

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -1700,4 +1700,101 @@ def pipeline p { input i; output o }
             "expected parse failure for `error` inside function body"
         );
     }
+
+    // ----- switch default position validation --------------------------
+
+    #[test]
+    fn switch_default_not_last_in_function_body_errors() {
+        // Regression: the runtime walks switch arms in source order and
+        // dispatches at the first match. `default` matches every value,
+        // so anything after it is unreachable. Pre-fix `--check` was
+        // silent on this shape; configs that meant "case 6 → tcp,
+        // otherwise null" but accidentally put default first sent every
+        // event to the default branch with no diagnostic.
+        let src = r#"
+def function bad(num) {
+    switch num {
+        default { null }
+        6 { "syslog_tcp" }
+    }
+}
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let errs = errors(&diags);
+        assert!(
+            errs.iter()
+                .any(|d| d.message.contains("`default`") && d.message.contains("unreachable")),
+            "expected default-not-last error, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn switch_multiple_defaults_in_function_body_errors() {
+        // Two `default` arms — ambiguous, only the first runs. Almost
+        // certainly an operator typo (probably one was meant to be a
+        // pattern arm).
+        let src = r#"
+def function bad(num) {
+    switch num {
+        6 { "syslog_tcp" }
+        default { "a" }
+        default { "b" }
+    }
+}
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let errs = errors(&diags);
+        assert!(
+            errs.iter()
+                .any(|d| d.message.contains("multiple `default`")),
+            "expected multiple-default error, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn switch_default_last_is_accepted() {
+        // Baseline: the common idiomatic shape (pattern arms first,
+        // `default` last) passes cleanly.
+        let src = r#"
+def function ok(num) {
+    switch num {
+        6 { "syslog_tcp" }
+        17 { "syslog_udp" }
+        default { null }
+    }
+}
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(errors(&diags).is_empty(), "got errors: {:?}", diags);
+    }
+
+    #[test]
+    fn switch_without_default_is_accepted() {
+        // Baseline: omitting `default` is legal (events that match no
+        // arm fall through unchanged). No diagnostic should fire.
+        let src = r#"
+def function partial(num) {
+    switch num {
+        6 { "syslog_tcp" }
+        17 { "syslog_udp" }
+    }
+}
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(errors(&diags).is_empty(), "got errors: {:?}", diags);
+    }
 }

--- a/crates/limpid/src/dsl/ast.rs
+++ b/crates/limpid/src/dsl/ast.rs
@@ -124,7 +124,7 @@ pub enum ProcessStatement {
     /// `if cond { ... } else if cond { ... } else { ... }`
     If(IfChain),
     /// `switch expr { "val" { ... } default { ... } }`
-    Switch(Expr, Vec<SwitchArm>),
+    Switch(Expr, Vec<SwitchStmtArm>),
     /// `try { ... } catch { ... }`
     TryCatch(Vec<ProcessStatement>, Vec<ProcessStatement>),
     /// Expression statement: `table_upsert(...)`, `table_delete(...)`, etc.
@@ -233,7 +233,7 @@ pub enum PipelineStatement {
     /// `if cond { ... } else if cond { ... } else { ... }`
     If(IfChain),
     /// `switch expr { ... }`
-    Switch(Expr, Vec<SwitchArm>),
+    Switch(Expr, Vec<SwitchStmtArm>),
 }
 
 /// An element within a `process a | b | { ... }` chain in a pipeline.
@@ -265,12 +265,28 @@ pub enum BranchBody {
     Pipeline(PipelineStatement),
 }
 
+/// One arm of a `switch` construct. Generic over body type so the
+/// statement-form switch (body = `Vec<BranchBody>`, run for side effects)
+/// and the expression-form switch (body = [`Expr`], evaluated to a value)
+/// share one definition. The `pattern: Option<Expr>` shape — `None` for
+/// `default` — is the only structural commonality the analyzer cares
+/// about, so default-position / duplicate-default checks operate on the
+/// generic form without touching the body.
+///
+/// Concrete forms are the type aliases [`SwitchStmtArm`] /
+/// [`SwitchExprArm`]; downstream code should write those rather than
+/// `SwitchArm<...>` directly.
 #[derive(Debug, Clone)]
-pub struct SwitchArm {
+pub struct SwitchArm<B> {
     /// `None` for `default`
     pub pattern: Option<Expr>,
-    pub body: Vec<BranchBody>,
+    pub body: B,
 }
+
+/// Arm of the statement-form `switch <expr> { ... }` inside a pipeline
+/// or process body — body is a list of branch statements run for their
+/// side effects (workspace mutation, routing, etc.).
+pub type SwitchStmtArm = SwitchArm<Vec<BranchBody>>;
 
 // ---------------------------------------------------------------------------
 // Assign targets
@@ -487,15 +503,12 @@ pub enum ExprKind {
     },
 }
 
-/// One arm of a [`ExprKind::SwitchExpr`]. `pattern = None` is the
-/// `default` arm; otherwise the arm's pattern expression is compared
-/// against the scrutinee value (using the same equality semantics as
-/// statement-form switch).
-#[derive(Debug, Clone)]
-pub struct SwitchExprArm {
-    pub pattern: Option<Expr>,
-    pub body: Expr,
-}
+/// Arm of the expression-form `switch <expr> { ... }` — body is a
+/// single [`Expr`] that the switch evaluates to when this arm matches.
+/// `pattern = None` is the `default` arm; otherwise the pattern is
+/// compared against the scrutinee using the same equality semantics as
+/// the statement-form switch.
+pub type SwitchExprArm = SwitchArm<Expr>;
 
 #[derive(Debug, Clone)]
 pub enum TemplateFragment {

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -509,7 +509,7 @@ fn parse_switch_arm_generic<F>(
     pair: Pair<Rule>,
     file_id: u32,
     mut parse_body: F,
-) -> Result<SwitchArm>
+) -> Result<SwitchStmtArm>
 where
     F: FnMut(Pair<Rule>, u32) -> Result<BranchBody>,
 {
@@ -529,7 +529,7 @@ where
         .map(|p| parse_body(p, file_id))
         .collect::<Result<Vec<_>>>()?;
 
-    Ok(SwitchArm { pattern, body })
+    Ok(SwitchStmtArm { pattern, body })
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Address audit finding #3 (Medium) on `release/0.7.8`: switch/check is silent when `default` is misplaced or duplicated, so configs that meant "case 6 → tcp, otherwise null" but accidentally put `default` first sent every event to the default branch with no diagnostic. Multiple defaults are similarly ambiguous (only the first runs). `docs/src/dsl-syntax.md:213` already documents 'no match falls to default' as the intended dispatch shape, so default-not-last makes the config contradict its own documentation without any operator warning.

Validate both shapes at `--check` time as `DiagKind::Dataflow` errors so the daemon refuses to start on a broken config.

## Commits

- **d3b4739** `refactor(ast): unify SwitchArm via generic body type` — `SwitchArm` / `SwitchExprArm` were two near-identical structs differing only in `body` field type. Unify into `SwitchArm<B>` with type aliases `SwitchStmtArm` / `SwitchExprArm`. Pure type-level refactor, behavior-preserving.
- **57ccd68** `fix(check): reject misplaced and duplicate switch default arms` — Single generic helper `validate_switch_default_position<B>(arms: &[SwitchArm<B>], ...)` covers all three code paths feeding switches into the analyzer (statement-form, expression-form, function-body switches). No duplication.

## Behavior change

`--check` now rejects:
1. `default` arm not at the last position (= trailing arms silently unreachable)
2. Multiple `default` arms (= only the first runs)

0.7.7 configs containing either pattern will fail to load on 0.7.8 startup. CHANGELOG operator note deferred to release prep (same pattern as PR-F / PR-H / PR-I — `--check` reject 範囲拡大).

## Test plan

- [x] `cargo test -p limpid` — 631 + 24 tests pass (+4 new regression tests covering default-not-last / multiple-defaults / default-last baseline / no-default baseline, all exercising the `walk_for_purity` path through function bodies)
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] uchgs push gate 7/7 scope receipts issued; standing findings (cicd-pipeline `release.yml` `contents: write` / RUSTSEC-2026-0185 quinn-proto + 2 bans duplicates) confirmed unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)