### PR TITLE
feat(output): expose retry / secondary in all output schemas (+ Ident kind)

### DIFF
--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -53,6 +53,15 @@ pub enum PropertyValueKind {
     /// `framing { octet_counting | non_transparent }`, `queue.type
     /// { memory | disk }`, etc.
     Enum(&'static [&'static str]),
+    /// Bare ident only — string literals and templates are rejected at
+    /// schema-check time. Used where the value must be the *name* of
+    /// another declared entity (e.g. `secondary <output_name>` cross-
+    /// references another `def output`). The runtime resolver reads it
+    /// with `props::get_ident`, which silently drops anything that
+    /// isn't a bare ident — accepting `String` here would let
+    /// `secondary "fallback"` pass `--check` and then silently disable
+    /// the fallback route at runtime (I-4 violation).
+    Ident,
     /// Nested block. The slice describes the inner schema; the
     /// validator recurses.
     Block(&'static [PropertySpec]),
@@ -83,6 +92,7 @@ impl PropertyValueKind {
             PropertyValueKind::Duration => "Duration",
             PropertyValueKind::Size => "Size",
             PropertyValueKind::Enum(_) => "Ident",
+            PropertyValueKind::Ident => "Ident",
             PropertyValueKind::Block(_) => "Block",
             PropertyValueKind::BlockMap(_) => "BlockMap",
             PropertyValueKind::StringMap => "StringMap",
@@ -615,6 +625,13 @@ fn check_value(
                 }
             }
             _ => mismatch("an identifier"),
+        },
+        PropertyValueKind::Ident => match &value.kind {
+            ExprKind::Ident(parts) if parts.len() == 1 => None,
+            // Multi-segment idents (`a.b`) aren't valid names for
+            // cross-referenced entities either — reject them the same
+            // way bare-only enums do.
+            _ => mismatch("a bare identifier (output name, not a quoted string)"),
         },
         PropertyValueKind::Block(_)
         | PropertyValueKind::BlockMap(_)

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -65,6 +65,8 @@ const FILE_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::String,
     },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -164,6 +164,8 @@ const HTTP_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::StringMap,
     },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -145,6 +145,8 @@ const KAFKA_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::Block(KAFKA_SASL_BLOCK_PROPERTIES),
     },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -67,7 +67,7 @@ use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::queue::{BackoffStrategy, RetryConfig};
 
-use super::{BatchLevel, OTLP_RETRY_BLOCK_PROPERTIES, OtlpPayload, decode_drained_to_request};
+use super::{BatchLevel, OtlpPayload, decode_drained_to_request};
 
 /// Upper bound on a single gRPC export. A stalled collector (TCP
 /// connection accepted but no HEADERS frame returned) would otherwise
@@ -189,13 +189,8 @@ const OTLP_GRPC_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::StringMap,
     },
-    PropertySpec {
-        name: "retry",
-        required: false,
-        repeatable: false,
-        exclusive_group: None,
-        kind: PropertyValueKind::Block(OTLP_RETRY_BLOCK_PROPERTIES),
-    },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -68,7 +68,7 @@ use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 use crate::queue::{BackoffStrategy, RetryConfig};
 use crate::tls::ClientTlsConfig;
 
-use super::{BatchLevel, OTLP_RETRY_BLOCK_PROPERTIES, OtlpPayload, decode_drained_to_request};
+use super::{BatchLevel, OtlpPayload, decode_drained_to_request};
 
 /// Upper bound on a single HTTP export — connect, TLS handshake,
 /// request body send, response headers, response body. A peer that
@@ -247,13 +247,8 @@ const OTLP_HTTP_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::StringMap,
     },
-    PropertySpec {
-        name: "retry",
-        required: false,
-        repeatable: false,
-        exclusive_group: None,
-        kind: PropertyValueKind::Block(OTLP_RETRY_BLOCK_PROPERTIES),
-    },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/modules/output/otlp/mod.rs
+++ b/crates/limpid/src/modules/output/otlp/mod.rs
@@ -2,9 +2,11 @@
 //! ([`http`] = `output otlp_http`, [`grpc`] = `output otlp_grpc`) own
 //! their own DSL schema, transport client, and ship path. The bits
 //! that are genuinely transport-agnostic — batch-level merging,
