### PR TITLE
refactor: queue carries Event end-to-end, Output trait collapse

### DIFF
--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -546,11 +546,12 @@ async fn handle_inject(
                 sent
             }
             Target::Output(tx) => {
-                // Inject is a cold path that always carries an
-                // `OwnedEvent`; route it as `SinkInput::Owned` so disk
-                // queues persist correctly and memory queues take the
-                // default `write_owned` path (transient render).
-                let sent = tx.send_owned(event).await.is_ok();
+                // Inject is a cold path that hands an OwnedEvent
+                // straight to the output's queue. After this change
+                // every queue carries `Event` end-to-end, so there is no
+                // longer a separate `send_owned` codepath — `send`
+                // is the only entry.
+                let sent = tx.send(event).await.is_ok();
                 if sent && let Some(m) = tx.metrics() {
                     m.events_injected
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -10,13 +10,21 @@
 //!    failures, surfaced as `(pipeline body)`).
 //! 2. **Output retry exhausted** — `queue/mod.rs` consumer routes the
 //!    payload here after the retry budget is spent, surfaced as
-//!    `(output <name>)` (PR-O).
+//!    `(output <name>)`.
 //! 3. **Output enqueue failures** — `runtime.rs` could not hand an
 //!    event to an output's queue (queue closed, disk write error,
-//!    unknown output), surfaced as `(output enqueue)` (PR-I).
+//!    unknown output), surfaced as `(output enqueue)`.
 //! 4. **Batched-output shutdown-flush leftovers** — `modules/mod.rs`
-//!    walks the remaining buffer of a batched output that could not
-//!    flush at shutdown, surfaced as `(output <name> shutdown)` (PR-P).
+//!    walks the remaining `Vec<Event>` buffer of a batched output that
+//!    could not flush at shutdown and routes each through the normal
+//!    `write()` path with the real source/ingress/received_at, surfaced
+//!    as `(output <name> shutdown)`. Before this change the path
+//!    synthesised an `Event` from the rendered bytes; now the buffer
+//!    is `Vec<Event>` already so no synthetic construction is needed.
+//! 5. **Batched-output per-event render failures** — `modules/output/*.rs`
+//!    routes events that fail `render()` during a batched flush
+//!    through the same writer with `reason = "render failed during
+//!    batch flush: ..."`, surfaced as `(output <name>)`.
 //!
 //! All four converge on this same JSONL file, the same replay recipe,
 //! and the same `events_errored` / `events_errored_unwritable` counter
@@ -43,16 +51,13 @@
 //! `tokio::sync::Mutex` before opening the file. The serialisation
 //! is inside the `error_log` boundary, not at the kernel layer.
 
-use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use bytes::Bytes;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
-use crate::event::Event;
 use crate::pipeline::ErroredEventContext;
 
 /// Writer for the configured `error_log` JSONL file.
@@ -113,44 +118,6 @@ impl ErrorLogWriter {
             );
         }
         Ok(())
-    }
-
-    /// Persist a rendered buffer entry that survived an
-    /// [`Output::shutdown`] flush failure (BC-4 / PR-P).
-    ///
-    /// The batched outputs (`http`, `otlp_http`, `otlp_grpc`) carry
-    /// rendered bytes in their in-memory buffer; by the time the
-    /// shutdown flush fails, the originating `OwnedEvent` is long gone
-    /// (the memory queue already counted the per-event `write()` as
-    /// delivered). We synthesise a minimal `OwnedEvent` carrying the
-    /// rendered payload as `ingress` so the existing
-    /// [`ErroredEventContext`] schema and `error_log` JSONL format are
-    /// reused verbatim. The `process` field is set to
-    /// `"(output <name> shutdown)"` so operators can distinguish
-    /// shutdown-recovery records from PR-O's retry-exhausted records
-    /// (which use `"(output <name>)"`).
-    ///
-    /// `source` is set to `127.0.0.1:0` — a marker that matches the
-    /// daemon's other synthetic events (control-socket inject,
-    /// `--test-pipeline`). `received_at` defaults to "now"; the
-    /// `timestamp` field on the outer context already records the
-    /// shutdown wall-clock.
-    pub async fn write_shutdown_payload(
-        &self,
-        output_name: &str,
-        payload: Bytes,
-        reason: &str,
-    ) -> Result<()> {
-        let source: SocketAddr = "127.0.0.1:0".parse().expect("static addr parses");
-        let event = Event::new(payload, source);
-        let ctx = ErroredEventContext {
-            timestamp: chrono::Utc::now(),
-            pipeline: String::new(),
-            process: format!("(output {} shutdown)", output_name),
-            reason: reason.to_string(),
-            event,
-        };
-        self.write(&ctx).await
     }
 
     /// Append one JSONL record for `ctx`. Errors here are surfaced to

--- a/crates/limpid/src/main.rs
+++ b/crates/limpid/src/main.rs
@@ -411,11 +411,9 @@ fn run_test(config_path: &str, pipeline_name: &str, input_json: Option<&str>) ->
     let _ = &registry;
 
     let event = build_test_event(input_json)?;
-    // --test-pipeline runs without a live runtime, so there are no
-    // constructed sinks. The pipeline executor handles this by falling
-    // back to `SinkInput::Owned` for every output statement.
-    let sinks: std::collections::HashMap<String, std::sync::Arc<dyn crate::modules::Output>> =
-        std::collections::HashMap::new();
+    // --test-pipeline runs without a live runtime; after this change
+    // the pipeline executor no longer takes an `output_sinks` map at all
+    // (render moved consumer-side, see `pipeline::run_pipeline`).
     let mut bump = bumpalo::Bump::new();
     let result = run_pipeline(
         pipeline_def,
@@ -423,7 +421,6 @@ fn run_test(config_path: &str, pipeline_name: &str, input_json: Option<&str>) ->
         &compiled,
         &func_registry,
         None,
-        &sinks,
         &mut bump,
     )?;
 
