### PR TITLE
fix(check): warn when recovery-dependent outputs lack error_log

### DIFF
--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -40,6 +40,7 @@ pub mod graph;
 mod module_props;
 mod outputs;
 mod parser_effects;
+mod recovery_readiness;
 pub mod render;
 pub mod suggestions;
 
@@ -290,6 +291,7 @@ pub fn analyze(config: &CompiledConfig, _source_map: &SourceMap) -> Vec<Diagnost
     function::check_all_functions(config, &registry, &mut diagnostics);
     module_props::analyze_all(config, &module_registry, &mut diagnostics);
     global_props::analyze_all(config, &mut diagnostics);
+    recovery_readiness::analyze_all(config, &mut diagnostics);
     for (name, pipeline) in &config.pipelines {
         analyze_pipeline(
             name,

--- a/crates/limpid/src/check/recovery_readiness.rs
+++ b/crates/limpid/src/check/recovery_readiness.rs
@@ -1,0 +1,289 @@
+//! Cross-cutting `--check` warning: configurations that rely on the
+//! `error_log` for failure recovery while leaving it unconfigured.
+//!
+//! Several recovery paths added in 0.7.8 (PR-O retry-exhausted recovery,
+//! PR-P shutdown-flush drain) only persist the original payload when
+//! `control { error_log "..." }` is set. With `error_log` missing the
+//! runtime falls back to the 0.7.7 behaviour (log + metric only, no
+//! replay-able record on disk) — so an operator writing a config with
+//! retry / secondary / batched outputs and *no* `error_log` silently
+//! voids the safety net those features were added to provide.
+//!
+//! This module raises one [`Level::Warning`] when:
+//!
+//! 1. `control { error_log "..." }` is not configured, AND
+//! 2. at least one `def output` either:
+//!    - declares a `retry { ... }` block (= invokes the
+//!      [`write_with_retry`] recovery routing path), OR
+//!    - names a `secondary <other>` fallback (= relies on the same
+//!      routing path), OR
+//!    - is a batched output type (`http`, `otlp_http`, `otlp_grpc`)
+//!      whose [`Output::shutdown`] implementation drains the buffer
+//!      to `error_log` on flush failure.
+//!
+//! The warning is intentionally [`Level::Warning`] rather than
+//! [`Level::Error`]: an operator may have made an informed choice to
+//! accept silent drops on failure (e.g. low-criticality telemetry on
+//! a host with no spare disk). `--check --ultra-strict` promotion is
+//! handled at the CLI layer per existing convention.
+//!
+//! Detection is config-shape-only — no runtime, no I/O. The set of
+//! "batched output types" is intentionally hardcoded to the three
+//! modules that currently override [`Output::shutdown`] with an
+//! error-log drain path; adding a new batched output should extend
+//! [`OUTPUT_TYPES_WITH_SHUTDOWN_DRAIN`] in lockstep.
+
+use crate::dsl::props;
+use crate::pipeline::CompiledConfig;
+
+use super::{DiagKind, Diagnostic, Level};
+
+/// Output `type` names whose `Output::shutdown` impl drains pending
+/// batch buffers to the configured `error_log` on flush failure.
+/// Kept in lockstep with the modules that override the default
+/// no-op `shutdown` in `OutputWriter`.
+const OUTPUT_TYPES_WITH_SHUTDOWN_DRAIN: &[&str] = &["http", "otlp_http", "otlp_grpc"];
+
+/// Returns `true` when the operator has set `control { error_log "..." }`.
+/// A bare `control { }` block (or no `control` block at all) reads as
+/// "not configured".
+fn error_log_configured(config: &CompiledConfig) -> bool {
+    config
+        .global_blocks
+        .get("control")
+        .and_then(|p| props::get_string(p, "error_log"))
+        .is_some()
+}
+
+/// Categorise *why* a given output needs `error_log` for full
+/// recovery. Returns `None` when the output has no recovery-worthy
+/// shape (e.g. a plain `file` output with no retry / secondary).
+fn recovery_reason(output: &crate::dsl::ast::OutputDef) -> Option<&'static str> {
+    let props_view = output.properties.user_properties();
+
+    // Retry block present → enters write_with_retry, which routes
+    // exhausted attempts through error_log when no secondary captures
+    // them (BC-3 / PR-O).
+    if props::get_block(props_view, "retry").is_some() {
+        return Some("retry");
+    }
+
+    // Secondary configured → same routing path: if the secondary
+    // enqueue itself fails, the payload falls through to error_log.
+    if props::get_ident(props_view, "secondary").is_some() {
+        return Some("secondary");
+    }
+
+    // Batched output: shutdown flush failures drain to error_log
+    // (BC-4 / PR-P). Detected by the output's `type` rather than by
+    // a property name because "batched-ness" is an implementation
+    // property of the module, not a config shape.
+    if OUTPUT_TYPES_WITH_SHUTDOWN_DRAIN.contains(&output.properties.type_name()) {
+        return Some("batched");
+    }
+
+    None
+}
+
+pub(super) fn analyze_all(config: &CompiledConfig, diags: &mut Vec<Diagnostic>) {
+    if error_log_configured(config) {
+        return;
+    }
+
+    // Collect every output that has a recovery-worthy shape. We emit
+    // a single warning for the whole config (rather than one per
+    // output) so the operator sees one actionable line, not a flood.
+    let mut affected: Vec<(&str, &'static str)> = Vec::new();
+    for (name, output) in &config.outputs {
+        if let Some(reason) = recovery_reason(output) {
+            affected.push((name.as_str(), reason));
+        }
+    }
+
+    if affected.is_empty() {
+        return;
+    }
+
+    // Stable ordering for deterministic test assertions and stable
+    // diff-able output between runs (HashMap iteration is otherwise
+    // arbitrary).
+    affected.sort_by(|a, b| a.0.cmp(b.0));
+
+    let summary: String = affected
+        .iter()
+        .map(|(name, reason)| format!("`{}` ({})", name, reason))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let message = format!(
+        "config has outputs that depend on `error_log` for failure recovery, \
+         but `control {{ error_log \"...\" }}` is not configured. \
+         Affected outputs: {}. \
+         On retry exhaustion, secondary-output failure, or shutdown flush failure, \
+         the original payload will be dropped silently (log + metric only, no \
+         replay-able record). To enable recovery, add:\n    \
+         control {{\n        error_log \"/var/log/limpid/error_log.jsonl\"\n    }}",
+        summary,
+    );
+
+    diags.push(Diagnostic {
+        level: Level::Warning,
+        kind: DiagKind::Other,
+        message,
+        span: None,
+        help: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::check::analyze;
+    use crate::dsl::parser::parse_config;
+    use crate::dsl::span::SourceMap;
+
+    fn analyze_str(src: &str) -> Vec<Diagnostic> {
+        let cfg = parse_config(src).expect("config should parse");
+        let compiled = CompiledConfig::from_config(cfg).expect("compile");
+        let mut sm = SourceMap::new();
+        sm.add_anonymous(src);
+        analyze(&compiled, &sm)
+    }
+
+    fn recovery_warnings(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+        diags
+            .iter()
+            .filter(|d| {
+                d.level == Level::Warning
+                    && d.message.contains("depend on `error_log` for failure recovery")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn warns_when_retry_block_present_without_error_log() {
+        // syslog_tcp with an explicit retry block but no
+        // `control { error_log }` — exactly the silent-drop scenario.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type syslog_tcp
+    peer { host "h" port 1 }
+    retry { max_attempts 3 }
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let ws = recovery_warnings(&diags);
+        assert_eq!(ws.len(), 1, "expected exactly one recovery warning, got: {:?}", diags);
+        assert!(ws[0].message.contains("`o` (retry)"), "got: {}", ws[0].message);
+    }
+
+    #[test]
+    fn warns_when_secondary_configured_without_error_log() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output primary {
+    type syslog_tcp
+    peer { host "h" port 1 }
+    secondary fallback
+}
+def output fallback {
+    type file
+    path "/tmp/fallback.log"
+}
+def pipeline p { input i; output primary }
+"#;
+        let diags = analyze_str(src);
+        let ws = recovery_warnings(&diags);
+        assert_eq!(ws.len(), 1, "got: {:?}", diags);
+        assert!(
+            ws[0].message.contains("`primary` (secondary)"),
+            "got: {}",
+            ws[0].message
+        );
+    }
+
+    #[test]
+    fn warns_for_batched_output_type_without_error_log() {
+        // http output is batched (overrides Output::shutdown to drain
+        // buffer to error_log on failure). Plain config, no retry,
+        // still recovery-worthy.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type http
+    url "https://example.com/ingest"
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let ws = recovery_warnings(&diags);
+        assert_eq!(ws.len(), 1, "got: {:?}", diags);
+        assert!(ws[0].message.contains("`o` (batched)"), "got: {}", ws[0].message);
+    }
+
+    #[test]
+    fn no_warning_when_error_log_configured() {
+        let src = r#"
+control { error_log "/var/log/limpid/error_log.jsonl" }
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type syslog_tcp
+    peer { host "h" port 1 }
+    retry { max_attempts 3 }
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            recovery_warnings(&diags).is_empty(),
+            "operator opted in via error_log, expected no warning, got: {:?}",
+            diags,
+        );
+    }
+
+    #[test]
+    fn no_warning_for_plain_file_output_without_recovery_shape() {
+        // file output, no retry, no secondary, not batched → no
+        // recovery-worthy path exists, so error_log is irrelevant.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type file
+    path "/tmp/o.log"
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            recovery_warnings(&diags).is_empty(),
+            "plain file output should not raise the warning, got: {:?}",
+            diags,
+        );
+    }
+
+    #[test]
+    fn collapses_multiple_affected_outputs_into_single_warning() {
+        // Two outputs each carry a different recovery-worthy shape.
+        // We still emit exactly one warning, listing both.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output a {
+    type syslog_tcp
+    peer { host "h" port 1 }
+    retry { max_attempts 3 }
+}
+def output b {
+    type http
+    url "https://example.com/ingest"
+}
+def pipeline p { input i; output a }
+"#;
+        let diags = analyze_str(src);
+        let ws = recovery_warnings(&diags);
+        assert_eq!(ws.len(), 1, "expected single coalesced warning, got: {:?}", diags);
+        assert!(ws[0].message.contains("`a` (retry)"), "got: {}", ws[0].message);
+        assert!(ws[0].message.contains("`b` (batched)"), "got: {}", ws[0].message);
+    }
+}


### PR DESCRIPTION
## Summary

Final code change in the boundary-contract follow-up. PR-O / PR-P established that `error_log` is the recovery store for output retry-exhaustion and shutdown flush failure — but only when an operator actually configures it. An operator who writes retry / secondary / batched outputs without `control { error_log "..." }` gets the 0.7.7 silent-drop behavior unchanged, and never finds out their recovery work is inactive.

This PR extends boundary-contract **I-4 (declarative surface ↔ runtime alignment)** into the validator: at `--check` time, scan the config and emit a single `Warning` if any output has a recovery-dependent shape but the global `error_log` is unset.

## Detection

A single warning fires when **any** output matches one of these shapes **and** `control { error_log "..." }` is absent:

1. `retry { ... }` block — PR-O's `write_with_retry` error_log fallback would be a no-op
2. `secondary <name>` — secondary enqueue failure falls through to the same fallback
3. output type is one of `http` / `otlp_http` / `otlp_grpc` — these three override `OutputWriter::shutdown` to drain the batched buffer via error_log (PR-P)

The batched set is pinned in `OUTPUT_TYPES_WITH_SHUTDOWN_DRAIN` with a lockstep comment. `syslog_tcp` / `kafka` / `file` are excluded — they have no shutdown drain. Disk queue alone (no retry / secondary) is excluded — no exhaustion gap.

## Message

\`\`\`
config has outputs that depend on `error_log` for failure recovery, but
`control { error_log "..." }` is not configured. Affected outputs: `a`
(retry), `b` (batched). On retry exhaustion, secondary-output failure,
or shutdown flush failure, the original payload will be dropped silently
(log + metric only, no replay-able record). To enable recovery, add:
    control {
        error_log "/var/log/limpid/error_log.jsonl"
    }
\`\`\`

Affected outputs sorted (HashMap-order avoidance); each entry carries its reason tag(s).

## Behavior

- `Warning` level, not `Error`. `--check` continues to exit 0.
- `--check --strict-warnings` / `--ultra-strict` promote it to a hard fail via the existing strict-warnings ladder.
- No new flag, no new `DiagKind` variant, no escape-hatch flag (operators who intentionally accept silent drops live with the warning).

## Tests

6 new in `check::recovery_readiness::tests`:

- retry block + no error_log → warns
- secondary + no error_log → warns
- batched output type + no error_log → warns
- error_log configured → no warning (regression check)
- plain file output + no retry/secondary → no warning (false-positive guard)
- multiple recovery-shaped outputs → single aggregated warning with both reason tags

Existing anchors preserved: `check_with_warning_still_exits_zero_and_mentions_warnings` and `check_clean_emits_summary_and_configuration_ok` pin the `--check` exit-code contract.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --no-fail-fast` — 658 + 24 + 9 + 1 = 692 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] uchgs push gate 8/8 scope receipts (Codex-issued); boundary-contract reports I-4 strengthened, abstraction `OUTPUT_TYPES_WITH_SHUTDOWN_DRAIN` hand-pinning Watch only (Rule-of-Three acceptable, revisit at fourth batched output)
- [x] No Cargo.{toml,lock} changes; no new dependencies; no CI / metrics touch
- [ ] **docs follow-up (PR-Q)**: `error_log` recovery posture / `--strict-warnings` enforcement path / synthetic event metadata / replay-triage example. Tracked as one separate docs-only PR within this same release/0.7.8 cycle.

## Trade-offs

- Batched-output set is a hand-pinned const. A future fourth batched output requires an edit. Trait-level `is_batched()` was considered and rejected on Rule-of-Three; revisit when a fourth lands.
- No explicit suppress flag. Strict-warnings ladder is the operator's enforcement lever. A `control { error_log_optout true }` is feasible if real demand appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)