-//! Resource / Scope equality, the retry block schema, the per-Event
-//! payload type — live here so both transports stay byte-equivalent at
-//! the OTLP wire layer regardless of which one a pipeline picks.
+//! Resource / Scope equality, the per-Event payload type — live here
+//! so both transports stay byte-equivalent at the OTLP wire layer
+//! regardless of which one a pipeline picks. The `retry { ... }`
+//! block schema lives in `crate::queue` because every output (not
+//! just OTLP) accepts it.
 //!
 //! Each Event's `egress` is expected to be the singleton ResourceLogs
 //! protobuf bytes produced by `otlp.encode_resourcelog_protobuf` —
@@ -44,8 +46,6 @@ use opentelemetry_proto::tonic::{
     resource::v1::Resource,
 };
 use prost::Message;
-
-use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 
 /// Transport-success outcome from a single OTLP export call.
 ///
@@ -94,37 +94,6 @@ impl BatchLevel {
         }
     }
 }
-
-pub(crate) const OTLP_RETRY_BLOCK_PROPERTIES: &[PropertySpec] = &[
-    PropertySpec {
-        name: "max_attempts",
-        required: false,
-        repeatable: false,
-        exclusive_group: None,
-        kind: PropertyValueKind::Int,
-    },
-    PropertySpec {
-        name: "initial_wait",
-        required: false,
-        repeatable: false,
-        exclusive_group: None,
-        kind: PropertyValueKind::Duration,
-    },
-    PropertySpec {
-        name: "max_wait",
-        required: false,
-        repeatable: false,
-        exclusive_group: None,
-        kind: PropertyValueKind::Duration,
-    },
-    PropertySpec {
-        name: "backoff",
-        required: false,
-        repeatable: false,
-        exclusive_group: None,
-        kind: PropertyValueKind::Enum(&["fixed", "exponential"]),
-    },
-];
 
 /// Decode a drained batch of per-Event ResourceLogs proto bytes and
 /// wrap them in one `ExportLogsServiceRequest`, merging per

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -12,9 +12,14 @@ use crate::event::BorrowedEvent;
 use crate::metrics::OutputMetrics;
 use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
 
-/// `output stdout` has no module-specific properties; only the common
-/// `queue { ... }` sub-block applies.
-const STDOUT_OUTPUT_SCHEMA: &[PropertySpec] = &[crate::queue::QUEUE_PROPERTY_SPEC];
+/// `output stdout` has no module-specific properties; only the
+/// common `retry { ... } / secondary <name> / queue { ... }`
+/// sub-blocks apply.
+const STDOUT_OUTPUT_SCHEMA: &[PropertySpec] = &[
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
+    crate::queue::QUEUE_PROPERTY_SPEC,
+];
 
 pub struct StdoutOutput {
     metrics: Arc<OutputMetrics>,

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -112,6 +112,8 @@ const SYSLOG_TCP_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: Some("destination"),
         kind: PropertyValueKind::Block(SYSLOG_TCP_PEERS_SCHEMA),
     },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -56,6 +56,8 @@ const SYSLOG_UDP_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: Some("destination"),
         kind: PropertyValueKind::Block(SYSLOG_UDP_PEERS_SCHEMA),
     },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -26,6 +26,8 @@ const UNIX_SOCKET_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::String,
     },
+    crate::queue::RETRY_PROPERTY_SPEC,
+    crate::queue::SECONDARY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -81,6 +81,83 @@ pub const QUEUE_PROPERTY_SPEC: PropertySpec = PropertySpec {
 };
 
 // ---------------------------------------------------------------------------
