### PR TITLE
refactor(dispatch): unify switch and if-chain dispatch across pipeline / process

### DIFF
--- a/crates/limpid/src/dsl/eval.rs
+++ b/crates/limpid/src/dsl/eval.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use anyhow::{Result, bail};
 
 use super::arena::EventArena;
-use super::ast::{BinOp, BlockArg, Expr, ExprKind, TemplateFragment, UnaryOp};
+use super::ast::{BinOp, BlockArg, BranchBody, Expr, ExprKind, IfChain, SwitchStmtArm, TemplateFragment, UnaryOp};
 use super::value::{ArrayBuilder, ObjectBuilder, Value};
 use crate::event::BorrowedEvent;
 use crate::functions::FunctionRegistry;
@@ -660,11 +660,64 @@ pub fn values_match(left: &Value<'_>, right: &Value<'_>) -> bool {
     }
 }
 
-/// True if `v` is truthy under DSL rules. Re-exported for callers that
-/// previously imported this from `eval` directly; the canonical
-/// implementation lives on [`Value::is_truthy`].
-pub fn is_truthy(v: &Value<'_>) -> bool {
-    v.is_truthy()
+/// Select the matching arm body of a statement-form `switch`.
+///
+/// Walks `arms` in source order and returns the body of the first arm
+/// whose pattern equals `disc_val` (per [`values_match`]). A `default`
+/// arm (`pattern.is_none()`) is returned immediately if encountered —
+/// `--check` enforces `default` as the last arm so only a trailing
+/// default can be hit this way, matching the documented
+/// `docs/src/dsl-syntax.md` dispatch contract.
+///
+/// Returns `None` when no pattern matched and no `default` is present.
+///
+/// Pure dispatch logic: the caller supplies `eval_pattern` to evaluate
+/// each arm's pattern expression against its execution context (with or
+/// without a `LocalScope`, with whichever funcs/arena), and is
+/// responsible for executing the returned body. Lets the pipeline and
+/// process executors share one first-match algorithm without coupling
+/// to either context.
+pub fn select_switch_arm<'bump, 'a, F>(
+    disc_val: &Value<'bump>,
+    arms: &'a [SwitchStmtArm],
+    mut eval_pattern: F,
+) -> Result<Option<&'a [BranchBody]>>
+where
+    F: FnMut(&Expr) -> Result<Value<'bump>>,
+{
+    for arm in arms {
+        let Some(pattern) = arm.pattern.as_ref() else {
+            return Ok(Some(&arm.body));
+        };
+        if values_match(disc_val, &eval_pattern(pattern)?) {
+            return Ok(Some(&arm.body));
+        }
+    }
+    Ok(None)
+}
+
+/// Select the matching branch body of an `if`/`else if`/`else` chain.
+///
+/// Walks `chain.branches` in source order and returns the first body
+/// whose condition evaluates truthy (per [`Value::is_truthy`]). Falls
+/// back to `chain.else_body` if no condition matched, returning `None`
+/// when both produce nothing.
+///
+/// Same pure-dispatch shape as [`select_switch_arm`]: the caller
+/// supplies `eval_condition` and executes the returned body.
+pub fn select_if_branch<'bump, 'a, F>(
+    chain: &'a IfChain,
+    mut eval_condition: F,
+) -> Result<Option<&'a [BranchBody]>>
+where
+    F: FnMut(&Expr) -> Result<Value<'bump>>,
+{
+    for (condition, body) in &chain.branches {
+        if eval_condition(condition)?.is_truthy() {
+            return Ok(Some(body));
+        }
+    }
+    Ok(chain.else_body.as_deref())
 }
 
 /// String coercion used by templates, format() placeholders, and any
@@ -1168,15 +1221,13 @@ mod tests {
 
     #[test]
     fn test_is_truthy() {
-        let _bump = ::bumpalo::Bump::new();
-        let _arena = EventArena::new(&_bump);
-        assert!(!is_truthy(&Value::Null));
-        assert!(!is_truthy(&Value::Bool(false)));
-        assert!(is_truthy(&Value::Bool(true)));
-        assert!(!is_truthy(&Value::String("")));
-        assert!(is_truthy(&Value::String("x")));
-        assert!(!is_truthy(&Value::Int(0)));
-        assert!(is_truthy(&Value::Int(1)));
+        assert!(!Value::Null.is_truthy());
+        assert!(!Value::Bool(false).is_truthy());
+        assert!(Value::Bool(true).is_truthy());
+        assert!(!Value::String("").is_truthy());
+        assert!(Value::String("x").is_truthy());
+        assert!(!Value::Int(0).is_truthy());
+        assert!(Value::Int(1).is_truthy());
     }
 
     #[test]

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use super::arena::EventArena;
 use super::ast::*;
-use super::eval::{LocalScope, eval_expr_with_scope, value_to_string, values_match};
+use super::eval::{LocalScope, eval_expr_with_scope, select_if_branch, select_switch_arm, value_to_string};
 use super::value::Value;
 use crate::event::BorrowedEvent;
 use crate::functions::FunctionRegistry;
@@ -166,33 +166,22 @@ fn exec_process_stmt<'bump>(
         }
 
         ProcessStatement::If(if_chain) => {
-            exec_if_chain_process(if_chain, event, registry, funcs, scope, arena)
+            match select_if_branch(if_chain, |c| {
+                eval_expr_with_scope(c, &event, funcs, scope, arena)
+            })? {
+                Some(body) => exec_branch_body_process(body, event, registry, funcs, scope, arena),
+                None => Ok(ExecResult::Continue(event)),
+            }
         }
 
         ProcessStatement::Switch(discriminant, arms) => {
             let disc_val = eval_expr_with_scope(discriminant, &event, funcs, scope, arena)?;
-            for arm in arms {
-                if arm.pattern.is_none() {
-                    // default arm
-                    return exec_branch_body_process(
-                        &arm.body, event, registry, funcs, scope, arena,
-                    );
-                }
-                let pattern_val = eval_expr_with_scope(
-                    arm.pattern.as_ref().unwrap(),
-                    &event,
-                    funcs,
-                    scope,
-                    arena,
-                )?;
-                if values_match(&disc_val, &pattern_val) {
-                    return exec_branch_body_process(
-                        &arm.body, event, registry, funcs, scope, arena,
-                    );
-                }
+            match select_switch_arm(&disc_val, arms, |e| {
+                eval_expr_with_scope(e, &event, funcs, scope, arena)
+            })? {
+                Some(body) => exec_branch_body_process(body, event, registry, funcs, scope, arena),
+                None => Ok(ExecResult::Continue(event)),
             }
-            // No arm matched, pass through
-            Ok(ExecResult::Continue(event))
         }
 
         ProcessStatement::TryCatch(try_body, catch_body) => {
@@ -257,26 +246,6 @@ fn exec_process_stmt<'bump>(
             Ok(ExecResult::Continue(event))
         }
     }
-}
-
-fn exec_if_chain_process<'bump>(
-    if_chain: &IfChain,
-    event: BorrowedEvent<'bump>,
-    registry: &dyn ProcessRegistry,
-    funcs: &FunctionRegistry,
-    scope: &mut LocalScope<'bump>,
-    arena: &'bump EventArena<'bump>,
-) -> Result<ExecResult<'bump>> {
-    for (condition, body) in &if_chain.branches {
-        let cond_val = eval_expr_with_scope(condition, &event, funcs, scope, arena)?;
-        if cond_val.is_truthy() {
-            return exec_branch_body_process(body, event, registry, funcs, scope, arena);
-        }
-    }
-    if let Some(else_body) = &if_chain.else_body {
-        return exec_branch_body_process(else_body, event, registry, funcs, scope, arena);
-    }
-    Ok(ExecResult::Continue(event))
 }
 
 fn exec_branch_body_process<'bump>(

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::dsl::arena::EventArena;
 use crate::dsl::ast::*;
