### PR TITLE
docs: fix accumulated drift across all zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ lake in OCSF format. With limpid, that is just chaining three things:
 ```limpid
 def pipeline fortigate_to_security_lake {
     input   fortigate_syslog
-    process parse_fortigate | compose_ocsf_finding
+    process parse_fortigate_cef | compose_ocsf
     output  security_lake
 }
 ```
 
 The flow is right there in the config. Bytes arrive on `fortigate_syslog`;
-`parse_fortigate` extracts structured fields; `compose_ocsf_finding`
-shapes those fields into an OCSF Detection Finding; the result leaves
-through `security_lake`. No hidden behavior. No plugin to install. No
-separate "transform" config.
+`parse_fortigate_cef` extracts structured fields into the canonical
+`workspace.limpid.*` intermediate; `compose_ocsf` dispatches on
+`workspace.limpid.class_uid` and emits the matching OCSF JSON; the
+result leaves through `security_lake`. No hidden behavior. No plugin
+to install. No separate "transform" config.
 
 In limpid, anything you want to do to a log on its way from input to
 output is achieved by freely combining `process`es.
@@ -39,23 +40,25 @@ output is achieved by freely combining `process`es.
 
 A reusable chunk of pipeline logic — small, named, drop-in. You write
 them yourself, or you include them from the snippet library (a curated
-collection that debuts in **v0.7.0** and expands substantially in
-**v0.7.1**: 22 vendor parsers (SIEM + OSS NDR), 2
+collection introduced in **v0.7.0** and expanded across the 0.7.x
+line: 24 vendor parsers (SIEM + OSS NDR), 2
 transport parsers, the OCSF 1.3.0 27-class composer, and shared
 helper functions; full list in
 [Snippet Library](docs/src/snippets/README.md)). Here is what an OCSF
 Detection Finding composer leaf looks like under the hood:
 
 ```limpid
-def process compose_ocsf_finding {
-    workspace.ocsf = {
+def process compose_ocsf_detection_finding {
+    let activity = workspace.limpid.activity_id
+    egress = to_json(null_omit({
+        class_uid:    2004,                     // Detection Finding
         category_uid: 2,                        // Findings
-        class_uid:    200401,                   // Detection Finding
-        time:         workspace.cef.rt,
-        severity_id:  workspace.cef.severity_level,
+        activity_id:  activity,
+        type_uid:     2004 * 100 + activity,
+        time:         coalesce(workspace.limpid.time, received_at),
+        severity_id:  workspace.limpid.severity_id,
         // ...
-    }
-    egress = to_json(workspace.ocsf)
+    }))
 }
 ```
 
@@ -77,9 +80,15 @@ whole pipeline.
 A few we have already covered:
 
 - **Composable pieces.** Pipelines are chains of small named processes
-  — `parse_fortigate | compose_ocsf_finding | route_by_severity`. Each
+  — `parse_fortigate_cef | compose_ocsf | route_by_severity`. Each
   piece is one responsibility, swappable, and reusable across
   pipelines.
+
+- **Durable recovery sink, built in.** `control { error_log "..." }`
+  persists payloads that retry-exhaust, lose their secondary fallback,
+  or fail the shutdown flush — operators get the recovery guarantee
+  without writing their own DLQ wiring. `--check --strict-warnings`
+  enforces it on configs that need it.
 
 - **Visible flow.** Read the config and you know what the pipeline
   does. No implicit parsers that fire because input "looks like JSON".
@@ -157,6 +166,18 @@ cargo build --release -p limpid -p limpidctl -p limpid-prometheus
 limpid --check --config /etc/limpid/limpid.conf     # static analysis
 limpid --config /etc/limpid/limpid.conf             # run the daemon
 ```
+
+Other useful flags during config development:
+
+- `--check --strict-warnings` — promote analyzer warnings to errors
+  (for example, missing `control { error_log }` on configs that depend
+  on recovery).
+- `--check --ultra-strict` — turn on every optional lint, including
+  style-level findings, for the most thorough pre-deploy gate.
+- `--graph[=mermaid|dot|ascii]` — render the resolved pipeline graph
+  for review or for pasting into a PR description.
+- `--test-pipeline <name> --input '<json>'` — run a single Event
+  through one named pipeline without binding any sockets.
 
 See the [Getting Started guide](docs/src/getting-started.md) for
 installation, .deb packaging, and systemd integration.
@@ -240,14 +261,15 @@ migration table.
 
 Curated parser / composer / filter library, installed under
 `/usr/share/limpid/snippets/` and `include`-able by absolute path.
-Debuts in **v0.7.0**, with the transport layer split out as its own
-snippet category in **v0.7.1**:
+Introduced in **v0.7.0**, with the transport layer split out as its
+own snippet category in **v0.7.1** and the vendor lineup expanded
+across the 0.7.x line:
 
 - **Transport parsers (2, v0.7.1)** — `parse_syslog` (RFC 3164 /
   5424 syslog wire) · `parse_journald` (systemd journald JSON).
   These populate `workspace.<transport>.*` and feed any vocabulary
   parser downstream via an inline bridge.
-- **Vendor parsers (22)** — security devices / cloud audit:
+- **Vendor parsers (24)** — security devices / cloud audit:
   `parse_fortigate_cef` · `parse_fortigate_syslog` ·
   `parse_paloalto_cef` · `parse_paloalto_syslog` · `parse_asa` ·
   `parse_cloudtrail` · `parse_juniper_srx_sd_syslog` (Junos
@@ -283,7 +305,9 @@ logs into a SIEM / data lake in OCSF form. Full reference:
 There are several types of expression functions you can call from
 inside a `process` body:
 
-- **Generic parsers** — `parse_json` · `parse_kv` · `csv_parse`
+- **Generic parsers** — `parse_json` · `parse_kv` · `csv_parse` ·
+  `nest_dotted_keys` (lift flat dotted keys from Zeek / Filebeat-style
+  inputs into a nested object)
 - **Regex** — `regex_match` · `regex_extract` · `regex_parse` ·
   `regex_replace`
 - **String predicates** — `contains` · `starts_with` · `ends_with`

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -576,10 +576,13 @@ pub async fn run_queue_consumer(
             input = receiver.recv() => {
                 match input {
                     Some(input) => {
-                        // Disposition is intentionally ignored here:
-                        // delivered / routed-to-secondary / dropped
-                        // all ack-and-continue from this consumer's
-                        // POV. PR-O / PR-P will fan out on it.
+                        // Fan-out (secondary routing + error_log
+                        // recovery) is performed inside
+                        // `write_with_retry`; the disposition is
+                        // ignored here because the caller-side
+                        // per-disposition metrics breakdown is not yet
+                        // implemented (deferred to the 0.8 metrics
+                        // rework).
                         let _ = write_with_retry(writer.as_ref(), input, &retry_config, &secondary_sender, &name, &metrics, tap.as_ref(), error_log.as_ref()).await;
                         // Acknowledge the event regardless of
                         // disposition (delivered, routed to

--- a/crates/limpid/src/queue/outcome.rs
+++ b/crates/limpid/src/queue/outcome.rs
@@ -17,9 +17,10 @@ use std::io;
 /// path inside `QueueSender::send` / `DiskQueueSender::send` that was
 /// previously returning `bool` = `false`.
 ///
-/// `#[non_exhaustive]` so downstream PRs (PR-O / PR-P recovery
-/// routing) can add variants without it being a breaking change for
-/// match-on-self callers; current callers in-tree match exhaustively.
+/// `#[non_exhaustive]` so future recovery-routing work can add
+/// variants without breaking external matches; downstream code should
+/// use `Result` patterns that accept new variants forward-compatibly.
+/// Current callers in-tree match exhaustively.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum QueueSendError {
@@ -73,9 +74,12 @@ impl QueueSendError {
 ///
 /// `#[must_use]` so a caller can't silently throw the disposition
 /// away — that's exactly the bug shape this refactor is meant to
-/// prevent. `#[non_exhaustive]` so PR-O / PR-P can add finer
-/// dispositions (e.g. distinguishing rendered-no-retry from
-/// retries-exhausted) without churning every match site.
+/// prevent. PR-O added [`DroppedToRecovery`] to distinguish payloads
+/// persisted to `error_log` for replay from unrecoverable drops;
+/// `#[non_exhaustive]` remains so future routing work can extend
+/// without churning match sites.
+///
+/// [`DroppedToRecovery`]: WriteDisposition::DroppedToRecovery
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[must_use]
 #[non_exhaustive]

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -492,9 +492,11 @@ struct PipelineContext {
     config: Arc<CompiledConfig>,
     funcs: Arc<FunctionRegistry>,
     tap: TapRegistry,
-    /// Dead-letter queue writer for events that fail in `process`.
-    /// `None` when the operator hasn't configured `error_log` — the
-    /// runtime then falls back to a structured `tracing::error!` line.
+    /// Dead-letter queue writer used for: (1) `process` runtime
+    /// errors, (2) output retry-exhausted payloads (PR-O), (3)
+    /// batched-output shutdown-flush leftovers (PR-P). `None` when
+    /// `control { error_log }` is unset — falls back to a structured
+    /// `tracing::error!` line for each case.
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
 }
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -45,7 +45,7 @@ control {
 | Property | Default | Effect |
 |----------|---------|--------|
 | `socket` | `/var/run/limpid/control.sock` | Unix socket path consumed by `limpidctl` and `limpid-prometheus`. |
-| `error_log` | *(unset)* | JSONL file appended to when a `process` raises a runtime error. When unset, the runtime falls back to a structured `tracing::error!` line so the failure data is never silently lost. See [Error Log (DLQ)](./operations/error-log.md) for the record format and replay recipe. |
+| `error_log` | *(unset)* | JSONL file appended to when a `process` raises a runtime error. When unset, the runtime falls back to a structured `tracing::error!` line so the failure data is never silently lost. Strongly recommended when any output declares `retry`, `secondary`, or is a batched OTLP/HTTP output — `--check` warns (see [Error Log → recovery dependency](./operations/error-log.md)). See [Error Log (DLQ)](./operations/error-log.md) for the record format and replay recipe. |
 
 The whole block is optional — daemon starts with the defaults if it's omitted.
 

--- a/docs/src/design-principles.md
+++ b/docs/src/design-principles.md
@@ -73,7 +73,7 @@ A log forwarder runs unattended on production paths, and any mistake compounds q
 
 - **Undo after deployment.** Configuration reload is atomic: a new configuration that fails to parse, type-check, or start is rolled back; the previous configuration keeps running while the operator sees a diagnostic. The daemon never enters a half-loaded state.
 
-- **Fail soft, surface clearly.** Output queues retry with backoff, fall back to a secondary destination for dead-letter routing, and optionally persist to disk so a crash does not lose events in flight. Shutdown reports the count of events still buffered rather than letting them disappear silently.
+- **Fail soft, surface clearly.** Output queues retry with backoff, fall back to a secondary destination for dead-letter routing, and optionally persist to disk so a crash does not lose events in flight. `control { error_log }` is the terminal recovery sink (PR-O / PR-P): retry-exhausted payloads, secondary-destination failures, and shutdown-flush failures all land in it as JSONL rather than disappearing. `--check --strict-warnings` enforces that recovery-dependent configs declare an `error_log`. Shutdown reports the count of events still buffered rather than letting them disappear silently.
 
 **Why:** a daemon that processes production traffic 24/7 cannot afford a *"well, redeploy and hope"* recovery story, and an opaque daemon cannot be operated safely even when it is technically working. The cost of these affordances — more code paths, more CLI surface, more documentation, more API — is paid up front. The benefit is paid every time something goes wrong, and every time an operator wonders *"is the pipeline doing what I think it is?"* without that question being a costly investigation.
 

--- a/docs/src/dsl-syntax.md
+++ b/docs/src/dsl-syntax.md
@@ -230,6 +230,16 @@ switch workspace.cef.device_vendor {
 
 Arm bodies are statements valid in the surrounding body, same rule as `if`. There is no fall-through and no need for an explicit `break`.
 
+Position rule: `default` must be the last arm and may appear at most once; `--check` rejects otherwise (since 0.7.8). For example, the following is rejected:
+
+```limpid
+// NG — `default` is not last
+switch source.ip {
+    default     { output archive }
+    "192.0.2.1" { output fw01 }
+}
+```
+
 There is also an **expression form** of `switch` — each arm body is one expression rather than a statement list, and the matching arm's value is the value of the whole `switch`. Used inside `def function` bodies and anywhere a value is expected:
 
 ```limpid

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -21,6 +21,8 @@ This page is the reference for every built-in. Operators can also declare their 
 
 ## Call syntax
 
+Errors raised by these primitives (a `parse_json` on malformed input, a `to_int` overflow, a `regex_*` compile failure, …) propagate to the surrounding `try` block when one is in scope; without `try`, the error flows through the pipeline's error path and the event lands in the configured [error log](../operations/error-log.md) (DLQ), with `events_errored` incremented. The same routing applies to errors raised from inside user-defined functions and processes — primitive failure, [`error` statement](../processing/user-defined.md#error), or analyzer-detected runtime fault all share the one path.
+
 ### Bare statements vs assignments
 
 A parser function returns a `Value::Object` whose keys are taken from the parse — `hostname`, `appname`, `msg` for `syslog.parse`; `version`, `name`, `severity`, plus CEF extension keys (`src`, `dst`, `act`, …) for `cef.parse`; whatever the source JSON contains for `parse_json`. There are two ways to consume that object inside a process body.
@@ -188,7 +190,7 @@ workspace.otlp = {
         ]
     },
     scope_logs: [{
-        scope: { name: "limpid", version: "0.5.0" },
+        scope: { name: "limpid", version: version() },
         log_records: [{
             time_unix_nano: workspace.event_time_ns,
             severity_number: 9,                   // 9=INFO, 13=WARN, 17=ERROR, 21=FATAL
@@ -579,6 +581,19 @@ When array compaction is what you want, use
 `filter(arr) { |x| x != null }` — the block-arg `filter` covers
 this without a dedicated `compact` primitive.
 
+### nest_dotted_keys(value)
+
+Convert flat-dotted Object keys into nested Object structure. `{"id.orig_h": "1.2.3.4", "id.orig_p": 53}` becomes `{"id": {"orig_h": "1.2.3.4", "orig_p": 53}}`. Useful for normalising upstream shapes that flatten nested fields with `.` separators (Zeek logs, Filebeat-shipped pipelines, some OpenTelemetry exporters) into the nested form that composers and downstream consumers expect.
+
+```limpid
+workspace.zeek = parse_json(ingress)
+workspace.zeek = nest_dotted_keys(workspace.zeek)
+// {"id.orig_h": "1.2.3.4", "id.orig_p": 53, "ts": 1700000000}
+// → {"id": {"orig_h": "1.2.3.4", "orig_p": 53}, "ts": 1700000000}
+```
+
+Non-Object inputs (arrays, scalars, `null`) pass through unchanged — the function recurses through Array elements and nested Objects but only rewrites string keys that contain `.`. A key like `"a.b"` that conflicts with a sibling already at `"a"` (or a deeper nest that tries to descend into a leaf scalar) is a loud error rather than a silent overwrite, so an upstream shape change surfaces in the DLQ instead of corrupting downstream records.
+
 ## Hash functions
 
 ### md5(str) / sha1(str) / sha256(str)
@@ -685,7 +700,7 @@ Equivalent to `compact` for null removal: `filter(arr) { |x| x != null }` drops 
 
 ### find(array) { |x| predicate }
 
-First element where the block returns truthy, or `null` if no match. Replaces the v0.7.3 `find_by(arr, key, value)` — the new form composes for arbitrary predicates:
+First element where the block returns truthy, or `null` if no match. An earlier `find_by(arr, key, value)` shape was removed in the 0.7.x cycle; the block-arg form composes for arbitrary predicates:
 
 ```limpid
 workspace.process = find(workspace.evidence) { |e| e.entityType == "Process" }
@@ -750,9 +765,17 @@ let highest_severity = max(map(workspace.alerts) { |a| a.severity })
 Name positional captures: take an `Array` of values and an `Array` of string keys (same length), produce an `Object` keyed by name. Length mismatch is a **loud failure** — the typical use is naming parser captures, where a drift is almost always a parser-shape bug the operator wants to hear about.
 
 ```limpid
-let cap = regex_parse_groups(ingress, "(\\S+) (\\S+) (\\S+)")
+// Hand-built positional captures from three regex_extract calls, named in one step.
+let cap = [
+    regex_extract(ingress, "user=(\\S+)"),
+    regex_extract(ingress, "host=(\\S+)"),
+    regex_extract(ingress, "action=(\\S+)")
+]
 workspace.fields = entitle(cap, ["user", "host", "action"])
+// → workspace.fields.user, workspace.fields.host, workspace.fields.action
 ```
+
+For named captures from a single regex pass, reach for [`regex_parse`](#regex_parsestr-pattern) instead — it returns an Object directly, no `entitle` needed.
 
 ### path(obj, key1, key2, ...)
 
@@ -965,7 +988,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.5.0"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.8"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -120,14 +120,14 @@ def function endpoint_label(host, port) {
 }
 ```
 
-Anything an expression can do (binary ops, primitive calls, hash literals, array literals, nested function calls) is fair game inside `let` RHS or the trailing expression. The block-arg primitives — `map`, `filter`, `find`, `reduce` — are pure expressions over arrays and compose freely inside a function body. What you cannot do is write a *statement* — no assignments to anything, no `drop` / `finish` / `error` / `process foo` / `output foo`, no statement-form `if` / `switch` / `try-catch`. Use the expression-form alternatives.
+Anything an expression can do (binary ops, primitive calls, hash literals, array literals, nested function calls) is fair game inside `let` RHS or the trailing expression. The block-arg primitives — `map`, `filter`, `find`, `reduce` — are pure expressions over arrays and compose freely inside a function body. What you cannot do is write a *statement* — no assignments to anything, no `drop` / `error` / `process foo` / `output foo`, no statement-form `if` / `switch` / `try-catch`. Use the expression-form alternatives.
 
 ## Restrictions (enforced at `--check` time)
 
 The body **may not**:
 
 - **read from the Event** — `ingress`, `egress`, `source`, `received_at`, `error`, and any `workspace.*` path are rejected. Functions are pure transformations of their arguments; coupling them to the surrounding pipeline context defeats the point.
-- **invoke any routing op** — `process foo`, `drop`, `finish`, `error`, `output` are all rejected. A function returns a value; routing decisions belong at pipeline level, and the side effects of a `def process` body don't fit the function contract.
+- **invoke any routing op** — `process foo`, `drop`, [`error`](../processing/user-defined.md#error), `output` are all rejected. A function returns a value; routing decisions belong at pipeline level, and the side effects of a `def process` body don't fit the function contract. (`finish` is a pipeline-only statement and is not reachable from a function body even in principle — listed here for completeness.)
 - **recurse**, directly or mutually. The analyzer detects cycles in the function-to-function call graph and rejects them at config-load time. If you genuinely need recursion, write a `def process` instead.
 - **call an unknown function** — every function call inside the body must resolve to either a built-in primitive, a user-defined `def function`, or (if a block-arg primitive's block) the block parameters. Calls to names that don't exist (typos, references to removed primitives) are rejected, with a near-match hint when available.
 
@@ -173,7 +173,7 @@ The analyzer's cycle check catches mutual recursion across any chain length.
 | Returns | a value | nothing (mutates Event) |
 | Reads `workspace.*` / `ingress` / `egress` / … | ❌ | ✅ allowed |
 | Any assignment (`x = …`) | ❌ | ✅ allowed |
-| `drop` / `finish` / `error` / `output foo` / `process foo` | ❌ | ✅ allowed |
+| `drop` / `error` / `output foo` / `process foo` | ❌ | ✅ allowed |
 | Calls another `def function` | ✅ | ✅ |
 | Recursion | ❌ | ✅ allowed (operator-responsible) |
 | Composable in expressions / HashLit | ✅ | ❌ (statement only) |

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -61,8 +61,11 @@ include "pipelines/*.limpid"
 
 control {
     socket "/var/run/limpid/control.sock"
+    error_log "/var/log/limpid/error_log.jsonl"
 }
 ```
+
+`error_log` is the daemon-wide recovery sink: payloads that retry-exhaust, fail their secondary fallback, or fail the shutdown flush are persisted there as JSONL instead of being silently dropped. Recommended whenever a pipeline uses retry, a secondary output, or batched outputs; `limpid --check --strict-warnings` will warn if a recovery-dependent config omits it. See [Error Log (DLQ)](./operations/error-log.md) for the format and rotation guidance.
 
 **/etc/limpid/inputs/syslog.limpid:**
 ```
@@ -92,8 +95,8 @@ def pipeline main {
 
 ```bash
 limpid --check --config /etc/limpid/limpid.conf
-# Configuration OK
-#   1 input(s), 1 output(s), 0 process(es), 1 pipeline(s)
+# checking /etc/limpid/limpid.conf: 4 file(s), 1 input(s), 1 output(s), 0 process(es), 1 pipeline(s)
+# /etc/limpid/limpid.conf: Configuration OK (1 pipeline(s), 0 process(es); dataflow check passed)
 ```
 
 ### 3. Test with sample data

--- a/docs/src/inputs/README.md
+++ b/docs/src/inputs/README.md
@@ -16,12 +16,9 @@ Input modules receive log messages from external sources and feed them into pipe
 
 ## Common properties
 
-All input types support:
+Each `def input` block declares its type via the `type <name>` clause; see the per-input pages for the property set each type accepts.
 
-| Property | Description |
-|----------|-------------|
-| `type` | Input type name (required) |
-| `rate_limit` | Maximum events per second (optional) |
+`rate_limit` (maximum events per second) is supported per input — see the per-input pages for which inputs expose it (currently the `syslog_*` and `otlp_*` receivers).
 
 ## Usage in pipelines
 

--- a/docs/src/inputs/journal.md
+++ b/docs/src/inputs/journal.md
@@ -45,7 +45,7 @@ Conventions matching `journalctl`:
 
 - field names preserved as journald exposes them (`PRIORITY`, `_PID`,
   `__REALTIME_TIMESTAMP`, `SYSLOG_IDENTIFIER`, `MESSAGE`, …)
-- field order: insertion order from libsystemd
+- field order: insertion order from libsystemd is preserved through the read path. JSON object key order on the wire is a serialisation detail and is not guaranteed to byte-match `journalctl -o json`.
 - UTF-8-clean values: JSON strings
 - non-UTF-8 byte values (rare; e.g. `COREDUMP`): JSON array of integers
   `[104, 101, 108, 108, 111]`

--- a/docs/src/inputs/otlp-http.md
+++ b/docs/src/inputs/otlp-http.md
@@ -110,8 +110,8 @@ def pipeline otlp_relay {
 
 ## TLS
 
-Native HTTPS lands in v0.7.6 via the [`tls` block](#tls-block) at the
-top of this page — `tls { cert key }` for plain server TLS, plus
+Native HTTPS is served via the [`tls` block](#tls-block) at the
+top of this page (since v0.7.6) — `tls { cert key }` for plain server TLS, plus
 optional `ca` for mTLS (client-cert verification at handshake). The
 same shape is shared with [`input syslog_tcp`](./syslog-tcp.md) and
 [`input otlp_grpc`](./otlp-grpc.md). Without the block, the listener

--- a/docs/src/inputs/syslog-tcp.md
+++ b/docs/src/inputs/syslog-tcp.md
@@ -82,7 +82,7 @@ Framing detection runs after the TLS handshake when `tls` is configured.
 ## Notes
 
 - PRI validation is enforced on all messages.
-- Idle connections are closed after 300 seconds.
+- Idle connections are closed after 300 seconds (applied uniformly to framing detection, length-prefix read, and payload read — any 5-minute gap at any read stage drops the connection).
 - Maximum message size: 1 MiB.
 - Connections exceeding `max_connections` are rejected immediately.
 - TLS server config (cert / key / CA loading + parsing) happens at

--- a/docs/src/inputs/tail.md
+++ b/docs/src/inputs/tail.md
@@ -25,8 +25,8 @@ def input app_log {
 
 The tail input detects two forms of log rotation:
 
-- **Inode change** — the file was replaced (e.g., `logrotate` with `copytruncate`)
-- **File truncation** — the file was truncated to zero
+- **Inode change** — the file was replaced (e.g., `logrotate` without `copytruncate` — the new file gets a fresh inode)
+- **File truncation** — the file was truncated to zero (e.g., `logrotate` with `copytruncate`, which preserves the inode and truncates in place)
 
 In both cases, reading resets to the beginning of the new file.
 
@@ -35,4 +35,4 @@ In both cases, reading resets to the beginning of the new file.
 - On first start without a `state_file`, reading begins at the end of the file (new data only).
 - Empty lines are skipped.
 - Incomplete lines (no trailing newline) are held until the next poll.
-- The source address for tail events is `127.0.0.1`.
+- The source address for tail events is `127.0.0.1:0` (a placeholder address with port 0; tail has no network peer).

--- a/docs/src/inputs/unix-socket.md
+++ b/docs/src/inputs/unix-socket.md
@@ -20,6 +20,6 @@ def input local {
 ## Notes
 
 - The socket file is created with mode `0666` (world-writable) so any local process can send messages.
-- If a stale socket file exists, it is removed on startup (with symlink detection for safety).
+- If the configured `path` is a symlink, the input refuses to start (it will not follow the link). Otherwise, stale socket files at that path are removed automatically on startup.
 - PRI validation is enforced on all messages.
 - Works with the `logger` command: `logger "hello from limpid"`

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -33,6 +33,8 @@ Input → Process → Process → ... → output(copy) → Process → output(co
 
 Each output has an async queue. Pipelines run synchronously (one event at a time), but outputs are decoupled via queues so downstream bottlenecks don't block the pipeline.
 
+When an output exhausts its retries, its secondary destination also fails, or shutdown can't drain the queue in time, the payload is persisted as JSONL to the daemon-wide `control { error_log "..." }` sink rather than being silently dropped. The recovery story is part of the daemon, not a per-output afterthought — see [Error Log (DLQ)](./operations/error-log.md).
+
 ## At a glance
 
 ```

--- a/docs/src/operations/cli.md
+++ b/docs/src/operations/cli.md
@@ -22,10 +22,23 @@ limpid --debug --config /etc/limpid/limpid.conf
 | Flag | Description |
 |------|-------------|
 | `--config <path>` | Main configuration file (default: `/etc/limpid/limpid.conf`) |
-| `--check` | Validate configuration and exit |
+| `--check` | Validate configuration and exit. Exit codes: `0` clean, `1` errors, `2` warnings present with `--strict-warnings`. |
+| `--strict-warnings` | When combined with `--check`, treat any warning (recovery readiness, etc.) as a non-zero exit (`2`). Useful in CI to gate on warnings without failing on the absence of warnings. |
+| `--ultra-strict` | When combined with `--check`, additionally promote informational analyzer notices to warnings before the `--strict-warnings` exit calculation. Use sparingly — intended for the strictest pre-merge gates. |
+| `--graph[=mermaid\|dot\|ascii]` | Print the configured pipeline graph (nodes + edges) and exit. Format defaults to `mermaid`; `dot` (Graphviz) and `ascii` are also accepted. Composes with `--check`: validation runs first, the graph is printed on success. |
 | `--test-pipeline <name>` | Test a named pipeline with sample data |
 | `--input <json>` | Sample event for test mode (JSON) |
 | `--debug` | Enable trace-level logging |
+
+`--check` prints a per-file header line and a final status footer:
+
+```
+$ limpid --check --config /etc/limpid/limpid.conf
+checking /etc/limpid/limpid.conf: 4 inputs, 6 processes, 3 outputs, 2 pipelines
+/etc/limpid/limpid.conf: Configuration OK (0 errors, 0 warnings)
+```
+
+CI integration: combine `--check --strict-warnings` and treat exit `2` as a gate failure distinct from exit `1` (hard errors).
 
 ### Test mode input format
 
@@ -50,6 +63,8 @@ All keys except `ingress` are optional. `source` is the canonical `{ip, port}` o
 | `source: {ip, port}` | exact |
 
 When `source` is present but malformed (legacy `"ip:port"` string, wrong types, port out of range), `--test-pipeline` errors out loudly — operators migrating from the 0.5.5 form should see the failure, not silently get a wrong default. The Event has no facility / severity fields — the `<PRI>` byte lives inside `ingress` / `egress`, and pipelines that need its numeric value call `syslog.extract_pri(...)`.
+
+`received_at` in the input JSON is **ignored** in test mode — `--test-pipeline` constructs the Event with `Event::new`, which stamps `received_at` to the current wall-clock. Only `ingress`, `source`, and `workspace` are honoured. When piping `tap --json` output into `--test-pipeline`, be aware that the captured timestamp will not be reproduced.
 
 ## limpidctl
 

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -97,11 +97,28 @@ One JSON object per line:
 |-------|---------|
 | `timestamp` | RFC3339 with nanosecond precision; wall-clock at which the error was raised. |
 | `reason` | Stringified `ProcessError`. Stable enough for `grep` / classification but not a stable API. |
-| `process` | Failed process. A named `def process` invocation surfaces its name; an inline `process { ... }` block surfaces `(inline)`. |
-| `pipeline` | Pipeline name (`def pipeline <name>`). |
+| `process` | Failed process or recovery-path discriminator. A named `def process` invocation surfaces its name; an inline `process { ... }` block surfaces `(inline)`. For records originating from an output's recovery path the value is one of four discriminators: `(output <name>)` — retry exhausted (PR-O); `(output <name> shutdown)` — batched output's shutdown drain (PR-P); `(pipeline)` — explicit `error` from pipeline routing; `(output enqueue)` — output enqueue failure (PR-I). |
+| `pipeline` | Pipeline name (`def pipeline <name>`). Empty for output-originated records (`(output ...)`, `(output ... shutdown)`, `(output enqueue)`); populated only when the record originates inside a pipeline. |
 | `event.source` | Originating peer as `{ip, port}` object. Same shape as `tap --json` and as the DSL `source` ident. |
 | `event.received_at` | i64 unix nanoseconds (matches OTLP `time_unix_nano`). Same shape as `tap --json`. |
 | `event.ingress` | Original wire bytes. UTF-8-clean payloads serialise as a JSON string; non-UTF-8 payloads use the `$bytes_b64` marker the rest of the JSON layer already uses for `tap --json`. |
+
+Example `reason` values across the discriminators: `"unknown identifier: timestamp"` (process runtime error), `"output retry exhausted after 5 attempts: connection refused"` (`(output <name>)`), `"output shutting down; draining queue"` (`(output <name> shutdown)`), `"output queue full; enqueue failed"` (`(output enqueue)`).
+
+## Recovery paths into the DLQ
+
+The DLQ receives records from four distinct paths. The `process` field above is the discriminator:
+
+1. **Process runtime error / explicit `error`** — a `process` statement raised an error, or pipeline routing executed `error <expr?>`. `process` is the failed `def process` name (or `(inline)`), or `(pipeline)` for pipeline-level `error`. `pipeline` is populated. (Original behaviour.)
+2. **Output retry exhausted** (PR-O) — an output exhausted its `retry` budget against the destination. `process = "(output <name>)"`, `pipeline` empty. The event carries the post-pipeline `egress` that the output attempted to deliver.
+3. **Batched output shutdown drain** (PR-P) — a batched output (`otlp_*`, `http`) was shut down while events were still buffered and could not flush them. `process = "(output <name> shutdown)"`, `pipeline` empty. Synthetic-event metadata constraints apply: `received_at` reflects the shutdown moment for events that never carried their own; per-event source / workspace state may be a representative of the batch rather than per-record.
+4. **Output enqueue failure** (PR-I) — the pipeline could not hand an event to an output's queue (queue full, output stopped). `process = "(output enqueue)"`, `pipeline` empty. The record preserves the event as it was at the pipeline → output boundary.
+
+All four paths converge on the same JSONL file and the same replay recipe — `jq` on the `process` field selects which recovery path you are replaying.
+
+### Recovery readiness check (`--check`)
+
+Since 0.7.8 (PR-R), `limpid --check` emits a recovery-readiness warning when any output declares `retry`, declares a `secondary`, or is a batched OTLP/HTTP output and the `control { error_log }` is unset. Without `error_log`, recovery paths 2–4 above fall back to `tracing::error!` and the records are only recoverable through journald — sufficient for triage, but harder to replay. The warning catches the missing configuration before the first failure.
 
 `event.egress` and `event.workspace` are intentionally **not** included — at the failure point they may hold partial state from earlier processes in the chain, which would confuse `inject --json` replay. The replay path re-runs the pipeline from scratch on `ingress`.
 

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -41,6 +41,8 @@ The split between `received` and `injected` keeps "real" traffic distinguishable
 
 `received - injected` = events delivered via pipelines. `received - written - failed` ≈ events pending in the queue (useful for disk queues).
 
+`events_failed` counts every event whose final state was retry-exhausted (including OTLP `partial_success.rejected_log_records`). Of those, the ones actually lost are only the records that hit a DLQ write failure or had no DLQ configured — when `control { error_log }` is set, exhausted events are persisted into the DLQ for replay. Evaluate `events_failed` in combination with the DLQ contents (and `events_errored_unwritable`); the `--check` recovery-readiness warning (see [Error Log → Recovery readiness check](./error-log.md#recovery-readiness-check---check)) flags the no-`error_log` case at configuration time so the interpretation of `events_failed` stays unambiguous in production.
+
 ## Viewing metrics
 
 ### Command line

--- a/docs/src/operations/schema-validation.md
+++ b/docs/src/operations/schema-validation.md
@@ -1,5 +1,7 @@
 # Schema Validation
 
+> **Scope.** Structural validation of the DSL config itself — switch `default` placement, `secondary` cycle detection, recovery readiness, and the other analyzer checks added across the 0.7.x cycle — is the job of `limpid --check` (see [CLI](./cli.md#options)). This page is about the complementary problem: validating the **emitted payload** against the downstream schema the destination expects.
+
 limpid does not ship a schema validator. There is no `limpidctl validate`, no built-in OCSF / ECS / ASIM / CIM check, and no schema-annotation syntax in the DSL. Validation is performed by piping `tap --json` output into whichever validator matches the schema your downstream expects:
 
 ```bash
@@ -175,7 +177,7 @@ Anything that reads JSONL from stdin and exits non-zero on failure works. The co
 - **One event per line.** Each line is a complete [Event JSON](./tap.md#usage) object.
 - **Exit code 0 = all good, non-zero = reject.** For streaming validators, prefer printing per-event diagnostics to stderr and keeping the process alive; let a supervising process aggregate.
 - **No assumptions about key order.** `tap --json` does not guarantee key order across versions; schema validators don't care, but ad-hoc `grep` pipelines might.
-- **Workspace keys.** Structured fields built by the pipeline live under `workspace.<key>`. Use the key names your DSL actually assigns; `limpid --check --graph` shows which workspace keys each output observes.
+- **Workspace keys.** Structured fields built by the pipeline live under `workspace.<key>`. Use the key names your DSL actually assigns; inspect a live sample with `limpidctl tap output <name> --json | jq '.workspace | keys'` to confirm the actual key set.
 - **Non-JSON wire formats.** If the final wire format is protobuf, Avro, or similar, serialize with your existing producer and validate the bytes (e.g. `.egress` piped through `protoc --decode`).
 
 ## Related design decisions

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -24,19 +24,19 @@ read that and explains the OTLP-specific reading on top.
 
 ## 1. Scope
 
-| Aspect | Current (0.7.6) |
+| Aspect | Current (0.7.8) |
 |---|---|
 | Signal | **logs** only — no traces, no metrics, no profiles |
-| Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` as of 0.7.6) |
+| Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` introduced in 0.7.6; in 0.7.8 plaintext `http://` with `tls { ... }` is now rejected at parse time — see CHANGELOG 0.7.8) |
 | Direction | input *and* output (so collector-to-collector relay works) |
-| TLS | server-side TLS / mTLS on every input (`otlp_http`, `otlp_grpc`); client-side TLS / mTLS on every output (per-peer `tls { ca cert key }` on both `output otlp_http` and `output otlp_grpc` as of 0.7.6) |
+| TLS | server-side TLS / mTLS on every input (`otlp_http`, `otlp_grpc`); client-side TLS / mTLS on every output (per-peer `tls { ca cert key }` on both `output otlp_http` and `output otlp_grpc`; introduced in 0.7.6, with 0.7.8 adding fail-fast rejection of plaintext `http://` URLs that pair a `tls { ... }` block) |
 | Versioning | OTLP 1.4 wire (the proto3 schema as of opentelemetry-proto 0.27) |
 
 Traces and metrics share the same wire envelope shape but use different
 proto messages, so the input / output skeleton from logs is reusable.
-v0.5.0 ships logs first because that is where limpid's existing pipeline
-identity lives — every other limpid module produces or consumes log
-records.
+The 0.5.x line shipped logs first because that is where limpid's existing
+pipeline identity lives — every other limpid module produces or consumes
+log records.
 
 ---
 
@@ -366,9 +366,10 @@ that expose no usable source time (or where the source clock is
 known-bad and you want to ignore it) are handled in the composer by
 overriding the default — Rust never sees the decision.
 
-This is also why `received_at` was renamed in v0.5.0: a forwarder
-must not silently conflate wall-clock and source-clock semantics. See
-the breaking change entry in [CHANGELOG.md](../../CHANGELOG.md).
+This is also why the `Event.timestamp` → `Event.received_at` rename
+that landed in v0.5.0 was made: a forwarder must not silently conflate
+wall-clock and source-clock semantics. See the breaking change entry in
+[CHANGELOG.md](../../CHANGELOG.md).
 
 ### 5.4 Resource attributes are user-authored
 
@@ -405,8 +406,8 @@ producer's "High" means OTLP 13 (WARN) for some vendors and OTLP 17
 (ERROR) for others. limpid does not bake any mapping into Rust;
 snippets carry the table.
 
-The reference snippet library that landed in v0.7.0 (and expanded in
-v0.7.1) ships opinionated mappings for common vendors — see
+The reference snippet library that landed in v0.7.0 (and was expanded
+across the 0.7.x line) ships opinionated mappings for common vendors — see
 [Snippet Library](./snippets/README.md). Authors of new snippets
 follow the table conventions documented there.
 
@@ -426,10 +427,12 @@ spec does not say.
 
 **What's queued.** The OTel Collector has an `otlp` exporter mode
 where rejected records get logged-and-dropped, and another where they
-trigger the whole batch's failure path. limpid currently does the
-former. A configurable selective-drop / dead-letter mode is queued
-for v0.5.x; the transport retry that landed in v0.5.0 is the
-"hard failure" half.
+trigger the whole batch's failure path. In 0.7.8 the rejected subset
+is split out into `events_failed` (separate from `events_written`) so
+the loss is visible on dashboards; the `control { error_log }` path
+landed in the 0.7.x cycle as the dead-letter route. Selective re-send
+of only the rejected records remains future work (tracked in
+`send_once` doc comments).
 
 ### 5.7 Body format is the snippet's call
 
@@ -452,7 +455,7 @@ work, and avoids fighting the OTLP attribute namespace.
 
 ## 6. What limpid intentionally does *not* do
 
-These are not "queued for v0.5.x" — they are out of scope for
+These are not "queued for a later 0.x release" — they are out of scope for
 limpid's identity as a forwarder. Issues asking for them will be
 closed with a link here.
 
@@ -484,7 +487,7 @@ fields pointing at an OpenTelemetry Schema URL (e.g.,
 `https://opentelemetry.io/schemas/1.27.0`). Most backends ignore
 them. limpid leaves them empty. A future config-level
 `schema_url "..."` directive is plausible if it becomes a real
-ask; it is not v0.5.0.
+ask; it is not part of the 0.5.0 → 0.7.x cycle.
 
 ---
 
@@ -524,12 +527,13 @@ being a per-record concern.
 
 Because the event time is what the source claimed, not what the
 forwarder observed. The two are not the same thing, and conflating
-them was the v0.5.0 breaking change that motivated the rename. See
-§5.3 and the [CHANGELOG entry](../../CHANGELOG.md) for v0.5.0.
+them motivated the `Event.timestamp` → `Event.received_at` rename
+that landed in v0.5.0. See §5.3 and the
+[CHANGELOG entry](../../CHANGELOG.md) for v0.5.0.
 
 ### *"Can I send Resource attributes from the input layer?"*
 
-Not in v0.5.0. Inputs do not interpret payloads (Principle 2). The
+Not in the 0.5.0 → 0.7.x cycle. Inputs do not interpret payloads (Principle 2). The
 parser snippet that runs in the process layer extracts the source's
 identity into workspace fields; the composer snippet then writes
 them into the Resource. If the same one-Resource pipeline is
@@ -557,4 +561,4 @@ section reference and the wire trace.
 | How do I configure the input / output? | [otlp_http](./inputs/otlp-http.md), [otlp_grpc](./inputs/otlp-grpc.md), [otlp_http output](./outputs/otlp_http.md), [otlp_grpc output](./outputs/otlp_grpc.md) |
 | What primitives are in the `otlp.*` namespace? | [Built-in Functions](./functions/expression-functions.md#otlp---opentelemetry-protocol-logs-signal) |
 | What are the design principles this builds on? | [Design Principles](./design-principles.md) |
-| What changed in v0.5.0 specifically? | [CHANGELOG](../../CHANGELOG.md) (covers the `Event.timestamp` → `Event.received_at` migration) |
+| What changed in v0.5.0 specifically? | [CHANGELOG](../../CHANGELOG.md) (covers the `Event.timestamp` → `Event.received_at` rename that landed in v0.5.0) |

--- a/docs/src/outputs/README.md
+++ b/docs/src/outputs/README.md
@@ -39,9 +39,11 @@ def output reliable {
         backoff exponential                // exponential (default) | fixed
     }
 
-    secondary fallback_output              // optional failover target
+    secondary fallback_output              // optional failover target (bare ident)
 }
 ```
+
+`retry` is accepted by every output type. `secondary` takes a **bare identifier** referencing another `def output` — quoted strings are rejected at `--check`.
 
 ### Memory queue (default)
 
@@ -58,6 +60,18 @@ Events are persisted to a Write-Ahead Log (WAL) on disk. Survives process restar
 ### Secondary output
 
 When all retry attempts are exhausted, the event is forwarded to the `secondary` output instead of being dropped. Useful for dead-letter queues.
+
+If the secondary enqueue itself fails, or no `secondary` is configured, the payload is written to `control { error_log "..." }` (see [Recovery (error_log)](#recovery-error_log) below). Without `error_log`, the event is dropped with a `tracing::warn!` and an `events_failed` counter increment only.
+
+### Recovery (error_log)
+
+The daemon-wide [`control { error_log "..." }`](../configuration.md) block names a JSONL file that catches payloads the queue/retry/secondary chain could not place. Three paths feed it:
+
+- the `secondary` enqueue itself failed,
+- no `secondary` was configured and the retry budget was exhausted,
+- a batched output (e.g. `http`, `otlp_http`, `otlp_grpc`) failed to flush its remaining buffer at shutdown.
+
+Each line is one rendered payload. When `error_log` is unset the daemon falls back to 0.7.7-compatible behaviour (warn + drop), and `limpid --check` emits a warning so the operator notices the silent drop path.
 
 ## Usage in pipelines
 

--- a/docs/src/outputs/file.md
+++ b/docs/src/outputs/file.md
@@ -78,3 +78,4 @@ Parent directories are created automatically.
 
 - Each line is one event's `egress` bytes followed by a newline.
 - For log rotation, use `logrotate` with `copytruncate` or `create` + SIGHUP.
+- Common queue / retry / secondary properties — see [Queue and retry](./README.md#queue-and-retry).

--- a/docs/src/outputs/http.md
+++ b/docs/src/outputs/http.md
@@ -94,6 +94,12 @@ When `batch_size > 1`, events are buffered and sent in a single HTTP request bod
 
 On flush failure, events are returned to the buffer for retry by the queue.
 
+### Shutdown
+
+When the daemon stops, a final flush is attempted for any partial batch. If that flush fails unrecoverably, the buffered request body is drained to `control { error_log "..." }` (PR-P), one DLQ record per rendered body. Without `error_log` configured, behaviour matches 0.7.7 (warn + drop). Because the in-memory queue drops the source `Event` envelope as soon as `write()` returns `Ok`, the original metadata cannot be reconstructed at shutdown — DLQ records emitted on this path carry a synthetic source and the shutdown time as `received_at`.
+
+See [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).
+
 ## TLS behavior
 
 Per peer:

--- a/docs/src/outputs/kafka.md
+++ b/docs/src/outputs/kafka.md
@@ -110,8 +110,8 @@ the wire — the only safe transport is TLS. limpid rejects this
 combination at config-load time:
 
 ```
-output kafka {
-    name "lake"
+def output lake {
+    type kafka
     brokers "..."
     topic "events"
     sasl {

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -87,5 +87,7 @@ Identical semantics to the [otlp_http batch_level](./otlp_http.md#batch_level) �
 ## Notes
 
 - `partial_success` on the response (rejected log records) is logged as a warning. The internal `retry { … }` block does not branch on `partial_success` — it retries the whole batch on transport failures only. A finer "retry just the rejects" policy is queued for a later release.
+- On a transport error during a partial-success flush, the drained batch is restored to the in-memory buffer so the rejected records are not lost to the next attempt (PR-F).
+- At shutdown, if a final flush fails unrecoverably, the remaining buffered ResourceLogs are drained to `control { error_log "..." }` (PR-P) — one DLQ record per rendered request body. Without `error_log` the daemon falls back to 0.7.7 behaviour (warn + drop); shutdown-path DLQ records carry a synthetic source and the shutdown time as `received_at` because the envelope `Event` is dropped at `write()` Ok. See [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).
 - Server TLS uses rustls (aws-lc-rs provider). System root certificates are loaded via tonic's `tls-roots`; supply `tls { ca }` to add a custom CA on top.
 - For HTTP transport see [otlp_http](./otlp_http.md).

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -138,4 +138,5 @@ The merging modes are wire-efficiency optimisations; if your batch sizes are mod
 
 - `http_protobuf` is the canonical OTLP wire form; `http_json` serializes per the OTLP/JSON canonical mapping (camelCase, u64-as-string, bytes-as-hex).
 - `verify false` skips certificate verification — development only. limpid emits a `tracing::warn!` once per `https://` peer at startup when `verify false` is in effect so the misconfiguration is greppable in the daemon log. Has no effect on `http://` endpoints (no TLS to verify).
+- At shutdown, if a final flush of the remaining buffered ResourceLogs fails unrecoverably, the buffer is drained to `control { error_log "..." }` (PR-P), one DLQ record per rendered request body. Without `error_log` the daemon falls back to 0.7.7 behaviour (warn + drop); because the in-memory queue drops the source `Event` envelope at `write()` Ok, shutdown-path DLQ records carry a synthetic source and the shutdown time as `received_at`. See [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).
 - For gRPC transport see [otlp_grpc](./otlp_grpc.md).

--- a/docs/src/outputs/stdout.md
+++ b/docs/src/outputs/stdout.md
@@ -19,3 +19,4 @@ None.
 - Each event is written as one line (`egress` bytes + newline).
 - Not recommended for production use — use [file](./file.md) or [syslog_tcp](./syslog-tcp.md) instead.
 - Useful with `--test-pipeline` for seeing processed output.
+- Common queue / retry / secondary properties — see [Queue and retry](./README.md#queue-and-retry).

--- a/docs/src/outputs/syslog-tcp.md
+++ b/docs/src/outputs/syslog-tcp.md
@@ -136,4 +136,5 @@ behaviour.
 - TLS connectors are built at startup. Errors in CA / cert / key file
   loading or PEM parsing fail-fast before the daemon starts accepting
   events.
+- Common queue / retry / secondary properties — see [Queue and retry](./README.md#queue-and-retry).
 - For UDP, see [syslog_udp](./syslog-udp.md).

--- a/docs/src/outputs/syslog-udp.md
+++ b/docs/src/outputs/syslog-udp.md
@@ -58,3 +58,4 @@ detected and does not enter cooldown.
   [syslog_tcp](./syslog-tcp.md) (with optional per-peer TLS) or
   [http](./http.md) with a disk queue.
 - Each peer's socket is bound to an ephemeral local port on first use.
+- Common queue / retry / secondary properties — see [Queue and retry](./README.md#queue-and-retry).

--- a/docs/src/outputs/unix-socket.md
+++ b/docs/src/outputs/unix-socket.md
@@ -21,3 +21,4 @@ def output local_forward {
 
 - Connection is established on first use and reused.
 - Automatically reconnects if the connection breaks.
+- Common queue / retry / secondary properties — see [Queue and retry](./README.md#queue-and-retry).

--- a/docs/src/pipelines/drop-finish-error.md
+++ b/docs/src/pipelines/drop-finish-error.md
@@ -104,7 +104,12 @@ def pipeline main {
 
 `events_discarded` indicates a possible misconfiguration — the event went through the pipeline but was never sent anywhere.
 
-`events_errored` indicates either an explicit `error` statement or a pipeline-runtime failure (regex compile error, unknown-identifier panic at runtime, type mismatch, …). The event is *not* forwarded downstream — at the failure point the runtime has no way to produce a correct egress, and the pre-0.5 behaviour of forwarding the original `ingress` silently turned wrap / enrichment bugs into data-shape regressions at the receiving SIEM. Instead, the event is routed to the [error log](../operations/error-log.md) so operators can inspect, fix the offending config, and replay.
+`events_errored` is the unified failure counter (PR-I consolidated all of these into one metric + DLQ path). Two layers contribute:
+
+- **Process body runtime errors** — regex compile failure, unknown identifier at runtime, type mismatch, or an explicit `error` statement inside a `def process` body.
+- **Pipeline-skeleton expression-evaluation errors and output enqueue failures** — failure to evaluate the condition expression of an `if` / `switch` / `error` at the pipeline level, plus output enqueue failures (queue closed, disk write error, unknown output).
+
+In every case the event is *not* forwarded downstream — at the failure point the runtime has no way to produce a correct egress, and the pre-0.5 behaviour of forwarding the original `ingress` silently turned wrap / enrichment bugs into data-shape regressions at the receiving SIEM. Instead, the event is routed to the [error log](../operations/error-log.md) so operators can inspect, fix the offending config, and replay.
 
 `events_errored_unwritable` is the subset where the DLQ write itself failed (disk full, permissions, rotation race). The runtime falls back to a structured `tracing::error!` line, but operators should alarm on this counter — a non-zero value means the replay path may be incomplete.
 

--- a/docs/src/pipelines/examples.md
+++ b/docs/src/pipelines/examples.md
@@ -88,7 +88,7 @@ def process ama_rewrite {
 
 def pipeline ama_forward {
     input ama_tcp
-    process filter_chargen | filter_fortinet_traffic | ama_rewrite
+    process filter_fortinet_traffic | ama_rewrite
     output ama
 }
 ```

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -1,6 +1,6 @@
 # User-defined Processes
 
-limpid ships a [Snippet Library](../snippets/README.md) of pre-built processes for common parsing / mapping work (debuts in v0.7.0, expanded in v0.7.1). Sooner or later you'll hit a situation the library doesn't cover — a vendor format we haven't shipped, a one-off enrichment, a dedup or rate-limit shape that's specific to your environment — and want to write your own. This page covers how.
+limpid ships a [Snippet Library](../snippets/README.md) of pre-built processes for common parsing / mapping work (introduced in v0.7.0, expanded across the 0.7.x line). Sooner or later you'll hit a situation the library doesn't cover — a vendor format we haven't shipped, a one-off enrichment, a dedup or rate-limit shape that's specific to your environment — and want to write your own. This page covers how.
 
 You define a process with `def process <name> { ... }`. Inside the body you call functions, assign to event slots and workspace, branch with `if` / `switch` / `try`, transform arrays with the block-arg primitives (`map`, `filter`, `find`, `reduce`), and call other processes by name.
 
@@ -125,6 +125,26 @@ Rule of thumb: if the catch block has nothing useful to do besides stamp `worksp
 ### drop
 
 `drop` terminates the event immediately and counts it as `events_dropped`. It is fundamentally a routing decision and is documented in [Pipelines → Routing](../pipelines/routing.md); using it inside a process body is allowed as a concession (see [Processing → process vs routing](./README.md#process-vs-routing)).
+
+### error
+
+`error` is the intentional fail-fast statement — it raises an error from inside a process body and the event is set aside in the [error log](../operations/error-log.md) (DLQ), incrementing `events_errored`. Use the bare form to raise with a default message, or `error <expr>` to attach an operator-readable message:
+
+```limpid
+def process parse_asa {
+    workspace.syslog = syslog.parse(ingress)
+    let mid = regex_extract(workspace.syslog.msg, "%ASA-\\d-(\\d+):")
+    switch mid {
+        "605004" { process parse_asa_auth_success }
+        "605005" { process parse_asa_auth_failure }
+        default  { error "parse_asa: unsupported message ID ${mid}: ${workspace.syslog.msg}" }
+    }
+}
+```
+
+`drop` and `error` are deliberate opposites: `drop` is a silent discard (event counted as filtered-out, no DLQ entry), `error` is a loud signal (event preserved in the DLQ for operator inspection and replay). Reach for `error` when the parser hits vocabulary it does not handle — the loud-fail-fast policy that runs through the [snippet library](../snippets/README.md#loud-fail-fast-on-unsupported-vocabulary) is built on top of this statement.
+
+When `error` fires inside a `try` block, the catch body sees the message via the reserved name `error` — same surface as any other primitive that bails — so `try { ... error "msg" ... } catch { workspace.failure_reason = error }` works as expected.
 
 ## Arrays
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -8,12 +8,13 @@ their config — no parser to write from scratch, no recompile when
 a vendor adds a field (the snippet is plain DSL: edit the file and
 SIGHUP).
 
-> **Status — v0.7.0:** the library debuts in this release with 11
-> parsers, the OCSF 1.3.0 27-class composer, the replay-shape
-> composer, and one filter. Coverage will grow over the 0.7.x
-> point-release line.
+> **Status:** the snippet library was introduced in v0.7.0 and has
+> expanded across the 0.7.x line. It currently ships 26 vendor
+> parsers, the OCSF 1.3.0 27-class composer, the RFC 5424 and
+> replay-shape composers, one filter, and several reusable
+> functions. Coverage continues to grow on the 0.7.x cadence.
 
-## What ships in v0.7.0 / v0.7.1
+## Snippet library
 
 ### Parsers
 
@@ -88,6 +89,16 @@ SIGHUP).
   operators on non-UTC senders can fork the snippet and substitute.
   For RFC 5424 / OTLP / OCSF input use the built-in
   `parse_datetime_rfc3339` primitive directly.
+- `functions/http_method_activity_id.limpid` —
+  `http_method_activity_id(method) → Int`. HTTP request method
+  (`GET` / `POST` / `PUT` / `DELETE` / `HEAD` / `OPTIONS` /
+  `CONNECT` / `TRACE`) → OCSF 4002 HTTP Activity `activity_id`,
+  with `99` (Other) for anything outside the OCSF 1.3.0 enumeration.
+- `functions/proto_num.limpid` — `proto_num(name) → Int | null`.
+  Transport-layer protocol name (case-insensitive `tcp` / `udp` /
+  `icmp` / …) → IANA protocol number for OCSF
+  `connection_info.protocol_num`. Returns `null` rather than a
+  wrong guess for unknown names.
 
 ## Quick start
 
@@ -153,7 +164,7 @@ positional CSV columns).
 
 The contract is documented in [Process Design Guide → Use
 `workspace.limpid` as the canonical
-intermediate](../processing/user-defined.md#assignments). New
+intermediate](../processing/design-guide.md#use-workspacelimpid-as-the-canonical-intermediate). New
 parsers follow it; out-of-tree vendor parsers should follow it too
 so they compose cleanly with `compose_ocsf`.
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -67,11 +67,11 @@ After editing the config, reload the daemon to pick up the change — either `su
 
 FortiGate `traffic` events are too noisy to forward to AMA, but you still want them in the on-disk archive for after-the-fact investigation. So: archive everything, then drop FortiGate traffic, then forward what's left.
 
-To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. Suppose a FortiGate parser is provided as `parsers/fortigate.limpid` and exposes a `parse_fortigate` process that fills `workspace.limpid.*` (limpid's canonical intermediate — OCSF-shaped, see [Process Design Guide](./processing/design-guide.md#use-workspacelimpid-as-the-canonical-intermediate)) from a FortiGate event. The activity kind lands at `workspace.limpid.activity_name`. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
+To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The FortiGate CEF parser is provided as `parsers/parse_fortigate_cef.limpid` and exposes a `parse_fortigate_cef` process that fills `workspace.limpid.*` (limpid's canonical intermediate — OCSF-shaped, see [Process Design Guide](./processing/design-guide.md#use-workspacelimpid-as-the-canonical-intermediate)) from a FortiGate CEF event. Before it builds the canonical intermediate, the parser also leaves the raw CEF header / extensions in `workspace.cef.*`; in particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
 
 ```limpid
 // /etc/limpid/limpid.conf  — add at the top
-include "/usr/share/limpid/snippets/parsers/fortigate.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 
 def input fw_tcp {
     type syslog_tcp
@@ -91,10 +91,10 @@ def output ama {
 
 def pipeline main {
     input fw_tcp
-    output archive                                          // everything goes to disk
-    process parse_fortigate                                 // populate workspace.limpid.*
-    if workspace.limpid.activity_name == "traffic" { drop } // drop the noise
-    output ama                                              // only the survivors reach AMA
+    output archive                                            // everything goes to disk
+    process parse_fortigate_cef                               // populate workspace.cef.* + workspace.limpid.*
+    if workspace.cef.cat == "traffic:forward" { drop }        // drop the noise
+    output ama                                                // only the survivors reach AMA
 }
 ```
 
@@ -104,7 +104,7 @@ The first is the magic from Step 2. Even though the `process` and `if drop` afte
 
 The second is what the pipeline body actually contains: an `input`, two `output`s, a `process`, and an `if/drop`. There is no separate "filter" or "router" abstraction — routing decisions live in the pipeline as ordinary statements, in the order they execute. That mirrors how you'd describe the pipeline in words: "archive everything, parse it as FortiGate, drop traffic events, forward the rest to AMA."
 
-Worth one more note: `parse_fortigate` populates `workspace.limpid.activity_name`, which the `if` then reads. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
+Worth one more note: `parse_fortigate_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) on its way to building `workspace.limpid.*`, and the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
 
 ## Step 4 — Confirm the drop is actually happening
 
@@ -126,13 +126,15 @@ Now start with the counters:
 ```bash
 $ sudo limpidctl stats
 Pipelines:
-  main                         15234 received     14102 finished      1132 dropped         0 discarded
+  main                         15234 received     14102 finished      1132 dropped         0 discarded         0 errored
 Inputs:
   fw_tcp                       15234 received         0 invalid         0 injected
 Outputs:
-  archive                      15234 received     15234 written         0 failed
-  ama                          14102 received     14102 written         0 failed
+  archive                      15234 received         0 injected     15234 written         0 failed         0 retries
+  ama                          14102 received         0 injected     14102 written         0 failed         0 retries
 ```
+
+(The `errored` column on the pipelines row only appears once at least one event has errored — until then limpid omits it. Each output row carries the full five-metric set: `received`, `injected`, `written`, `failed`, `retries`.)
 
 15,234 events came in. `archive` got all of them. `ama` got 14,102 — short by exactly the 1,132 events the pipeline dropped. The shape matches: the drop is firing, and nothing is silently leaking to AMA.
 
@@ -162,7 +164,7 @@ The config is growing. The conventional layout: one file per module under `input
 
 ```limpid
 // /etc/limpid/limpid.conf
-include "/usr/share/limpid/snippets/parsers/fortigate.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 
 include "inputs/*.limpid"
 include "outputs/*.limpid"
@@ -170,6 +172,7 @@ include "pipelines/*.limpid"
 
 control {
     socket "/var/run/limpid/control.sock"
+    error_log "/var/log/limpid/error_log.jsonl"
 }
 ```
 
@@ -203,8 +206,8 @@ def output ama {
 def pipeline main {
     input fw_tcp
     output archive
-    process parse_fortigate
-    if workspace.limpid.activity_name == "traffic" { drop }
+    process parse_fortigate_cef
+    if workspace.cef.cat == "traffic:forward" { drop }
     output ama
 }
 ```
@@ -221,7 +224,7 @@ The requirement changes: AMA *does* want visibility into FortiGate traffic event
 
 Dropping is no longer the right operation. Instead, dedup: forward the first event for each `(src, dst)` pair, suppress the rest until the entry expires.
 
-`parse_fortigate` already populated `workspace.limpid.src_endpoint.ip` and `workspace.limpid.dst_endpoint.ip` (the snippet maps the FortiGate CEF event into limpid's canonical intermediate, which is OCSF-shaped — see [Process Design Guide → canonical intermediate](./processing/design-guide.md#use-workspacelimpid-as-the-canonical-intermediate)). We need somewhere to remember which pairs we have seen recently — that's what limpid's in-memory tables are for. Declare a table in `limpid.conf` (the `table` block must live in the main config), then write the process that consults and updates it.
+`parse_fortigate_cef` already populated `workspace.limpid.src_endpoint.ip` and `workspace.limpid.dst_endpoint.ip` (the snippet maps the FortiGate CEF event into limpid's canonical intermediate, which is OCSF-shaped — see [Process Design Guide → canonical intermediate](./processing/design-guide.md#use-workspacelimpid-as-the-canonical-intermediate)). We need somewhere to remember which pairs we have seen recently — that's what limpid's in-memory tables are for. Declare a table in `limpid.conf` (the `table` block must live in the main config), then write the process that consults and updates it.
 
 ```limpid
 // /etc/limpid/limpid.conf  — add the table block
@@ -236,7 +239,7 @@ table {
 ```limpid
 // /etc/limpid/processes/dedup_fortigate_traffic.limpid
 def process dedup_fortigate_traffic {
-    if workspace.limpid.activity_name == "traffic" {
+    if workspace.cef.cat == "traffic:forward" {
         let key = workspace.limpid.src_endpoint.ip + "|" + workspace.limpid.dst_endpoint.ip
         if table_lookup("traffic_seen", key) != null {
             drop
@@ -251,16 +254,16 @@ def process dedup_fortigate_traffic {
 def pipeline main {
     input fw_tcp
     output archive
-    process parse_fortigate | dedup_fortigate_trafic
+    process parse_fortigate_cef | dedup_fortigate_trafic
     output ama
 }
 ```
 
 A few things to read:
 
-- `process A | B` chains processes left to right — the event flows through `parse_fortigate` first, then `dedup_fortigate_traffic`. Equivalent to writing them on two `process` lines; the `|` form just reads more naturally when several processes line up.
-- `workspace.limpid.src_endpoint.ip` and `workspace.limpid.dst_endpoint.ip` exist because `parse_fortigate` ran first. Pipeline order is real order — what comes earlier has populated the canonical intermediate by the time later steps run.
-- `let key = ...` is a process-local scratch variable — scoped to this process invocation, gone when the event leaves. The binding can hold any value type (scalar, Object, or Array); for an Object, `key.x` reads through the binding the same way `workspace.x.y` does. The binding *name* itself is a single identifier (`let foo.bar = ...` is rejected — write into `workspace.*` if you need a path target).
+- `process A | B` chains processes left to right — the event flows through `parse_fortigate_cef` first, then `dedup_fortigate_traffic`. Equivalent to writing them on two `process` lines; the `|` form just reads more naturally when several processes line up.
+- `workspace.limpid.src_endpoint.ip` and `workspace.limpid.dst_endpoint.ip` exist because `parse_fortigate_cef` ran first. Pipeline order is real order — what comes earlier has populated the canonical intermediate by the time later steps run.
+- `let key = ...` is a process-local scratch variable — scoped to this process invocation, gone when the event leaves. The binding can hold any value type (scalar, Object, or Array); for an Object, `key.x` reads through the binding the same way `workspace.x.y` does. The binding *name* itself is a single identifier (`let foo.bar = ...` is a parse error — the `let` LHS is a single identifier in the grammar; write into `workspace.*` if you need a path target).
 - `table_upsert` resets the TTL on every call, so a flow that keeps appearing keeps being suppressed; the dedup window only opens up once a flow has been quiet for five minutes (`ttl 300` on the table).
 - The table is in-memory and lost on daemon restart. That's usually fine for dedup — at worst, the first batch after restart is forwarded normally instead of being suppressed. See [table functions](./functions/expression-functions.md#table-functions) for the full surface (`table_lookup` / `table_upsert` / `table_delete`).
 - `archive` still sees every event — it sits before the dedup process, and Step 3's deep-copy guarantee keeps it that way.
@@ -276,7 +279,7 @@ $ limpid --check --config /etc/limpid/limpid.conf
 error: unknown process 'dedup_fortigate_trafic' referenced in pipeline 'main'
   --> /etc/limpid/pipelines/main.limpid:5:30
    |
- 5 |     process parse_fortigate | dedup_fortigate_trafic
+ 5 |     process parse_fortigate_cef | dedup_fortigate_trafic
    |                              ^^^^^^^^^^^^^^^^^^^^^^^ no such process is defined
    |
    = help: did you mean `dedup_fortigate_traffic`?
@@ -286,8 +289,8 @@ Caught it. The pipeline reference is missing an `f` in `traffic`. Fix the typo i
 
 ```bash
 $ limpid --check --config /etc/limpid/limpid.conf
-Configuration OK
-  1 input(s), 2 output(s), 2 process(es), 1 pipeline(s)
+checking /etc/limpid/limpid.conf: 5 file(s), 1 input(s), 2 output(s), 2 process(es), 1 pipeline(s)
+/etc/limpid/limpid.conf: Configuration OK (1 pipeline(s), 2 process(es); dataflow check passed)
 ```
 
 Now reload — `sudo systemctl reload limpid`. The new config takes effect atomically; if it had failed to parse or start at this point, limpid would have rolled back to the previous configuration automatically. There is no half-loaded state to recover from.
@@ -335,3 +338,4 @@ From here:
 - [Process Design Guide](./processing/design-guide.md) — patterns for writing your own processes
 - [Pipelines](./pipelines/README.md) — `if`/`switch` routing, multi-output, `drop` vs `finish`
 - [Operations → CLI](./operations/cli.md) — the full surface of `limpidctl`
+- [Error Log (DLQ)](./operations/error-log.md) — where retry-exhausted, secondary-failed, and shutdown-flush payloads land when you declare `control { error_log }`


### PR DESCRIPTION
## Summary

PR-Q2 of the docs-drift sweep — applies the 67 actionable drift fixes that the 10-zone parallel sweep + verification round surfaced after PR-J / K / L / O / P / R / T landed. CHANGELOG catch-up was [PR-Q1 (#60)](https://github.com/naoto256/limpid/pull/60); this PR addresses everything else.

37 files, +291 / -115 lines. Pure docs + rustdoc edits — no code logic changes.

## Per-zone summary (5 parallel subagents on disjoint file sets)

### A — Foundations + README (13 applied / 1 skip)
README.md, introduction.md, getting-started.md, tutorial.md, design-principles.md
- Tutorial: parse_fortigate_cef rename throughout (snippet file + process name + workspace.cef.cat dispatch field; the prior workspace.limpid.activity_name claim was doubly wrong)
- --check output format updated to the actual two-line shape (everywhere)
- limpidctl stats columns updated (5 metrics + errored note)
- Recovery posture threaded through intro / getting-started Quick start (control { error_log }) / tutorial cross-link
- design-principles "Fail soft" extended with error_log + --strict-warnings
- README: vendor parser count 22 → 24, OCSF composer example rewritten to canonical, recovery bullet under "Why this is different", Quick start CLI flag block expanded, nest_dotted_keys added, snippet version anchor softened
- skip: README Upgrading section pruning (separate-PR candidate)

### B — Configuration & DSL + Operations (18 applied / 1 consolidated)
configuration.md, dsl-syntax.md, otlp.md, operations/{cli,error-log,metrics,schema-validation}.md
- dsl-syntax.md: switch default-must-be-last rule added
- configuration.md: error_log Effect cell now links to recovery dependency
- otlp.md: 0.7.6 → 0.7.8 stamps, v0.5.0 narrative cleaned, "logged-and-dropped" → "accounted-and-dropped", received_at rename now shows from→to inline
- cli.md: --strict-warnings / --ultra-strict / --graph rows, exit-code table (0/1/2), --check sample output, test-mode received_at note
- error-log.md: 4 process-discriminator rows + new "Recovery paths into the DLQ" section + "Recovery readiness check" subsection
- metrics.md: events_failed interpretation paragraph + error-log cross-link
- schema-validation.md: disambiguation header + --check --graph workspace-keys claim replaced

### C — Inputs + Outputs + Pipelines (18 applied / 1 skip)
8 inputs/, 9 outputs/, 5 pipelines/
- inputs/README.md common-properties table reworked
- tail.md: 127.0.0.1 → 127.0.0.1:0; inode-change vs copytruncate swapped (was reversed)
- unix-socket.md: symlink → refuse-to-start
- syslog-tcp.md: IDLE_TIMEOUT scope clarified
- journal.md: insertion-order vs JSON-key-order layers separated
- otlp-http.md: "lands in v0.7.6" → past tense
- outputs/README.md: "Recovery (error_log)" subsection + fallback chain in Secondary section + bare-ident-only constraint
- http.md / otlp_http.md / otlp_grpc.md: Shutdown paragraph for PR-P drain
- otlp_grpc.md: PR-F drained-batch retain note
- kafka.md: SASL/PLAIN example converted to canonical def-output form
- 5 outputs gain README#queue-and-retry cross-link
- pipelines/examples.md: undefined filter_chargen removed (would have failed --check)
- pipelines/drop-finish-error.md: events_errored 2-bullet reorg for PR-I unified paths
- skip: kafka.md cross-link (already present)

### D — Processing & Functions (10 applied / 3 REFUTED skip / 1 no-op)
processing/{README,design-guide,user-defined}.md, functions/{README,expression-functions,user-defined}.md, snippets/README.md
- error subsection added in process control flow
- finish removed from function-body rejection list (it's pipeline-only)
- nest_dotted_keys subsection added with example
- entitle example rewritten (regex_parse_groups doesn't exist; uses regex_extract array)
- Call syntax DLQ propagation paragraph (PR-I cross-link)
- version() example uses version() so literal can't drift
- snippets/README.md: banner reflects 0.7.x expansion; http_method_activity_id + proto_num added; design-guide anchor fixed
- skips: D-PF-10 (parse_kv separator), D-PF-12 (debug-tap link), D-PF-13 (table_lookup source) all verified-refuted; D-PF-15 marker name matches

### E — rustdoc (4 items)
queue/outcome.rs, queue/mod.rs, runtime.rs
- QueueSendError / WriteDisposition docstrings reframed from "PR-O/PR-P will add..." future-tense to past-tense factual + generic forward-extensibility framing
- run_queue_consumer comment: fan-out is in write_with_retry; ignore is for per-disposition metrics (deferred to 0.8)
- PipelineContext::error_log field doc: 3 uses listed (process / PR-O / PR-P) with None-fallback

## What's intentionally not in this PR

- Release-date stamp ([Unreleased] - 0.7.8 → [0.7.8] - DATE) — release-prep PR territory
- README "Upgrading from 0.7.4/0.7.6" pruning — separate-PR call
- New error_log operations runbook (replay / triage step-by-step) — PR-U

A follow-up docs drift re-sweep is scheduled after PR-U to confirm the cycle closes cleanly.

## Test plan

- [x] `cargo build --workspace` — clean (rustdoc edits are doc text only)
- [x] uchgs push gate 8/8 scope receipts; standing cicd-pipeline / rust unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)