+// Declarative schema for the per-output `retry { ... }` sub-block and
+// the `secondary <name>` property
+// ---------------------------------------------------------------------------
+//
+// Both surfaces are honored by `RetryConfig::from_output_properties`
+// (below) for *every* output the queue consumer drives — the runtime
+// has always read `retry` and `secondary` uniformly. Historically only
+// the two OTLP outputs declared them in their `property_schema()`, so
+// non-OTLP configs that set `retry { ... }` or `secondary <name>` got
+// hard-failed at `--check` time as "unknown property" even though the
+// runtime would happily accept them. Hoisting the schema here and
+// splicing the two consts into every output's schema closes that gap
+// without touching the runtime — schema acceptance now matches the
+// runtime's existing intent.
+//
+// Sub-property names mirror the keys read by
+// `RetryConfig::from_output_properties`; renames stay in lock-step
+// with the parser because both definitions live in this file.
+
+const RETRY_BLOCK_PROPERTIES: &[PropertySpec] = &[
+    PropertySpec {
+        name: "max_attempts",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::Int,
+    },
+    PropertySpec {
+        name: "initial_wait",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::Duration,
+    },
+    PropertySpec {
+        name: "max_wait",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::Duration,
+    },
+    PropertySpec {
+        name: "backoff",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::Enum(&["fixed", "exponential"]),
+    },
+];
+
+/// `retry { ... }` sub-block specification shared by every output
+/// Module's property schema. Splice alongside [`QUEUE_PROPERTY_SPEC`].
+pub const RETRY_PROPERTY_SPEC: PropertySpec = PropertySpec {
+    name: "retry",
+    required: false,
+    repeatable: false,
+    exclusive_group: None,
+    kind: PropertyValueKind::Block(RETRY_BLOCK_PROPERTIES),
+};
+
+/// `secondary <name>` property specification shared by every output
+/// Module's property schema. Splice alongside [`QUEUE_PROPERTY_SPEC`].
+///
+/// The value is read by `props::get_ident` at runtime; schema-wise
+/// `PropertyValueKind::String` accepts bare idents, string literals,
+/// and templates — the wider shape is fine because the runtime then
+/// resolves the value against the set of declared output names and
+/// rejects unknowns / self-references / cycles in `runtime.rs`.
+pub const SECONDARY_PROPERTY_SPEC: PropertySpec = PropertySpec {
+    name: "secondary",
+    required: false,
+    repeatable: false,
+    exclusive_group: None,
+    kind: PropertyValueKind::String,
+};
+
+// ---------------------------------------------------------------------------
 // SinkInput — what flows over the per-output queue
 // ---------------------------------------------------------------------------
 //