@@ -445,26 +442,18 @@ fn run_test(config_path: &str, pipeline_name: &str, input_json: Option<&str>) ->
 
     if !result.outputs.is_empty() {
         println!();
-        for (name, sink_input) in &result.outputs {
-            // `--test-pipeline` skips sink wiring (see above), so the
-            // pipeline always emits the `Owned` form here. The
-            // `Rendered` arm prints a placeholder for completeness.
-            match sink_input {
-                crate::queue::SinkInput::Owned(evt) => {
-                    println!(
-                        "[output]  → {}  egress: {}",
-                        name,
-                        String::from_utf8_lossy(&evt.egress)
-                    );
-                    if !evt.workspace.is_empty() {
-                        print!("  workspace: {:?}", evt.workspace);
-                    }
-                    println!();
-                }
-                crate::queue::SinkInput::Rendered(_) => {
-                    println!("[output]  → {}  (rendered payload)", name);
-                }
+        for (name, evt) in &result.outputs {
+            // After this change every output statement emits a plain
+            // Event; print egress + workspace directly.
+            println!(
+                "[output]  → {}  egress: {}",
+                name,
+                String::from_utf8_lossy(&evt.egress)
+            );
+            if !evt.workspace.is_empty() {
+                print!("  workspace: {:?}", evt.workspace);
             }
+            println!();
         }
     }
 

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -11,65 +11,63 @@ pub mod input;
 pub mod output;
 pub mod schema;
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
 use tokio::sync::mpsc;
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::ast::{Expr, ExprKind, Property};
 use crate::dsl::schema::{self as property_schema, PropertySpec};
 use crate::dsl::span::Span;
-use crate::event::{BorrowedEvent, Event};
+use crate::event::Event;
 use crate::functions::FunctionRegistry;
 use crate::metrics::{InputMetrics, OutputMetrics};
-use crate::queue::{OutputWriter, SinkInput};
 
 // ---------------------------------------------------------------------------
-// RenderedPayload — type-erased per-event sink payload
+// RenderError — marker for render-vs-write error disambiguation
+// (render errors bypass retry and route directly to recovery)
 // ---------------------------------------------------------------------------
 //
-// Outputs participate in the pipeline's hot path (v0.6.0) by
-// rendering a sink-specific payload from a `BorrowedEvent` (no
-// `to_owned()` round-trip). The pipeline-internal channel between
-// pipeline and sink consumer carries a `RenderedPayload` (this type)
-// for memory queues and an `OwnedEvent` for disk-persisted queues.
+// `Output::consume` returns `anyhow::Result<()>` — the consumer
+// (`write_with_retry`) used to assume every Err was a transport failure
+// and apply the retry budget. After this change each sink's `consume` runs
+// render internally (the trait no longer carries a `render` method);
+// render failures are deterministic on the event so retrying only
+// delays the DLQ landing without changing the outcome.
 //
-// `Box<dyn Any + Send>` is the simplest dyn-safe transport for a
-// heterogeneous payload — each concrete sink defines its own
-// `Payload` struct (e.g. `FilePayload { egress, path }`) and downcasts
-// inside `write`. Per-event cost is one heap alloc for the box plus
-// whatever the payload struct contains internally; same order as the
-// previous `to_owned()` workspace clone but without copying the
-// workspace `HashMap` on every event.
+// `RenderError` is the in-band tag that lets sinks signal "render
+// failed permanently, skip retries" while keeping `consume`'s return
+// type a plain `Result<()>`. Sinks wrap their internal render error in
+// `RenderError::new(e)` before returning; `write_with_retry`
+// downcasts on `anyhow::Error::downcast_ref::<RenderError>()` and
+// routes straight to DLQ.
 
-/// Opaque payload produced by `Output::render` and consumed by
-/// `Output::write`. Holds a sink-specific concrete type behind
-/// `Box<dyn Any + Send>`.
-pub struct RenderedPayload(Box<dyn Any + Send>);
+/// Render-error sentinel. Wraps any underlying `anyhow::Error` raised
+/// by a sink's internal render step. Detected by `write_with_retry`
+/// via `anyhow::Error::downcast_ref::<RenderError>()` so the retry
+/// budget is bypassed.
+#[derive(Debug)]
+pub struct RenderError(pub anyhow::Error);
 
-impl RenderedPayload {
-    pub fn new<T: Any + Send>(value: T) -> Self {
-        Self(Box::new(value))
-    }
-
-    /// Recover the concrete payload type. Returns an error if the
-    /// stored type does not match `T` — this can only happen if the
-    /// pipeline misroutes a payload to the wrong sink, which would be
-    /// an internal bug.
-    pub fn downcast<T: Any>(self) -> Result<T> {
-        self.0
-            .downcast::<T>()
-            .map(|b| *b)
-            .map_err(|_| anyhow::anyhow!("RenderedPayload downcast type mismatch"))
+impl RenderError {
+    pub fn new(e: anyhow::Error) -> Self {
+        Self(e)
     }
 }
 
-impl std::fmt::Debug for RenderedPayload {
+impl std::fmt::Display for RenderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("RenderedPayload(<opaque>)")
+        // Forward to the inner error so the JSONL `reason` field stays
+        // operator-friendly (`render failed: <inner>` already prefixes
+        // in `write_with_retry`).
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for RenderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
     }
 }
 
@@ -328,40 +326,33 @@ pub trait Input: Module + HasMetrics<Stats = InputMetrics> + Send + 'static {
 /// — `Module::from_properties` requires `Self: Sized` (factory return),
 /// which would forbid `dyn Output`. Construction sites add the
 /// `Module` bound where they need it (see `register_output_type`),
-/// but the `dyn Output` we hand to the pipeline executor (for hot-path
-/// `render`) and to the queue consumer (for `write` / `write_owned`)
-/// stays object-safe.
+/// but the `dyn Output` we hand to the queue consumer stays
+/// object-safe.
+///
+/// After this change the trait is a single per-event entry point: each sink
+/// decides internally whether to ship the event inline (file, stdout,
+/// syslog_tcp, syslog_udp, kafka, unix_socket) or buffer for a later
+/// batched flush (http, otlp_http, otlp_grpc). The earlier
+/// `render → write` decomposition is now per-sink implementation
+/// detail (private helpers) — the trait no longer constrains its
+/// shape.
 #[async_trait::async_trait]
 pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
-    /// Hot path: build a sink-specific `RenderedPayload` from a borrowed
-    /// view of the event. Any DSL evaluation needed (e.g. path templates)
-    /// happens against the pipeline's per-event arena, so the payload
-    /// can capture `String` / `Bytes` results without paying for a
-    /// `to_owned` round-trip on the event's `workspace`.
-    fn render(&self, event: &BorrowedEvent<'_>, arena: &EventArena<'_>) -> Result<RenderedPayload>;
-
-    /// Hot path: consume a `RenderedPayload` produced by `render` and
-    /// perform the actual I/O. Each sink downcasts the payload to its
-    /// own concrete type internally.
-    async fn write(&self, payload: RenderedPayload) -> Result<()>;
-
-    /// Cold path (Disk-queue replay, control-socket inject): consume an
-    /// `OwnedEvent` directly. Default impl builds a transient arena,
-    /// views the event into it, calls `render`, then `write`. Sinks
-    /// with a faster owned-path may override.
+    /// Per-event entry point called by the queue consumer
+    /// (`write_with_retry`). Sinks own the full event lifecycle:
+    /// render (when applicable), serialise, ship — or buffer for a
+    /// batched flush. Return:
     ///
-    /// The arena/borrowed-event scope is closed before the `await` on
-    /// `write` so the resulting future stays `Send` (bumpalo's `Bump`
-    /// is !Sync).
-    async fn write_owned(&self, event: &Event) -> Result<()> {
-        let payload = {
-            let bump = bumpalo::Bump::new();
-            let arena = EventArena::new(&bump);
-            let bevent = event.view_in(&arena);
-            self.render(&bevent, &arena)?
-        };
-        self.write(payload).await
-    }
+    /// - `Ok(())` — event accepted (delivered, or durably enqueued
+    ///   into the sink's own batch buffer for a future flush).
+    /// - `Err(e)` — failure. If `e` is `crate::modules::RenderError`,
+    ///   the consumer treats it as a permanent failure on this event
+    ///   and routes straight to DLQ without consuming the retry
+    ///   budget (render errors bypass retry and route directly to
+    ///   recovery). Any other `Err` is treated as
+    ///   a transient transport failure and counted against
+    ///   `RetryConfig::max_attempts`.
+    async fn consume(&self, event: &Event) -> Result<()>;
 
     /// Called once after construction to hand the output a reference to
     /// the pipeline's `FunctionRegistry`. Outputs that evaluate DSL
@@ -386,10 +377,10 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     /// the shutdown sequence regardless — there is no further retry
     /// path available at this point.
     ///
-    /// `error_log` is the operator-configured DLQ writer (BC-4 /
-    /// PR-P). Batched outputs that override this method use it to
-    /// persist buffer contents that survive a failed final flush —
-    /// the parallel of PR-O's retry-exhausted recovery on the
+    /// `error_log` is the operator-configured DLQ writer used by the
+    /// shutdown-flush recovery path. Batched outputs that override this
+    /// method use it to persist buffer contents that survive a failed
+    /// final flush — the parallel of retry-exhausted recovery on the
     /// per-event path. `None` preserves the 0.7.7 behaviour
     /// (warn + drop). Implementations that hold no buffer ignore
     /// the argument.
@@ -401,88 +392,28 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     }
 }
 
-/// Helper for `Output::write_owned` overrides that ship a single Owned
-/// event inline, bypassing any internal buffer. Renders the event in a
-/// transient arena (same scope discipline as the default impl), awaits
-/// the caller-supplied `ship` closure, then updates the
-/// `events_written` / `events_failed` counters on the metrics handle.
-///
-/// The closure returns `Result<u64>` where the `u64` is the number of
-/// records the server acknowledged as rejected (OTLP's
-/// `partial_success.rejected_log_records`; always 0 for outputs that
-/// have no equivalent concept, like `output http`). For a single Owned
-/// event a non-zero rejection means the server processed the request
-/// but refused our one record — transport-success, data-loss — so
-/// we count it as `events_failed` even though the call returns Ok
-/// (the queue layer must not retry; the server already said no).
-///
-/// The batched outputs (`otlp_grpc`, `otlp_http`, `output http`)
-/// each need to override `write_owned` so the queue consumer's
-/// per-event `Ok`/`Err` contract is honored (disk-replay events
-/// would otherwise be merged into a batched flush and the verdict
-/// would be lost). They differ only in the `ship` body — payload
-/// downcast and the per-module `send_batch` shape — so the
-/// scaffolding lives here once.
-pub async fn ship_owned_inline<O, F, Fut>(
-    output: &O,
-    event: &Event,
-    metrics: &OutputMetrics,
-    ship: F,
-) -> Result<()>
-where
-    O: Output + ?Sized,
-    F: FnOnce(RenderedPayload) -> Fut,
-    Fut: std::future::Future<Output = Result<u64>>,
-{
-    use std::sync::atomic::Ordering;
-
-    let payload = {
-        let bump = bumpalo::Bump::new();
-        let arena = EventArena::new(&bump);
-        let bevent = event.view_in(&arena);
-        output.render(&bevent, &arena)?
-    };
-    match ship(payload).await {
-        Ok(0) => {
-            metrics.events_written.fetch_add(1, Ordering::Relaxed);
-            Ok(())
-        }
-        Ok(_rejected) => {
-            // Transport said OK, server rejected the single record we
-            // sent. Count as failed so dashboards reflect the data
-            // loss; return Ok so the queue does not retry — the
-            // server already refused this exact bytes.
-            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-            Ok(())
-        }
-        Err(e) => {
-            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-            Err(e)
-        }
-    }
-}
-
-/// Shared helper: walk the leftover rendered payloads from a failed
-/// shutdown flush and write each to the configured `error_log` (BC-4 /
-/// PR-P). On per-record write failure we warn and continue — the loop
-/// must not recurse back into the DLQ on its own failures, otherwise
-/// a broken `error_log` path would spin a tight error loop at
-/// shutdown. Called from each batched output's `shutdown()` override
-/// (`http`, `otlp_http`, `otlp_grpc`); the per-output indirection
-/// only differs in how their internal buffer is normalised to
-/// `Vec<Bytes>`.
-pub async fn write_shutdown_buffer_to_error_log(
+/// Shared helper: walk the leftover `Event`s from a failed batched-
+/// output shutdown flush and write each to the configured `error_log`.
+/// Each record carries the original `Event` (real `source`, `ingress`,
+/// `received_at`) — no synthetic payload construction. On per-record
+/// write failure we warn and continue, so a broken `error_log` path
+/// can't spin a tight error loop at shutdown.
+pub async fn write_shutdown_events_to_error_log(
     writer: &Arc<crate::error_log::ErrorLogWriter>,
     output_name: &str,
-    payloads: Vec<bytes::Bytes>,
+    events: Vec<Event>,
     flush_err: &anyhow::Error,
 ) {
     let reason = format!("shutdown flush failed: {}", flush_err);
-    for payload in payloads {
-        if let Err(write_err) = writer
-            .write_shutdown_payload(output_name, payload, &reason)
-            .await
-        {
+    for ev in events {
+        let ctx = crate::pipeline::ErroredEventContext {
+            timestamp: chrono::Utc::now(),
+            pipeline: String::new(),
+            process: format!("(output {} shutdown)", output_name),
+            reason: reason.clone(),
+            event: ev,
+        };
+        if let Err(write_err) = writer.write(&ctx).await {
             tracing::warn!(
                 "output '{}': error_log write during shutdown failed: {} — dropping event",
                 output_name,
@@ -502,15 +433,16 @@ pub struct CreatedInput {
     pub metrics: Arc<InputMetrics>,
 }
 
-/// Returned by output factory: the writer + metrics handle.
+/// Returned by output factory: the constructed sink + metrics handle.
 ///
-/// `output` is the `Arc<dyn Output>` so the pipeline executor can call
-/// `render` on the hot path; `writer` is a thin `OutputWriter` adapter
-/// that the queue consumer uses to call `write` (or `write_owned` for
-/// disk-replay paths). Both share the same underlying instance.
+/// `output` is the `Arc<dyn Output>` handed to the queue consumer
+/// (which calls `Output::consume` directly — after this change there is no
+/// intermediate `OutputWriter` adapter trait). Batched outputs that
+/// need the operator-configured `error_log` receive it as a
+/// constructor argument via the factory; no post-construction setter
+/// remains on the trait.
 pub struct CreatedOutput {
     pub output: Arc<dyn Output>,
-    pub writer: Box<dyn OutputWriter>,
     pub metrics: Arc<OutputMetrics>,
 }
 
@@ -530,7 +462,14 @@ type InputFactory = Box<
 >;
 
 type OutputFactory = Box<
-    dyn Fn(&str, &ModuleProperties, Arc<FunctionRegistry>) -> Result<CreatedOutput> + Send + Sync,
+    dyn Fn(
+            &str,
+            &ModuleProperties,
+            Arc<FunctionRegistry>,
+            Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ) -> Result<CreatedOutput>
+        + Send
+        + Sync,
 >;
 
 struct InputEntry {
@@ -595,7 +534,12 @@ impl ModuleRegistry {
         schema: Option<&'static [PropertySpec]>,
         factory: F,
     ) where
-        F: Fn(&str, &ModuleProperties, Arc<FunctionRegistry>) -> Result<CreatedOutput>
+        F: Fn(
+                &str,
+                &ModuleProperties,
+                Arc<FunctionRegistry>,
+                Option<Arc<crate::error_log::ErrorLogWriter>>,
+            ) -> Result<CreatedOutput>
             + Send
             + Sync
             + 'static,
@@ -659,6 +603,7 @@ impl ModuleRegistry {
         name: &str,
         properties: &ModuleProperties,
         funcs: Arc<FunctionRegistry>,
+        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<CreatedOutput> {
         let type_name = properties.type_name();
         let entry = self
@@ -673,7 +618,7 @@ impl ModuleRegistry {
                 ));
             }
         }
-        (entry.factory)(name, properties, funcs)
+        (entry.factory)(name, properties, funcs, error_log)
     }
 }
 
@@ -712,9 +657,9 @@ pub fn register_builtins(registry: &mut ModuleRegistry) {
     register_output_type::<output::file::FileOutput>(registry, "file");
     register_output_type::<output::unix_socket::UnixSocketOutput>(registry, "unix_socket");
     register_output_type::<output::syslog_tcp::SyslogTcpOutput>(registry, "syslog_tcp");
-    register_output_type::<output::http::HttpOutput>(registry, "http");
-    register_output_type::<output::otlp::http::OtlpHttpOutput>(registry, "otlp_http");
-    register_output_type::<output::otlp::grpc::OtlpGrpcOutput>(registry, "otlp_grpc");
+    register_batched_output_type::<output::http::HttpOutput>(registry, "http");
+    register_batched_output_type::<output::otlp::http::OtlpHttpOutput>(registry, "otlp_http");
+    register_batched_output_type::<output::otlp::grpc::OtlpGrpcOutput>(registry, "otlp_grpc");
     register_output_type::<output::syslog_udp::SyslogUdpOutput>(registry, "syslog_udp");
     register_output_type::<output::stdout::StdoutOutput>(registry, "stdout");
     #[cfg(feature = "kafka")]
@@ -759,37 +704,57 @@ where
     registry.register_output(
         type_name,
         T::property_schema(),
-        |name, properties: &ModuleProperties, funcs| {
+        // `_error_log` is unused: non-batched outputs (file, stdout,
+        // syslog_tcp, syslog_udp, kafka, unix_socket) get DLQ routing
+        // for retry-exhausted events through the queue consumer's
+        // `write_with_retry`, not through their own internal buffers.
+        // Only the 3 batched outputs (http, otlp_http, otlp_grpc)
+        // need a constructor-time `error_log` handle; those register
+        // via [`register_batched_output_type`] below.
+        |name, properties: &ModuleProperties, funcs, _error_log| {
             let mut output = T::from_properties(name, properties)?;
             output.attach_funcs(funcs);
             let metrics = HasMetrics::metrics(&output);
             let output_arc: Arc<dyn Output> = Arc::new(output);
             Ok(CreatedOutput {
-                output: Arc::clone(&output_arc),
-                writer: Box::new(OutputWriterWrapper(output_arc)),
+                output: output_arc,
                 metrics,
             })
         },
     );
 }
 
-struct OutputWriterWrapper(Arc<dyn Output>);
+/// Trait marker for the 3 batched outputs (`http`, `otlp_http`,
+/// `otlp_grpc`) that consume `error_log` at construction time. Lives
+/// next to `Module` rather than on it so non-batched outputs aren't
+/// forced to carry an unused method, and so the `Input` half of the
+/// `Module` trait isn't polluted with output-only plumbing.
+pub trait OutputBuilderWithErrorLog: Module {
+    fn from_properties_with_error_log(
+        name: &str,
+        properties: &ModuleProperties,
+        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    ) -> Result<Self>;
+}
 
-#[async_trait::async_trait]
-impl OutputWriter for OutputWriterWrapper {
-    async fn consume(&self, input: SinkInput) -> anyhow::Result<()> {
-        match input {
-            SinkInput::Rendered(payload) => self.0.write(payload).await,
-            SinkInput::Owned(event) => self.0.write_owned(&event).await,
-        }
-    }
-
-    async fn shutdown(
-        &self,
-        error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
-    ) -> anyhow::Result<()> {
-        self.0.shutdown(error_log).await
-    }
+fn register_batched_output_type<T>(registry: &mut ModuleRegistry, type_name: &str)
+where
+    T: OutputBuilderWithErrorLog + Output + Sync + 'static,
+{
+    registry.register_output(
+        type_name,
+        T::property_schema(),
+        |name, properties: &ModuleProperties, funcs, error_log| {
+            let mut output = T::from_properties_with_error_log(name, properties, error_log)?;
+            output.attach_funcs(funcs);
+            let metrics = HasMetrics::metrics(&output);
+            let output_arc: Arc<dyn Output> = Arc::new(output);
+            Ok(CreatedOutput {
+                output: output_arc,
+                metrics,
+            })
+        },
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -30,10 +30,10 @@ use crate::dsl::ast::{Expr, ExprKind, TemplateFragment};
 use crate::dsl::eval::{eval_expr, value_to_string};
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::{BorrowedEvent, Event};
 use crate::functions::FunctionRegistry;
 use crate::metrics::OutputMetrics;
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output, RenderError};
 
 const FILE_OUTPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
@@ -155,17 +155,37 @@ impl Output for FileOutput {
         self.funcs = Some(funcs);
     }
 
-    fn render(&self, event: &BorrowedEvent<'_>, arena: &EventArena<'_>) -> Result<RenderedPayload> {
-        let (resolved, is_dynamic) = self.render_path_in(event, arena)?;
-        Ok(RenderedPayload::new(FilePayload {
-            egress: event.egress.clone(),
-            path: resolved,
-            is_dynamic,
-        }))
+    async fn consume(&self, event: &Event) -> Result<()> {
+        // Render the path template against a transient per-event
+        // arena, then hand the resolved payload to the async write
+        // helper. The arena scope closes before the `await` so the
+        // resulting future stays `Send` (bumpalo's `Bump` is !Sync).
+        //
+        // Path-render errors are wrapped in `RenderError` so the queue
+        // consumer (`write_with_retry`) downcasts and routes them
+        // straight to DLQ without burning the retry budget — a broken
+        // template is deterministic on the event.
+        let payload = {
+            let bump = bumpalo::Bump::new();
+            let arena = EventArena::new(&bump);
+            let bevent = event.view_in(&arena);
+            match self.render_path_in(&bevent, &arena) {
+                Ok((resolved, is_dynamic)) => FilePayload {
+                    egress: event.egress.clone(),
+                    path: resolved,
+                    is_dynamic,
+                },
+                Err(e) => return Err(RenderError::new(e).into()),
+            }
+        };
+        self.write_payload(payload).await
     }
+}
 
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: FilePayload = payload.downcast()?;
+impl FileOutput {
+    /// Append the rendered payload to its resolved path. Private —
+    /// reached only from [`Output::consume`].
+    async fn write_payload(&self, payload: FilePayload) -> Result<()> {
         let resolved = payload.path;
         let is_dynamic = payload.is_dynamic;
         let path = PathBuf::from(&resolved);

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -58,15 +58,14 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use tokio::sync::Mutex;
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::{BorrowedEvent, Event};
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::tls::ClientTlsConfig;
 
 const HTTP_PEER_SCHEMA: &[PropertySpec] = &[
@@ -168,10 +167,6 @@ const HTTP_OUTPUT_SCHEMA: &[PropertySpec] = &[
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
 
-struct HttpPayload {
-    msg: String,
-}
-
 struct HttpPeer {
     url: String,
     client: reqwest::Client,
@@ -199,15 +194,25 @@ struct Inner {
     headers: Vec<(String, String)>,
     batch_timeout: Duration,
     compress: bool,
-    batch: Mutex<Vec<String>>,
+    /// Buffered events awaiting flush. Render happens at flush time
+    /// (batch buffers retain Event until flush) so a per-event render
+    /// failure can be routed to DLQ on its own without dropping the
+    /// rest of the batch.
+    batch: Mutex<Vec<Event>>,
+    /// Operator-facing instance name; surfaced on shutdown-flush
+    /// recovery and render-failure records.
+    name: String,
+    /// `error_log` writer injected at construction time by the
+    /// runtime via `OutputBuilderWithErrorLog::from_properties_with_error_log`.
+    /// Used by the flush path to route per-event render failures and
+    /// shutdown-flush leftovers into the DLQ. `None` when the
+    /// operator did not configure `control { error_log "..." }` —
+    /// the flush path then falls back to a `tracing::error!` line.
+    error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    metrics: Arc<OutputMetrics>,
 }
 
 pub struct HttpOutput {
-    /// Operator-facing instance name (the `def output <name>` ident).
-    /// Used in the BC-4 / PR-P shutdown-recovery `process` field so
-    /// `error_log` records can be grouped by output instance, mirroring
-    /// PR-O's `(output <name>)` retry-exhausted records.
-    name: String,
     inner: Arc<Inner>,
     batch_size: usize,
     flush_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -336,6 +341,23 @@ impl Module for HttpOutput {
     }
 
     fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+        // Delegates to the error_log-aware ctor with `None` so the
+        // bare `Module::from_properties` path (used by unit tests and
+        // direct callers) still works; the runtime always goes
+        // through `OutputBuilderWithErrorLog::from_properties_with_error_log`
+        // to inject the operator-configured writer.
+        <Self as crate::modules::OutputBuilderWithErrorLog>::from_properties_with_error_log(
+            name, properties, None,
+        )
+    }
+}
+
+impl crate::modules::OutputBuilderWithErrorLog for HttpOutput {
+    fn from_properties_with_error_log(
+        name: &str,
+        properties: &crate::modules::ModuleProperties,
+        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
 
         // Parse the configured method into a typed `reqwest::Method`
@@ -390,8 +412,8 @@ impl Module for HttpOutput {
 
         let peer_state = peers.iter().map(|_| PeerState::default()).collect();
 
+        let metrics = Arc::new(OutputMetrics::default());
         Ok(Self {
-            name: name.to_string(),
             inner: Arc::new(Inner {
                 peers,
                 peer_state,
@@ -402,10 +424,13 @@ impl Module for HttpOutput {
                 batch_timeout,
                 compress,
                 batch: Mutex::new(Vec::with_capacity(batch_size.max(1))),
+                name: name.to_string(),
+                error_log,
+                metrics: Arc::clone(&metrics),
             }),
             batch_size,
             flush_handle: Mutex::new(None),
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics,
         })
     }
 }
@@ -419,33 +444,23 @@ impl HasMetrics for HttpOutput {
 
 #[async_trait::async_trait]
 impl Output for HttpOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        // The HTTP body is text — building the `String` here (a small,
-        // unavoidable allocation for the request body) keeps the
-        // serialisation cost on the pipeline thread instead of the
-        // sink consumer thread, but does not duplicate any work.
-        let msg = String::from_utf8_lossy(&event.egress).into_owned();
-        Ok(RenderedPayload::new(HttpPayload { msg }))
-    }
-
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: HttpPayload = payload.downcast()?;
-        let msg = payload.msg;
-
+    /// Batched-buffer rendering: buffer the `Event` (no render yet), decide
+    /// flush-or-arm-timer. Render happens later in `flush()` so a
+    /// per-event render failure is routed to DLQ on its own without
+    /// dropping the rest of the batch. Returns `Ok(())` as soon as the
+    /// event is durably enqueued into the in-memory batch buffer;
+    /// the actual HTTP transport may run later inside `flush()` and
+    /// surface its error to the next `consume` call.
+    async fn consume(&self, event: &Event) -> Result<()> {
         if self.batch_size <= 1 {
-            self.inner.send_batch(&[msg]).await?;
-            self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
-            return Ok(());
+            // Short-circuit: render + ship a single event inline.
+            // Mirrors the prior `batch_size <= 1` fast path.
+            return self.consume_singleton(event).await;
         }
 
-        // Batching mode
         let should_flush = {
             let mut buf = self.inner.batch.lock().await;
-            buf.push(msg);
+            buf.push(event.clone());
             buf.len() >= self.batch_size
         };
 
@@ -454,40 +469,16 @@ impl Output for HttpOutput {
             let res = self.flush().await;
             if res.is_err() {
                 // flush() put the batch back into the buffer on
-                // failure. Without re-arming the timer the batch
-                // would sit there until the next write() arrives —
-                // which may never come, since the queue layer
-                // counted this event as failed (Rendered payloads
-                // don't retry; see queue/mod.rs). The operator then
-                // sees events_failed += 1 but the batch is still
-                // pending in our buffer with no timer to drain it.
-                // Re-arm so the stuck batch retries after
-                // batch_timeout, restoring "no event silently lost
-                // in the HTTP buffer".
+                // failure. Re-arm so batch_timeout drives a retry
+                // — without it the stuck batch would sit there
+                // until the next consume arrives.
                 self.reset_timer().await;
             }
-            res?;
+            res
         } else {
             self.reset_timer().await;
+            Ok(())
         }
-
-        Ok(())
-    }
-
-    /// Owned-event path (disk-queue replay, control-socket inject). The
-    /// queue consumer needs a per-event ship verdict; routing Owned
-    /// events through the batched buffer would silently merge them into
-    /// a later flush and the caller would lose the verdict. Ship inline
-    /// here, bypassing the batch (same disposition as the
-    /// `batch_size <= 1` short-circuit in `write`).
-    async fn write_owned(&self, event: &Event) -> Result<()> {
-        crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
-            let payload: HttpPayload = payload.downcast()?;
-            // Plain HTTP has no partial-success concept; either the
-            // POST succeeds end-to-end or it errors. Always Ok(0).
-            self.inner.send_batch(&[payload.msg]).await.map(|()| 0)
-        })
-        .await
     }
 
     async fn shutdown(
@@ -501,24 +492,21 @@ impl Output for HttpOutput {
         match self.flush().await {
             Ok(()) => Ok(()),
             Err(e) => {
-                // BC-4 / PR-P: PR-F's `flush()` restored the drained
-                // batch into `self.inner.batch` on Err. Without
-                // recovery the buffer would be dropped together with
-                // the output instance as the daemon exits. When the
-                // operator opted in to `control { error_log "..." }`
-                // we persist each rendered body as a synthetic DLQ
-                // record so a `jq | inject` recipe can replay them
-                // later. `error_log` unset preserves 0.7.7 behaviour
-                // (the queue consumer logs a warn and the bytes are
-                // lost).
+                // Shutdown-flush recovery (batch buffers retain Event
+                // until flush): `flush()` restored the
+                // drained batch into `self.inner.batch` on Err. When
+                // the operator opted in to `control { error_log "..." }`
+                // we persist each buffered `Event` as a DLQ record
+                // carrying real source/ingress/received_at (no
+                // synthetic Event construction).
                 if let Some(writer) = error_log {
-                    let payloads: Vec<bytes::Bytes> =
-                        std::mem::take(&mut *self.inner.batch.lock().await)
-                            .into_iter()
-                            .map(|s| bytes::Bytes::from(s.into_bytes()))
-                            .collect();
-                    crate::modules::write_shutdown_buffer_to_error_log(
-                        writer, &self.name, payloads, &e,
+                    let events: Vec<Event> =
+                        std::mem::take(&mut *self.inner.batch.lock().await);
+                    crate::modules::write_shutdown_events_to_error_log(
+                        writer,
+                        &self.inner.name,
+                        events,
+                        &e,
                     )
                     .await;
                     Ok(())
@@ -531,6 +519,21 @@ impl Output for HttpOutput {
 }
 
 impl HttpOutput {
+    /// Render+ship one event inline (used by both the `batch_size <= 1`
+    /// short-circuit and shared with the singleton path). Render errors
+    /// are wrapped in `RenderError` so the queue consumer routes them
+    /// straight to DLQ; transport errors propagate normally for the
+    /// retry budget.
+    async fn consume_singleton(&self, event: &Event) -> Result<()> {
+        let msg = match render_event(event) {
+            Ok(m) => m,
+            Err(e) => return Err(crate::modules::RenderError::new(e).into()),
+        };
+        self.inner.send_batch(&[msg]).await?;
+        self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
     async fn flush(&self) -> Result<()> {
         let batch = {
             let mut buf = self.inner.batch.lock().await;
@@ -539,24 +542,7 @@ impl HttpOutput {
             }
             std::mem::take(&mut *buf)
         };
-
-        let count = batch.len();
-        match self.inner.send_batch(&batch).await {
-            Ok(()) => {
-                self.metrics
-                    .events_written
-                    .fetch_add(count as u64, Ordering::Relaxed);
-                Ok(())
-            }
-            Err(e) => {
-                // Put events back for retry
-                let mut buf = self.inner.batch.lock().await;
-                let new_events = std::mem::take(&mut *buf);
-                *buf = batch;
-                buf.extend(new_events);
-                Err(e)
-            }
-        }
+        self.inner.flush_events(batch).await
     }
 
     async fn cancel_timer(&self) {
@@ -572,11 +558,9 @@ impl HttpOutput {
             h.abort();
         }
         let inner = Arc::clone(&self.inner);
-        let metrics = Arc::clone(&self.metrics);
         let timeout = self.inner.batch_timeout;
         *handle = Some(tokio::spawn(async move {
             tokio::time::sleep(timeout).await;
-
             let batch = {
                 let mut buf = inner.batch.lock().await;
                 if buf.is_empty() {
@@ -584,28 +568,101 @@ impl HttpOutput {
                 }
                 std::mem::take(&mut *buf)
             };
-
-            let count = batch.len();
-            if let Err(e) = inner.send_batch(&batch).await {
-                tracing::warn!(
-                    "http output: timer flush failed: {} — {} events returned to buffer",
-                    e,
-                    count
-                );
-                let mut buf = inner.batch.lock().await;
-                let new_events = std::mem::take(&mut *buf);
-                *buf = batch;
-                buf.extend(new_events);
-            } else {
-                metrics
-                    .events_written
-                    .fetch_add(count as u64, Ordering::Relaxed);
+            if let Err(e) = inner.flush_events(batch).await {
+                tracing::warn!("http output: timer flush failed: {}", e);
             }
         }));
     }
 }
 
+/// Render a single event into its HTTP body string. Mirrors the body
+/// of `HttpOutput::render` but operates on an owned `Event` so it can
+/// be called from the consumer-side flush path without setting up the
+/// borrowed-view arena.
+fn render_event(event: &Event) -> Result<String> {
+    Ok(String::from_utf8_lossy(&event.egress).into_owned())
+}
+
 impl Inner {
+    /// Render each buffered event, route per-event render failures to
+    /// DLQ (skipping them in the batch), then ship the remaining
+    /// rendered bodies. On transport failure the un-rendered events
+    /// are restored to the buffer (rendering re-runs on retry; render
+    /// is cheap text-extraction here).
+    async fn flush_events(&self, batch: Vec<Event>) -> Result<()> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        // Partition: render-success → messages, render-failure → DLQ.
+        let mut messages: Vec<String> = Vec::with_capacity(batch.len());
+        let mut shippable: Vec<Event> = Vec::with_capacity(batch.len());
+        let mut render_failures: Vec<(Event, anyhow::Error)> = Vec::new();
+        for ev in batch {
+            match render_event(&ev) {
+                Ok(m) => {
+                    messages.push(m);
+                    shippable.push(ev);
+                }
+                Err(e) => render_failures.push((ev, e)),
+            }
+        }
+        if !render_failures.is_empty() {
+            // Route each render failure to DLQ on its own. Reuse the
+            // shared shutdown helper's per-event write recipe.
+            let error_log = self.error_log.as_ref();
+            for (ev, err) in render_failures {
+                self.metrics
+                    .events_failed
+                    .fetch_add(1, Ordering::Relaxed);
+                if let Some(writer) = &error_log {
+                    let ctx = crate::pipeline::ErroredEventContext {
+                        timestamp: chrono::Utc::now(),
+                        pipeline: String::new(),
+                        process: format!("(output {})", self.name),
+                        reason: format!("render failed during batch flush: {}", err),
+                        event: ev,
+                    };
+                    if let Err(write_err) = writer.write(&ctx).await {
+                        tracing::warn!(
+                            "output '{}': error_log write failed during batch render: {}",
+                            self.name,
+                            write_err
+                        );
+                    }
+                } else {
+                    tracing::error!(
+                        "output '{}': render failed during batch flush ({}); dropping event (no error_log)",
+                        self.name,
+                        err
+                    );
+                }
+            }
+        }
+        if messages.is_empty() {
+            return Ok(());
+        }
+        let count = messages.len() as u64;
+        match self.send_batch(&messages).await {
+            Ok(()) => {
+                self.metrics
+                    .events_written
+                    .fetch_add(count, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(e) => {
+                // Transport error: restore the shippable events into
+                // the buffer so the next consume_event / timer firing
+                // can retry. Do NOT bump events_failed — they're
+                // retained, not permanently rejected.
+                let mut buf = self.batch.lock().await;
+                let new_events = std::mem::take(&mut *buf);
+                *buf = shippable;
+                buf.extend(new_events);
+                Err(e)
+            }
+        }
+    }
+
     /// Ship `messages` to one of the configured peers, rotating to the
     /// next peer in round-robin order. A peer that fails the request
     /// is cooled down for `PEER_COOLDOWN` and skipped on subsequent
@@ -711,6 +768,9 @@ impl Drop for HttpOutput {
         if let Some(h) = self.flush_handle.get_mut().take() {
             h.abort();
         }
+        // Best-effort warn on leaked buffered events. Holding an Arc
+        // here would block the warn under contention; try_lock is the
+        // right behaviour for a Drop path.
         if let Ok(buf) = self.inner.batch.try_lock()
             && !buf.is_empty()
         {
@@ -845,6 +905,12 @@ mod tests {
         e
     }
 
+    /// Test shim mirroring the queue consumer's call into
+    /// `Output::consume`.
+    async fn consume(output: &HttpOutput, ev: &Event) -> Result<()> {
+        output.consume(ev).await
+    }
+
     async fn run_echo_collector() -> (
         SocketAddr,
         Arc<Mutex<Vec<String>>>,
@@ -889,9 +955,7 @@ mod tests {
             &mp(&[peer_block(&url), prop_int("batch_size", 1)]),
         )
         .unwrap();
-        output
-            .write_owned(&event_with("hello-single"))
-            .await
+        consume(&output, &event_with("hello-single")).await
             .unwrap();
         for _ in 0..50 {
             if !received.lock().await.is_empty() {
@@ -920,8 +984,7 @@ mod tests {
         ];
         let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
         for i in 0..9 {
-            output
-                .write_owned(&event_with(&format!("rr-{}", i)))
+            consume(&output, &event_with(&format!("rr-{}", i)))
                 .await
                 .unwrap();
         }
@@ -972,10 +1035,10 @@ mod tests {
         // First send goes to A (cursor 0), fails, A cools down.
         // The queue layer would normally re-send; here we just send
         // again and expect B to take it (cursor advances to 1).
-        let first = output.write_owned(&event_with("rr-fail")).await;
+        let first = consume(&output, &event_with("rr-fail")).await;
         assert!(first.is_err(), "first attempt should fail (peer A is 500)");
         // Second event goes to peer B (next in rotation, A cooled).
-        output.write_owned(&event_with("rr-ok")).await.unwrap();
+        consume(&output, &event_with("rr-ok")).await.unwrap();
         s_a.abort();
         s_b.abort();
     }
@@ -1084,7 +1147,7 @@ mod tests {
             ident_prop("method", "PATCH"),
         ];
         let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
-        output.write_owned(&event_with("hello")).await.unwrap();
+        consume(&output, &event_with("hello")).await.unwrap();
         for _ in 0..50 {
             if !received.lock().await.is_empty() {
                 break;
@@ -1122,9 +1185,7 @@ mod tests {
         let url = format!("http://{}/", addr);
         let props = vec![peer_block(&url), prop_int("batch_size", 1)];
         let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
-        let err = output
-            .write_owned(&event_with("hello"))
-            .await
+        let err = consume(&output, &event_with("hello")).await
             .expect_err("500 must surface as Err");
         server.abort();
         let msg = err.to_string();
@@ -1176,9 +1237,7 @@ mod tests {
         let url = format!("http://{}/", addr);
         let props = vec![peer_block(&url), prop_int("batch_size", 1)];
         let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
-        let err = output
-            .write_owned(&event_with("hello"))
-            .await
+        let err = consume(&output, &event_with("hello")).await
             .expect_err("502 must surface as Err");
         server.abort();
         let msg = err.to_string();
@@ -1215,7 +1274,7 @@ mod tests {
         let props = vec![peer_block(&url), prop_int("batch_size", 1)];
         let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
         let pre_call = Instant::now();
-        let _ = output.write_owned(&event_with("hello")).await;
+        let _ = consume(&output, &event_with("hello")).await;
         let cooldown_until = output.inner.peer_state[0]
             .cooldown_until
             .lock()
@@ -1238,24 +1297,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_owned_bypasses_batch_buffer() {
-        // Owned events ship inline rather than landing in the batch
-        // buffer, so the queue consumer's per-event Ok/Err contract is
-        // honored. Verify the buffer stays empty and no flush timer is
-        // armed even with batch_size > 1.
+    async fn singleton_batch_size_ships_inline_without_buffering() {
+        // When `batch_size <= 1`, `consume` short-circuits through the
+        // singleton path that renders + ships in one shot (no buffer,
+        // no timer). Mirrors the prior `write_owned` bypass behaviour
+        // but for the unified queue path.
         let mut props = vec![peer_block("http://127.0.0.1:1/")];
-        props.push(prop_int("batch_size", 1024));
-        props.push(prop_str("batch_timeout", "30s"));
+        props.push(prop_int("batch_size", 1));
         let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
-        let err = output
-            .write_owned(&event_with("bypass"))
+        let err = consume(&output, &event_with("singleton"))
             .await
             .expect_err("send must fail against unreachable peer");
         assert!(err.to_string().contains("http"), "got: {err}");
         let batch_len = output.inner.batch.lock().await.len();
-        assert_eq!(batch_len, 0, "Owned event must not land in the batch");
+        assert_eq!(
+            batch_len, 0,
+            "singleton path must not land the event in the batch"
+        );
         let timer_armed = output.flush_handle.lock().await.is_some();
-        assert!(!timer_armed, "Owned event must not arm the flush timer");
+        assert!(
+            !timer_armed,
+            "singleton path must not arm the flush timer"
+        );
     }
 
     #[tokio::test]
@@ -1312,12 +1375,12 @@ mod tests {
         ];
         let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
 
-        // Two writes → triggers should_flush → first POST is the
-        // failing one → Err propagates and the batch is restored.
-        let p1 = RenderedPayload::new(HttpPayload { msg: "e1".into() });
-        output.write(p1).await.unwrap();
-        let p2 = RenderedPayload::new(HttpPayload { msg: "e2".into() });
-        let err = output.write(p2).await.expect_err("first flush must fail");
+        // Two consume_event calls → triggers should_flush → first POST
+        // is the failing one → Err propagates and the batch is restored.
+        consume(&output, &event_with("e1")).await.unwrap();
+        let err = consume(&output, &event_with("e2"))
+            .await
+            .expect_err("first flush must fail");
         assert!(
             err.to_string().contains("http") || err.to_string().contains("500"),
             "got: {err}"
@@ -1381,10 +1444,8 @@ mod tests {
         )
         .unwrap();
 
-        let p1 = RenderedPayload::new(HttpPayload { msg: "ev1".into() });
-        output.write(p1).await.unwrap();
-        let p2 = RenderedPayload::new(HttpPayload { msg: "ev2".into() });
-        output.write(p2).await.unwrap();
+        consume(&output, &event_with("ev1")).await.unwrap();
+        consume(&output, &event_with("ev2")).await.unwrap();
         assert_eq!(
             output.inner.batch.lock().await.len(),
             2,
@@ -1420,7 +1481,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // BC-4 / PR-P: shutdown-time buffer-loss recovery via `error_log`.
+    // Shutdown-flush recovery: shutdown-time buffer-loss recovery via `error_log`.
     // -----------------------------------------------------------------------
 
     async fn run_failing_collector() -> (SocketAddr, tokio::task::JoinHandle<()>) {
@@ -1455,14 +1516,8 @@ mod tests {
         .unwrap();
 
         // Drop two events into the buffer (no flush triggered).
-        output
-            .write(RenderedPayload::new(HttpPayload { msg: "ev1".into() }))
-            .await
-            .unwrap();
-        output
-            .write(RenderedPayload::new(HttpPayload { msg: "ev2".into() }))
-            .await
-            .unwrap();
+        consume(&output, &event_with("ev1")).await.unwrap();
+        consume(&output, &event_with("ev2")).await.unwrap();
         assert_eq!(output.inner.batch.lock().await.len(), 2);
 
         let dir = tempfile::TempDir::new().unwrap();
@@ -1528,10 +1583,7 @@ mod tests {
             ]),
         )
         .unwrap();
-        output
-            .write(RenderedPayload::new(HttpPayload { msg: "ev1".into() }))
-            .await
-            .unwrap();
+        consume(&output, &event_with("ev1")).await.unwrap();
 
         let err = output.shutdown(None).await.expect_err("flush must Err");
         server.abort();
@@ -1541,12 +1593,13 @@ mod tests {
             err.to_string().contains("http") || err.to_string().contains("500"),
             "got: {err}"
         );
-        // Buffer left intact (= PR-F retain-on-failure contract).
+        // Buffer left intact (= retain-on-failure contract).
         assert_eq!(output.inner.batch.lock().await.len(), 1);
     }
 
     /// shutdown flush succeeds + error_log set → success path is
-    /// completely unchanged from PR-F. The DLQ writer must not be
+    /// completely unchanged from the prior retain-on-failure path.
+    /// The DLQ writer must not be
     /// touched (regression check: a stray write would change the
     /// operator's audit trail).
     #[tokio::test]
@@ -1562,10 +1615,7 @@ mod tests {
             ]),
         )
         .unwrap();
-        output
-            .write(RenderedPayload::new(HttpPayload { msg: "ev1".into() }))
-            .await
-            .unwrap();
+        consume(&output, &event_with("ev1")).await.unwrap();
 
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("errored.jsonl");
@@ -1606,14 +1656,8 @@ mod tests {
             ]),
         )
         .unwrap();
-        output
-            .write(RenderedPayload::new(HttpPayload { msg: "ev1".into() }))
-            .await
-            .unwrap();
-        output
-            .write(RenderedPayload::new(HttpPayload { msg: "ev2".into() }))
-            .await
-            .unwrap();
+        consume(&output, &event_with("ev1")).await.unwrap();
+        consume(&output, &event_with("ev2")).await.unwrap();
 
         // Parent dir does not exist → every `write_shutdown_payload`
         // call returns Err. The helper must warn and continue rather
@@ -1627,5 +1671,35 @@ mod tests {
         // Buffer is drained either way (we took() before attempting
         // the DLQ write); the contract is that we don't crash.
         assert_eq!(output.inner.batch.lock().await.len(), 0);
+    }
+
+    /// Constructor-time error_log injection (replaces the prior
+    /// `attach_error_log(&self, ...)` setter). The runtime always
+    /// goes through `OutputBuilderWithErrorLog::from_properties_with_error_log`;
+    /// this test pins that the writer ends up on the Inner field so
+    /// subsequent flush paths (render-failure routing, shutdown
+    /// recovery) can reach it without any post-construction wiring.
+    #[tokio::test]
+    async fn constructor_injects_error_log_into_inner() {
+        use crate::modules::OutputBuilderWithErrorLog;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
+
+        let output = HttpOutput::from_properties_with_error_log(
+            "test",
+            &mp(&[peer_block("http://127.0.0.1:1/"), prop_int("batch_size", 8)]),
+            Some(Arc::clone(&writer)),
+        )
+        .unwrap();
+        // The Inner's `error_log` field must point at the same writer
+        // the runtime would have handed to us — no Mutex, no None
+        // window between construction and consumer spawn.
+        let stored = output.inner.error_log.as_ref().expect("error_log must be set");
+        assert!(
+            Arc::ptr_eq(stored, &writer),
+            "constructor must store the exact Arc passed in"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -34,17 +34,15 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use bytes::Bytes;
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::tls::ClientTlsConfig;
 
 /// Supported SASL mechanisms. The DSL spelling is underscore-separated
@@ -308,11 +306,6 @@ fn security_protocol(has_tls: bool, has_sasl: bool) -> Option<&'static str> {
     }
 }
 
-struct KafkaPayload {
-    egress: Bytes,
-    key: Option<String>,
-}
-
 pub struct KafkaOutput {
     producer: FutureProducer,
     topic: String,
@@ -432,22 +425,15 @@ impl HasMetrics for KafkaOutput {
 
 #[async_trait::async_trait]
 impl Output for KafkaOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        let key = self.resolve_key_borrowed(event);
-        Ok(RenderedPayload::new(KafkaPayload {
-            egress: event.egress.clone(),
-            key,
-        }))
-    }
+    async fn consume(&self, event: &Event) -> Result<()> {
+        // Render the key inline against the owned event. Kafka's
+        // payload (egress bytes + optional key) is light enough that
+        // we skip the `RenderedPayload` boxing entirely.
+        let key = self.resolve_key(event);
+        let egress = event.egress.clone();
 
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: KafkaPayload = payload.downcast()?;
-        let mut record = FutureRecord::to(&self.topic).payload(payload.egress.as_ref());
-        if let Some(ref k) = payload.key {
+        let mut record = FutureRecord::to(&self.topic).payload(egress.as_ref());
+        if let Some(ref k) = key {
             record = record.key(k);
         }
 
@@ -470,13 +456,18 @@ impl Drop for KafkaOutput {
 }
 
 impl KafkaOutput {
-    fn resolve_key_borrowed(&self, event: &BorrowedEvent<'_>) -> Option<String> {
+    /// Compute the optional Kafka message key from `event`. Returns
+    /// `None` when no `key_field` is configured or when the referenced
+    /// workspace entry is missing / non-string. Reads owned-event
+    /// state directly after this change (no `BorrowedEvent` indirection).
+    fn resolve_key(&self, event: &Event) -> Option<String> {
         let kf = self.key_field.as_ref()?;
         let value = match kf {
             KeyField::Source => event.source.ip().to_string(),
-            KeyField::Field(name) => event
-                .workspace_get(name)
-                .and_then(|v| v.as_str().map(|s| s.to_string()))?,
+            KeyField::Field(name) => event.workspace.get(name).and_then(|v| match v {
+                crate::dsl::value::OwnedValue::String(s) => Some(s.clone()),
+                _ => None,
+            })?,
         };
         Some(value)
     }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -57,17 +57,16 @@ use opentelemetry_proto::tonic::collector::logs::v1::{
 use tokio::sync::Mutex;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::{BorrowedEvent, Event};
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{BackoffStrategy, RetryConfig};
 
-use super::{BatchLevel, OtlpPayload, decode_drained_to_request};
+use super::{BatchLevel, decode_drained_to_request};
 
 /// Upper bound on a single gRPC export. A stalled collector (TCP
 /// connection accepted but no HEADERS frame returned) would otherwise
@@ -111,14 +110,23 @@ struct Inner {
     /// because the queue layer's per-event retry only re-pushes the
     /// most recent Event).
     retry_config: RetryConfig,
-    /// Buffered per-Event singleton ResourceLogs proto bytes.
-    batch: Mutex<Vec<Bytes>>,
+    /// Buffered events awaiting flush. Render happens at flush time
+    /// (batch buffers retain Event until flush) so per-event render
+    /// failures can be routed to DLQ on their own without dropping the
+    /// rest of the batch.
+    batch: Mutex<Vec<Event>>,
+    /// Operator-facing instance name; surfaced on shutdown-flush
+    /// recovery and render-failure records.
+    name: String,
+    /// `error_log` writer injected at construction time by the
+    /// runtime via `OutputBuilderWithErrorLog::from_properties_with_error_log`.
+    /// Used by the flush path to route per-event render failures and
+    /// shutdown-flush leftovers into the DLQ.
+    error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    metrics: Arc<OutputMetrics>,
 }
 
 pub struct OtlpGrpcOutput {
-    /// Operator-facing instance name; surfaced on PR-P shutdown-recovery
-    /// records as `(output <name> shutdown)`.
-    name: String,
     inner: Arc<Inner>,
     batch_size: usize,
     flush_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -269,6 +277,18 @@ impl Module for OtlpGrpcOutput {
     }
 
     fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+        <Self as crate::modules::OutputBuilderWithErrorLog>::from_properties_with_error_log(
+            name, properties, None,
+        )
+    }
+}
+
+impl crate::modules::OutputBuilderWithErrorLog for OtlpGrpcOutput {
+    fn from_properties_with_error_log(
+        name: &str,
+        properties: &crate::modules::ModuleProperties,
+        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
 
         let batch_size = props::get_positive_int(properties, "batch_size")?.unwrap_or(1) as usize;
@@ -306,8 +326,8 @@ impl Module for OtlpGrpcOutput {
 
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
+        let metrics = Arc::new(OutputMetrics::default());
         Ok(Self {
-            name: name.to_string(),
             inner: Arc::new(Inner {
                 peers,
                 peer_state,
@@ -317,10 +337,13 @@ impl Module for OtlpGrpcOutput {
                 batch_timeout,
                 retry_config,
                 batch: Mutex::new(Vec::new()),
+                name: name.to_string(),
+                error_log,
+                metrics: Arc::clone(&metrics),
             }),
             batch_size,
             flush_handle: Mutex::new(None),
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics,
         })
     }
 }
@@ -334,74 +357,41 @@ impl HasMetrics for OtlpGrpcOutput {
 
 #[async_trait::async_trait]
 impl Output for OtlpGrpcOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(OtlpPayload {
-            egress: event.egress.clone(),
-        }))
-    }
-
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: OtlpPayload = payload.downcast()?;
-        let proto = payload.egress;
+    /// Batched-buffer rendering: buffer the `Event` (no render yet), decide
+    /// flush-or-arm-timer. Render happens later in `flush()`.
+    async fn consume(&self, event: &Event) -> Result<()> {
         let mut batch = self.inner.batch.lock().await;
-        batch.push(proto);
+        batch.push(event.clone());
         let should_flush = batch.len() >= self.batch_size;
         drop(batch);
-
         if should_flush {
-            self.flush().await?;
+            self.flush().await
         } else {
             self.ensure_flush_timer().await;
+            Ok(())
         }
-        Ok(())
-    }
-
-    /// Owned-event path (disk-queue replay, control-socket inject). The
-    /// queue consumer needs a per-event ship verdict — Ok ⇒ drop from
-    /// the queue, Err ⇒ retry / disk-replay — so routing
-    /// Owned events through the batched buffer would silently merge them
-    /// into a later flush and the caller would lose the verdict. Ship
-    /// inline here, bypassing the batch.
-    async fn write_owned(&self, event: &Event) -> Result<()> {
-        crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
-            let payload: OtlpPayload = payload.downcast()?;
-            send_batch(&self.inner, vec![payload.egress])
-                .await
-                .map(|o| o.rejected)
-        })
-        .await
     }
 
     async fn shutdown(
         &self,
         error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // Same contract as `otlp_http::shutdown`: abort the timer to
-        // avoid a race for the buffer lock, then drain in one final
-        // send. Without this the queue consumer's shutdown call
-        // races the timer task, and either Drop's abort or the
-        // process exit can leave the in-flight buffer behind.
         if let Some(h) = self.flush_handle.lock().await.take() {
             h.abort();
         }
         match self.flush().await {
             Ok(()) => Ok(()),
             Err(e) => {
-                // BC-4 / PR-P: `flush()` restored the drained batch
-                // into `self.inner.batch` on transport error. Drain
-                // it into `error_log` when the operator opted in;
-                // otherwise return Err and preserve 0.7.7 behaviour
-                // (queue consumer logs a warn and the buffer is
-                // lost).
+                // Shutdown-flush recovery: drain leftover `Event`s into
+                // `error_log` carrying real source/ingress/received_at.
                 if let Some(writer) = error_log {
-                    let payloads: Vec<bytes::Bytes> =
+                    let events: Vec<Event> =
                         std::mem::take(&mut *self.inner.batch.lock().await);
-                    crate::modules::write_shutdown_buffer_to_error_log(
-                        writer, &self.name, payloads, &e,
+                    crate::modules::write_shutdown_events_to_error_log(
+                        writer,
+                        &self.inner.name,
+                        events,
+                        &e,
                     )
                     .await;
                     Ok(())
@@ -415,19 +405,92 @@ impl Output for OtlpGrpcOutput {
 
 impl OtlpGrpcOutput {
     async fn flush(&self) -> Result<()> {
-        let drained: Vec<Bytes> = {
-            let mut batch = self.inner.batch.lock().await;
-            std::mem::take(&mut *batch)
+        let batch: Vec<Event> = {
+            let mut buf = self.inner.batch.lock().await;
+            std::mem::take(&mut *buf)
         };
-        if drained.is_empty() {
+        self.inner.flush_events(batch).await
+    }
+
+    async fn ensure_flush_timer(&self) {
+        let mut handle = self.flush_handle.lock().await;
+        if let Some(h) = handle.as_ref()
+            && !h.is_finished()
+        {
+            return;
+        }
+
+        let inner = Arc::clone(&self.inner);
+        let new_handle = tokio::spawn(async move {
+            tokio::time::sleep(inner.batch_timeout).await;
+            let batch: Vec<Event> = {
+                let mut buf = inner.batch.lock().await;
+                std::mem::take(&mut *buf)
+            };
+            if let Err(e) = inner.flush_events(batch).await {
+                tracing::warn!("otlp_grpc flush timer: {}", e);
+            }
+        });
+        *handle = Some(new_handle);
+    }
+}
+
+impl Inner {
+    /// Render each buffered event, route per-event render failures to
+    /// DLQ, ship the rest via `send_batch`. On transport failure
+    /// restore the un-rendered events to the buffer for retry.
+    async fn flush_events(&self, batch: Vec<Event>) -> Result<()> {
+        if batch.is_empty() {
             return Ok(());
         }
-        let count = drained.len() as u64;
-        // Clone for the send so the original survives for retry
-        // restoration on transport error. `Bytes::clone` is a
-        // refcount bump, no payload copy.
-        let result = send_batch(&self.inner, drained.clone()).await;
-        match result {
+        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
+        let mut shippable: Vec<Event> = Vec::with_capacity(batch.len());
+        let mut render_failures: Vec<(Event, anyhow::Error)> = Vec::new();
+        for ev in batch {
+            // OTLP render is a refcount bump on `event.egress` — same
+            // body as `OtlpGrpcOutput::render` above.
+            let res: Result<Bytes> = Ok(ev.egress.clone());
+            match res {
+                Ok(p) => {
+                    payloads.push(p);
+                    shippable.push(ev);
+                }
+                Err(e) => render_failures.push((ev, e)),
+            }
+        }
+        if !render_failures.is_empty() {
+            let error_log = self.error_log.as_ref();
+            for (ev, err) in render_failures {
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                if let Some(writer) = &error_log {
+                    let ctx = crate::pipeline::ErroredEventContext {
+                        timestamp: chrono::Utc::now(),
+                        pipeline: String::new(),
+                        process: format!("(output {})", self.name),
+                        reason: format!("render failed during batch flush: {}", err),
+                        event: ev,
+                    };
+                    if let Err(write_err) = writer.write(&ctx).await {
+                        tracing::warn!(
+                            "output '{}': error_log write failed during batch render: {}",
+                            self.name,
+                            write_err
+                        );
+                    }
+                } else {
+                    tracing::error!(
+                        "output '{}': render failed during batch flush ({}); dropping event (no error_log)",
+                        self.name,
+                        err
+                    );
+                }
+            }
+        }
+        if payloads.is_empty() {
+            return Ok(());
+        }
+        let count = payloads.len() as u64;
+        match send_batch(self, payloads.clone()).await {
             Ok(outcome) => {
                 let rejected = outcome.rejected.min(count);
                 let written = count - rejected;
@@ -444,69 +507,13 @@ impl OtlpGrpcOutput {
                 Ok(())
             }
             Err(e) => {
-                // Transport error: put the drained batch back into
-                // the buffer for retry instead of dropping it.
-                // Mirrors `output http` (PR limpid#33) and the
-                // sibling `otlp_http` write-flush path. Do NOT bump
-                // events_failed — the events are retained, not
-                // permanently rejected.
-                let mut batch = self.inner.batch.lock().await;
-                let new_events = std::mem::take(&mut *batch);
-                *batch = drained;
-                batch.extend(new_events);
+                let mut buf = self.batch.lock().await;
+                let new_events = std::mem::take(&mut *buf);
+                *buf = shippable;
+                buf.extend(new_events);
                 Err(e)
             }
         }
-    }
-
-    async fn ensure_flush_timer(&self) {
-        let mut handle = self.flush_handle.lock().await;
-        if let Some(h) = handle.as_ref()
-            && !h.is_finished()
-        {
-            return;
-        }
-
-        let inner = Arc::clone(&self.inner);
-        let metrics = Arc::clone(&self.metrics);
-        let new_handle = tokio::spawn(async move {
-            tokio::time::sleep(inner.batch_timeout).await;
-            let drained: Vec<Bytes> = {
-                let mut batch = inner.batch.lock().await;
-                std::mem::take(&mut *batch)
-            };
-            if drained.is_empty() {
-                return;
-            }
-            let count = drained.len() as u64;
-            match send_batch(&inner, drained.clone()).await {
-                Ok(outcome) => {
-                    let rejected = outcome.rejected.min(count);
-                    let written = count - rejected;
-                    if written > 0 {
-                        metrics.events_written.fetch_add(written, Ordering::Relaxed);
-                    }
-                    if rejected > 0 {
-                        metrics.events_failed.fetch_add(rejected, Ordering::Relaxed);
-                    }
-                }
-                Err(e) => {
-                    // Same retention contract as the write-triggered
-                    // flush: return the drained batch to the buffer
-                    // for the next write or timer firing to retry.
-                    tracing::warn!(
-                        "otlp_grpc flush timer: send failed ({}) — {} events returned to buffer",
-                        e,
-                        count
-                    );
-                    let mut buf = inner.batch.lock().await;
-                    let new_events = std::mem::take(&mut *buf);
-                    *buf = drained;
-                    buf.extend(new_events);
-                }
-            }
-        });
-        *handle = Some(new_handle);
     }
 }
 
@@ -916,6 +923,11 @@ mod tests {
         e
     }
 
+    /// Test shim mirroring the queue consumer's `consume` call.
+    async fn consume(output: &OtlpGrpcOutput, ev: &Event) -> Result<()> {
+        output.consume(ev).await
+    }
+
     async fn wait_for<T>(mut probe: impl FnMut() -> Option<T>) -> T {
         for _ in 0..50 {
             if let Some(v) = probe() {
@@ -967,11 +979,9 @@ mod tests {
         let mut props = one_peer_props(&endpoint);
         props.push(prop_int("batch_size", 1));
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
-        output
-            .write_owned(&event_with_egress(singleton_bytes(
+        consume(&output, &event_with_egress(singleton_bytes(
                 1_700_000_000_000_000_000,
-            )))
-            .await
+            ))).await
             .unwrap();
 
         let probe = || {
@@ -1043,19 +1053,9 @@ mod tests {
         props.push(prop_int("batch_size", 3));
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
 
-        let mut payloads: Vec<RenderedPayload> = Vec::new();
         for i in 0..3 {
             let ev = event_with_egress(singleton_bytes(1_000_000_000 + i));
-            let payload = {
-                let bump = bumpalo::Bump::new();
-                let arena = EventArena::new(&bump);
-                let bev = ev.view_in(&arena);
-                output.render(&bev, &arena).unwrap()
-            };
-            payloads.push(payload);
-        }
-        for p in payloads {
-            output.write(p).await.unwrap();
+            consume(&output, &ev).await.unwrap();
         }
         // Give the inline flush a moment.
         for _ in 0..50 {
@@ -1084,24 +1084,18 @@ mod tests {
 
     #[tokio::test]
     async fn drop_aborts_pending_flush_timer() {
-        // The flush timer is only armed by the Rendered (memory hot
-        // path) buffer write — Owned events bypass the batch entirely
-        // (see `write_owned`) so they never arm the timer. Drive the
-        // timer via the Rendered path here.
+        // The flush timer is armed by `consume_event` while the buffer
+        // is below `batch_size`. Drop must abort it so the spawned
+        // task doesn't leak past process exit.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
-        let ev = event_with_egress(singleton_bytes(1));
-        let payload = {
-            let bump = bumpalo::Bump::new();
-            let arena = EventArena::new(&bump);
-            let bev = ev.view_in(&arena);
-            output.render(&bev, &arena).unwrap()
-        };
-        output.write(payload).await.unwrap();
+        consume(&output, &event_with_egress(singleton_bytes(1)))
+            .await
+            .unwrap();
         let handle_before = output.flush_handle.lock().await.is_some();
-        assert!(handle_before, "Rendered write must arm the flush timer");
+        assert!(handle_before, "consume_event must arm the flush timer");
         drop(output);
     }
 
@@ -1149,9 +1143,7 @@ mod tests {
         });
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
         let send = tokio::spawn(async move {
-            output
-                .write_owned(&event_with_egress(singleton_bytes(1)))
-                .await
+            consume(&output, &event_with_egress(singleton_bytes(1))).await
         });
 
         // Let the spawned future reach the timeout-wrapped await,
@@ -1175,39 +1167,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_owned_bypasses_batch_buffer() {
-        // Owned events ship inline rather than landing in the batch
-        // buffer, so the queue consumer's per-event Ok/Err contract is
-        // honored (Err → disk-replay / retry). Use an
-        // unreachable endpoint and large batch_size so the only way
-        // the assertion can fail is if write_owned routed through the
-        // batch instead of bypassing it.
+    async fn consume_event_buffers_below_batch_size() {
+        // `consume` always buffers under `batch_size > 1`, arming the
+        // deferred-flush timer. (Before this change the Owned-event
+        // path bypassed the buffer; now there is no separate path —
+        // every event lands in the buffer for batching.)
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
-        // Single attempt with no backoff so the test finishes fast.
-        props.push(Property::Block {
-            key: "retry".into(),
-            key_span: None,
-            properties: vec![
-                prop_int("max_attempts", 1),
-                prop_str("initial_wait", "1ms"),
-                prop_str("max_wait", "1ms"),
-            ],
-        });
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
-        let err = output
-            .write_owned(&event_with_egress(singleton_bytes(1)))
+        consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
-            .expect_err("send must fail against unreachable peer");
-        assert!(
-            err.to_string().contains("otlp_grpc"),
-            "expected ship error, got: {err}"
-        );
+            .expect("buffering a single event must succeed");
         let batch_len = output.inner.batch.lock().await.len();
-        assert_eq!(batch_len, 0, "Owned event must not land in the batch");
+        assert_eq!(batch_len, 1, "event must sit in the buffer");
         let timer_armed = output.flush_handle.lock().await.is_some();
-        assert!(!timer_armed, "Owned event must not arm the flush timer");
+        assert!(timer_armed, "consume_event must arm the flush timer");
     }
 
     #[tokio::test]
@@ -1242,12 +1217,10 @@ mod tests {
         props.push(prop_str("batch_timeout", "30s"));
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
 
-        let arena_bump = bumpalo::Bump::new();
-        let arena = EventArena::new(&arena_bump);
         for ts in [1u64, 2u64] {
-            let ev = event_with_egress(singleton_bytes(ts));
-            let payload = output.render(&ev.view_in(&arena), &arena).unwrap();
-            output.write(payload).await.unwrap();
+            consume(&output, &event_with_egress(singleton_bytes(ts)))
+                .await
+                .unwrap();
         }
         assert_eq!(
             output.inner.batch.lock().await.len(),
@@ -1306,17 +1279,12 @@ mod tests {
         });
         let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
 
-        let arena_bump = bumpalo::Bump::new();
-        let arena = EventArena::new(&arena_bump);
-        let e1 = event_with_egress(singleton_bytes(1));
-        let p1 = output.render(&e1.view_in(&arena), &arena).unwrap();
-        output.write(p1).await.unwrap();
+        consume(&output, &event_with_egress(singleton_bytes(1)))
+            .await
+            .unwrap();
         assert_eq!(output.inner.batch.lock().await.len(), 1);
 
-        let e2 = event_with_egress(singleton_bytes(2));
-        let p2 = output.render(&e2.view_in(&arena), &arena).unwrap();
-        let err = output
-            .write(p2)
+        let err = consume(&output, &event_with_egress(singleton_bytes(2)))
             .await
             .expect_err("flush against unreachable peer must fail");
         assert!(
@@ -1337,7 +1305,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // BC-4 / PR-P: shutdown-time buffer-loss recovery via `error_log`.
+    // Shutdown-flush recovery: shutdown-time buffer-loss recovery via `error_log`.
     // -----------------------------------------------------------------------
 
     fn shutdown_recovery_props(endpoint: &str) -> Vec<Property> {
@@ -1359,20 +1327,19 @@ mod tests {
     }
 
     async fn buffer_two(output: &OtlpGrpcOutput) {
-        let arena_bump = bumpalo::Bump::new();
-        let arena = EventArena::new(&arena_bump);
         for ts in [1u64, 2u64] {
-            let ev = event_with_egress(singleton_bytes(ts));
-            let p = output.render(&ev.view_in(&arena), &arena).unwrap();
-            output.write(p).await.unwrap();
+            consume(output, &event_with_egress(singleton_bytes(ts)))
+                .await
+                .unwrap();
         }
         assert_eq!(output.inner.batch.lock().await.len(), 2);
     }
 
     #[tokio::test]
     async fn shutdown_failure_with_error_log_persists_buffer() {
-        // Unreachable peer → flush() fails inside shutdown and PR-F
-        // restores the batch into the buffer. The new recovery path
+        // Unreachable peer → flush() fails inside shutdown and the
+        // retain-on-failure path restores the batch into the buffer.
+        // The new recovery path
         // drains it into the operator-configured `error_log` and the
         // override returns Ok so the consumer treats the daemon as
         // cleanly stopped.
@@ -1460,5 +1427,28 @@ mod tests {
         ));
         output.shutdown(Some(&writer)).await.unwrap();
         assert_eq!(output.inner.batch.lock().await.len(), 0);
+    }
+
+    /// Constructor-time error_log injection — see the matching test
+    /// in `output::http` for the rationale.
+    #[tokio::test]
+    async fn constructor_injects_error_log_into_inner() {
+        use crate::modules::OutputBuilderWithErrorLog;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
+
+        let output = OtlpGrpcOutput::from_properties_with_error_log(
+            "test",
+            &mp(&one_peer_props("http://127.0.0.1:1")),
+            Some(Arc::clone(&writer)),
+        )
+        .unwrap();
+        let stored = output.inner.error_log.as_ref().expect("error_log must be set");
+        assert!(
+            Arc::ptr_eq(stored, &writer),
+            "constructor must store the exact Arc passed in"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -56,19 +56,18 @@ use opentelemetry_proto::tonic::collector::logs::v1::{
 use prost::Message;
 use tokio::sync::Mutex;
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::{BorrowedEvent, Event};
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{BackoffStrategy, RetryConfig};
 use crate::tls::ClientTlsConfig;
 
-use super::{BatchLevel, OtlpPayload, decode_drained_to_request};
+use super::{BatchLevel, decode_drained_to_request};
 
 /// Upper bound on a single HTTP export — connect, TLS handshake,
 /// request body send, response headers, response body. A peer that
@@ -149,14 +148,23 @@ struct Inner {
     /// drained batch (the queue layer's per-event retry only re-pushes
     /// the most recent Event).
     retry_config: RetryConfig,
-    /// Buffered per-Event singleton ResourceLogs proto bytes.
-    batch: Mutex<Vec<Bytes>>,
+    /// Buffered events awaiting flush. Render happens at flush time
+    /// (batch buffers retain Event until flush) so per-event render
+    /// failures can be routed to DLQ on their own without dropping the
+    /// rest of the batch.
+    batch: Mutex<Vec<Event>>,
+    /// Operator-facing instance name; surfaced on shutdown-flush
+    /// recovery and render-failure records.
+    name: String,
+    /// `error_log` writer injected at construction time by the
+    /// runtime via `OutputBuilderWithErrorLog::from_properties_with_error_log`.
+    /// Used by the flush path to route per-event render failures and
+    /// shutdown-flush leftovers into the DLQ.
+    error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    metrics: Arc<OutputMetrics>,
 }
 
 pub struct OtlpHttpOutput {
-    /// Operator-facing instance name; surfaced on PR-P shutdown-recovery
-    /// records as `(output <name> shutdown)`.
-    name: String,
     inner: Arc<Inner>,
     batch_size: usize,
     flush_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -350,6 +358,18 @@ impl Module for OtlpHttpOutput {
     }
 
     fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+        <Self as crate::modules::OutputBuilderWithErrorLog>::from_properties_with_error_log(
+            name, properties, None,
+        )
+    }
+}
+
+impl crate::modules::OutputBuilderWithErrorLog for OtlpHttpOutput {
+    fn from_properties_with_error_log(
+        name: &str,
+        properties: &crate::modules::ModuleProperties,
+        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
 
         let protocol_str = props::get_string(properties, "protocol")
@@ -395,8 +415,8 @@ impl Module for OtlpHttpOutput {
 
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
+        let metrics = Arc::new(OutputMetrics::default());
         Ok(Self {
-            name: name.to_string(),
             inner: Arc::new(Inner {
                 peers,
                 peer_state,
@@ -407,10 +427,13 @@ impl Module for OtlpHttpOutput {
                 batch_timeout,
                 retry_config,
                 batch: Mutex::new(Vec::new()),
+                name: name.to_string(),
+                error_log,
+                metrics: Arc::clone(&metrics),
             }),
             batch_size,
             flush_handle: Mutex::new(None),
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics,
         })
     }
 }
@@ -424,44 +447,21 @@ impl HasMetrics for OtlpHttpOutput {
 
 #[async_trait::async_trait]
 impl Output for OtlpHttpOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(OtlpPayload {
-            egress: event.egress.clone(),
-        }))
-    }
-
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: OtlpPayload = payload.downcast()?;
-        let proto = payload.egress;
+    /// Batched-buffer rendering: buffer the `Event` (no render yet), decide
+    /// flush-or-arm-timer. Render happens later in `flush()` so a
+    /// per-event render failure is routed to DLQ on its own without
+    /// dropping the rest of the batch.
+    async fn consume(&self, event: &Event) -> Result<()> {
         let mut batch = self.inner.batch.lock().await;
-        batch.push(proto);
+        batch.push(event.clone());
         let should_flush = batch.len() >= self.batch_size;
         drop(batch);
-
         if should_flush {
-            self.flush().await?;
+            self.flush().await
         } else {
             self.ensure_flush_timer().await;
+            Ok(())
         }
-        Ok(())
-    }
-
-    /// Owned-event path (disk-queue replay, control-socket inject). See
-    /// the rationale on `OtlpGrpcOutput::write_owned`: the queue
-    /// consumer needs a per-event ship verdict, and the batched buffer
-    /// would lose it. Ship inline here, bypassing the batch.
-    async fn write_owned(&self, event: &Event) -> Result<()> {
-        crate::modules::ship_owned_inline(self, event, &self.metrics, |payload| async move {
-            let payload: OtlpPayload = payload.downcast()?;
-            send_batch(&self.inner, vec![payload.egress])
-                .await
-                .map(|o| o.rejected)
-        })
-        .await
     }
 
     async fn shutdown(
@@ -470,24 +470,25 @@ impl Output for OtlpHttpOutput {
     ) -> Result<()> {
         // Abort any pending timer so it cannot race with us for the
         // buffer lock. Then drain whatever is left in one final
-        // send. Without this the queue consumer's `shutdown()` call
-        // would race the timer and the in-flight events could be
-        // dropped between the timer's abort (via `Drop`) and the
-        // process exit.
+        // send.
         if let Some(h) = self.flush_handle.lock().await.take() {
             h.abort();
         }
         match self.flush().await {
             Ok(()) => Ok(()),
             Err(e) => {
-                // BC-4 / PR-P: drain the put-back batch into
-                // `error_log` when configured; preserve 0.7.7
-                // (warn + drop via the queue consumer) when not.
+                // Shutdown-flush recovery: drain leftover `Event`s into
+                // `error_log` carrying real source/ingress/received_at;
+                // preserve 0.7.7 (warn + drop via the queue consumer)
+                // when not configured.
                 if let Some(writer) = error_log {
-                    let payloads: Vec<bytes::Bytes> =
+                    let events: Vec<Event> =
                         std::mem::take(&mut *self.inner.batch.lock().await);
-                    crate::modules::write_shutdown_buffer_to_error_log(
-                        writer, &self.name, payloads, &e,
+                    crate::modules::write_shutdown_events_to_error_log(
+                        writer,
+                        &self.inner.name,
+                        events,
+                        &e,
                     )
                     .await;
                     Ok(())
@@ -503,20 +504,94 @@ impl OtlpHttpOutput {
     /// Drain the current batch, build an ExportLogsServiceRequest, and
     /// ship it. No-op if the buffer is empty.
     async fn flush(&self) -> Result<()> {
-        let drained: Vec<Bytes> = {
-            let mut batch = self.inner.batch.lock().await;
-            std::mem::take(&mut *batch)
+        let batch: Vec<Event> = {
+            let mut buf = self.inner.batch.lock().await;
+            std::mem::take(&mut *buf)
         };
-        if drained.is_empty() {
+        self.inner.flush_events(batch).await
+    }
+
+    /// Schedule (or refresh) a deferred flush so events do not sit in
+    /// the buffer indefinitely when traffic is below `batch_size`.
+    async fn ensure_flush_timer(&self) {
+        let mut handle = self.flush_handle.lock().await;
+        if let Some(h) = handle.as_ref()
+            && !h.is_finished()
+        {
+            return;
+        }
+
+        let inner = Arc::clone(&self.inner);
+        let new_handle = tokio::spawn(async move {
+            tokio::time::sleep(inner.batch_timeout).await;
+            let batch: Vec<Event> = {
+                let mut buf = inner.batch.lock().await;
+                std::mem::take(&mut *buf)
+            };
+            if let Err(e) = inner.flush_events(batch).await {
+                tracing::warn!("otlp_http flush timer: {}", e);
+            }
+        });
+        *handle = Some(new_handle);
+    }
+}
+
+impl Inner {
+    /// Render each buffered event, route per-event render failures to
+    /// DLQ (skipping them in the batch), then ship the remaining
+    /// payloads via `send_batch`. On transport failure the un-rendered
+    /// events are restored to the buffer for retry.
+    async fn flush_events(&self, batch: Vec<Event>) -> Result<()> {
+        if batch.is_empty() {
             return Ok(());
         }
-        let count = drained.len() as u64;
-        // Clone for the send so the original is available for
-        // restoration on transport error. `Bytes::clone` is a cheap
-        // refcount bump (no payload copy), so this scales linearly
-        // with batch length rather than with batch byte size.
-        let result = send_batch(&self.inner, drained.clone()).await;
-        match result {
+        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
+        let mut shippable: Vec<Event> = Vec::with_capacity(batch.len());
+        let mut render_failures: Vec<(Event, anyhow::Error)> = Vec::new();
+        for ev in batch {
+            match render_event(&ev) {
+                Ok(p) => {
+                    payloads.push(p);
+                    shippable.push(ev);
+                }
+                Err(e) => render_failures.push((ev, e)),
+            }
+        }
+        if !render_failures.is_empty() {
+            let error_log = self.error_log.as_ref();
+            for (ev, err) in render_failures {
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                if let Some(writer) = &error_log {
+                    let ctx = crate::pipeline::ErroredEventContext {
+                        timestamp: chrono::Utc::now(),
+                        pipeline: String::new(),
+                        process: format!("(output {})", self.name),
+                        reason: format!("render failed during batch flush: {}", err),
+                        event: ev,
+                    };
+                    if let Err(write_err) = writer.write(&ctx).await {
+                        tracing::warn!(
+                            "output '{}': error_log write failed during batch render: {}",
+                            self.name,
+                            write_err
+                        );
+                    }
+                } else {
+                    tracing::error!(
+                        "output '{}': render failed during batch flush ({}); dropping event (no error_log)",
+                        self.name,
+                        err
+                    );
+                }
+            }
+        }
+        if payloads.is_empty() {
+            return Ok(());
+        }
+        let count = payloads.len() as u64;
+        // Clone payloads so the originals survive for buffer restore
+        // on transport error. `Bytes::clone` is a refcount bump.
+        match send_batch(self, payloads.clone()).await {
             Ok(outcome) => {
                 let rejected = outcome.rejected.min(count);
                 let written = count - rejected;
@@ -533,75 +608,26 @@ impl OtlpHttpOutput {
                 Ok(())
             }
             Err(e) => {
-                // Transport error: put the drained batch back into
-                // the buffer for retry instead of dropping it. The
-                // queue layer counts Rendered payloads as failed and
-                // does not replay them (see queue/mod.rs), so this
-                // is the only chance these events have. `output
-                // http` does the same (PR limpid#33); OTLP was the
-                // odd one out. Do NOT bump events_failed here — the
-                // events are retained, not permanently rejected.
-                let mut batch = self.inner.batch.lock().await;
-                let new_events = std::mem::take(&mut *batch);
-                *batch = drained;
-                batch.extend(new_events);
+                // Restore the shippable events for retry (the queue
+                // layer's per-event retry only re-pushes the latest
+                // event; OTLP batches need internal retention).
+                let mut buf = self.batch.lock().await;
+                let new_events = std::mem::take(&mut *buf);
+                *buf = shippable;
+                buf.extend(new_events);
                 Err(e)
             }
         }
     }
+}
 
-    /// Schedule (or refresh) a deferred flush so events do not sit in
-    /// the buffer indefinitely when traffic is below `batch_size`.
-    async fn ensure_flush_timer(&self) {
-        let mut handle = self.flush_handle.lock().await;
-        if let Some(h) = handle.as_ref()
-            && !h.is_finished()
-        {
-            return;
-        }
-
-        let inner = Arc::clone(&self.inner);
-        let metrics = Arc::clone(&self.metrics);
-        let new_handle = tokio::spawn(async move {
-            tokio::time::sleep(inner.batch_timeout).await;
-            let drained: Vec<Bytes> = {
-                let mut batch = inner.batch.lock().await;
-                std::mem::take(&mut *batch)
-            };
-            if drained.is_empty() {
-                return;
-            }
-            let count = drained.len() as u64;
-            match send_batch(&inner, drained.clone()).await {
-                Ok(outcome) => {
-                    let rejected = outcome.rejected.min(count);
-                    let written = count - rejected;
-                    if written > 0 {
-                        metrics.events_written.fetch_add(written, Ordering::Relaxed);
-                    }
-                    if rejected > 0 {
-                        metrics.events_failed.fetch_add(rejected, Ordering::Relaxed);
-                    }
-                }
-                Err(e) => {
-                    // Same retention contract as the write-triggered
-                    // flush above: put the drained batch back so the
-                    // next write or timer firing can retry, instead
-                    // of silently dropping events here.
-                    tracing::warn!(
-                        "otlp_http flush timer: send failed ({}) — {} events returned to buffer",
-                        e,
-                        count
-                    );
-                    let mut buf = inner.batch.lock().await;
-                    let new_events = std::mem::take(&mut *buf);
-                    *buf = drained;
-                    buf.extend(new_events);
-                }
-            }
-        });
-        *handle = Some(new_handle);
-    }
+/// Render a single Event into its OTLP `ResourceLogs` proto bytes —
+/// just a refcount bump on `event.egress`. Mirrors the body of
+/// `OtlpHttpOutput::render` / `OtlpGrpcOutput::render` so the
+/// consumer-side flush path can call it directly without setting up
+/// a borrowed-view arena.
+fn render_event(event: &Event) -> Result<Bytes> {
+    Ok(event.egress.clone())
 }
 
 impl Drop for OtlpHttpOutput {
@@ -993,6 +1019,11 @@ mod tests {
         e
     }
 
+    /// Test shim mirroring the queue consumer's `consume` call.
+    async fn consume(output: &OtlpHttpOutput, ev: &Event) -> Result<()> {
+        output.consume(ev).await
+    }
+
     async fn wait_for<T>(mut probe: impl FnMut() -> Option<T>) -> T {
         for _ in 0..50 {
             if let Some(v) = probe() {
@@ -1140,9 +1171,7 @@ mod tests {
         });
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
 
-        output
-            .write_owned(&event_with_egress(singleton_bytes(123)))
-            .await
+        consume(&output, &event_with_egress(singleton_bytes(123))).await
             .unwrap();
         assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 3);
         server.abort();
@@ -1192,9 +1221,7 @@ mod tests {
             },
         ];
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
-        output
-            .write_owned(&event_with_egress(singleton_bytes(42)))
-            .await
+        consume(&output, &event_with_egress(singleton_bytes(42))).await
             .unwrap();
 
         s_a.abort();
@@ -1230,9 +1257,7 @@ mod tests {
             ],
         });
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
-        let err = output
-            .write_owned(&event_with_egress(singleton_bytes(456)))
-            .await
+        let err = consume(&output, &event_with_egress(singleton_bytes(456))).await
             .expect_err("send must fail after retries exhausted");
         assert!(
             err.to_string().contains("503") || err.to_string().contains("HTTP"),
@@ -1249,9 +1274,7 @@ mod tests {
         props.push(prop_str("protocol", "http_protobuf"));
         props.push(prop_int("batch_size", 1));
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
-        output
-            .write_owned(&event_with_egress(singleton_bytes(123)))
-            .await
+        consume(&output, &event_with_egress(singleton_bytes(123))).await
             .unwrap();
         let probe = || {
             let g = received.try_lock().ok()?;
@@ -1274,9 +1297,7 @@ mod tests {
         props.push(prop_str("protocol", "http_json"));
         props.push(prop_int("batch_size", 1));
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
-        output
-            .write_owned(&event_with_egress(singleton_bytes(456)))
-            .await
+        consume(&output, &event_with_egress(singleton_bytes(456))).await
             .unwrap();
         let probe = || {
             let g = received.try_lock().ok()?;
@@ -1353,19 +1374,9 @@ mod tests {
         props.push(prop_int("batch_size", 3));
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
 
-        let mut payloads: Vec<RenderedPayload> = Vec::new();
         for i in 0..3 {
             let ev = event_with_egress(singleton_bytes(900_000_000 + i));
-            let payload = {
-                let bump = bumpalo::Bump::new();
-                let arena = EventArena::new(&bump);
-                let bev = ev.view_in(&arena);
-                output.render(&bev, &arena).unwrap()
-            };
-            payloads.push(payload);
-        }
-        for p in payloads {
-            output.write(p).await.unwrap();
+            consume(&output, &ev).await.unwrap();
         }
         for _ in 0..50 {
             if output.metrics.events_written.load(Ordering::Relaxed)
@@ -1392,54 +1403,39 @@ mod tests {
 
     #[tokio::test]
     async fn drop_aborts_pending_flush_timer() {
-        // The flush timer is only armed by the Rendered (memory hot
-        // path) buffer write — Owned events bypass the batch entirely
-        // (see `write_owned`) so they never arm the timer. Drive the
-        // timer via the Rendered path here.
+        // The flush timer is armed by `consume_event` when the buffer
+        // is below `batch_size`. Drop must abort the timer so the
+        // process exit doesn't leak the spawned task.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
-        let ev = event_with_egress(singleton_bytes(1));
-        let payload = {
-            let bump = bumpalo::Bump::new();
-            let arena = EventArena::new(&bump);
-            let bev = ev.view_in(&arena);
-            output.render(&bev, &arena).unwrap()
-        };
-        output.write(payload).await.unwrap();
+        consume(&output, &event_with_egress(singleton_bytes(1)))
+            .await
+            .unwrap();
         let handle_before = output.flush_handle.lock().await.is_some();
-        assert!(handle_before, "Rendered write must arm the flush timer");
+        assert!(handle_before, "consume_event must arm the flush timer");
         drop(output);
     }
 
     #[tokio::test]
-    async fn write_owned_bypasses_batch_buffer() {
+    async fn consume_event_buffers_below_batch_size() {
+        // `consume` always buffers under `batch_size > 1`, arming the
+        // deferred-flush timer. (Before this change the Owned-event
+        // path bypassed the buffer; now there is no separate
+        // Owned-event path — every event lands in the buffer for OTLP
+        // batching.)
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
-        props.push(Property::Block {
-            key: "retry".into(),
-            key_span: None,
-            properties: vec![
-                prop_int("max_attempts", 1),
-                prop_str("initial_wait", "1ms"),
-                prop_str("max_wait", "1ms"),
-            ],
-        });
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
-        let err = output
-            .write_owned(&event_with_egress(singleton_bytes(1)))
+        consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
-            .expect_err("send must fail against unreachable peer");
-        assert!(
-            err.to_string().contains("otlp_http"),
-            "expected ship error, got: {err}"
-        );
+            .expect("buffering a single event must succeed");
         let batch_len = output.inner.batch.lock().await.len();
-        assert_eq!(batch_len, 0, "Owned event must not land in the batch");
+        assert_eq!(batch_len, 1, "event must sit in the buffer");
         let timer_armed = output.flush_handle.lock().await.is_some();
-        assert!(!timer_armed, "Owned event must not arm the flush timer");
+        assert!(timer_armed, "consume_event must arm the flush timer");
     }
 
     #[tokio::test]
@@ -1466,20 +1462,15 @@ mod tests {
         });
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
 
-        // First write fills the buffer below batch_size — no flush.
-        let arena_bump = bumpalo::Bump::new();
-        let arena = EventArena::new(&arena_bump);
-        let e1 = event_with_egress(singleton_bytes(1));
-        let p1 = output.render(&e1.view_in(&arena), &arena).unwrap();
-        output.write(p1).await.unwrap();
+        // First consume fills the buffer below batch_size — no flush.
+        consume(&output, &event_with_egress(singleton_bytes(1)))
+            .await
+            .unwrap();
         assert_eq!(output.inner.batch.lock().await.len(), 1);
 
-        // Second write tips the batch over batch_size, triggers
+        // Second consume tips the batch over batch_size, triggers
         // flush() against the unreachable peer, which must Err.
-        let e2 = event_with_egress(singleton_bytes(2));
-        let p2 = output.render(&e2.view_in(&arena), &arena).unwrap();
-        let err = output
-            .write(p2)
+        let err = consume(&output, &event_with_egress(singleton_bytes(2)))
             .await
             .expect_err("flush against unreachable peer must fail");
         assert!(
@@ -1520,13 +1511,11 @@ mod tests {
         props.push(prop_str("batch_timeout", "30s"));
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
 
-        // Drive the batched path with two render→write round trips.
-        let arena_bump = bumpalo::Bump::new();
-        let arena = EventArena::new(&arena_bump);
+        // Drive the batched path via consume_event.
         for ts in [1u64, 2u64] {
-            let ev = event_with_egress(singleton_bytes(ts));
-            let payload = output.render(&ev.view_in(&arena), &arena).unwrap();
-            output.write(payload).await.unwrap();
+            consume(&output, &event_with_egress(singleton_bytes(ts)))
+                .await
+                .unwrap();
         }
         assert_eq!(
             output.inner.batch.lock().await.len(),
@@ -1636,9 +1625,7 @@ mod tests {
         });
         let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
         let send = tokio::spawn(async move {
-            output
-                .write_owned(&event_with_egress(singleton_bytes(1)))
-                .await
+            consume(&output, &event_with_egress(singleton_bytes(1))).await
         });
 
         for _ in 0..20 {
@@ -1693,7 +1680,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // BC-4 / PR-P: shutdown-time buffer-loss recovery via `error_log`.
+    // Shutdown-flush recovery: shutdown-time buffer-loss recovery via `error_log`.
     // -----------------------------------------------------------------------
 
     fn shutdown_recovery_props(endpoint: &str) -> Vec<Property> {
@@ -1716,12 +1703,10 @@ mod tests {
     }
 
     async fn buffer_two(output: &OtlpHttpOutput) {
-        let arena_bump = bumpalo::Bump::new();
-        let arena = EventArena::new(&arena_bump);
         for ts in [1u64, 2u64] {
-            let ev = event_with_egress(singleton_bytes(ts));
-            let payload = output.render(&ev.view_in(&arena), &arena).unwrap();
-            output.write(payload).await.unwrap();
+            consume(output, &event_with_egress(singleton_bytes(ts)))
+                .await
+                .unwrap();
         }
         assert_eq!(output.inner.batch.lock().await.len(), 2);
     }
@@ -1798,5 +1783,28 @@ mod tests {
         ));
         output.shutdown(Some(&writer)).await.unwrap();
         assert_eq!(output.inner.batch.lock().await.len(), 0);
+    }
+
+    /// Constructor-time error_log injection — see the matching test
+    /// in `output::http` for the rationale.
+    #[tokio::test]
+    async fn constructor_injects_error_log_into_inner() {
+        use crate::modules::OutputBuilderWithErrorLog;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
+
+        let output = OtlpHttpOutput::from_properties_with_error_log(
+            "test",
+            &mp(&one_peer_props("http://127.0.0.1:1/v1/logs")),
+            Some(Arc::clone(&writer)),
+        )
+        .unwrap();
+        let stored = output.inner.error_log.as_ref().expect("error_log must be set");
+        assert!(
+            Arc::ptr_eq(stored, &writer),
+            "constructor must store the exact Arc passed in"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/otlp/mod.rs
+++ b/crates/limpid/src/modules/output/otlp/mod.rs
@@ -62,10 +62,6 @@ pub(crate) struct SendOutcome {
     pub rejected: u64,
 }
 
-pub(crate) struct OtlpPayload {
-    pub(crate) egress: Bytes,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BatchLevel {
     /// One ResourceLogs entry per buffered Event — pure concat, no

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -4,13 +4,11 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use anyhow::Result;
-use bytes::Bytes;
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::schema::PropertySpec;
-use crate::event::BorrowedEvent;
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 
 /// `output stdout` has no module-specific properties; only the
 /// common `retry { ... } / queue { ... }` sub-blocks apply.
@@ -21,11 +19,6 @@ const STDOUT_OUTPUT_SCHEMA: &[PropertySpec] = &[
 
 pub struct StdoutOutput {
     metrics: Arc<OutputMetrics>,
-}
-
-/// Per-event payload: just the egress bytes (refcounted clone).
-struct StdoutPayload {
-    egress: Bytes,
 }
 
 impl Module for StdoutOutput {
@@ -52,19 +45,12 @@ impl HasMetrics for StdoutOutput {
 
 #[async_trait::async_trait]
 impl Output for StdoutOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(StdoutPayload {
-            egress: event.egress.clone(),
-        }))
-    }
-
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: StdoutPayload = payload.downcast()?;
-        let msg = String::from_utf8_lossy(&payload.egress);
+    async fn consume(&self, event: &Event) -> Result<()> {
+        // Trivial sink: no template rendering, no transport batching —
+        // print the egress bytes directly. `String::from_utf8_lossy`
+        // is the same egress→stdout step the previous `write` path
+        // ran; only the `RenderedPayload` plumbing is gone.
+        let msg = String::from_utf8_lossy(&event.egress);
         println!("{}", msg);
         self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
         Ok(())

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -26,17 +26,16 @@ use tokio_rustls::TlsConnector;
 use tokio_rustls::client::TlsStream;
 use tokio_rustls::rustls::pki_types::ServerName;
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::ast::{ExprKind, Property};
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
     PEER_CONNECT_TIMEOUT, PEER_HANDSHAKE_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList,
     SyslogFraming, SyslogPayload, parse_host_port, write_framed,
 };
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::tls::{ClientTlsConfig, build_client_config_sync};
 
 // ---------------------------------------------------------------------------
@@ -333,18 +332,21 @@ impl HasMetrics for SyslogTcpOutput {
 
 #[async_trait::async_trait]
 impl Output for SyslogTcpOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(SyslogPayload {
+    async fn consume(&self, event: &Event) -> Result<()> {
+        // Syslog-TCP has no per-event template work — the payload is
+        // just the egress bytes. Build it inline and hand it to the
+        // private write helper.
+        let payload = SyslogPayload {
             egress: event.egress.clone(),
-        }))
+        };
+        self.write_payload(payload).await
     }
+}
 
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: SyslogPayload = payload.downcast()?;
+impl SyslogTcpOutput {
+    /// Send one syslog frame via the peer-rotation helper. Private —
+    /// reached only from [`Output::consume`].
+    async fn write_payload(&self, payload: SyslogPayload) -> Result<()> {
         let framing = self.framing;
         let metrics = Arc::clone(&self.metrics);
         let connectors = self.connectors.clone();

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -6,15 +6,14 @@ use std::sync::atomic::Ordering;
 use anyhow::{Context, Result};
 use tokio::net::UdpSocket;
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::ast::Property;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
     PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogPayload, parse_host_port,
 };
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 
 const SYSLOG_UDP_PEER_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
@@ -107,18 +106,22 @@ impl HasMetrics for SyslogUdpOutput {
 
 #[async_trait::async_trait]
 impl Output for SyslogUdpOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(SyslogPayload {
+    async fn consume(&self, event: &Event) -> Result<()> {
+        // Syslog-UDP has no per-event template work — the payload is
+        // just the egress bytes. Build it inline and hand it to the
+        // private write helper.
+        let payload = SyslogPayload {
             egress: event.egress.clone(),
-        }))
+        };
+        self.write_payload(payload).await
     }
+}
 
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: SyslogPayload = payload.downcast()?;
+impl SyslogUdpOutput {
+    /// Send one rendered datagram via the peer-rotation helper.
+    /// Private — used only by [`Output::consume`] and unit tests that
+    /// drive the transport directly without constructing an `Event`.
+    async fn write_payload(&self, payload: SyslogPayload) -> Result<()> {
         let metrics = Arc::clone(&self.metrics);
         let result = self
             .peers
@@ -423,11 +426,15 @@ mod tests {
         )
         .expect("build");
 
-        // Hand-craft a RenderedPayload the way the runtime does.
-        let payload = RenderedPayload::new(SyslogPayload {
+        // Hand-craft a SyslogPayload the way the runtime would after
+        // its inline render step.
+        let payload = SyslogPayload {
             egress: Bytes::from_static(b"<134>hello-v6"),
-        });
-        output.write(payload).await.expect("write should succeed");
+        };
+        output
+            .write_payload(payload)
+            .await
+            .expect("write should succeed");
 
         // Read one datagram off the listener.
         let mut buf = [0u8; 64];

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -10,13 +10,12 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tokio::sync::Mutex;
 
-use crate::dsl::arena::EventArena;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
-use crate::event::BorrowedEvent;
+use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::persistent_conn::{PersistentConn, write_with_reconnect};
-use crate::modules::{HasMetrics, Module, Output, RenderedPayload};
+use crate::modules::{HasMetrics, Module, Output};
 
 const UNIX_SOCKET_OUTPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
@@ -29,10 +28,6 @@ const UNIX_SOCKET_OUTPUT_SCHEMA: &[PropertySpec] = &[
     crate::queue::RETRY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
-
-struct UnixSocketPayload {
-    egress: Bytes,
-}
 
 pub struct UnixSocketOutput {
     pub path: PathBuf,
@@ -66,19 +61,11 @@ impl HasMetrics for UnixSocketOutput {
 
 #[async_trait::async_trait]
 impl Output for UnixSocketOutput {
-    fn render(
-        &self,
-        event: &BorrowedEvent<'_>,
-        _arena: &EventArena<'_>,
-    ) -> Result<RenderedPayload> {
-        Ok(RenderedPayload::new(UnixSocketPayload {
-            egress: event.egress.clone(),
-        }))
-    }
-
-    async fn write(&self, payload: RenderedPayload) -> Result<()> {
-        let payload: UnixSocketPayload = payload.downcast()?;
-        write_with_reconnect(self, &self.conn, &self.metrics, &payload.egress).await
+    async fn consume(&self, event: &Event) -> Result<()> {
+        // No template rendering — the egress bytes are the payload.
+        // `write_with_reconnect` handles the reconnect-on-failure
+        // semantics via the `PersistentConn` impl below.
+        write_with_reconnect(self, &self.conn, &self.metrics, &event.egress).await
     }
 }
 

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -17,8 +17,6 @@ use std::collections::HashMap;
 use anyhow::{Result, bail};
 use tracing::trace;
 
-use std::sync::Arc;
-
 use crate::dsl::arena::EventArena;
 use crate::dsl::ast::*;
 use crate::dsl::eval::{eval_expr, select_if_branch, select_switch_arm, value_to_string};
@@ -26,8 +24,7 @@ use crate::dsl::exec::{ExecResult, ProcessError, ProcessRegistry, exec_process_b
 use crate::dsl::value::Value;
 use crate::event::{BorrowedEvent, OwnedEvent};
 use crate::functions::FunctionRegistry;
-use crate::modules::{ModuleRegistry, Output};
-use crate::queue::{QueueKind, SinkInput};
+use crate::modules::ModuleRegistry;
 use crate::tap::TapRegistry;
 
 // ---------------------------------------------------------------------------
@@ -47,11 +44,6 @@ pub struct CompiledConfig {
     /// as built-in primitives.
     pub functions: HashMap<String, FunctionDef>,
     pub global_blocks: HashMap<String, Vec<Property>>,
-    /// Per-output queue kind, derived from each output's `queue { type }`.
-    /// Drives the pipeline's output-statement dispatch: `Memory` outputs
-    /// take the render hot path (`SinkInput::Rendered`), `Disk` outputs
-    /// take the owned-event persist path (`SinkInput::Owned`).
-    pub outputs_queue_kind: HashMap<String, QueueKind>,
 }
 
 impl CompiledConfig {
@@ -102,14 +94,6 @@ impl CompiledConfig {
             global_blocks.insert(block.name, block.properties);
         }
 
-        let mut outputs_queue_kind: HashMap<String, QueueKind> = HashMap::new();
-        for (name, output_def) in &outputs {
-            let kind = crate::queue::QueueConfig::kind_from_output_properties(
-                output_def.properties.user_properties(),
-            );
-            outputs_queue_kind.insert(name.clone(), kind);
-        }
-
         let compiled = Self {
             inputs,
             outputs,
@@ -117,7 +101,6 @@ impl CompiledConfig {
             pipelines,
             functions,
             global_blocks,
-            outputs_queue_kind,
         };
         Ok(compiled)
     }
@@ -307,7 +290,7 @@ impl ErroredEventContext {
 /// Result of running an event through a pipeline.
 pub struct PipelineRunResult {
     pub trace: Vec<TraceEntry>,
-    pub outputs: Vec<(String, SinkInput)>,
+    pub outputs: Vec<(String, OwnedEvent)>,
     /// True iff at least one `output` statement was reached during
     /// execution (i.e. `outputs` was non-empty *before* the runtime
     /// drained it into the per-output queues). Needed because the
@@ -404,18 +387,17 @@ impl DslProcessRegistry<'_> {
 
 /// Run a single event through a pipeline definition.
 ///
-/// `output_sinks` maps output names to their concrete `Output` instances
-/// so the `output` statement can call `render` directly on the per-event
-/// arena (no `to_owned()` round-trip on the workspace). Outputs that
-/// aren't in the map (or that map to a disk queue) fall back to the
-/// owned-event path.
+/// After this change the executor never resolves an output sink — the `output`
+/// statement just enqueues the owned event, and render happens
+/// consumer-side inside each sink's `Output::consume`. The previous
+/// `output_sinks: &HashMap<String, Arc<dyn Output>>` parameter is gone
+/// as part of that cleanup.
 pub fn run_pipeline(
     pipeline: &PipelineDef,
     event: &OwnedEvent,
     config: &CompiledConfig,
     funcs: &FunctionRegistry,
     tap: Option<&TapRegistry>,
-    output_sinks: &HashMap<String, Arc<dyn Output>>,
     bump: &mut bumpalo::Bump,
 ) -> Result<PipelineRunResult> {
     let registry = DslProcessRegistry::new(&config.processes, funcs, tap);
@@ -450,8 +432,6 @@ pub fn run_pipeline(
         registry: &registry,
         funcs,
         arena: &arena,
-        outputs_queue_kind: &config.outputs_queue_kind,
-        output_sinks,
     };
     let mut exec_out = PipelineExecOut {
         trace: &mut trace_entries,
@@ -484,12 +464,6 @@ struct PipelineExecCtx<'a, 'bump: 'a> {
     registry: &'a DslProcessRegistry<'a>,
     funcs: &'a FunctionRegistry,
     arena: &'bump EventArena<'bump>,
-    /// Queue kind per output (Memory → render hot path,
-    /// Disk → owned-event persist path).
-    outputs_queue_kind: &'a HashMap<String, QueueKind>,
-    /// Concrete `Output` instances looked up at the `output` statement
-    /// to render a sink-specific payload from the borrowed event.
-    output_sinks: &'a HashMap<String, Arc<dyn Output>>,
 }
 
 /// Mutable accumulators threaded through the pipeline executor:
@@ -502,7 +476,7 @@ struct PipelineExecCtx<'a, 'bump: 'a> {
 /// per-event arena boundary on the way out of `run_pipeline`.
 struct PipelineExecOut<'a> {
     trace: &'a mut Vec<TraceEntry>,
-    outputs: &'a mut Vec<(String, SinkInput)>,
+    outputs: &'a mut Vec<(String, OwnedEvent)>,
     errored: &'a mut Option<ErroredEventContext>,
 }
 
@@ -679,40 +653,12 @@ fn exec_pipeline_stmt<'bump>(
                 label: format!("→ {}", name),
                 detail: String::new(),
             });
-            // Pick render hot-path or owned persist-path based on the
-            // output's queue type. Memory queues take a sink-specific
-            // `RenderedPayload` built against the per-event arena;
-            // disk-persist queues take an `OwnedEvent` because the
-            // payload must outlive the arena and survive a process
-            // restart via JSONL serialisation.
-            let kind = ctx
-                .outputs_queue_kind
-                .get(name)
-                .copied()
-                .unwrap_or(QueueKind::Memory);
-            let sink_input = match kind {
-                QueueKind::Disk => SinkInput::Owned(event.to_owned()),
-                QueueKind::Memory => match ctx.output_sinks.get(name) {
-                    Some(sink) => match sink.render(&event, ctx.arena) {
-                        Ok(payload) => SinkInput::Rendered(payload),
-                        Err(e) => {
-                            tracing::warn!(
-                                "output '{}': render failed ({}); falling back to owned-event path",
-                                name,
-                                e
-                            );
-                            SinkInput::Owned(event.to_owned())
-                        }
-                    },
-                    None => {
-                        // No registered sink (e.g. tests, --test-pipeline,
-                        // or --check). Fall back to the owned-event form
-                        // so callers can still inspect outputs.
-                        SinkInput::Owned(event.to_owned())
-                    }
-                },
-            };
-            out.outputs.push((name.clone(), sink_input));
+            // Every output statement enqueues a plain `OwnedEvent`.
+            // The queue no longer distinguishes between a rendered
+            // payload and an owned event — both memory and disk queues
+            // carry `Event` end-to-end, and render runs consumer-side
+            // inside each sink's `Output::consume`.
+            out.outputs.push((name.clone(), event.to_owned()));
             cont(event)
         }
 
@@ -862,14 +808,12 @@ def pipeline p {
             Bytes::from_static(b"original payload"),
             "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
         );
-        let sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
         let result = run_pipeline(
             pipeline,
             &event,
             &cfg,
             &funcs,
             None,
-            &sinks,
             &mut bumpalo::Bump::new(),
         )
         .unwrap();
@@ -922,14 +866,12 @@ def pipeline p {
             Bytes::from_static(b"payload"),
             "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
         );
-        let sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
         let result = run_pipeline(
             pipeline,
             &event,
             &cfg,
             &funcs,
             None,
-            &sinks,
             &mut bumpalo::Bump::new(),
         )
         .unwrap();
@@ -974,14 +916,12 @@ def pipeline p {
             Bytes::from_static(b"payload"),
             "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
         );
-        let sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
         let result = run_pipeline(
             pipeline,
             &event,
             &cfg,
             &funcs,
             None,
-            &sinks,
             &mut bumpalo::Bump::new(),
         )
         .unwrap();
@@ -997,106 +937,12 @@ def pipeline p {
         assert!(result.outputs.is_empty());
     }
 
-    #[test]
-    fn render_failure_falls_back_to_owned_sink_input() {
-        // The memory-queue render path catches a sink's `render` Err
-        // and falls back to `SinkInput::Owned(event.to_owned())` so
-        // the pipeline never drops an event because of a renderer
-        // bug. Mock an Output whose render() always errors, dispatch
-        // through run_pipeline, and assert the output_sinks list
-        // contains an Owned variant — not Rendered, not empty.
-        use crate::event::{BorrowedEvent, Event, OwnedEvent};
-        use crate::functions::{FunctionRegistry, register_builtins, table::TableStore};
-        use crate::metrics::OutputMetrics;
-        use crate::modules::{HasMetrics, Output, RenderedPayload};
-        use bytes::Bytes;
-        use std::net::SocketAddr;
-
-        struct AlwaysFailRender {
-            metrics: Arc<OutputMetrics>,
-        }
-        impl HasMetrics for AlwaysFailRender {
-            type Stats = OutputMetrics;
-            fn metrics(&self) -> Arc<OutputMetrics> {
-                Arc::clone(&self.metrics)
-            }
-        }
-        #[async_trait::async_trait]
-        impl Output for AlwaysFailRender {
-            fn render(
-                &self,
-                _event: &BorrowedEvent<'_>,
-                _arena: &crate::dsl::arena::EventArena<'_>,
-            ) -> anyhow::Result<RenderedPayload> {
-                anyhow::bail!("intentional render failure")
-            }
-            async fn write(&self, _payload: RenderedPayload) -> anyhow::Result<()> {
-                unreachable!("write must not be called when render errored")
-            }
-        }
-
-        let src = r#"
-def input i { type syslog_tcp bind "0.0.0.0:514" }
-def output o { type stdout }
-def pipeline p {
-    input i
-    output o
-}
-"#;
-        let cfg = compile(src).unwrap();
-        let pipeline = cfg.pipelines.get("p").unwrap();
-        let mut funcs = FunctionRegistry::new();
-        let store = TableStore::from_configs(vec![]).unwrap();
-        register_builtins(&mut funcs, store);
-
-        // Replace `o`'s sink with the mock so render() errors.
-        let mut sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
-        sinks.insert(
-            "o".into(),
-            Arc::new(AlwaysFailRender {
-                metrics: Arc::new(OutputMetrics::default()),
-            }) as Arc<dyn Output>,
-        );
-
-        let event = OwnedEvent::new(
-            Bytes::from_static(b"payload"),
-            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
-        );
-        let result = run_pipeline(
-            pipeline,
-            &event,
-            &cfg,
-            &funcs,
-            None,
-            &sinks,
-            &mut bumpalo::Bump::new(),
-        )
-        .unwrap();
-        assert_eq!(result.termination, PipelineTermination::Finished);
-        assert_eq!(
-            result.outputs.len(),
-            1,
-            "expected 1 output, got {}",
-            result.outputs.len()
-        );
-        let (name, sink_input) = &result.outputs[0];
-        assert_eq!(name, "o");
-        assert!(
-            matches!(sink_input, SinkInput::Owned(_)),
-            "render failure must fall back to Owned, got Rendered"
-        );
-        // Round-trip: the Owned event's ingress must equal what we fed.
-        if let SinkInput::Owned(ev) = sink_input {
-            assert_eq!(&ev.ingress[..], b"payload");
-        }
-        // Drop unused name to keep clippy happy in case the assert
-        // above doesn't reference it.
-        let _ = name;
-        let _: &Event = match sink_input {
-            SinkInput::Owned(e) => e,
-            SinkInput::Rendered(_) => unreachable!(),
-        };
-    }
+    // This restructure deleted `render_failure_falls_back_to_owned_sink_input`.
+    // The pipeline-side render-Err → Owned fallback no longer exists;
+    // render now runs consumer-side inside each sink's `Output::consume`
+    // and a render failure routes straight to the DLQ via
+    // `RenderError` (see `queue::mod::write_with_retry_tests::
+    // render_err_goes_straight_to_dlq`).
 
     #[test]
     fn validate_accepts_fan_in_when_all_inputs_exist() {

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -17,7 +17,6 @@ use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
-use crate::modules::RenderedPayload;
 
 // ---------------------------------------------------------------------------
 // Declarative schema for the per-output `queue { ... }` sub-block
@@ -139,33 +138,16 @@ pub const RETRY_PROPERTY_SPEC: PropertySpec = PropertySpec {
 };
 
 // ---------------------------------------------------------------------------
-// SinkInput — what flows over the per-output queue
+// Queue item — every queue (memory + disk) now carries `Event` end-to-end
 // ---------------------------------------------------------------------------
 //
-// The pipeline → output sink transport carries either a pre-rendered,
-// sink-specific payload (memory-queue hot path) or an `OwnedEvent`
-// (disk-queue persist, control-socket inject — cold paths where the
-// event must be serializable). The pipeline picks at the output
-// statement based on each output's queue type.
-
-/// Item carried by an output queue.
-pub enum SinkInput {
-    /// Disk-queue persist / inject path. Serialisable, outlives the
-    /// pipeline's per-event arena.
-    Owned(Event),
-    /// Memory-queue hot path. Type-erased payload built by
-    /// `Output::render`; the matching `Output::write` downcasts it.
-    Rendered(RenderedPayload),
-}
-
-/// Memory-vs-disk queue discriminator surfaced on `CompiledConfig` so
-/// the pipeline can pick `SinkInput::Owned` (disk persist) vs
-/// `SinkInput::Rendered` (memory hot path) at the `output` statement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QueueKind {
-    Memory,
-    Disk,
-}
+// Before this change the queue distinguished between a pre-rendered sink
+// payload (memory hot path) and an `OwnedEvent` (disk persist / inject).
+// After this change the queue uniformly carries `Event`; rendering moves from
+// the pipeline-side (enqueue time) to the consumer-side (send time,
+// inside each sink's `Output::consume`). Memory and disk queues are
+// distinguished only by the `SenderInner` variant — there is no
+// `QueueKind` tag because the pipeline never branches on it.
 
 /// Configuration for an output queue.
 #[derive(Debug, Clone)]
@@ -197,20 +179,6 @@ impl Default for QueueConfig {
 }
 
 impl QueueConfig {
-    /// Light-weight scan: peek at an output's properties and return
-    /// the queue kind without parsing capacities or paths. Used at
-    /// `CompiledConfig` build time to populate the per-output queue
-    /// kind map driving pipeline output dispatch.
-    pub fn kind_from_output_properties(output_props: &[Property]) -> QueueKind {
-        if let Some(block) = props::get_block(output_props, "queue")
-            && matches!(props::get_ident(block, "type").as_deref(), Some("disk"))
-        {
-            QueueKind::Disk
-        } else {
-            QueueKind::Memory
-        }
-    }
-
     /// Parse from an output definition's `queue { ... }` block.
     pub fn from_output_properties(
         output_name: &str,
@@ -254,9 +222,12 @@ pub enum OverflowStrategy {
 #[derive(Clone)]
 pub struct QueueSender {
     inner: SenderInner,
+    // 0.8 metrics will surface queue-level counters (depth, enqueue
+    // pressure) that need a label distinct from the output name.
+    // Holding the Arc<String> avoids re-plumbing it then; the per-queue
+    // allocation is trivial.
+    #[allow(dead_code)]
     name: Arc<String>,
-    #[allow(dead_code)] // surfaced via `kind()` for future memory/disk-aware callers
-    kind: QueueKind,
     /// Optional metrics — if set, `send()` increments `events_received` on success.
     /// Set by the runtime after the output module's metrics handle is available.
     metrics: Option<Arc<crate::metrics::OutputMetrics>>,
@@ -264,42 +235,26 @@ pub struct QueueSender {
 
 #[derive(Clone)]
 enum SenderInner {
-    Memory(tokio::sync::mpsc::Sender<SinkInput>),
+    Memory(tokio::sync::mpsc::Sender<Event>),
     Disk(disk::DiskQueueSender),
 }
 
 impl QueueSender {
-    /// Memory or disk discriminator. The pipeline reads this to decide
-    /// between the render hot-path (memory) and the owned/serialise
-    /// path (disk).
-    #[allow(dead_code)] // currently consumed via the `kind` map on CompiledConfig
-    pub fn kind(&self) -> QueueKind {
-        self.kind
-    }
-
-    /// Send a `SinkInput` into the queue.
+    /// Send an `Event` into the queue.
     ///
-    /// Disk queues only accept `SinkInput::Owned(...)` because the
-    /// `Rendered` variant holds a `Box<dyn Any>` payload which has no
-    /// serialisable shape. Pipeline-output dispatch (`pipeline.rs`)
-    /// already gates this by inspecting `kind()` at the output
-    /// statement; the `Rendered`-on-Disk arm here is a defence-in-depth
-    /// log+drop so a programmer mistake elsewhere doesn't silently
-    /// corrupt the persist path.
-    pub async fn send(&self, input: SinkInput) -> Result<(), QueueSendError> {
-        let result: Result<(), QueueSendError> = match (&self.inner, input) {
-            (SenderInner::Memory(tx), input) => {
-                tx.send(input).await.map_err(|_| QueueSendError::ChannelClosed)
-            }
-            (SenderInner::Disk(tx), SinkInput::Owned(ev)) => tx.send(ev).await,
-            (SenderInner::Disk(_), SinkInput::Rendered(_)) => {
-                error!(
-                    "queue '{}': pipeline routed a Rendered payload to a disk-persist queue \
-                     — this is a programmer bug; dropping event",
-                    self.name
-                );
-                Err(QueueSendError::RenderedOnDisk)
-            }
+    /// Both queue kinds carry `Event` end-to-end after this change: memory
+    /// queues forward the event to the consumer where the configured
+    /// output renders it inside `Output::consume`, and disk queues
+    /// serialise the same `Event` to JSON for replay. There is no
+    /// longer a `Rendered`-vs-`Owned` discriminator at this level
+    /// because the queue does not see sink-specific payloads anymore.
+    pub async fn send(&self, event: Event) -> Result<(), QueueSendError> {
+        let result: Result<(), QueueSendError> = match &self.inner {
+            SenderInner::Memory(tx) => tx
+                .send(event)
+                .await
+                .map_err(|_| QueueSendError::ChannelClosed),
+            SenderInner::Disk(tx) => tx.send(event).await,
         };
         if let Some(m) = &self.metrics {
             if result.is_ok() {
@@ -308,8 +263,7 @@ impl QueueSender {
             } else {
                 // Enqueue failure: memory-queue receiver dropped (=
                 // consumer task gone, daemon usually shutting down),
-                // disk-queue serialise/write error, or
-                // Rendered-on-Disk routing bug above. From this
+                // or disk-queue serialise/write error. From this
                 // sender's POV the event never made it into the
                 // queue and can't be retried by the consumer (the
                 // consumer never sees it). Bump `events_failed` so
@@ -322,13 +276,6 @@ impl QueueSender {
             }
         }
         result
-    }
-
-    /// Convenience: send an `OwnedEvent` regardless of queue kind.
-    /// Used by the cold paths (control-socket inject) that already hold
-    /// an owned event and don't go through the render path.
-    pub async fn send_owned(&self, event: Event) -> Result<(), QueueSendError> {
-        self.send(SinkInput::Owned(event)).await
     }
 
     /// Attach output metrics so subsequent `send()` calls count `events_received`.
@@ -349,22 +296,22 @@ pub struct QueueReceiver {
 }
 
 enum ReceiverInner {
-    Memory(tokio::sync::mpsc::Receiver<SinkInput>),
+    Memory(tokio::sync::mpsc::Receiver<Event>),
     Disk(disk::DiskQueueReceiver),
 }
 
 impl QueueReceiver {
-    pub async fn recv(&mut self) -> Option<SinkInput> {
+    pub async fn recv(&mut self) -> Option<Event> {
         match &mut self.inner {
             ReceiverInner::Memory(rx) => rx.recv().await,
-            ReceiverInner::Disk(rx) => rx.recv().await.map(SinkInput::Owned),
+            ReceiverInner::Disk(rx) => rx.recv().await,
         }
     }
 
-    pub fn try_recv(&mut self) -> Option<SinkInput> {
+    pub fn try_recv(&mut self) -> Option<Event> {
         match &mut self.inner {
             ReceiverInner::Memory(rx) => rx.try_recv().ok(),
-            ReceiverInner::Disk(rx) => rx.try_recv().map(SinkInput::Owned),
+            ReceiverInner::Disk(rx) => rx.try_recv(),
         }
     }
 
@@ -401,7 +348,6 @@ pub fn create_queue(
                 QueueSender {
                     inner: SenderInner::Memory(tx),
                     name: Arc::clone(&name),
-                    kind: QueueKind::Memory,
                     metrics: None,
                 },
                 QueueReceiver {
@@ -416,7 +362,6 @@ pub fn create_queue(
                 QueueSender {
                     inner: SenderInner::Disk(tx),
                     name: Arc::clone(&name),
-                    kind: QueueKind::Disk,
                     metrics: None,
                 },
                 QueueReceiver {
@@ -479,48 +424,16 @@ pub enum BackoffStrategy {
     Fixed,
 }
 
-/// Narrow `dyn`-safe adapter the queue consumer holds onto an output
-/// through. Lives separately from [`Output`] (in `modules::mod`) on
-/// purpose: `Output` carries `render`, which takes a `BorrowedEvent`
-/// tied to the per-event arena — that lifetime makes the trait object
-/// non-object-safe for the queue's `Box<dyn _>` storage, and the
-/// hot-path `render` isn't called from the queue side anyway.
-///
-/// Currently the only implementer is `modules::OutputWriterWrapper`,
-/// which forwards `consume` to the underlying `Arc<dyn Output>`. The
-/// trait is intentionally 1-impl: it exists as a **dyn-safety
-/// boundary**, not as an extension point, and stays that shape until
-/// a second writer kind appears (e.g. a side-channel sink that
-/// consumes `SinkInput` without going through a full `Output`).
-///
-/// `SinkInput` discriminates between a pipeline-rendered payload
-/// (memory-queue hot path) and an `OwnedEvent` (disk-queue replay,
-/// control-socket inject). Implementors dispatch on the variant.
-#[async_trait::async_trait]
-pub trait OutputWriter: Send + Sync + 'static {
-    async fn consume(&self, input: SinkInput) -> anyhow::Result<()>;
-
-    /// Drain any buffered events before the consumer stops. Forwarded
-    /// to the underlying `Output::shutdown` for `OutputWriterWrapper`;
-    /// default no-op for any future writer kind that holds no
-    /// internal buffer.
-    ///
-    /// `error_log` is the DLQ writer the consumer was launched with
-    /// — batched outputs use it to persist buffer entries that
-    /// survive a failed final flush (BC-4 / PR-P).
-    async fn shutdown(
-        &self,
-        _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-
 /// Run a queue consumer that drains events and writes them to an output.
+///
+/// Takes `Arc<dyn Output>` directly: after this change the `Output` trait is
+/// already dyn-safe (the lifetime-bound `render` method was removed in
+/// the trait collapse), so the earlier adapter trait that wrapped it
+/// purely to hide that lifetime is no longer needed.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_queue_consumer(
     mut receiver: QueueReceiver,
-    writer: Box<dyn OutputWriter>,
+    writer: Arc<dyn crate::modules::Output>,
     retry_config: RetryConfig,
     tap: Option<crate::tap::TapRegistry>,
     metrics: Arc<crate::metrics::OutputMetrics>,
@@ -544,14 +457,14 @@ pub async fn run_queue_consumer(
 
             input = receiver.recv() => {
                 match input {
-                    Some(input) => {
+                    Some(event) => {
                         // `error_log` recovery is performed inside
                         // `write_with_retry`; the disposition is
                         // ignored here because the caller-side
                         // per-disposition metrics breakdown is not yet
                         // implemented (deferred to the 0.8 metrics
                         // rework).
-                        let _ = write_with_retry(writer.as_ref(), input, &retry_config, &name, &metrics, tap.as_ref(), error_log.as_ref()).await;
+                        let _ = write_with_retry(writer.as_ref(), event, &retry_config, &name, &metrics, tap.as_ref(), error_log.as_ref()).await;
                         // Acknowledge the event regardless of
                         // disposition (delivered or retries exhausted):
                         // from this queue's POV the event has been
@@ -587,7 +500,7 @@ pub async fn run_queue_consumer(
 #[allow(clippy::too_many_arguments)]
 async fn drain_remaining(
     receiver: &mut QueueReceiver,
-    writer: &dyn OutputWriter,
+    writer: &dyn crate::modules::Output,
     retry_config: &RetryConfig,
     name: &str,
     metrics: &crate::metrics::OutputMetrics,
@@ -595,12 +508,12 @@ async fn drain_remaining(
     error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
 ) {
     let mut count = 0u64;
-    while let Some(input) = receiver.try_recv() {
+    while let Some(event) = receiver.try_recv() {
         // Disposition ignored: same rationale as the steady-state
         // loop — drain just needs to ack each event.
         let _ = write_with_retry(
             writer,
-            input,
+            event,
             retry_config,
             name,
             metrics,
@@ -625,19 +538,17 @@ async fn drain_remaining(
 /// Returns a [`WriteDisposition`] indicating whether the event was
 /// delivered, persisted to `error_log` for recovery, or dropped.
 ///
-/// Retry semantics:
-/// - `SinkInput::Owned(event)` is cloneable, so each attempt re-runs the
-///   write with the same event up to `max_attempts`.
-/// - `SinkInput::Rendered(payload)` consumes the (`Box<dyn Any>`)
-///   payload on the first call into `OutputWriter::consume` and is not
-///   re-buildable from the consumer, so on failure we fall through
-///   immediately. Operators who need full retry semantics on a sink
-///   should configure a disk queue (which always carries
-///   `SinkInput::Owned`).
+/// Retry semantics (after this change): the queue always carries `Event` so
+/// every attempt re-runs against the same event up to `max_attempts`.
+/// Render failures (signalled by [`crate::modules::RenderError`])
+/// bypass retries and go straight to DLQ — the render output is
+/// deterministic on the event, so retrying would only repeat the same
+/// failure. Transport / write failures continue to consume the retry
+/// budget as before.
 #[allow(clippy::too_many_arguments)]
 async fn write_with_retry(
-    writer: &dyn OutputWriter,
-    input: SinkInput,
+    writer: &dyn crate::modules::Output,
+    event: Event,
     config: &RetryConfig,
     name: &str,
     metrics: &crate::metrics::OutputMetrics,
@@ -646,41 +557,32 @@ async fn write_with_retry(
 ) -> WriteDisposition {
     use std::sync::atomic::Ordering;
 
-    // Fast-split: extract the optional Owned event (used for tap emit
-    // and retry/error_log fallback) without consuming the input we
-    // hand to the writer on the first attempt.
-    let mut owned_for_retry: Option<Event> = match &input {
-        SinkInput::Owned(ev) => Some(ev.clone()),
-        SinkInput::Rendered(_) => None,
-    };
-
-    if let Some(tap) = tap
-        && let Some(ev) = &owned_for_retry
-    {
-        tap.emit(&format!("output {}", name), ev).await;
+    if let Some(tap) = tap {
+        tap.emit(&format!("output {}", name), &event).await;
     }
 
-    let mut next_attempt: Option<SinkInput> = Some(input);
     let mut attempt = 0u32;
     let mut wait = config.initial_wait;
 
     loop {
-        let this = match next_attempt.take() {
-            Some(i) => i,
-            None => break,
-        };
-        let is_owned = matches!(this, SinkInput::Owned(_));
-        match writer.consume(this).await {
+        match writer.consume(&event).await {
             Ok(()) => return WriteDisposition::Delivered,
             Err(e) => {
+                // Render errors are deterministic on the event — no
+                // amount of retrying will salvage a broken template.
+                // Route straight to DLQ with a distinct `reason` so
+                // operators can tell render failures apart from
+                // transport exhaustion.
+                let is_render_err = e.downcast_ref::<crate::modules::RenderError>().is_some();
+
                 attempt += 1;
-                metrics.retries.fetch_add(1, Ordering::Relaxed);
-                if attempt >= config.max_attempts || !is_owned {
-                    if !is_owned {
-                        warn!(
-                            "output '{}': write failed (rendered payload, no retry): {}",
-                            name, e
-                        );
+                if !is_render_err {
+                    metrics.retries.fetch_add(1, Ordering::Relaxed);
+                }
+
+                if is_render_err || attempt >= config.max_attempts {
+                    if is_render_err {
+                        error!("output '{}': render failed: {}", name, e);
                     } else {
                         error!(
                             "output '{}': write failed after {} attempts: {}",
@@ -688,24 +590,18 @@ async fn write_with_retry(
                         );
                     }
                     metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                    // Recovery routing (BC-3 / PR-O):
-                    //   1. error_log configured + Owned available →
-                    //      write a JSONL record mirroring the pipeline
-                    //      DLQ format. Success returns
-                    //      `DroppedToRecovery`; failure warns and falls
-                    //      through to `Dropped`.
-                    //   2. neither path captured the payload → preserve
-                    //      the existing `Dropped` behaviour
-                    //      (warn + give up). The `Rendered` case (no
-                    //      owned payload to capture) also collapses
-                    //      here.
-                    if let (Some(writer), Some(ev)) = (error_log, owned_for_retry.take()) {
+                    let reason = if is_render_err {
+                        format!("render failed: {}", e)
+                    } else {
+                        format!("output write failed after {} attempts: {}", attempt, e)
+                    };
+                    if let Some(writer) = error_log {
                         let ctx = crate::pipeline::ErroredEventContext {
                             timestamp: chrono::Utc::now(),
                             pipeline: String::new(),
                             process: format!("(output {})", name),
-                            reason: format!("output write failed after {} attempts: {}", attempt, e),
-                            event: ev,
+                            reason,
+                            event: event.clone(),
                         };
                         match writer.write(&ctx).await {
                             Ok(()) => return WriteDisposition::DroppedToRecovery,
@@ -718,10 +614,7 @@ async fn write_with_retry(
                         }
                     } else {
                         // No recovery path configured.
-                        error!(
-                            "output '{}': dropping event (no error_log)",
-                            name
-                        );
+                        error!("output '{}': dropping event (no error_log)", name);
                     }
                     return WriteDisposition::Dropped;
                 }
@@ -734,24 +627,15 @@ async fn write_with_retry(
                     BackoffStrategy::Exponential => (wait * 2).min(config.max_wait),
                     BackoffStrategy::Fixed => wait,
                 };
-                // Rebuild the next-attempt input from the cloned owned
-                // event we kept aside.
-                if let Some(ev) = owned_for_retry.as_ref() {
-                    next_attempt = Some(SinkInput::Owned(ev.clone()));
-                } else {
-                    break;
-                }
             }
         }
     }
-    // Loop ran out of next-attempt inputs without a return — treated
-    // as dropped, matching the previous `false` fall-through.
-    WriteDisposition::Dropped
 }
 
 #[cfg(test)]
 mod write_with_retry_tests {
     use super::*;
+    use crate::modules::{HasMetrics, Output};
     use bytes::Bytes;
     use std::net::SocketAddr;
     use std::sync::Mutex;
@@ -763,6 +647,7 @@ mod write_with_retry_tests {
     struct ScriptedWriter {
         script: Mutex<Vec<anyhow::Result<()>>>,
         calls: std::sync::atomic::AtomicUsize,
+        metrics: Arc<crate::metrics::OutputMetrics>,
     }
 
     impl ScriptedWriter {
@@ -770,6 +655,7 @@ mod write_with_retry_tests {
             Self {
                 script: Mutex::new(script),
                 calls: std::sync::atomic::AtomicUsize::new(0),
+                metrics: Arc::new(crate::metrics::OutputMetrics::default()),
             }
         }
         fn calls(&self) -> usize {
@@ -777,9 +663,16 @@ mod write_with_retry_tests {
         }
     }
 
+    impl HasMetrics for ScriptedWriter {
+        type Stats = crate::metrics::OutputMetrics;
+        fn metrics(&self) -> Arc<crate::metrics::OutputMetrics> {
+            Arc::clone(&self.metrics)
+        }
+    }
+
     #[async_trait::async_trait]
-    impl OutputWriter for ScriptedWriter {
-        async fn consume(&self, _input: SinkInput) -> anyhow::Result<()> {
+    impl Output for ScriptedWriter {
+        async fn consume(&self, _event: &Event) -> anyhow::Result<()> {
             self.calls.fetch_add(1, Ordering::Relaxed);
             let mut s = self.script.lock().unwrap();
             if s.is_empty() { Ok(()) } else { s.remove(0) }
@@ -802,10 +695,6 @@ mod write_with_retry_tests {
         )
     }
 
-    fn rendered_event() -> SinkInput {
-        SinkInput::Rendered(RenderedPayload::new(()))
-    }
-
     fn fresh_metrics() -> crate::metrics::OutputMetrics {
         crate::metrics::OutputMetrics::default()
     }
@@ -816,7 +705,7 @@ mod write_with_retry_tests {
         let m = fresh_metrics();
         let disposition = write_with_retry(
             &w,
-            SinkInput::Owned(owned_event()),
+            owned_event(),
             &fast_cfg(3),
             "test",
             &m,
@@ -840,7 +729,7 @@ mod write_with_retry_tests {
         let m = fresh_metrics();
         let disposition = write_with_retry(
             &w,
-            SinkInput::Owned(owned_event()),
+            owned_event(),
             &fast_cfg(5),
             "test",
             &m,
@@ -864,7 +753,7 @@ mod write_with_retry_tests {
         let m = fresh_metrics();
         let disposition = write_with_retry(
             &w,
-            SinkInput::Owned(owned_event()),
+            owned_event(),
             &fast_cfg(3),
             "test",
             &m,
@@ -877,37 +766,6 @@ mod write_with_retry_tests {
         assert_eq!(w.calls(), 3);
         assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
         assert_eq!(m.retries.load(Ordering::Relaxed), 3);
-    }
-
-    #[tokio::test]
-    async fn rendered_failure_skips_retries_and_logs() {
-        // Rendered payloads cannot be retried (the Box<dyn Any>
-        // payload was consumed by the first consume call). The
-        // retry-loop must take exactly one shot and then bump
-        // events_failed once with the "rendered payload, no retry"
-        // warn — never loop. A regression that mistakenly retries a
-        // Rendered would panic or silently no-op since the closure
-        // has nothing left to consume.
-        let w = ScriptedWriter::new(vec![Err(anyhow::anyhow!("nope"))]);
-        let m = fresh_metrics();
-        let disposition = write_with_retry(
-            &w,
-            rendered_event(),
-            &fast_cfg(5), // 5 allowed but only 1 attempt should happen
-            "test",
-            &m,
-            None,
-            None,
-        )
-        .await;
-        assert_eq!(disposition, WriteDisposition::Dropped);
-        assert_eq!(
-            w.calls(),
-            1,
-            "Rendered must NOT retry, got {} calls",
-            w.calls()
-        );
-        assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -925,7 +783,7 @@ mod write_with_retry_tests {
         .unwrap();
         drop(rx);
         let err = tx
-            .send(SinkInput::Owned(owned_event()))
+            .send(owned_event())
             .await
             .expect_err("send to closed memory channel must fail");
         assert!(
@@ -935,46 +793,125 @@ mod write_with_retry_tests {
         );
     }
 
+    /// Writer that always returns a `RenderError`-wrapped error — used
+    /// to drive the "render-err goes straight to DLQ" path.
+    struct RenderFailWriter {
+        metrics: Arc<crate::metrics::OutputMetrics>,
+    }
+
+    impl RenderFailWriter {
+        fn new() -> Self {
+            Self {
+                metrics: Arc::new(crate::metrics::OutputMetrics::default()),
+            }
+        }
+    }
+
+    impl HasMetrics for RenderFailWriter {
+        type Stats = crate::metrics::OutputMetrics;
+        fn metrics(&self) -> Arc<crate::metrics::OutputMetrics> {
+            Arc::clone(&self.metrics)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Output for RenderFailWriter {
+        async fn consume(&self, _event: &Event) -> anyhow::Result<()> {
+            Err(crate::modules::RenderError::new(anyhow::anyhow!(
+                "intentional render failure"
+            ))
+            .into())
+        }
+    }
+
     #[tokio::test]
-    async fn queue_sender_send_returns_rendered_on_disk_when_misrouted() {
-        // Routing a Rendered payload to a disk queue is a programmer
-        // bug — the disk sink only accepts serialisable Owned events.
-        // The send must return QueueSendError::RenderedOnDisk so the
-        // pipeline-level DLQ path is taken.
+    async fn render_err_goes_straight_to_dlq() {
+        // Render errors bypass retry and route directly to recovery:
+        // a RenderError from `consume` bypasses the
+        // retry budget and lands directly in the DLQ. Exactly 1 call,
+        // 0 retries counted, events_failed += 1, JSONL record's reason
+        // contains "render failed".
         let dir = tempfile::tempdir().unwrap();
-        let (tx, _rx) = create_queue(
-            "disk".into(),
-            QueueConfig {
-                queue_type: QueueType::Disk {
-                    path: dir.path().to_string_lossy().into_owned(),
-                    max_size: 0,
-                },
-                capacity: 4,
-                overflow: OverflowStrategy::Block,
-            },
+        let path = dir.path().join("errored.jsonl");
+        let el = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
+        let m = fresh_metrics();
+        let disposition = write_with_retry(
+            &RenderFailWriter::new(),
+            owned_event(),
+            &fast_cfg(5),
+            "primary",
+            &m,
+            None,
+            Some(&el),
         )
-        .unwrap();
-        let err = tx
-            .send(rendered_event())
-            .await
-            .expect_err("Rendered-on-Disk must fail");
+        .await;
+        assert_eq!(disposition, WriteDisposition::DroppedToRecovery);
+        assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            m.retries.load(Ordering::Relaxed),
+            0,
+            "render error must not count as a retry"
+        );
+        let body = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let v: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(v["process"], "(output primary)");
         assert!(
-            matches!(err, QueueSendError::RenderedOnDisk),
-            "expected RenderedOnDisk, got {:?}",
-            err
+            v["reason"].as_str().unwrap().contains("render failed"),
+            "reason should mark render failure, got: {}",
+            v["reason"]
         );
     }
 
-    // ---- BC-3 error_log recovery routing (PR-O) ----
+    #[tokio::test]
+    async fn render_err_with_no_error_log_returns_dropped() {
+        // Same render-err shape but no DLQ configured: behave like the
+        // legacy unrecoverable drop path — `Dropped`, events_failed += 1,
+        // no retries.
+        let m = fresh_metrics();
+        let disposition = write_with_retry(
+            &RenderFailWriter::new(),
+            owned_event(),
+            &fast_cfg(5),
+            "primary",
+            &m,
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(disposition, WriteDisposition::Dropped);
+        assert_eq!(m.events_failed.load(Ordering::Relaxed), 1);
+        assert_eq!(m.retries.load(Ordering::Relaxed), 0);
+    }
+
+    // ---- retry-exhausted recovery routing ----
 
     /// Stub writer that *always* refuses the write — every test below
     /// drives the retry-exhaustion path, so the underlying writer just
     /// has to fail predictably without any per-test scripting.
-    struct AlwaysFailWriter;
+    struct AlwaysFailWriter {
+        metrics: Arc<crate::metrics::OutputMetrics>,
+    }
+
+    impl AlwaysFailWriter {
+        fn new() -> Self {
+            Self {
+                metrics: Arc::new(crate::metrics::OutputMetrics::default()),
+            }
+        }
+    }
+
+    impl HasMetrics for AlwaysFailWriter {
+        type Stats = crate::metrics::OutputMetrics;
+        fn metrics(&self) -> Arc<crate::metrics::OutputMetrics> {
+            Arc::clone(&self.metrics)
+        }
+    }
 
     #[async_trait::async_trait]
-    impl OutputWriter for AlwaysFailWriter {
-        async fn consume(&self, _input: SinkInput) -> anyhow::Result<()> {
+    impl Output for AlwaysFailWriter {
+        async fn consume(&self, _event: &Event) -> anyhow::Result<()> {
             Err(anyhow::anyhow!("permanent failure"))
         }
     }
@@ -991,15 +928,15 @@ mod write_with_retry_tests {
 
     #[tokio::test]
     async fn error_log_persists_and_returns_dropped_to_recovery() {
-        // BC-3 happy path: retries exhaust, `error_log` captures the
+        // Retry-exhausted recovery happy path: retries exhaust, `error_log` captures the
         // payload. Must report `DroppedToRecovery` and the JSONL file
         // must contain one record carrying the original ingress.
         let dir = tempfile::tempdir().unwrap();
         let (el, path) = error_log_in(&dir);
         let m = fresh_metrics();
         let disposition = write_with_retry(
-            &AlwaysFailWriter,
-            SinkInput::Owned(owned_event()),
+            &AlwaysFailWriter::new(),
+            owned_event(),
             &fast_cfg(2),
             "primary",
             &m,
@@ -1020,14 +957,14 @@ mod write_with_retry_tests {
 
     #[tokio::test]
     async fn no_error_log_preserves_existing_dropped_behavior() {
-        // BC-3 regression anchor for the 0.7.7 baseline: with no
+        // Boundary-contract regression anchor for the 0.7.7 baseline: with no
         // `error_log` configured, retry-exhaustion must still surface
         // `Dropped`. The warn line is observable in logs but not
         // asserted here.
         let m = fresh_metrics();
         let disposition = write_with_retry(
-            &AlwaysFailWriter,
-            SinkInput::Owned(owned_event()),
+            &AlwaysFailWriter::new(),
+            owned_event(),
             &fast_cfg(2),
             "primary",
             &m,
@@ -1041,7 +978,7 @@ mod write_with_retry_tests {
 
     #[tokio::test]
     async fn error_log_write_failure_falls_back_to_dropped_without_recursion() {
-        // BC-3 last-resort path: error_log is configured but its
+        // Last-resort recovery path: error_log is configured but its
         // parent dir does not exist, so `write()` returns Err. The
         // function must warn and return `Dropped` (NOT
         // `DroppedToRecovery`), and must not retry the error_log write
@@ -1053,8 +990,8 @@ mod write_with_retry_tests {
         let el = Arc::new(crate::error_log::ErrorLogWriter::new(bad_path));
         let m = fresh_metrics();
         let disposition = write_with_retry(
-            &AlwaysFailWriter,
-            SinkInput::Owned(owned_event()),
+            &AlwaysFailWriter::new(),
+            owned_event(),
             &fast_cfg(2),
             "primary",
             &m,
@@ -1071,10 +1008,11 @@ mod write_with_retry_tests {
 // Schema-splice regression tests
 // ---------------------------------------------------------------------------
 //
-// Pre-PR-T, only the two OTLP outputs declared `retry` in their
-// `property_schema()` even though `RetryConfig::from_output_properties`
-// reads it for *every* output. The tests below pin the post-PR-T
-// invariant: every non-OTLP output's schema accepts a `retry { ... }`
+// Before the retry-schema splice, only the two OTLP outputs declared
+// `retry` in their `property_schema()` even though
+// `RetryConfig::from_output_properties` reads it for *every* output.
+// The tests below pin the invariant: every non-OTLP output's schema
+// accepts a `retry { ... }`
 // block without raising `UnknownKey`. Adding a third output schema
 // later is then a hard failure here if the splice is forgotten.
 #[cfg(test)]

--- a/crates/limpid/src/queue/outcome.rs
+++ b/crates/limpid/src/queue/outcome.rs
@@ -30,15 +30,6 @@ pub enum QueueSendError {
     #[error("queue receiver dropped (channel closed)")]
     ChannelClosed,
 
-    /// The pipeline routed a `SinkInput::Rendered` payload onto a
-    /// disk-persist queue. Disk queues only carry serialisable
-    /// `Owned` events; `Rendered` carries a non-serialisable
-    /// `Box<dyn Any>`. Pipeline dispatch already gates this — hitting
-    /// this variant means a programmer mistake elsewhere routed a
-    /// rendered payload to a disk sink.
-    #[error("rendered payload routed to a disk-persist queue (programmer bug)")]
-    RenderedOnDisk,
-
     /// Disk queue failed to serialise the event to JSON before
     /// writing. The underlying error is preserved for logging.
     #[error("disk queue: failed to serialize event: {0}")]
@@ -74,7 +65,7 @@ impl QueueSendError {
 ///
 /// `#[must_use]` so a caller can't silently throw the disposition
 /// away — that's exactly the bug shape this refactor is meant to
-/// prevent. PR-O added [`DroppedToRecovery`] to distinguish payloads
+/// prevent. [`DroppedToRecovery`] distinguishes payloads
 /// persisted to `error_log` for replay from unrecoverable drops;
 /// `#[non_exhaustive]` remains so future routing work can extend
 /// without churning match sites.
@@ -96,8 +87,8 @@ pub enum WriteDisposition {
     /// `consume` ultimately failed and the payload was persisted to
     /// the configured `error_log` JSONL file for manual recovery.
     /// Distinguishes the "payload survives on disk" outcome from the
-    /// unrecoverable [`Dropped`] case so PR-Q metrics can count
-    /// recoverable losses separately.
+    /// unrecoverable [`Dropped`] case so recovery-routing metrics can
+    /// count recoverable losses separately.
     ///
     /// [`Dropped`]: WriteDisposition::Dropped
     DroppedToRecovery,

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -18,7 +18,7 @@ use crate::dsl::props;
 use crate::event::Event;
 use crate::functions::FunctionRegistry;
 use crate::metrics::{MetricsRegistry, PipelineMetrics};
-use crate::modules::{self, HasMetrics, ModuleRegistry, Output};
+use crate::modules::{self, HasMetrics, ModuleRegistry};
 use crate::pipeline::CompiledConfig;
 use crate::queue::{self, QueueConfig, QueueSender, RetryConfig};
 use crate::tap::TapRegistry;
@@ -53,9 +53,36 @@ impl Runtime {
         let mut metrics_registry = MetricsRegistry::new();
         let tap = TapRegistry::new();
 
+        // Optional dead-letter queue for events that fail in `process`
+        // or that an output drops after exhausting retries
+        // (retry-exhausted recovery). `control { error_log "..." }` opts in to
+        // file-based recovery; when unset, the runtime falls back to a
+        // structured tracing line for the pipeline path and a plain
+        // `Dropped` disposition for the output path. The path is
+        // validated at startup (parent dir reachable) so operator typos
+        // surface before the first failure event.
+        //
+        // Built *before* outputs are constructed so each batched output
+        // (`http`, `otlp_http`, `otlp_grpc`) receives the handle via its
+        // constructor — no post-construction setter, no interior
+        // mutability. Non-batched outputs ignore the parameter; the
+        // queue consumer threads `error_log` in via `write_with_retry`
+        // for retry-exhausted recovery.
+        let error_log_path = config
+            .global_blocks
+            .get("control")
+            .and_then(|p| props::get_string(p, "error_log"));
+        let error_log = match error_log_path {
+            Some(p) => {
+                let writer = crate::error_log::ErrorLogWriter::new(PathBuf::from(p));
+                writer.validate_at_startup().await?;
+                Some(Arc::new(writer))
+            }
+            None => None,
+        };
+
         // --- 1. Create outputs (each output owns its own OutputMetrics) ---
         let mut output_senders: HashMap<String, QueueSender> = HashMap::new();
-        let mut output_sinks: HashMap<String, Arc<dyn Output>> = HashMap::new();
         let mut output_receivers = Vec::new();
 
         for (name, output_def) in &config.outputs {
@@ -68,11 +95,13 @@ impl Runtime {
             // `output_def.properties` is a `ModuleProperties`: it carries the
             // resolved `type` already, so `create_output` doesn't take a
             // separate type_name argument (and can't be passed one — the
-            // strip is the whole point).
+            // strip is the whole point). `error_log` is threaded in so
+            // batched outputs can stash it at construction time.
             let created = match registry.create_output(
                 name,
                 &output_def.properties,
                 Arc::clone(&func_registry),
+                error_log.as_ref().map(Arc::clone),
             ) {
                 Ok(c) => c,
                 Err(e) => {
@@ -93,7 +122,6 @@ impl Runtime {
             // Attach metrics so QueueSender::send counts events_received.
             sender.attach_metrics(Arc::clone(&created.metrics));
             output_senders.insert(name.clone(), sender);
-            output_sinks.insert(name.clone(), Arc::clone(&created.output));
 
             // Collect metrics handle (output owns the data, we just hold a reference)
             let output_metrics = Arc::clone(&created.metrics);
@@ -103,37 +131,11 @@ impl Runtime {
             output_receivers.push((
                 name.clone(),
                 receiver,
-                created.writer,
+                created.output,
                 retry_config,
                 output_metrics,
             ));
         }
-
-        // Optional dead-letter queue for events that fail in `process`
-        // or that an output drops after exhausting retries (BC-3
-        // recovery, PR-O). `control { error_log "..." }` opts in to
-        // file-based recovery; when unset, the runtime falls back to a
-        // structured tracing line for the pipeline path and a plain
-        // `Dropped` disposition for the output path. The path is
-        // validated at startup (parent dir reachable) so operator typos
-        // surface before the first failure event.
-        //
-        // Built *before* output consumers spawn so each consumer can
-        // hold an `Arc` reference for retry-exhausted recovery; the
-        // same handle is later passed into the pipeline context for
-        // process-error DLQ writes.
-        let error_log_path = config
-            .global_blocks
-            .get("control")
-            .and_then(|p| props::get_string(p, "error_log"));
-        let error_log = match error_log_path {
-            Some(p) => {
-                let writer = crate::error_log::ErrorLogWriter::new(PathBuf::from(p));
-                writer.validate_at_startup().await?;
-                Some(Arc::new(writer))
-            }
-            None => None,
-        };
 
         // Start queue consumers (no metrics counting here — output does it)
         for (_name, receiver, writer, retry_config, output_metrics) in output_receivers {
@@ -155,7 +157,6 @@ impl Runtime {
         }
 
         let output_senders = Arc::new(output_senders);
-        let output_sinks = Arc::new(output_sinks);
 
         // --- 2. Group pipelines by input ---
         //
@@ -214,7 +215,6 @@ impl Runtime {
             let workers: Arc<Vec<Arc<PipelineWorker>>> = Arc::new(pipelines);
             let ctx = PipelineContext {
                 output_senders: Arc::clone(&output_senders),
-                output_sinks: Arc::clone(&output_sinks),
                 config: Arc::clone(&config),
                 funcs: Arc::clone(&func_registry),
                 tap: tap.clone(),
@@ -390,15 +390,12 @@ pub(crate) fn init_tables(config: &CompiledConfig) -> Result<crate::functions::t
 
 struct PipelineContext {
     output_senders: Arc<HashMap<String, QueueSender>>,
-    /// Output sinks, looked up by `run_pipeline` to render a payload
-    /// against the per-event arena (memory-queue hot path).
-    output_sinks: Arc<HashMap<String, Arc<dyn Output>>>,
     config: Arc<CompiledConfig>,
     funcs: Arc<FunctionRegistry>,
     tap: TapRegistry,
     /// Dead-letter queue writer used for: (1) `process` runtime
-    /// errors, (2) output retry-exhausted payloads (PR-O), (3)
-    /// batched-output shutdown-flush leftovers (PR-P). `None` when
+    /// errors, (2) output retry-exhausted payloads, (3)
+    /// batched-output shutdown-flush leftovers. `None` when
     /// `control { error_log }` is unset — falls back to a structured
     /// `tracing::error!` line for each case.
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
@@ -497,14 +494,13 @@ async fn run_pipeline_with_outputs(
         &ctx.config,
         &ctx.funcs,
         Some(&ctx.tap),
-        &ctx.output_sinks,
         bump,
     )?;
 
-    // Drain the per-event outputs vec into the queues. Each output is
-    // pre-routed to either `SinkInput::Rendered` (memory queue hot
-    // path) or `SinkInput::Owned` (disk persist path) by the pipeline
-    // executor at the `output` statement.
+    // Drain the per-event outputs vec into the queues. After this
+    // change every output statement enqueues a plain `OwnedEvent`
+    // regardless of the queue kind; render happens consumer-side
+    // inside each sink's `Output::consume`.
     //
     // `result.had_outputs` was set inside `run_pipeline` *before* the
     // vec was moved out here, so the downstream
@@ -512,9 +508,9 @@ async fn run_pipeline_with_outputs(
     // the original semantics (Finished AND emitted ≥1 output → finished).
     let outputs = std::mem::take(&mut result.outputs);
     let mut failed_outputs: Vec<String> = Vec::new();
-    for (output_name, sink_input) in outputs {
+    for (output_name, event) in outputs {
         if let Some(sender) = ctx.output_senders.get(&output_name) {
-            if let Err(e) = sender.send(sink_input).await {
+            if let Err(e) = sender.send(event).await {
                 // QueueSender::send already bumped per-output
                 // `events_failed` on the Err branch — that gives the
                 // operator per-output visibility. Collect the names
@@ -795,7 +791,6 @@ mod tests {
         let cfg = CompiledConfig::from_config(parse_config("").unwrap()).unwrap();
         let ctx_a = PipelineContext {
             output_senders: Arc::new(HashMap::new()),
-            output_sinks: Arc::new(HashMap::new()),
             config: Arc::new(cfg.clone()),
             funcs: Arc::new(FunctionRegistry::new()),
             tap: tap.clone(),
@@ -803,7 +798,6 @@ mod tests {
         };
         let ctx_b = PipelineContext {
             output_senders: Arc::clone(&ctx_a.output_senders),
-            output_sinks: Arc::clone(&ctx_a.output_sinks),
             config: Arc::clone(&ctx_a.config),
             funcs: Arc::clone(&ctx_a.funcs),
             tap: tap.clone(),


### PR DESCRIPTION
## Summary

Restructures the per-output queue so memory and disk queues uniformly carry `Event` end-to-end, and collapses the `Output` trait to a single `consume(&Event)` entry point. Groundwork for the planned Limpid Transport Protocol (hop-to-hop event tracking via a hidden Event attribute), which requires the queue to preserve the full `Event` through every output's path.

Side-effect: fixes a silent-loss bug on the memory-queue path. Previously, memory-queue outputs pre-rendered at the `output` DSL statement and discarded the `Event`; when transport retries exhausted, no `Event` was left to hand to the DLQ writer and the failure dropped silently. With the `Event` retained, retry-exhaustion always reaches the DLQ when `control { error_log }` is configured.

## What changed

- `SinkInput { Owned | Rendered }` collapsed to plain `Event`. The pipeline `output` statement always enqueues `event.to_owned()`; the queue no longer distinguishes a pre-rendered payload from an owned event.
- `Output` trait collapsed: single `async fn consume(&self, event: &Event) -> Result<()>`. The earlier `render` / `write` / `consume_event` triplet is gone. Sinks decide internally whether to render-on-call or buffer for a batched flush; that's no longer an abstraction-layer concern.
- Render errors are tagged via a downcast sentinel (`RenderError`) so the retry loop can route them straight to the DLQ without consuming the retry budget — the budget is for transport attempts, not render bugs.
- Batched outputs (`http`, `otlp_http`, `otlp_grpc`) now buffer `Vec<Event>` and render at flush time. Per-event render failures inside a batch flush route to the DLQ individually without dropping the rest of the batch. Shutdown leftover events use the normal DLQ path (real `Event`, real source / ingress / received_at), so the prior synthetic-event hack is gone.
- `error_log` is now passed as a constructor argument to the three batched outputs via a new `OutputBuilderWithErrorLog` sub-trait. The prior `attach_error_log(&self, ...)` setter, its `Mutex<Option<Arc<ErrorLogWriter>>>` interior-mutability dance, the runtime's transient `output_sinks` HashMap, and the explicit `drop(output_sinks)` are all gone.
- Dead-by-restructure types deleted: `QueueKind` enum, `QueueSender.kind` field, `OutputWriterWrapper` (was a 1-line passthrough after the trait collapse), `CreatedOutput.writer`, `PipelineExecCtx.output_sinks`, plus the `output_sinks: &HashMap<...>` parameter on `run_pipeline`.

## Known issues (intentionally left for follow-up PRs)

- **BCZ-1** — batched output ack lifecycle: `consume` returns `Ok(())` as soon as the event lands in the in-memory batch buffer, before the next flush actually ships it. A process crash between buffer admission and flush will lose the buffered events, and disk-queue cursors advance under that assumption. To be fixed in a dedicated follow-up PR by deferring the `Ok(())` return until flush completes. The misleading "durably enqueued" comments on `Output::consume` and `HttpOutput::consume` will be corrected in the same PR (= same root cause, no point fixing one without the other).
- **DLQ schema** — record currently uses an `event: { source, received_at, ingress }` shape that fits pipeline-side failures. Output-side failures (retry-exhaustion, batched-shutdown flush) now have full `Event` available, so the schema can carry rendered bytes for transport replay without re-running the pipeline. To be redesigned as a sum-typed event field in a separate PR.
- **Pre-existing internal labels** in unchanged files (`check/recovery_readiness.rs`, `modules/input/tail.rs`) — flagged by the confidentiality audit as standing leaks; out of PR-Z scope, will be handled in a separate sweep / release-prep cleanup.
- **`render()` signature** still bundles wire bytes with transport metadata (file `path`, kafka `key`). The principle "render produces wire bytes only, transport metadata stays on the transport side" is recognized but the split is deferred to a later refactor.

## CHANGELOG

Untouched. The 0.7.8 section will be rewritten at release-prep as the net 0.7.7 → 0.7.8 diff.

## Audit

push-gate 8 scopes all PASS (`uchgs verify push` summary: `would_push_succeed: true`):

- security / ci-precheck / readme-current → no findings
- abstraction → confirmed: BCZ-1-paired comment drift, to be corrected in follow-up
- confidentiality (commit-gate) → no findings post label scrub
- confidentiality (push-gate) → confirmed: pre-existing base file labels, separate sweep
- cicd-pipeline → confirmed: standing baseline (release.yml contents:write)
- boundary-contract → confirmed: BCZ-1 follow-up PR queued, BCZ-2 + Watch items standing
- rust → confirmed: standing supply-chain baseline (RUSTSEC-2026-0185 + duplicate-crate warnings)

## Test plan

- [x] `cargo check --workspace --all-targets`: clean
- [x] `cargo test --workspace`: 692 passed / 0 failed (= +3 new constructor-injection tests vs 0.7.7 baseline)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean