### PR TITLE
refactor(modules): unify Module::from_properties via BuildContext

### DIFF
--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -84,7 +84,11 @@ impl Module for JournalInput {
         Some(JOURNAL_INPUT_SCHEMA)
     }
 
-    fn from_properties(_name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+    fn from_properties(
+        _name: &str,
+        properties: &crate::modules::ModuleProperties,
+        _ctx: &crate::modules::BuildContext,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
         let mut matches = Vec::new();
         if let Some(m) = props::get_string(properties, "match") {

--- a/crates/limpid/src/modules/input/otlp/grpc.rs
+++ b/crates/limpid/src/modules/input/otlp/grpc.rs
@@ -91,7 +91,11 @@ impl Module for OtlpGrpcInput {
         Some(OTLP_GRPC_INPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+    fn from_properties(
+        name: &str,
+        properties: &crate::modules::ModuleProperties,
+        _ctx: &crate::modules::BuildContext,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
         let bind =
             props::get_string(properties, "bind").unwrap_or_else(|| "0.0.0.0:4317".to_string());
@@ -278,7 +282,7 @@ mod tests {
 
     #[test]
     fn defaults_bind_address_no_rate_limit_no_tls() {
-        let i = OtlpGrpcInput::from_properties("o", &mp(&[])).unwrap();
+        let i = OtlpGrpcInput::from_properties("o", &mp(&[]), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(i.bind_addr, "0.0.0.0:4317");
         assert_eq!(i.rate_limit, None);
         assert!(i.tls.is_none());
@@ -292,7 +296,7 @@ mod tests {
             value: crate::dsl::ast::Expr::spanless(crate::dsl::ast::ExprKind::IntLit(2500)),
             value_span: None,
         };
-        let i = OtlpGrpcInput::from_properties("o", &mp(&[prop])).unwrap();
+        let i = OtlpGrpcInput::from_properties("o", &mp(&[prop]), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(i.rate_limit, Some(2500));
     }
 
@@ -335,7 +339,7 @@ mod tests {
     #[test]
     fn tls_block_records_cert_key() {
         let props = vec![tls_block("/c.pem", "/k.pem", None)];
-        let i = OtlpGrpcInput::from_properties("o", &mp(&props)).unwrap();
+        let i = OtlpGrpcInput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let tls = i.tls.expect("tls present");
         assert_eq!(tls.cert_path, "/c.pem");
         assert_eq!(tls.key_path, "/k.pem");
@@ -345,7 +349,7 @@ mod tests {
     #[test]
     fn tls_block_records_ca_for_mtls() {
         let props = vec![tls_block("/c.pem", "/k.pem", Some("/ca.pem"))];
-        let i = OtlpGrpcInput::from_properties("o", &mp(&props)).unwrap();
+        let i = OtlpGrpcInput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let tls = i.tls.expect("tls present");
         assert_eq!(tls.ca_path.as_deref(), Some("/ca.pem"));
     }
@@ -364,7 +368,7 @@ mod tests {
                 value_span: None,
             }],
         }];
-        let err = OtlpGrpcInput::from_properties("o", &mp(&props))
+        let err = OtlpGrpcInput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(

--- a/crates/limpid/src/modules/input/otlp/http.rs
+++ b/crates/limpid/src/modules/input/otlp/http.rs
@@ -167,7 +167,11 @@ impl Module for OtlpHttpInput {
         Some(OTLP_HTTP_INPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+    fn from_properties(
+        name: &str,
+        properties: &crate::modules::ModuleProperties,
+        _ctx: &crate::modules::BuildContext,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
         let tls_config =
             TlsConfig::from_properties_block(&format!("input '{}'", name), properties)?;
@@ -464,7 +468,7 @@ mod tests {
 
     #[test]
     fn defaults_have_no_request_throttles() {
-        let i = OtlpHttpInput::from_properties("o", &mp(&[])).unwrap();
+        let i = OtlpHttpInput::from_properties("o", &mp(&[]), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(i.bind_addr, "0.0.0.0:4318");
         assert_eq!(i.body_limit, DEFAULT_BODY_LIMIT_BYTES);
         assert_eq!(i.rate_limit, None);
@@ -480,6 +484,7 @@ mod tests {
                 prop_int("request_rate_limit", 100),
                 prop_int("max_concurrent_requests", 32),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         assert_eq!(i.request_rate_limit, Some(100));
@@ -491,7 +496,7 @@ mod tests {
         // get_strictly_positive_int forbids 0; the property is
         // documented as "off when absent", so 0 is meaningless.
         let err =
-            OtlpHttpInput::from_properties("o", &mp(&[prop_int("max_concurrent_requests", 0)]))
+            OtlpHttpInput::from_properties("o", &mp(&[prop_int("max_concurrent_requests", 0)]), &crate::modules::BuildContext::for_testing())
                 .err()
                 .unwrap();
         assert!(
@@ -502,16 +507,16 @@ mod tests {
 
     #[test]
     fn body_limit_accepts_size_suffix() {
-        let i = OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "1MB")])).unwrap();
+        let i = OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "1MB")]), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(i.body_limit, 1024 * 1024);
         let i =
-            OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "64MB")])).unwrap();
+            OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "64MB")]), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(i.body_limit, 64 * 1024 * 1024);
     }
 
     #[test]
     fn body_limit_zero_is_rejected() {
-        let err = OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "0")]))
+        let err = OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "0")]), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(
@@ -524,7 +529,7 @@ mod tests {
     #[test]
     fn body_limit_unrecognised_format_propagates_parse_error() {
         // parse_size's own error wording carries through.
-        let err = OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "huge")]))
+        let err = OtlpHttpInput::from_properties("o", &mp(&[prop_str("body_limit", "huge")]), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(
@@ -570,7 +575,7 @@ mod tests {
 
     #[test]
     fn defaults_have_no_tls() {
-        let i = OtlpHttpInput::from_properties("o", &mp(&[])).unwrap();
+        let i = OtlpHttpInput::from_properties("o", &mp(&[]), &crate::modules::BuildContext::for_testing()).unwrap();
         assert!(i.tls_config.is_none());
     }
 
@@ -583,6 +588,7 @@ mod tests {
                 "tls",
                 vec![prop_str("cert", &files.cert), prop_str("key", &files.key)],
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         let tls = i.tls_config.as_ref().expect("tls present");
@@ -604,6 +610,7 @@ mod tests {
                     prop_str("ca", &files.cert),
                 ],
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         let tls = i.tls_config.as_ref().expect("tls present");
@@ -616,6 +623,7 @@ mod tests {
         let err = OtlpHttpInput::from_properties(
             "o",
             &mp(&[prop_block("tls", vec![prop_str("key", &files.key)])]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .err()
         .unwrap();
@@ -654,6 +662,7 @@ mod tests {
                 prop_str("bind", &addr.to_string()),
                 prop_str("body_limit", "256"),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         let (tx, _rx) = mpsc::channel(8);
@@ -745,6 +754,7 @@ mod tests {
                 prop_str("bind", &addr.to_string()),
                 prop_str("body_limit", "1KB"),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         let (tx, mut rx) = mpsc::channel(8);
@@ -779,13 +789,13 @@ mod tests {
 
     #[test]
     fn rate_limit_is_parsed_as_positive_int() {
-        let i = OtlpHttpInput::from_properties("o", &mp(&[prop_int("rate_limit", 5000)])).unwrap();
+        let i = OtlpHttpInput::from_properties("o", &mp(&[prop_int("rate_limit", 5000)]), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(i.rate_limit, Some(5000));
     }
 
     #[test]
     fn rate_limit_zero_is_rejected() {
-        let err = OtlpHttpInput::from_properties("o", &mp(&[prop_int("rate_limit", 0)]))
+        let err = OtlpHttpInput::from_properties("o", &mp(&[prop_int("rate_limit", 0)]), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(err.to_string().contains("rate_limit"), "unexpected: {err}");
@@ -820,6 +830,7 @@ mod tests {
                 prop_str("bind", &addr.to_string()),
                 prop_int("rate_limit", 5),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         let (tx, mut rx) = mpsc::channel(64);
@@ -925,6 +936,7 @@ mod tests {
                 // taken the semaphore permit.
                 prop_int("request_rate_limit", 1),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         let (tx, mut rx) = mpsc::channel(8);

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -164,6 +164,7 @@ impl Module for SyslogTcpInput {
     fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
+        _ctx: &crate::modules::BuildContext,
     ) -> anyhow::Result<Self> {
         let properties = properties.user_properties();
         let tls_config =
@@ -1065,7 +1066,7 @@ mod tests {
 
     #[test]
     fn build_plaintext_defaults_to_port_514() {
-        let i = SyslogTcpInput::build("relay", &mp(&[])).expect("should build");
+        let i = SyslogTcpInput::build("relay", &mp(&[]), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(i.bind_addr, "0.0.0.0:514");
         assert!(i.tls_config.is_none());
     }
@@ -1080,7 +1081,7 @@ mod tests {
                 kv("key", ExprKind::StringLit(files.key.clone())),
             ],
         )];
-        let i = SyslogTcpInput::build("relay", &mp(&props)).expect("should build");
+        let i = SyslogTcpInput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(i.bind_addr, "0.0.0.0:6514");
         let tls = i.tls_config.as_ref().expect("tls present");
         assert_eq!(tls.cert_path, files.cert);
@@ -1099,7 +1100,7 @@ mod tests {
                 kv("ca", ExprKind::StringLit(files.cert.clone())),
             ],
         )];
-        let i = SyslogTcpInput::build("relay", &mp(&props)).expect("should build");
+        let i = SyslogTcpInput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         let tls = i.tls_config.as_ref().expect("tls present");
         assert_eq!(tls.ca_path.as_deref(), Some(files.cert.as_str()));
     }
@@ -1111,7 +1112,7 @@ mod tests {
             "tls",
             vec![kv("key", ExprKind::StringLit(files.key))],
         )];
-        let err = SyslogTcpInput::build("relay", &mp(&props))
+        let err = SyslogTcpInput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         assert!(err.to_string().to_lowercase().contains("cert"), "{}", err);
@@ -1130,7 +1131,7 @@ mod tests {
                 ],
             ),
         ];
-        let i = SyslogTcpInput::build("relay", &mp(&props)).expect("should build");
+        let i = SyslogTcpInput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(i.bind_addr, "127.0.0.1:9999");
     }
 

--- a/crates/limpid/src/modules/input/syslog_udp.rs
+++ b/crates/limpid/src/modules/input/syslog_udp.rs
@@ -45,7 +45,11 @@ impl Module for SyslogUdpInput {
         Some(SYSLOG_UDP_INPUT_SCHEMA)
     }
 
-    fn from_properties(_name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+    fn from_properties(
+        _name: &str,
+        properties: &crate::modules::ModuleProperties,
+        _ctx: &crate::modules::BuildContext,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
         let bind =
             props::get_string(properties, "bind").unwrap_or_else(|| "0.0.0.0:514".to_string());

--- a/crates/limpid/src/modules/input/tail.rs
+++ b/crates/limpid/src/modules/input/tail.rs
@@ -69,7 +69,11 @@ impl Module for TailInput {
         Some(TAIL_INPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+    fn from_properties(
+        name: &str,
+        properties: &crate::modules::ModuleProperties,
+        _ctx: &crate::modules::BuildContext,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
         let path = props::get_string(properties, "path")
             .ok_or_else(|| anyhow::anyhow!("input '{}': tail requires 'path'", name))?;

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -40,7 +40,11 @@ impl Module for UnixSocketInput {
         Some(UNIX_SOCKET_INPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
+    fn from_properties(
+        name: &str,
+        properties: &crate::modules::ModuleProperties,
+        _ctx: &crate::modules::BuildContext,
+    ) -> Result<Self> {
         let properties = properties.user_properties();
         let path = props::get_string(properties, "path")
             .ok_or_else(|| anyhow::anyhow!("input '{}': unix_socket requires 'path'", name))?;

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -21,8 +21,41 @@ use crate::dsl::ast::{Expr, ExprKind, Property};
 use crate::dsl::schema::{self as property_schema, PropertySpec};
 use crate::dsl::span::Span;
 use crate::event::Event;
-use crate::functions::FunctionRegistry;
 use crate::metrics::{InputMetrics, OutputMetrics};
+
+// ---------------------------------------------------------------------------
+// BuildContext — build-time dependencies threaded to every module factory
+// ---------------------------------------------------------------------------
+
+/// Build-time dependencies provided by the runtime to every Input
+/// and Output factory. Constructed once at startup, threaded into
+/// every `Module::from_properties` call.
+///
+/// Fields are `Option<>` where the dependency is optional config
+/// (e.g. `error_log` is None when the operator did not configure
+/// `control { error_log "..." }`). `funcs` is always present once
+/// the function registry is built (= early in runtime startup,
+/// before module construction).
+///
+/// Forward-compatible: future transport-key registry / metrics
+/// hooks / etc. land as new fields. Modules consume what they need
+/// and ignore the rest.
+#[derive(Clone)]
+pub struct BuildContext {
+    pub funcs: Arc<crate::functions::FunctionRegistry>,
+    pub error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+}
+
+impl BuildContext {
+    /// Test-only ctor with a no-op funcs registry and no error_log.
+    #[cfg(test)]
+    pub fn for_testing() -> Self {
+        Self {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: None,
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // RenderError — marker for render-vs-write error disambiguation
@@ -274,7 +307,11 @@ pub trait Module: Sized {
     /// validation (if any) has already run; cross-field rules ("at
     /// least one of address or host+port") still belong here — those
     /// are semantic, not shape-level.
-    fn from_properties(name: &str, properties: &ModuleProperties) -> Result<Self>;
+    fn from_properties(
+        name: &str,
+        properties: &ModuleProperties,
+        ctx: &BuildContext,
+    ) -> Result<Self>;
 
     /// Validation + construction entry. The runtime's registry path
     /// already validates the schema before invoking the factory, so
@@ -283,14 +320,14 @@ pub trait Module: Sized {
     /// loud validation surface.
     #[allow(dead_code)] // used by module unit tests; production path
     // validates inside `ModuleRegistry::create_*`
-    fn build(name: &str, properties: &ModuleProperties) -> Result<Self> {
+    fn build(name: &str, properties: &ModuleProperties, ctx: &BuildContext) -> Result<Self> {
         if let Some(spec) = Self::property_schema() {
             let errs = property_schema::validate(properties.user_properties(), spec);
             if !errs.is_empty() {
                 anyhow::bail!(format_module_schema_errors(name, &errs));
             }
         }
-        Self::from_properties(name, properties)
+        Self::from_properties(name, properties, ctx)
     }
 }
 
@@ -359,12 +396,6 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     /// take ownership of the lifecycle. The queue consumer logs the
     /// error and the handle's `Drop` impl fires `Dropped`.
     async fn consume(&self, event: &Event, ack: crate::queue::QueueAckHandle) -> Result<()>;
-
-    /// Called once after construction to hand the output a reference to
-    /// the pipeline's `FunctionRegistry`. Outputs that evaluate DSL
-    /// expressions at write time (e.g. `${...}` templates in a path)
-    /// override this to stash the registry. Default: no-op.
-    fn attach_funcs(&mut self, _funcs: Arc<FunctionRegistry>) {}
 
     /// Called once when the daemon is shutting down, before the queue
     /// consumer exits. The output is responsible for draining any
@@ -509,6 +540,7 @@ type InputFactory = Box<
     dyn Fn(
             &str,
             &ModuleProperties,
+            &BuildContext,
             mpsc::Sender<Event>,
             tokio::sync::watch::Receiver<bool>,
         ) -> Result<CreatedInput>
@@ -517,14 +549,7 @@ type InputFactory = Box<
 >;
 
 type OutputFactory = Box<
-    dyn Fn(
-            &str,
-            &ModuleProperties,
-            Arc<FunctionRegistry>,
-            Option<Arc<crate::error_log::ErrorLogWriter>>,
-        ) -> Result<CreatedOutput>
-        + Send
-        + Sync,
+    dyn Fn(&str, &ModuleProperties, &BuildContext) -> Result<CreatedOutput> + Send + Sync,
 >;
 
 struct InputEntry {
@@ -567,6 +592,7 @@ impl ModuleRegistry {
         F: Fn(
                 &str,
                 &ModuleProperties,
+                &BuildContext,
                 mpsc::Sender<Event>,
                 tokio::sync::watch::Receiver<bool>,
             ) -> Result<CreatedInput>
@@ -589,12 +615,7 @@ impl ModuleRegistry {
         schema: Option<&'static [PropertySpec]>,
         factory: F,
     ) where
-        F: Fn(
-                &str,
-                &ModuleProperties,
-                Arc<FunctionRegistry>,
-                Option<Arc<crate::error_log::ErrorLogWriter>>,
-            ) -> Result<CreatedOutput>
+        F: Fn(&str, &ModuleProperties, &BuildContext) -> Result<CreatedOutput>
             + Send
             + Sync
             + 'static,
@@ -634,6 +655,7 @@ impl ModuleRegistry {
         &self,
         name: &str,
         properties: &ModuleProperties,
+        ctx: &BuildContext,
         tx: mpsc::Sender<Event>,
         shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<CreatedInput> {
@@ -650,15 +672,14 @@ impl ModuleRegistry {
                 ));
             }
         }
-        (entry.factory)(name, properties, tx, shutdown)
+        (entry.factory)(name, properties, ctx, tx, shutdown)
     }
 
     pub fn create_output(
         &self,
         name: &str,
         properties: &ModuleProperties,
-        funcs: Arc<FunctionRegistry>,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &BuildContext,
     ) -> Result<CreatedOutput> {
         let type_name = properties.type_name();
         let entry = self
@@ -673,7 +694,7 @@ impl ModuleRegistry {
                 ));
             }
         }
-        (entry.factory)(name, properties, funcs, error_log)
+        (entry.factory)(name, properties, ctx)
     }
 }
 
@@ -708,35 +729,19 @@ pub fn register_builtins(registry: &mut ModuleRegistry) {
     #[cfg(feature = "journal")]
     register_input_type::<input::journal::JournalInput>(registry, "journal");
 
-    // Outputs — every output owns its own retry + DLQ routing, so
-    // every output type goes through the error_log-aware factory. The
-    // dedicated `register_batched_output_type` helper collapsed into
-    // `register_output_type_with_error_log` below.
-    register_output_type_with_error_log::<output::file::FileOutput>(registry, "file");
-    register_output_type_with_error_log::<output::unix_socket::UnixSocketOutput>(
-        registry,
-        "unix_socket",
-    );
-    register_output_type_with_error_log::<output::syslog_tcp::SyslogTcpOutput>(
-        registry,
-        "syslog_tcp",
-    );
-    register_output_type_with_error_log::<output::http::HttpOutput>(registry, "http");
-    register_output_type_with_error_log::<output::otlp::http::OtlpHttpOutput>(
-        registry,
-        "otlp_http",
-    );
-    register_output_type_with_error_log::<output::otlp::grpc::OtlpGrpcOutput>(
-        registry,
-        "otlp_grpc",
-    );
-    register_output_type_with_error_log::<output::syslog_udp::SyslogUdpOutput>(
-        registry,
-        "syslog_udp",
-    );
-    register_output_type_with_error_log::<output::stdout::StdoutOutput>(registry, "stdout");
+    // Outputs — every output owns its own retry + DLQ routing.
+    // Build-time dependencies (`error_log`, `funcs`) arrive via
+    // `BuildContext` in `from_properties`.
+    register_output_type::<output::file::FileOutput>(registry, "file");
+    register_output_type::<output::unix_socket::UnixSocketOutput>(registry, "unix_socket");
+    register_output_type::<output::syslog_tcp::SyslogTcpOutput>(registry, "syslog_tcp");
+    register_output_type::<output::http::HttpOutput>(registry, "http");
+    register_output_type::<output::otlp::http::OtlpHttpOutput>(registry, "otlp_http");
+    register_output_type::<output::otlp::grpc::OtlpGrpcOutput>(registry, "otlp_grpc");
+    register_output_type::<output::syslog_udp::SyslogUdpOutput>(registry, "syslog_udp");
+    register_output_type::<output::stdout::StdoutOutput>(registry, "stdout");
     #[cfg(feature = "kafka")]
-    register_output_type_with_error_log::<output::kafka::KafkaOutput>(registry, "kafka");
+    register_output_type::<output::kafka::KafkaOutput>(registry, "kafka");
 
     // No built-in processes — v0.3.0 removed the native process
     // layer. Schema-specific parsers are DSL functions (`syslog.parse`,
@@ -752,12 +757,12 @@ where
     registry.register_input(
         type_name,
         T::property_schema(),
-        |name, properties: &ModuleProperties, tx, shutdown| {
+        |name, properties: &ModuleProperties, ctx, tx, shutdown| {
             // The registry has already run schema validation before
             // calling this closure (when a schema is declared); here we
             // only build the concrete value, so `from_properties` is
             // the right entry point.
-            let input = T::from_properties(name, properties)?;
+            let input = T::from_properties(name, properties, ctx)?;
             let metrics = HasMetrics::metrics(&input);
             let input_name = name.to_string();
             let handle = tokio::spawn(async move {
@@ -770,32 +775,15 @@ where
     );
 }
 
-/// Trait marker for outputs that consume the configured `error_log` at
-/// construction time. Every output owns its own retry + DLQ routing,
-/// so every output type implements this trait — the previously-named
-/// `register_batched_output_type` collapsed into the universal
-/// `register_output_type_with_error_log` below.
-///
-/// Lives next to `Module` rather than on it so the `Input` half of the
-/// `Module` trait isn't polluted with output-only plumbing.
-pub trait OutputBuilderWithErrorLog: Module {
-    fn from_properties_with_error_log(
-        name: &str,
-        properties: &ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
-    ) -> Result<Self>;
-}
-
-fn register_output_type_with_error_log<T>(registry: &mut ModuleRegistry, type_name: &str)
+fn register_output_type<T>(registry: &mut ModuleRegistry, type_name: &str)
 where
-    T: OutputBuilderWithErrorLog + Output + Sync + 'static,
+    T: Module + Output + Sync + 'static,
 {
     registry.register_output(
         type_name,
         T::property_schema(),
-        |name, properties: &ModuleProperties, funcs, error_log| {
-            let mut output = T::from_properties_with_error_log(name, properties, error_log)?;
-            output.attach_funcs(funcs);
+        |name, properties: &ModuleProperties, ctx| {
+            let output = T::from_properties(name, properties, ctx)?;
             let metrics = HasMetrics::metrics(&output);
             let output_arc: Arc<dyn Output> = Arc::new(output);
             Ok(CreatedOutput {

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -33,7 +33,7 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::{BorrowedEvent, Event};
 use crate::functions::FunctionRegistry;
 use crate::metrics::OutputMetrics;
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog, RenderError};
+use crate::modules::{HasMetrics, Module, Output, RenderError};
 use crate::queue::{QueueAckHandle, RetryConfig};
 
 const FILE_OUTPUT_SCHEMA: &[PropertySpec] = &[
@@ -90,7 +90,7 @@ pub struct FileOutput {
     group: Option<String>,
     /// Tracks which paths have been created (for applying mode/owner/group once)
     created_paths: Mutex<HashSet<PathBuf>>,
-    funcs: Option<Arc<FunctionRegistry>>,
+    funcs: Arc<FunctionRegistry>,
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
@@ -101,17 +101,13 @@ impl Module for FileOutput {
         Some(FILE_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        Self::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for FileOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
+        let error_log = ctx.error_log.as_ref().map(Arc::clone);
+        let funcs = Arc::clone(&ctx.funcs);
         let retry = RetryConfig::from_output_properties(properties.user_properties())?;
         let properties = properties.user_properties();
         let path = props::get_expr(properties, "path")
@@ -152,7 +148,7 @@ impl OutputBuilderWithErrorLog for FileOutput {
             owner,
             group,
             created_paths: Mutex::new(HashSet::new()),
-            funcs: None,
+            funcs,
             retry,
             error_log,
             metrics: Arc::new(OutputMetrics::default()),
@@ -169,10 +165,6 @@ impl HasMetrics for FileOutput {
 
 #[async_trait::async_trait]
 impl Output for FileOutput {
-    fn attach_funcs(&mut self, funcs: Arc<FunctionRegistry>) {
-        self.funcs = Some(funcs);
-    }
-
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         // Per-event lifecycle: render → write (with internal retry) →
         // resolve. Render failures are deterministic on the event and
@@ -354,12 +346,7 @@ impl FileOutput {
         match &self.path.kind {
             ExprKind::StringLit(s) => Ok((s.clone(), false)),
             ExprKind::Template(fragments) => {
-                let funcs = self.funcs.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "output file: FunctionRegistry not attached — \
-                         dynamic path template requires attach_funcs() before render"
-                    )
-                })?;
+                let funcs = &self.funcs;
                 let mut out = String::new();
                 for frag in fragments {
                     match frag {
@@ -625,7 +612,7 @@ mod tests {
             owner: None,
             group: None,
             created_paths: Mutex::new(HashSet::new()),
-            funcs: Some(funcs()),
+            funcs: funcs(),
             retry: RetryConfig::default(),
             error_log: None,
             metrics: Arc::new(OutputMetrics::default()),
@@ -831,16 +818,6 @@ mod tests {
             "unexpected error: {}",
             err
         );
-    }
-
-    #[test]
-    fn render_template_errors_without_attached_funcs() {
-        let mut out = make_output(ek(ExprKind::Template(vec![TemplateFragment::Interp(ek(
-            ExprKind::Ident(vec!["source".into()]),
-        ))])));
-        out.funcs = None;
-        let err = render_path_owned(&out, &event_with_workspace()).unwrap_err();
-        assert!(err.to_string().contains("FunctionRegistry not attached"));
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -65,7 +65,7 @@ use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 use crate::tls::ClientTlsConfig;
 
@@ -212,7 +212,7 @@ struct Inner {
     /// entirely here.
     retry: RetryConfig,
     /// `error_log` writer injected at construction time by the
-    /// runtime via `OutputBuilderWithErrorLog::from_properties_with_error_log`.
+    /// runtime via `BuildContext` in `from_properties`.
     /// Used by the flush path to route per-event render failures and
     /// shutdown-flush leftovers into the DLQ. `None` when the
     /// operator did not configure `control { error_log "..." }` —
@@ -349,22 +349,12 @@ impl Module for HttpOutput {
         Some(HTTP_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        // Delegates to the error_log-aware ctor with `None` so the
-        // bare `Module::from_properties` path (used by unit tests and
-        // direct callers) still works; the runtime always goes
-        // through `OutputBuilderWithErrorLog::from_properties_with_error_log`
-        // to inject the operator-configured writer.
-        <Self as OutputBuilderWithErrorLog>::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for HttpOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
+        let error_log = ctx.error_log.as_ref().map(Arc::clone);
         let properties = properties.user_properties();
 
         // Parse the configured method into a typed `reqwest::Method`
@@ -917,7 +907,7 @@ mod tests {
 
     #[test]
     fn requires_peer_or_peers_block() {
-        let err = HttpOutput::from_properties("o", &mp(&[])).err().unwrap();
+        let err = HttpOutput::from_properties("o", &mp(&[]), &crate::modules::BuildContext::for_testing()).err().unwrap();
         assert!(
             err.to_string().contains("'peer {") && err.to_string().contains("'peers {"),
             "unexpected: {err}"
@@ -931,14 +921,14 @@ mod tests {
             key_span: None,
             properties: vec![],
         }];
-        let err = HttpOutput::from_properties("o", &mp(&props)).err().unwrap();
+        let err = HttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).err().unwrap();
         assert!(err.to_string().contains("url"), "unexpected: {err}");
     }
 
     #[test]
     fn accepts_single_peer_shorthand() {
         let props = vec![peer_block("http://x:8080/")];
-        let output = HttpOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 1);
         assert_eq!(output.inner.peers[0].url, "http://x:8080/");
     }
@@ -950,7 +940,7 @@ mod tests {
             peer_block("http://b:8080/"),
             peer_block("http://c:8080/"),
         ])];
-        let output = HttpOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 3);
         assert_eq!(output.inner.peers[2].url, "http://c:8080/");
     }
@@ -969,7 +959,7 @@ mod tests {
                 },
             ],
         }];
-        let err = HttpOutput::from_properties("o", &mp(&props)).err().unwrap();
+        let err = HttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).err().unwrap();
         assert!(
             err.to_string().contains("cert and key"),
             "unexpected: {err}"
@@ -1048,6 +1038,7 @@ mod tests {
         let output = HttpOutput::from_properties(
             "test",
             &mp(&[peer_block(&url), prop_int("batch_size", 1)]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         consume(&output, &event_with("hello-single")).await
@@ -1077,7 +1068,7 @@ mod tests {
             ]),
             prop_int("batch_size", 1),
         ];
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         for i in 0..9 {
             consume(&output, &event_with(&format!("rr-{}", i)))
                 .await
@@ -1128,7 +1119,7 @@ mod tests {
         ];
         let mut props = props;
         props.push(fast_retry_block());
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         // First send goes to A (cursor 0), fails. With max_attempts=1
         // the failure routes to Recovered (DLQ). A is cooled down.
         let first = consume(&output, &event_with("rr-fail")).await;
@@ -1153,7 +1144,7 @@ mod tests {
             peer_block("http://example.com/"),
             ident_prop("method", "CARRIER PIGEON"),
         ];
-        let err = HttpOutput::from_properties("test", &mp(&props))
+        let err = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("invalid method must reject");
         let msg = err.to_string();
@@ -1204,7 +1195,7 @@ mod tests {
         // `verify false` must NOT discard the client identity. Old
         // behaviour: tls block silently ignored; reqwest builds a
         // plain client without the identity → mTLS broken at runtime.
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 1);
     }
 
@@ -1246,7 +1237,7 @@ mod tests {
             prop_int("batch_size", 1),
             ident_prop("method", "PATCH"),
         ];
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with("hello")).await.unwrap();
         for _ in 0..50 {
             if !received.lock().await.is_empty() {
@@ -1284,7 +1275,7 @@ mod tests {
 
         let url = format!("http://{}/", addr);
         let props = vec![peer_block(&url), prop_int("batch_size", 1)];
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         // `consume` resolves the ack and swallows the underlying
         // transport error inside its DLQ-routing path.
         // Hit `Inner::send_batch` directly so we can still assert on
@@ -1340,7 +1331,7 @@ mod tests {
 
         let url = format!("http://{}/", addr);
         let props = vec![peer_block(&url), prop_int("batch_size", 1)];
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let err = output
             .inner
             .send_batch(&["hello".to_string()])
@@ -1379,7 +1370,7 @@ mod tests {
 
         let url = format!("http://{}/", addr);
         let props = vec![peer_block(&url), prop_int("batch_size", 1), fast_retry_block()];
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let pre_call = Instant::now();
         let _ = consume(&output, &event_with("hello")).await;
         let cooldown_until = output.inner.peer_state[0]
@@ -1412,7 +1403,7 @@ mod tests {
         let mut props = vec![peer_block("http://127.0.0.1:1/")];
         props.push(prop_int("batch_size", 1));
         props.push(fast_retry_block());
-        let output = HttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = HttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let err = consume(&output, &event_with("singleton"))
             .await
             .expect_err("send must fail against unreachable peer");
@@ -1462,12 +1453,11 @@ mod tests {
             prop_str("batch_timeout", "10s"),
             fast_retry_block(),
         ];
-        let output = <HttpOutput as OutputBuilderWithErrorLog>::from_properties_with_error_log(
-            "test",
-            &mp(&props),
-            Some(Arc::clone(&writer)),
-        )
-        .unwrap();
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = HttpOutput::from_properties("test", &mp(&props), &ctx).unwrap();
 
         // First consume parks the event with no flush. Watch the ack
         // channel: it must NOT resolve until the flush actually runs.
@@ -1513,6 +1503,7 @@ mod tests {
                 prop_int("batch_size", 2),
                 prop_str("batch_timeout", "10s"),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         let (ack, mut rx) = QueueAckHandle::for_test();
@@ -1557,6 +1548,7 @@ mod tests {
                 prop_int("batch_size", 100),
                 prop_str("batch_timeout", "30s"),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
 
@@ -1624,7 +1616,11 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
-        let output = <HttpOutput as OutputBuilderWithErrorLog>::from_properties_with_error_log(
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = HttpOutput::from_properties(
             "myout",
             &mp(&[
                 peer_block(&url),
@@ -1632,7 +1628,7 @@ mod tests {
                 prop_str("batch_timeout", "30s"),
                 fast_retry_block(),
             ]),
-            Some(Arc::clone(&writer)),
+            &ctx,
         )
         .unwrap();
 
@@ -1688,6 +1684,7 @@ mod tests {
                 prop_str("batch_timeout", "30s"),
                 fast_retry_block(),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         consume(&output, &event_with("ev1")).await.unwrap();
@@ -1715,6 +1712,7 @@ mod tests {
                 prop_int("batch_size", 100),
                 prop_str("batch_timeout", "30s"),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         consume(&output, &event_with("ev1")).await.unwrap();
@@ -1757,6 +1755,7 @@ mod tests {
                 prop_str("batch_timeout", "30s"),
                 fast_retry_block(),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         consume(&output, &event_with("ev1")).await.unwrap();
@@ -1778,22 +1777,25 @@ mod tests {
 
     /// Constructor-time error_log injection (replaces the prior
     /// `attach_error_log(&self, ...)` setter). The runtime always
-    /// goes through `OutputBuilderWithErrorLog::from_properties_with_error_log`;
-    /// this test pins that the writer ends up on the Inner field so
-    /// subsequent flush paths (render-failure routing, shutdown
-    /// recovery) can reach it without any post-construction wiring.
+    /// goes through `from_properties` with a `BuildContext` carrying
+    /// the `error_log`; this test pins that the writer ends up on the
+    /// Inner field so subsequent flush paths (render-failure routing,
+    /// shutdown recovery) can reach it without any post-construction
+    /// wiring.
     #[tokio::test]
     async fn constructor_injects_error_log_into_inner() {
-        use crate::modules::OutputBuilderWithErrorLog;
-
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
 
-        let output = HttpOutput::from_properties_with_error_log(
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = HttpOutput::from_properties(
             "test",
             &mp(&[peer_block("http://127.0.0.1:1/"), prop_int("batch_size", 8)]),
-            Some(Arc::clone(&writer)),
+            &ctx,
         )
         .unwrap();
         // The Inner's `error_log` field must point at the same writer

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -42,7 +42,7 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 use crate::tls::ClientTlsConfig;
 
@@ -330,17 +330,12 @@ impl Module for KafkaOutput {
         Some(KAFKA_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        Self::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for KafkaOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
+        let error_log = ctx.error_log.as_ref().map(Arc::clone);
         let retry = RetryConfig::from_output_properties(properties.user_properties())?;
         let properties = properties.user_properties();
         let brokers = props::get_string(properties, "brokers")

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -63,7 +63,7 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{BackoffStrategy, QueueAckHandle, RetryConfig};
 
 use super::{BatchLevel, decode_drained_to_request};
@@ -118,7 +118,7 @@ struct Inner {
     /// recovery and render-failure records.
     name: String,
     /// `error_log` writer injected at construction time by the
-    /// runtime via `OutputBuilderWithErrorLog::from_properties_with_error_log`.
+    /// runtime via `BuildContext` in `from_properties`.
     /// Used by the flush path to route per-event render failures and
     /// shutdown-flush leftovers into the DLQ.
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
@@ -275,17 +275,12 @@ impl Module for OtlpGrpcOutput {
         Some(OTLP_GRPC_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        <Self as OutputBuilderWithErrorLog>::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for OtlpGrpcOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
+        let error_log = ctx.error_log.as_ref().map(Arc::clone);
         let properties = properties.user_properties();
 
         let batch_size = props::get_positive_int(properties, "batch_size")?.unwrap_or(1) as usize;
@@ -718,7 +713,7 @@ mod tests {
 
     #[test]
     fn requires_peer_or_peers_block() {
-        let err = OtlpGrpcOutput::from_properties("o", &mp(&[]))
+        let err = OtlpGrpcOutput::from_properties("o", &mp(&[]), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(
@@ -734,7 +729,7 @@ mod tests {
             key_span: None,
             properties: vec![prop_str("endpoint", "http://x:4317")],
         }];
-        let output = OtlpGrpcOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 1);
         assert_eq!(output.inner.peers[0].endpoint, "http://x:4317");
     }
@@ -742,7 +737,7 @@ mod tests {
     #[test]
     fn rejects_peers_block_with_no_peer() {
         let props = vec![peers_block_with(vec![])];
-        let err = OtlpGrpcOutput::from_properties("o", &mp(&props))
+        let err = OtlpGrpcOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(err.to_string().contains("at least one peer"));
@@ -751,7 +746,7 @@ mod tests {
     #[tokio::test]
     async fn accepts_plain_http_endpoint() {
         let output =
-            OtlpGrpcOutput::from_properties("o", &mp(&one_peer_props("http://localhost:4317")))
+            OtlpGrpcOutput::from_properties("o", &mp(&one_peer_props("http://localhost:4317")), &crate::modules::BuildContext::for_testing())
                 .unwrap();
         assert_eq!(output.inner.peers.len(), 1);
     }
@@ -776,7 +771,7 @@ mod tests {
                 },
             ],
         }])];
-        let err = OtlpGrpcOutput::from_properties("o", &mp(&props))
+        let err = OtlpGrpcOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         let msg = err.to_string();
@@ -803,7 +798,7 @@ mod tests {
                 },
             ],
         }])];
-        let output = OtlpGrpcOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 1);
     }
 
@@ -812,6 +807,7 @@ mod tests {
         let output = OtlpGrpcOutput::from_properties(
             "o",
             &mp(&one_peer_props("https://collector.example.com:4317")),
+            &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         assert_eq!(output.inner.peers.len(), 1);
@@ -823,7 +819,7 @@ mod tests {
             peer_block("http://a:4317"),
             peer_block("http://b:4317"),
         ])];
-        let output = OtlpGrpcOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 2);
         assert_eq!(output.inner.peers[0].endpoint, "http://a:4317");
     }
@@ -842,7 +838,7 @@ mod tests {
                 },
             ],
         }])];
-        let err = OtlpGrpcOutput::from_properties("o", &mp(&props))
+        let err = OtlpGrpcOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(err.to_string().contains("cert and key"));
@@ -851,14 +847,14 @@ mod tests {
     #[tokio::test]
     async fn batch_level_default_is_none() {
         let output =
-            OtlpGrpcOutput::from_properties("o", &mp(&one_peer_props("http://x"))).unwrap();
+            OtlpGrpcOutput::from_properties("o", &mp(&one_peer_props("http://x")), &crate::modules::BuildContext::for_testing()).unwrap();
         assert!(matches!(output.inner.batch_level, BatchLevel::None));
     }
 
     #[tokio::test]
     async fn batch_size_defaults_to_one() {
         let output =
-            OtlpGrpcOutput::from_properties("o", &mp(&one_peer_props("http://x"))).unwrap();
+            OtlpGrpcOutput::from_properties("o", &mp(&one_peer_props("http://x")), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.batch_size, 1);
     }
 
@@ -873,7 +869,7 @@ mod tests {
                 prop_str("initial_wait", "100ms"),
             ],
         });
-        let output = OtlpGrpcOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.retry_config.max_attempts, 2);
     }
 
@@ -977,7 +973,7 @@ mod tests {
         let endpoint = format!("http://{}", addr);
         let mut props = one_peer_props(&endpoint);
         props.push(prop_int("batch_size", 1));
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(
                 1_700_000_000_000_000_000,
             ))).await
@@ -1050,7 +1046,7 @@ mod tests {
         // exactly 3 events; receiver rejects 2 of them.
         let mut props = one_peer_props(&endpoint);
         props.push(prop_int("batch_size", 3));
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
 
         for i in 0..3 {
             let ev = event_with_egress(singleton_bytes(1_000_000_000 + i));
@@ -1096,7 +1092,7 @@ mod tests {
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .unwrap();
@@ -1147,7 +1143,7 @@ mod tests {
                 prop_str("max_wait", "1ms"),
             ],
         });
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let send = tokio::spawn(async move {
             consume(&output, &event_with_egress(singleton_bytes(1))).await
         });
@@ -1177,7 +1173,7 @@ mod tests {
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .expect("buffering a single event must succeed");
@@ -1217,7 +1213,7 @@ mod tests {
         // Large batch + long timer: only shutdown drains the buffer.
         props.push(prop_int("batch_size", 100));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
 
         for ts in [1u64, 2u64] {
             consume(&output, &event_with_egress(singleton_bytes(ts)))
@@ -1275,7 +1271,7 @@ mod tests {
                 prop_str("max_wait", "1ms"),
             ],
         });
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
 
         let (ack1, mut rx1) = QueueAckHandle::for_test();
         output
@@ -1333,12 +1329,11 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
-        let output = OtlpGrpcOutput::from_properties_with_error_log(
-            "myout",
-            &mp(&props),
-            Some(Arc::clone(&writer)),
-        )
-        .unwrap();
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = OtlpGrpcOutput::from_properties("myout", &mp(&props), &ctx).unwrap();
         buffer_two(&output).await;
 
         output.shutdown(Some(&writer)).await.unwrap();
@@ -1358,7 +1353,7 @@ mod tests {
     async fn shutdown_failure_without_error_log_returns_ok() {
         // Shutdown is infallible.
         let props = shutdown_recovery_props("http://127.0.0.1:1");
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         buffer_two(&output).await;
 
         output.shutdown(None).await.expect("shutdown is infallible");
@@ -1389,7 +1384,7 @@ mod tests {
         let mut props = one_peer_props(&endpoint);
         props.push(prop_int("batch_size", 100));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         buffer_two(&output).await;
 
         let dir = tempfile::TempDir::new().unwrap();
@@ -1406,7 +1401,7 @@ mod tests {
         // error_log writer itself fails on every record (parent dir
         // missing). Helper must warn + continue, never loop or panic.
         let props = shutdown_recovery_props("http://127.0.0.1:1");
-        let output = OtlpGrpcOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpGrpcOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         buffer_two(&output).await;
 
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(
@@ -1420,16 +1415,18 @@ mod tests {
     /// in `output::http` for the rationale.
     #[tokio::test]
     async fn constructor_injects_error_log_into_inner() {
-        use crate::modules::OutputBuilderWithErrorLog;
-
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
 
-        let output = OtlpGrpcOutput::from_properties_with_error_log(
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = OtlpGrpcOutput::from_properties(
             "test",
             &mp(&one_peer_props("http://127.0.0.1:1")),
-            Some(Arc::clone(&writer)),
+            &ctx,
         )
         .unwrap();
         let stored = output.inner.error_log.as_ref().expect("error_log must be set");

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -63,7 +63,7 @@ use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{BackoffStrategy, QueueAckHandle, RetryConfig};
 use crate::tls::ClientTlsConfig;
 
@@ -157,7 +157,7 @@ struct Inner {
     /// recovery and render-failure records.
     name: String,
     /// `error_log` writer injected at construction time by the
-    /// runtime via `OutputBuilderWithErrorLog::from_properties_with_error_log`.
+    /// runtime via `BuildContext` in `from_properties`.
     /// Used by the flush path to route per-event render failures and
     /// shutdown-flush leftovers into the DLQ.
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
@@ -357,17 +357,12 @@ impl Module for OtlpHttpOutput {
         Some(OTLP_HTTP_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        <Self as OutputBuilderWithErrorLog>::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for OtlpHttpOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
+        let error_log = ctx.error_log.as_ref().map(Arc::clone);
         let properties = properties.user_properties();
 
         let protocol_str = props::get_string(properties, "protocol")
@@ -857,7 +852,7 @@ mod tests {
 
     #[test]
     fn requires_peer_or_peers_block() {
-        let err = OtlpHttpOutput::from_properties("o", &mp(&[]))
+        let err = OtlpHttpOutput::from_properties("o", &mp(&[]), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(
@@ -873,7 +868,7 @@ mod tests {
             key_span: None,
             properties: vec![prop_str("endpoint", "http://x:4318/v1/logs")],
         }];
-        let output = OtlpHttpOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 1);
         assert_eq!(output.inner.peers[0].endpoint, "http://x:4318/v1/logs");
     }
@@ -881,7 +876,7 @@ mod tests {
     #[test]
     fn rejects_peers_block_with_no_peer() {
         let props = vec![peers_block_with(vec![])];
-        let err = OtlpHttpOutput::from_properties("o", &mp(&props))
+        let err = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(err.to_string().contains("at least one peer"));
@@ -894,7 +889,7 @@ mod tests {
             key_span: None,
             properties: vec![],
         }])];
-        let err = OtlpHttpOutput::from_properties("o", &mp(&props))
+        let err = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(err.to_string().contains("endpoint"));
@@ -903,7 +898,7 @@ mod tests {
     #[test]
     fn defaults_protocol_to_http_protobuf() {
         let output =
-            OtlpHttpOutput::from_properties("o", &mp(&one_peer_props("http://x"))).unwrap();
+            OtlpHttpOutput::from_properties("o", &mp(&one_peer_props("http://x")), &crate::modules::BuildContext::for_testing()).unwrap();
         assert!(matches!(output.inner.protocol, HttpProtocol::Protobuf));
     }
 
@@ -911,7 +906,7 @@ mod tests {
     fn rejects_unknown_protocol_value() {
         let mut props = one_peer_props("http://x");
         props.push(prop_str("protocol", "carrier_pigeon"));
-        let err = OtlpHttpOutput::from_properties("o", &mp(&props))
+        let err = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(err.to_string().contains("unknown"));
@@ -920,14 +915,14 @@ mod tests {
     #[test]
     fn batch_level_default_is_none() {
         let output =
-            OtlpHttpOutput::from_properties("o", &mp(&one_peer_props("http://x"))).unwrap();
+            OtlpHttpOutput::from_properties("o", &mp(&one_peer_props("http://x")), &crate::modules::BuildContext::for_testing()).unwrap();
         assert!(matches!(output.inner.batch_level, BatchLevel::None));
     }
 
     #[test]
     fn batch_size_defaults_to_one() {
         let output =
-            OtlpHttpOutput::from_properties("o", &mp(&one_peer_props("http://x"))).unwrap();
+            OtlpHttpOutput::from_properties("o", &mp(&one_peer_props("http://x")), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.batch_size, 1);
     }
 
@@ -938,7 +933,7 @@ mod tests {
             peer_block("http://b"),
             peer_block("http://c"),
         ])];
-        let output = OtlpHttpOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 3);
         assert_eq!(output.inner.peers[0].endpoint, "http://a");
         assert_eq!(output.inner.peers[2].endpoint, "http://c");
@@ -958,7 +953,7 @@ mod tests {
                 },
             ],
         }])];
-        let err = OtlpHttpOutput::from_properties("o", &mp(&props))
+        let err = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         assert!(err.to_string().contains("cert and key"));
@@ -976,7 +971,7 @@ mod tests {
                 prop_str("max_wait", "500ms"),
             ],
         });
-        let output = OtlpHttpOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.retry_config.max_attempts, 2);
         assert_eq!(
             output.inner.retry_config.initial_wait,
@@ -1180,7 +1175,7 @@ mod tests {
                 prop_str("max_wait", "50ms"),
             ],
         });
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
 
         consume(&output, &event_with_egress(singleton_bytes(123))).await
             .unwrap();
@@ -1231,7 +1226,7 @@ mod tests {
                 ],
             },
         ];
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(42))).await
             .unwrap();
 
@@ -1267,7 +1262,7 @@ mod tests {
                 prop_str("max_wait", "20ms"),
             ],
         });
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let err = consume(&output, &event_with_egress(singleton_bytes(456))).await
             .expect_err("send must fail after retries exhausted");
         // The underlying transport error is consumed by the
@@ -1284,7 +1279,7 @@ mod tests {
         let mut props = one_peer_props(&endpoint);
         props.push(prop_str("protocol", "http_protobuf"));
         props.push(prop_int("batch_size", 1));
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(123))).await
             .unwrap();
         let probe = || {
@@ -1307,7 +1302,7 @@ mod tests {
         let mut props = one_peer_props(&endpoint);
         props.push(prop_str("protocol", "http_json"));
         props.push(prop_int("batch_size", 1));
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(456))).await
             .unwrap();
         let probe = || {
@@ -1383,7 +1378,7 @@ mod tests {
         let mut props = one_peer_props(&endpoint);
         props.push(prop_str("protocol", "http_protobuf"));
         props.push(prop_int("batch_size", 3));
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
 
         for i in 0..3 {
             let ev = event_with_egress(singleton_bytes(900_000_000 + i));
@@ -1427,7 +1422,7 @@ mod tests {
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .unwrap();
@@ -1446,7 +1441,7 @@ mod tests {
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .expect("buffering a single event must succeed");
@@ -1475,7 +1470,7 @@ mod tests {
                 prop_str("max_wait", "1ms"),
             ],
         });
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
 
         let (ack1, mut rx1) = QueueAckHandle::for_test();
         output
@@ -1513,7 +1508,7 @@ mod tests {
         // drain this buffer.
         props.push(prop_int("batch_size", 100));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
 
         // Drive the batched path via consume_event.
         for ts in [1u64, 2u64] {
@@ -1576,7 +1571,7 @@ mod tests {
                 },
             ],
         }])];
-        let err = OtlpHttpOutput::from_properties("o", &mp(&props))
+        let err = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .unwrap();
         let msg = err.to_string();
@@ -1627,7 +1622,7 @@ mod tests {
                 prop_str("max_wait", "1ms"),
             ],
         });
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         let send = tokio::spawn(async move {
             consume(&output, &event_with_egress(singleton_bytes(1))).await
         });
@@ -1667,7 +1662,7 @@ mod tests {
                 },
             ],
         }])];
-        let output = OtlpHttpOutput::from_properties("o", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("o", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         assert_eq!(output.inner.peers.len(), 1);
     }
 
@@ -1709,12 +1704,11 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
-        let output = OtlpHttpOutput::from_properties_with_error_log(
-            "myout",
-            &mp(&props),
-            Some(Arc::clone(&writer)),
-        )
-        .unwrap();
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = OtlpHttpOutput::from_properties("myout", &mp(&props), &ctx).unwrap();
         buffer_two(&output).await;
 
         output.shutdown(Some(&writer)).await.unwrap();
@@ -1737,7 +1731,7 @@ mod tests {
     async fn shutdown_failure_without_error_log_returns_ok() {
         // Shutdown is infallible from the caller's POV.
         let props = shutdown_recovery_props("http://127.0.0.1:1/v1/logs");
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         buffer_two(&output).await;
 
         output.shutdown(None).await.expect("shutdown is infallible");
@@ -1752,7 +1746,7 @@ mod tests {
         props.push(prop_str("protocol", "http_protobuf"));
         props.push(prop_int("batch_size", 100));
         props.push(prop_str("batch_timeout", "30s"));
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         buffer_two(&output).await;
 
         let dir = tempfile::TempDir::new().unwrap();
@@ -1774,7 +1768,7 @@ mod tests {
     #[tokio::test]
     async fn shutdown_recovery_writer_failure_does_not_recurse() {
         let props = shutdown_recovery_props("http://127.0.0.1:1/v1/logs");
-        let output = OtlpHttpOutput::from_properties("test", &mp(&props)).unwrap();
+        let output = OtlpHttpOutput::from_properties("test", &mp(&props), &crate::modules::BuildContext::for_testing()).unwrap();
         buffer_two(&output).await;
 
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(
@@ -1788,16 +1782,18 @@ mod tests {
     /// in `output::http` for the rationale.
     #[tokio::test]
     async fn constructor_injects_error_log_into_inner() {
-        use crate::modules::OutputBuilderWithErrorLog;
-
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
 
-        let output = OtlpHttpOutput::from_properties_with_error_log(
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = OtlpHttpOutput::from_properties(
             "test",
             &mp(&one_peer_props("http://127.0.0.1:1/v1/logs")),
-            Some(Arc::clone(&writer)),
+            &ctx,
         )
         .unwrap();
         let stored = output.inner.error_log.as_ref().expect("error_log must be set");

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use crate::dsl::schema::PropertySpec;
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 
 /// `output stdout` has no module-specific properties; only the
@@ -33,22 +33,13 @@ impl Module for StdoutOutput {
     fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-    ) -> Result<Self> {
-        Self::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for StdoutOutput {
-    fn from_properties_with_error_log(
-        name: &str,
-        properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let retry = RetryConfig::from_output_properties(properties.user_properties())?;
         Ok(Self {
             name: name.to_string(),
             retry,
-            error_log,
+            error_log: ctx.error_log.as_ref().map(Arc::clone),
             metrics: Arc::new(OutputMetrics::default()),
         })
     }

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -35,7 +35,7 @@ use crate::modules::output::syslog_peers::{
     PEER_CONNECT_TIMEOUT, PEER_HANDSHAKE_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList,
     SyslogFraming, SyslogPayload, parse_host_port, write_framed,
 };
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 use crate::tls::{ClientTlsConfig, build_client_config_sync};
 
@@ -182,17 +182,12 @@ impl Module for SyslogTcpOutput {
         Some(SYSLOG_TCP_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        Self::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for SyslogTcpOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
+        let error_log = ctx.error_log.as_ref().map(Arc::clone);
         let retry = RetryConfig::from_output_properties(properties.user_properties())?;
         let properties = properties.user_properties();
         let framing = parse_framing(name, properties)?;
@@ -577,7 +572,7 @@ mod tests {
     #[test]
     fn build_accepts_single_peer() {
         let props = vec![peer_plain("127.0.0.1", 514)];
-        let tcp = SyslogTcpOutput::build("relay", &mp(&props)).expect("should build");
+        let tcp = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(tcp.peers.len(), 1);
         assert_eq!(tcp.peers.peers()[0].address(), "127.0.0.1:514");
         assert_eq!(tcp.framing, SyslogFraming::OctetCounting);
@@ -591,7 +586,7 @@ mod tests {
             "peer",
             vec![kv("host", ExprKind::StringLit("127.0.0.1".into()))],
         )];
-        let tcp = SyslogTcpOutput::build("relay", &mp(&props)).expect("should build");
+        let tcp = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(tcp.peers.peers()[0].address(), "127.0.0.1:514");
     }
 
@@ -601,7 +596,7 @@ mod tests {
             "peers",
             vec![peer_plain("a", 514), peer_plain("b", 1514)],
         )];
-        let tcp = SyslogTcpOutput::build("relay", &mp(&props)).expect("should build");
+        let tcp = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(tcp.peers.len(), 2);
         assert_eq!(tcp.peers.peers()[0].address(), "a:514");
         assert_eq!(tcp.peers.peers()[1].address(), "b:1514");
@@ -613,7 +608,7 @@ mod tests {
             peer_plain("h", 1),
             kv("framing", ExprKind::Ident(vec!["non_transparent".into()])),
         ];
-        let tcp = SyslogTcpOutput::build("relay", &mp(&props)).expect("should build");
+        let tcp = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(tcp.framing, SyslogFraming::NonTransparent);
     }
 
@@ -623,7 +618,7 @@ mod tests {
             peer_plain("h", 1),
             kv("framing", ExprKind::Ident(vec!["non_trasnaprent".into()])),
         ];
-        let err = SyslogTcpOutput::build("relay", &mp(&props))
+        let err = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         let msg = err.to_string();
@@ -641,7 +636,7 @@ mod tests {
             "per",
             vec![kv("host", ExprKind::StringLit("h".into()))],
         )];
-        let err = SyslogTcpOutput::build("relay", &mp(&props))
+        let err = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         let msg = err.to_string();
@@ -658,7 +653,7 @@ mod tests {
                 kv("port", ExprKind::StringLit("five-fourteen".into())),
             ],
         )];
-        let err = SyslogTcpOutput::build("relay", &mp(&props))
+        let err = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         let msg = err.to_string();
@@ -672,7 +667,7 @@ mod tests {
             block("per", vec![kv("host", ExprKind::StringLit("h".into()))]),
             kv("framing", ExprKind::Ident(vec!["xx".into()])),
         ];
-        let err = SyslogTcpOutput::build("relay", &mp(&props))
+        let err = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         let msg = err.to_string();
@@ -686,7 +681,7 @@ mod tests {
             peer_plain("a", 514),
             block("peers", vec![peer_plain("b", 514)]),
         ];
-        let err = SyslogTcpOutput::build("relay", &mp(&props))
+        let err = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         let msg = err.to_string();
@@ -705,7 +700,7 @@ mod tests {
             peer_plain("a", 514),
             block("peers", vec![peer_plain("b", 514)]),
         ];
-        let err = SyslogTcpOutput::from_properties("relay", &mp(&props))
+        let err = SyslogTcpOutput::from_properties("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("from_properties should reject both blocks");
         let msg = err.to_string();
@@ -714,7 +709,7 @@ mod tests {
 
     #[test]
     fn build_rejects_missing_destination() {
-        let err = SyslogTcpOutput::build("relay", &mp(&[]))
+        let err = SyslogTcpOutput::build("relay", &mp(&[]), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         assert!(
@@ -727,7 +722,7 @@ mod tests {
 
     #[test]
     fn build_rejects_empty_peers_block() {
-        let err = SyslogTcpOutput::from_properties("relay", &mp(&[block("peers", vec![])]))
+        let err = SyslogTcpOutput::from_properties("relay", &mp(&[block("peers", vec![])]), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         assert!(
@@ -749,7 +744,7 @@ mod tests {
     #[test]
     fn build_rejects_peer_missing_host() {
         let props = vec![block("peer", vec![kv("port", ExprKind::IntLit(514))])];
-        let err = SyslogTcpOutput::build("relay", &mp(&props))
+        let err = SyslogTcpOutput::build("relay", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         assert!(err.to_string().contains("host"), "{}", err);
@@ -758,7 +753,7 @@ mod tests {
     #[test]
     fn from_properties_directly_still_works_for_existing_call_sites() {
         let props = vec![peer_plain("h", 1)];
-        let tcp = SyslogTcpOutput::from_properties("relay", &mp(&props)).expect("should build");
+        let tcp = SyslogTcpOutput::from_properties("relay", &mp(&props), &crate::modules::BuildContext::for_testing()).expect("should build");
         assert_eq!(tcp.peers.peers()[0].address(), "h:1");
     }
 
@@ -772,6 +767,7 @@ mod tests {
         let output = SyslogTcpOutput::build(
             "relay",
             &mp(&[peer_with_tls("example.com", 6514, ca_block(&files.cert))]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("should build");
         let peer0 = &output.peers.peers()[0];
@@ -789,6 +785,7 @@ mod tests {
                 6514,
                 mtls_block(&files.cert, &files.key, &files.cert),
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("should build");
         let tls = output.peers.peers()[0].tls.as_ref().unwrap();
@@ -815,6 +812,7 @@ mod tests {
                     kv("tls", ExprKind::Ident(vec!["my_p".into()])),
                 ),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("should build");
         assert_eq!(
@@ -837,6 +835,7 @@ mod tests {
                 6514,
                 kv("tls", ExprKind::Ident(vec!["missing".into()])),
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .err()
         .expect("should fail");
@@ -852,6 +851,7 @@ mod tests {
                 6514,
                 tls_block(vec![kv("cert", ExprKind::StringLit("x.crt".into()))]),
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .err()
         .expect("should fail");
@@ -867,6 +867,7 @@ mod tests {
                 6514,
                 tls_block(vec![kv("key", ExprKind::StringLit("x.key".into()))]),
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .err()
         .expect("should fail");
@@ -903,6 +904,7 @@ mod tests {
                     ],
                 ),
             ]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("should build");
         assert_eq!(output.peers.len(), 3);
@@ -924,6 +926,7 @@ mod tests {
                     peer_with_tls_default_port("plain.example.com", None),
                 ],
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("should build");
         // TLS peer → 6514 (RFC 5425), plain peer → 514 (RFC 6587).

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -13,7 +13,7 @@ use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
     PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, SyslogPayload, parse_host_port,
 };
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 
 const SYSLOG_UDP_PEER_SCHEMA: &[PropertySpec] = &[
@@ -73,16 +73,10 @@ impl Module for SyslogUdpOutput {
         Some(SYSLOG_UDP_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        Self::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for SyslogUdpOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let retry = RetryConfig::from_output_properties(properties.user_properties())?;
         let properties = properties.user_properties();
@@ -91,7 +85,7 @@ impl OutputBuilderWithErrorLog for SyslogUdpOutput {
             name: name.to_string(),
             peers: PeerList::new(peers),
             retry,
-            error_log,
+            error_log: ctx.error_log.as_ref().map(Arc::clone),
             metrics: Arc::new(OutputMetrics::default()),
         })
     }
@@ -336,7 +330,7 @@ mod tests {
 
     #[test]
     fn build_accepts_single_peer() {
-        let u = SyslogUdpOutput::build("u", &mp(&[peer("h", 1)])).expect("ok");
+        let u = SyslogUdpOutput::build("u", &mp(&[peer("h", 1)]), &crate::modules::BuildContext::for_testing()).expect("ok");
         assert_eq!(u.peers.len(), 1);
         assert_eq!(u.peers.peers()[0].address(), "h:1");
     }
@@ -349,6 +343,7 @@ mod tests {
                 "peer",
                 vec![kv("host", ExprKind::StringLit("h".into()))],
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("ok");
         assert_eq!(u.peers.peers()[0].address(), "h:514");
@@ -359,6 +354,7 @@ mod tests {
         let u = SyslogUdpOutput::build(
             "u",
             &mp(&[block("peers", vec![peer("a", 1), peer("b", 2)])]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("ok");
         assert_eq!(u.peers.len(), 2);
@@ -368,7 +364,7 @@ mod tests {
 
     #[test]
     fn build_rejects_missing_destination() {
-        let err = SyslogUdpOutput::build("u", &mp(&[]))
+        let err = SyslogUdpOutput::build("u", &mp(&[]), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("missing destination");
         assert!(
@@ -385,7 +381,7 @@ mod tests {
             "per",
             vec![kv("host", ExprKind::StringLit("h".into()))],
         )];
-        let err = SyslogUdpOutput::build("u", &mp(&props))
+        let err = SyslogUdpOutput::build("u", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("typo");
         let msg = err.to_string();
@@ -395,7 +391,7 @@ mod tests {
     #[test]
     fn build_rejects_peer_and_peers_together() {
         let props = vec![peer("a", 1), block("peers", vec![peer("b", 2)])];
-        let err = SyslogUdpOutput::build("u", &mp(&props))
+        let err = SyslogUdpOutput::build("u", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         let msg = err.to_string();
@@ -413,7 +409,7 @@ mod tests {
         // silently take the first `peer` block and discard the
         // `peers` block. Belt-and-braces.
         let props = vec![peer("a", 1), block("peers", vec![peer("b", 2)])];
-        let err = SyslogUdpOutput::from_properties("u", &mp(&props))
+        let err = SyslogUdpOutput::from_properties("u", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("from_properties should reject both blocks");
         let msg = err.to_string();
@@ -422,7 +418,7 @@ mod tests {
 
     #[test]
     fn build_rejects_empty_peers_block() {
-        let err = SyslogUdpOutput::from_properties("u", &mp(&[block("peers", vec![])]))
+        let err = SyslogUdpOutput::from_properties("u", &mp(&[block("peers", vec![])]), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         assert!(
@@ -444,7 +440,7 @@ mod tests {
     #[test]
     fn build_rejects_peer_missing_host() {
         let props = vec![block("peer", vec![kv("port", ExprKind::IntLit(514))])];
-        let err = SyslogUdpOutput::build("u", &mp(&props))
+        let err = SyslogUdpOutput::build("u", &mp(&props), &crate::modules::BuildContext::for_testing())
             .err()
             .expect("should fail");
         assert!(err.to_string().contains("host"), "{}", err);
@@ -475,6 +471,7 @@ mod tests {
                     kv("port", ExprKind::IntLit(port)),
                 ],
             )]),
+            &crate::modules::BuildContext::for_testing(),
         )
         .expect("build");
 

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -16,7 +16,7 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::persistent_conn::{PersistentConn, write_with_reconnect};
-use crate::modules::{HasMetrics, Module, Output, OutputBuilderWithErrorLog};
+use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 
 const UNIX_SOCKET_OUTPUT_SCHEMA: &[PropertySpec] = &[
@@ -45,16 +45,10 @@ impl Module for UnixSocketOutput {
         Some(UNIX_SOCKET_OUTPUT_SCHEMA)
     }
 
-    fn from_properties(name: &str, properties: &crate::modules::ModuleProperties) -> Result<Self> {
-        Self::from_properties_with_error_log(name, properties, None)
-    }
-}
-
-impl OutputBuilderWithErrorLog for UnixSocketOutput {
-    fn from_properties_with_error_log(
+    fn from_properties(
         name: &str,
         properties: &crate::modules::ModuleProperties,
-        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let retry = RetryConfig::from_output_properties(properties.user_properties())?;
         let properties = properties.user_properties();
@@ -65,7 +59,7 @@ impl OutputBuilderWithErrorLog for UnixSocketOutput {
             path: PathBuf::from(path),
             conn: Mutex::new(None),
             retry,
-            error_log,
+            error_log: ctx.error_log.as_ref().map(Arc::clone),
             metrics: Arc::new(OutputMetrics::default()),
         })
     }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -81,6 +81,14 @@ impl Runtime {
             None => None,
         };
 
+        // Single bundle threaded into every Input/Output factory. Future
+        // build-time dependencies (transport-key registry, metrics hooks)
+        // land as new fields on this struct rather than as new parameters.
+        let build_ctx = crate::modules::BuildContext {
+            funcs: Arc::clone(&func_registry),
+            error_log: error_log.as_ref().map(Arc::clone),
+        };
+
         // --- 1. Create outputs (each output owns its own OutputMetrics) ---
         let mut output_senders: HashMap<String, QueueSender> = HashMap::new();
         let mut output_receivers = Vec::new();
@@ -88,21 +96,21 @@ impl Runtime {
         for (name, output_def) in &config.outputs {
             let queue_config =
                 QueueConfig::from_output_properties(name, output_def.properties.user_properties())?;
-            // Retry config is parsed by each output's
-            // `from_properties_with_error_log` (outputs own retry +
-            // DLQ). The runtime no longer needs a copy here.
+            // Retry config is parsed by each output's `from_properties`
+            // (outputs own retry + DLQ). The runtime no longer needs a
+            // copy here.
             let (mut sender, receiver) = queue::create_queue(name.clone(), queue_config)?;
 
             // `output_def.properties` is a `ModuleProperties`: it carries the
             // resolved `type` already, so `create_output` doesn't take a
             // separate type_name argument (and can't be passed one — the
-            // strip is the whole point). `error_log` is threaded in so
-            // batched outputs can stash it at construction time.
+            // strip is the whole point). `BuildContext` carries `funcs` and
+            // the optional `error_log` so outputs can stash them at
+            // construction time.
             let created = match registry.create_output(
                 name,
                 &output_def.properties,
-                Arc::clone(&func_registry),
-                error_log.as_ref().map(Arc::clone),
+                &build_ctx,
             ) {
                 Ok(c) => c,
                 Err(e) => {
@@ -232,6 +240,7 @@ impl Runtime {
             let created = match registry.create_input(
                 &input_name,
                 &input_def.properties,
+                &build_ctx,
                 event_tx,
                 shutdown_rx.clone(),
             ) {


### PR DESCRIPTION
## Summary

Collapses build-time dependencies (`error_log`, `funcs`) into a single `BuildContext` struct that's threaded into every `Module::from_properties` call. Deletes the `OutputBuilderWithErrorLog` sub-trait (now redundant after the BCZ-1 PR universalised it across all outputs) and the `Input::attach_funcs` / `Output::attach_funcs` post-construction setters. Modules that need build-time dependencies hold them as plain `Arc<…>` fields assigned at construction, eliminating the prior interior-mutability dances.

## What changed

- New `BuildContext { funcs: Arc<FunctionRegistry>, error_log: Option<Arc<ErrorLogWriter>> }`. Forward-compatible — future LTP transport-key registry, metrics hooks, etc. land as additional fields without rippling through every module signature.
- `Module::from_properties` signature gains a `&BuildContext` parameter. All 9 input + 9 output factories updated; modules that don't consume any `ctx` fields just ignore the parameter.
- `OutputBuilderWithErrorLog` sub-trait deleted. The factory closure type collapses to a single signature; the `register_output_type_with_error_log` helper goes away. Every output's `from_properties` body now reads `ctx.error_log` directly.
- `Output::attach_funcs` and `Input::attach_funcs` deleted from both traits. Modules that previously held `Option<Arc<FunctionRegistry>>` for late attachment now hold a plain `Arc<FunctionRegistry>` populated from `ctx.funcs.clone()` at construction. The runtime wiring loop that walked outputs to call `attach_funcs(...)` is gone.
- `FileOutput`'s `"FunctionRegistry not attached"` error branch (and its `render_template_errors_without_attached_funcs` test) deleted — the branch was unreachable once `funcs` became a construction-time requirement.

## Diff size

18 files changed, 329 insertions / 347 deletions — **net −18 lines** (delegating boilerplate gone).

## Known issues (intentionally left for follow-up PRs)

- **DLQ schema sum-type** — separate planned PR.
- **`unreachable!()` / `.expect()` audit on production hot paths** — separate planned PR.
- **Pre-existing internal labels** in `check/recovery_readiness.rs` and `modules/input/tail.rs` — out of scope; separate sweep / release-prep cleanup.
- **kafka feature build error** — pre-existing baseline on `origin/release/0.7.8`, unrelated to this PR.

## Watch items from audit (= observations, not findings)

- `BuildContext`-as-service-locator concern: as fields accumulate, the struct could become a god-object obscuring which dependencies each module actually consumes. Principle to maintain: build-time deps only (no runtime mutable state), bounded field count, intent-documented additions.

## CHANGELOG

Untouched. The 0.7.8 section will be rewritten at release-prep as the net 0.7.7 → 0.7.8 diff.

## Audit

push-gate 8 scopes all PASS (`uchgs verify push` summary: `would_push_succeed: true`):

- abstraction → no findings (Watch: service-locator observation)
- security → no findings
- ci-precheck → no findings
- readme-current → no findings
- boundary-contract → no findings (Watch only)
- confidentiality (commit-gate) → no findings post label scrub
- confidentiality (push-gate) → confirmed: pre-existing base file labels, separate sweep
- cicd-pipeline → confirmed: standing baseline (release.yml contents:write)
- rust → confirmed: standing supply-chain baseline (RUSTSEC-2026-0185 + duplicate-crate warnings)

## Test plan

- [x] `cargo check --workspace --all-targets`: clean
- [x] `cargo test --workspace`: 691 passed / 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `git diff --check HEAD^..HEAD`: clean