@@ -1261,5 +1338,160 @@ mod write_with_retry_tests {
         .await;
         assert_eq!(disposition, WriteDisposition::Dropped);
         assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Schema-splice regression tests
+// ---------------------------------------------------------------------------
+//
+// Pre-PR-T, only the two OTLP outputs declared `retry` and `secondary`
+// in their `property_schema()` even though `RetryConfig::from_output_properties`
+// reads both for *every* output. The tests below pin the post-PR-T
+// invariant: every non-OTLP output's schema accepts a `retry { ... }`
+// block and a `secondary <name>` property without raising
+// `UnknownKey`. Adding a third output schema later is then a hard
+// failure here if the splice is forgotten.
+#[cfg(test)]
+mod schema_splice_tests {
+    use super::{BackoffStrategy, RetryConfig};
+    use crate::dsl::ast::{Expr, ExprKind, Property};
+    use crate::dsl::schema::{PropertySpec, SchemaError, SchemaErrorKind, validate};
+    use crate::modules::Module;
+    use crate::modules::output::file::FileOutput;
+    use crate::modules::output::http::HttpOutput;
+    use crate::modules::output::otlp::grpc::OtlpGrpcOutput;
+    use crate::modules::output::otlp::http::OtlpHttpOutput;
+    use crate::modules::output::stdout::StdoutOutput;
+    use crate::modules::output::syslog_tcp::SyslogTcpOutput;
+    use crate::modules::output::syslog_udp::SyslogUdpOutput;
+    use crate::modules::output::unix_socket::UnixSocketOutput;
+
+    #[cfg(feature = "kafka")]
+    use crate::modules::output::kafka::KafkaOutput;
+
+    fn kv(key: &str, kind: ExprKind) -> Property {
+        Property::KeyValue {
+            key: key.into(),
+            key_span: None,
+            value: Expr::spanless(kind),
+            value_span: None,
+        }
+    }
+
+    fn block(key: &str, properties: Vec<Property>) -> Property {
+        Property::Block {
+            key: key.into(),
+            key_span: None,
+            properties,
+        }
+    }
+
+    /// `retry { max_attempts 3 initial_wait "100ms" max_wait "5s" backoff exponential }`
+    fn full_retry_block() -> Property {
+        block(
+            "retry",
+            vec![
+                kv("max_attempts", ExprKind::IntLit(3)),
+                kv("initial_wait", ExprKind::StringLit("100ms".into())),
+                kv("max_wait", ExprKind::StringLit("5s".into())),
+                kv("backoff", ExprKind::Ident(vec!["exponential".into()])),
+            ],
+        )
+    }
+
+    fn secondary_prop() -> Property {
+        kv("secondary", ExprKind::Ident(vec!["fallback".into()]))
+    }
+
+    /// Filter out `UnknownKey` errors for the splice contract — other
+    /// errors (e.g. missing required keys we didn't supply for the
+    /// schema under test) are off-topic for this test.
+    fn unknown_key_errs(errs: &[SchemaError]) -> Vec<&SchemaError> {
+        errs.iter()
+            .filter(|e| matches!(e.kind, SchemaErrorKind::UnknownKey))
+            .collect()
+    }
+
+    fn assert_accepts(schema: &[PropertySpec], output_name: &str) {
+        let props = vec![full_retry_block(), secondary_prop()];
+        let errs = validate(&props, schema);
+        let unknown = unknown_key_errs(&errs);
+        assert!(
+            unknown.is_empty(),
+            "output '{}': retry / secondary should be accepted by schema, \
+             got UnknownKey errors for: {:?}",
+            output_name,
+            unknown.iter().map(|e| e.key.as_str()).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn every_output_schema_accepts_retry_and_secondary() {
+        // The full matrix lives in one test so adding a new output
+        // either splices the common consts into its schema or fails
+        // this test loudly.
+        assert_accepts(StdoutOutput::property_schema().unwrap(), "stdout");
+        assert_accepts(FileOutput::property_schema().unwrap(), "file");
+        assert_accepts(HttpOutput::property_schema().unwrap(), "http");
+        assert_accepts(SyslogTcpOutput::property_schema().unwrap(), "syslog_tcp");
+        assert_accepts(SyslogUdpOutput::property_schema().unwrap(), "syslog_udp");
+        assert_accepts(UnixSocketOutput::property_schema().unwrap(), "unix_socket");
+        assert_accepts(OtlpGrpcOutput::property_schema().unwrap(), "otlp_grpc");
+        assert_accepts(OtlpHttpOutput::property_schema().unwrap(), "otlp_http");
+        #[cfg(feature = "kafka")]
+        assert_accepts(KafkaOutput::property_schema().unwrap(), "kafka");
+    }
+
+    /// Inside the `retry { ... }` block, the four documented keys must
+    /// be the only accepted ones across every output schema —
+    /// confirms the hoist into `crate::queue` keeps the OTLP-era block
+    /// shape exactly (no key drift).
+    #[test]
+    fn retry_block_rejects_unknown_inner_key_in_all_outputs() {
+        let bad_retry = block("retry", vec![kv("typo", ExprKind::IntLit(1))]);
+        let props = vec![bad_retry];
+        #[allow(unused_mut)]
+        let mut schemas: Vec<(&[PropertySpec], &str)> = vec![
+            (StdoutOutput::property_schema().unwrap(), "stdout"),
+            (FileOutput::property_schema().unwrap(), "file"),
+            (HttpOutput::property_schema().unwrap(), "http"),
+            (SyslogTcpOutput::property_schema().unwrap(), "syslog_tcp"),
+            (SyslogUdpOutput::property_schema().unwrap(), "syslog_udp"),
+            (UnixSocketOutput::property_schema().unwrap(), "unix_socket"),
+            (OtlpGrpcOutput::property_schema().unwrap(), "otlp_grpc"),
+            (OtlpHttpOutput::property_schema().unwrap(), "otlp_http"),
+        ];
+        #[cfg(feature = "kafka")]
+        schemas.push((KafkaOutput::property_schema().unwrap(), "kafka"));
+        for (schema, name) in schemas {
+            let errs = validate(&props, schema);
+            let typo_err = errs
+                .iter()
+                .find(|e| matches!(e.kind, SchemaErrorKind::UnknownKey) && e.key == "typo");
+            assert!(
+                typo_err.is_some(),
+                "output '{}': retry block should reject unknown inner key 'typo', got errs={:?}",
+                name,
+                errs.iter().map(|e| (&e.kind, &e.key)).collect::<Vec<_>>(),
+            );
+        }
+    }
+
+    /// `RetryConfig::from_output_properties` parses identical retry +
+    /// secondary props on a non-OTLP output (kafka here) into the
+    /// same fields the OTLP outputs have always populated. Anchors
+    /// the "runtime behavior already matched, schema just caught up"
+    /// invariant.
+    #[test]
+    fn retry_config_parser_reads_same_fields_for_non_otlp_outputs() {
+        let props = vec![full_retry_block(), secondary_prop()];
+        let cfg = RetryConfig::from_output_properties(&props)
+            .expect("retry block parses for non-OTLP output");
+        assert_eq!(cfg.max_attempts, 3);
+        assert_eq!(cfg.initial_wait, std::time::Duration::from_millis(100));
+        assert_eq!(cfg.max_wait, std::time::Duration::from_secs(5));
+        assert!(matches!(cfg.backoff, BackoffStrategy::Exponential));
+        assert_eq!(cfg.secondary.as_deref(), Some("fallback"));
     }
 }

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -144,17 +144,21 @@ pub const RETRY_PROPERTY_SPEC: PropertySpec = PropertySpec {
 /// `secondary <name>` property specification shared by every output
 /// Module's property schema. Splice alongside [`QUEUE_PROPERTY_SPEC`].
 ///
-/// The value is read by `props::get_ident` at runtime; schema-wise
-/// `PropertyValueKind::String` accepts bare idents, string literals,
-/// and templates — the wider shape is fine because the runtime then
-/// resolves the value against the set of declared output names and
-/// rejects unknowns / self-references / cycles in `runtime.rs`.
+/// The value is read by `props::get_ident` at runtime, which only
+/// accepts a bare ident — `secondary "fallback"` (string literal) or
+/// `secondary $tpl` (template) would silently return `None`, disabling
+/// the fallback route without any schema-level signal (I-4 violation
+/// caught by the boundary-contract audit). `PropertyValueKind::Ident`
+/// rejects those shapes at `--check` time so the operator sees the
+/// mismatch up front. The runtime still resolves the resulting ident
+/// against the set of declared output names and rejects unknowns /
+/// self-references / cycles in `runtime.rs`.
 pub const SECONDARY_PROPERTY_SPEC: PropertySpec = PropertySpec {
     name: "secondary",
     required: false,
     repeatable: false,
     exclusive_group: None,
-    kind: PropertyValueKind::String,
+    kind: PropertyValueKind::Ident,
 };
 
 // ---------------------------------------------------------------------------
@@ -1474,6 +1478,121 @@ mod schema_splice_tests {
                 "output '{}': retry block should reject unknown inner key 'typo', got errs={:?}",
                 name,
                 errs.iter().map(|e| (&e.kind, &e.key)).collect::<Vec<_>>(),
+            );
+        }
+    }
+
+    /// I-4 invariant guard: `secondary` is read at runtime by
+    /// `props::get_ident`, which silently discards anything that
+    /// isn't a bare ident. The schema must reject string literals
+    /// and templates so the operator sees the mismatch at `--check`
+    /// time rather than booting with a silently-disabled fallback
+    /// route. Covers every output's shared schema in one pass.
+    #[test]
+    fn secondary_rejects_non_ident_shapes_in_all_outputs() {
+        #[allow(unused_mut)]
+        let mut schemas: Vec<(&[PropertySpec], &str)> = vec![
+            (StdoutOutput::property_schema().unwrap(), "stdout"),
+            (FileOutput::property_schema().unwrap(), "file"),
+            (HttpOutput::property_schema().unwrap(), "http"),
+            (SyslogTcpOutput::property_schema().unwrap(), "syslog_tcp"),
+            (SyslogUdpOutput::property_schema().unwrap(), "syslog_udp"),
+            (UnixSocketOutput::property_schema().unwrap(), "unix_socket"),
+            (OtlpGrpcOutput::property_schema().unwrap(), "otlp_grpc"),
+            (OtlpHttpOutput::property_schema().unwrap(), "otlp_http"),
+        ];
+        #[cfg(feature = "kafka")]
+        schemas.push((KafkaOutput::property_schema().unwrap(), "kafka"));
+
+        // Each bad shape must produce a TypeMismatch on the `secondary`
+        // key — UnknownKey would mean the splice itself broke (covered
+        // by the accept-test above), other errs are fine to ignore.
+        let bad_shapes: Vec<(Property, &str)> = vec![
+            (
+                kv("secondary", ExprKind::StringLit("fallback".into())),
+                "string literal",
+            ),
+            (
+                kv(
+                    "secondary",
+                    ExprKind::Template(vec![
+                        crate::dsl::ast::TemplateFragment::Literal("fall".into()),
+                        crate::dsl::ast::TemplateFragment::Interp(Expr::spanless(
+                            ExprKind::Ident(vec!["env".into(), "FB".into()]),
+                        )),
+                    ]),
+                ),
+                "template",
+            ),
+            (
+                kv(
+                    "secondary",
+                    ExprKind::Ident(vec!["pkg".into(), "fallback".into()]),
+                ),
+                "multi-segment ident",
+            ),
+        ];
+
+        for (schema, name) in &schemas {
+            for (bad, shape_label) in &bad_shapes {
+                let errs = validate(std::slice::from_ref(bad), schema);
+                let mismatch = errs.iter().find(|e| {
+                    e.key == "secondary"
+                        && matches!(e.kind, SchemaErrorKind::TypeMismatch { .. })
+                });
+                assert!(
+                    mismatch.is_some(),
+                    "output '{}': secondary {} should be rejected by schema, \
+                     got errs={:?}",
+                    name,
+                    shape_label,
+                    errs.iter().map(|e| (&e.kind, &e.key)).collect::<Vec<_>>(),
+                );
+            }
+        }
+    }
+
+    /// Companion to the negative test: bare-ident form (the only valid
+    /// shape) and absence must both pass without a `secondary`-keyed
+    /// error. Pins the post-fix accept range so the schema stays a
+    /// faithful mirror of what `props::get_ident` reads at runtime.
+    #[test]
+    fn secondary_accepts_bare_ident_and_absence_in_all_outputs() {
+        #[allow(unused_mut)]
+        let mut schemas: Vec<(&[PropertySpec], &str)> = vec![
+            (StdoutOutput::property_schema().unwrap(), "stdout"),
+            (FileOutput::property_schema().unwrap(), "file"),
+            (HttpOutput::property_schema().unwrap(), "http"),
+            (SyslogTcpOutput::property_schema().unwrap(), "syslog_tcp"),
+            (SyslogUdpOutput::property_schema().unwrap(), "syslog_udp"),
+            (UnixSocketOutput::property_schema().unwrap(), "unix_socket"),
+            (OtlpGrpcOutput::property_schema().unwrap(), "otlp_grpc"),
+            (OtlpHttpOutput::property_schema().unwrap(), "otlp_http"),
+        ];
+        #[cfg(feature = "kafka")]
+        schemas.push((KafkaOutput::property_schema().unwrap(), "kafka"));
+
+        for (schema, name) in &schemas {
+            // Bare ident — must pass.
+            let with_ident = vec![secondary_prop()];
+            let errs = validate(&with_ident, schema);
+            let bad = errs.iter().find(|e| e.key == "secondary");
+            assert!(
+                bad.is_none(),
+                "output '{}': bare-ident secondary should be accepted, got {:?}",
+                name,
+                bad,
+            );
+
+            // Absent — must pass.
+            let empty: Vec<Property> = vec![];
+            let errs = validate(&empty, schema);
+            let bad = errs.iter().find(|e| e.key == "secondary");
+            assert!(
+                bad.is_none(),
+                "output '{}': absent secondary should be accepted, got {:?}",
+                name,
+                bad,
             );
         }
     }


### PR DESCRIPTION
## Summary

Docs-drift sweep + Codex-audit follow-up resolved an undeclared three-way mismatch between docs, schema, and runtime around output `retry` / `secondary`:

- **runtime** has always accepted `retry { ... }` and `secondary <name>` on every output type (`RetryConfig::from_output_properties` is called for all outputs at `runtime.rs:65`).
- **schema** only declared them on `otlp_grpc` and `otlp_http`. Any other output type rejected them at `--check` as "unknown property".
- **docs** describe both as common queue/retry properties.

Operators copy-pasting any retry example onto kafka / file / http / syslog / stdout / unix_socket got a hard-fail at startup despite the runtime being prepared to honour the config.

## Commits

- **15f6ad6** `feat(output): expose retry / secondary in all output schemas` — hoists `RETRY_PROPERTY_SPEC` and `SECONDARY_PROPERTY_SPEC` into `queue/mod.rs` next to `QUEUE_PROPERTY_SPEC` and splices them into every output's schema (kafka / file / http / stdout / syslog_tcp / syslog_udp / unix_socket plus the two OTLP outputs, where the previous per-OTLP retry spec collapses into the common reference).
- **cb21a8e** `fix(schema): reject string-literal secondary references (Ident kind)` — Codex audit on commit 1 flagged that `SECONDARY_PROPERTY_SPEC` used `PropertyValueKind::String` while the runtime read via `props::get_ident`. `secondary "fallback"` passed `--check` but the runtime quietly dropped it — exactly the silent-recovery-loss class PR-R was added to prevent. Adds `PropertyValueKind::Ident` variant; only bare idents are accepted, string literals / templates / dotted paths now fail `--check` with a precise error.

## Behavior

- `otlp_grpc` / `otlp_http` with `retry { ... }` / `secondary <name>` — unchanged. The schema entries moved file, the runtime path is identical.
- kafka / file / http / stdout / syslog_* / unix_socket with `retry { ... }` or `secondary <name>` — was rejected at `--check`, now accepted and runtime-honoured per the unchanged `RetryConfig::from_output_properties`.
- `secondary fallback` — unchanged (bare ident).
- `secondary "fallback"` / `secondary $tpl` / `secondary a.b` — was silent-drop (recovery quietly disabled), now hard-fail at `--check` with a precise message.
- outputs without either property — unchanged.

Non-breaking on the positive direction: configs that started up keep starting up. Configs that previously failed at `--check` for this specific reason now succeed and run. The string-literal `secondary` case shifts from silent-drop to loud-fail — an invariant reinforcement, not a regression.

## DRY

- `retry { }` block schema definition: 2 OTLP-local copies → 1 canonical in `queue/mod.rs`, 9 splice references.
- `OTLP_RETRY_BLOCK_PROPERTIES` const in `modules/output/otlp/mod.rs` removed; its block-property table is now the single `RETRY_BLOCK_PROPERTIES` in `queue/mod.rs`.

## Tests

5 new in `queue::schema_splice_tests`:
- `every_output_schema_accepts_retry_and_secondary` — matrix asserts all nine outputs accept both specs.
- `retry_block_rejects_unknown_inner_key_in_all_outputs` — after-hoist drift guard: a typo inside `retry { ... }` is still caught on every schema.
- `retry_config_parser_reads_same_fields_for_non_otlp_outputs` — runtime parser anchor: `RetryConfig::from_output_properties` extracts the same fields from non-OTLP shapes as from OTLP shapes.
- `secondary_rejects_non_ident_shapes_in_all_outputs` — matrix asserts every output rejects string-literal, template, and dotted-path secondary forms.
- `secondary_accepts_bare_ident_and_absence_in_all_outputs` — matrix asserts every output still accepts bare ident and absence (positive baseline preserved).

Existing OTLP retry / secondary tests (`grpc.rs` / `http.rs`) and PR-R's recovery_readiness tests all pass unchanged — the schema move is structurally identical for the OTLP path, and bare-ident secondary was already the only shape recovery_readiness exercised.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --no-fail-fast` — 663 + 24 + 9 + 1 = 697 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] uchgs push gate 8/8 scope receipts (Codex-issued on first commit, `uchgs-audit`-issued Phase 1D on the follow-up); boundary-contract reports I-4 invariant restored, abstraction reports Drift resolved
- [x] No Cargo.{toml,lock} changes; no new dependencies; no docs / CI / metrics touch

## CHANGELOG follow-up (PR-Q1)

Add a "Behavior changes (non-breaking)" entry:

> `retry { ... }` and `secondary <name>` are now accepted on all output types (previously OTLP-only at the schema layer; the runtime already supported them everywhere). String-literal `secondary "..."` is now a hard `--check` error — bare-ident references continue to work, matching the runtime's longstanding read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)