-use crate::dsl::eval::{eval_expr, is_truthy, value_to_string, values_match};
+use crate::dsl::eval::{eval_expr, select_if_branch, select_switch_arm, value_to_string};
 use crate::dsl::exec::{ExecResult, ProcessError, ProcessRegistry, exec_process_body};
 use crate::dsl::value::Value;
 use crate::event::{BorrowedEvent, OwnedEvent};
@@ -736,41 +736,23 @@ fn exec_pipeline_stmt<'bump>(
             finished()
         }
 
-        PipelineStatement::If(if_chain) => exec_pipeline_if(if_chain, event, ctx, out),
+        PipelineStatement::If(if_chain) => {
+            match select_if_branch(if_chain, |c| eval_expr(c, &event, ctx.funcs, ctx.arena))? {
+                Some(body) => exec_pipeline_branch_body(body, event, ctx, out),
+                None => cont(event),
+            }
+        }
 
         PipelineStatement::Switch(discriminant, arms) => {
             let disc_val = eval_expr(discriminant, &event, ctx.funcs, ctx.arena)?;
-            for arm in arms {
-                if arm.pattern.is_none() {
-                    return exec_pipeline_branch_body(&arm.body, event, ctx, out);
-                }
-                let pattern_val =
-                    eval_expr(arm.pattern.as_ref().unwrap(), &event, ctx.funcs, ctx.arena)?;
-                if values_match(&disc_val, &pattern_val) {
-                    return exec_pipeline_branch_body(&arm.body, event, ctx, out);
-                }
+            match select_switch_arm(&disc_val, arms, |e| {
+                eval_expr(e, &event, ctx.funcs, ctx.arena)
+            })? {
+                Some(body) => exec_pipeline_branch_body(body, event, ctx, out),
+                None => cont(event),
             }
-            cont(event)
         }
     }
-}
-
-fn exec_pipeline_if<'bump>(
-    if_chain: &IfChain,
-    event: BorrowedEvent<'bump>,
-    ctx: &PipelineExecCtx<'_, 'bump>,
-    out: &mut PipelineExecOut<'_>,
-) -> Result<(Option<BorrowedEvent<'bump>>, PipelineTermination)> {
-    for (condition, body) in &if_chain.branches {
-        let cond_val = eval_expr(condition, &event, ctx.funcs, ctx.arena)?;
-        if is_truthy(&cond_val) {
-            return exec_pipeline_branch_body(body, event, ctx, out);
-        }
-    }
-    if let Some(else_body) = &if_chain.else_body {
-        return exec_pipeline_branch_body(else_body, event, ctx, out);
-    }
-    Ok((Some(event), PipelineTermination::Finished))
 }
 
 fn exec_pipeline_branch_body<'bump>(


### PR DESCRIPTION
## Summary

Follow-up to [PR #53](https://github.com/naoto256/limpid/pull/53). The runtime executed switch / if-chain dispatch twice (pipeline context in `pipeline.rs`, process context in `dsl/exec.rs`) with identical first-match algorithms diverging only in surrounding execution context (eval helper, body executor, result wrapper). Factor the algorithm out into two pure helpers.

## What changed

Two new helpers in `dsl/eval.rs`:

\`\`\`rust
pub fn select_switch_arm<'bump, 'a, F>(disc_val, arms, eval_pattern)
    -> Result<Option<&'a [BranchBody]>>
where F: FnMut(&Expr) -> Result<Value<'bump>>;

pub fn select_if_branch<'bump, 'a, F>(chain, eval_condition)
    -> Result<Option<&'a [BranchBody]>>
where F: FnMut(&Expr) -> Result<Value<'bump>>;
\`\`\`

Caller supplies \`eval_*\` as a closure capturing context-specific state (with/without LocalScope) and executes the returned body. Body executors stay context-bound because pipeline / process bodies are genuinely different (different statement executors, different result types).

## Effect

- \`exec_pipeline_if\` and \`exec_if_chain_process\` deleted entirely.
- PipelineStatement::Switch / ProcessStatement::Switch dispatch shrinks to a 4-line match in each call site.
- Free \`is_truthy\` wrapper in eval.rs removed (only callers were the deleted dispatchers; canonical \`Value::is_truthy\` stands alone).

Behavior-preserving — monomorphization keeps generated code identical.

## Test plan

- [x] \`cargo build --workspace\` — clean
- [x] \`cargo test --workspace\` — 631 + 24 + 9 + 1 = 665 tests pass
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] uchgs push gate 7/7 scope receipts; standing findings (cicd-pipeline \`release.yml contents: write\` / RUSTSEC-2026-0185 quinn-proto + 2 bans duplicates) confirmed unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)