### PR TITLE
refactor: reject workspace/egress/error from output config

### DIFF
--- a/crates/limpid/src/check/bindings.rs
+++ b/crates/limpid/src/check/bindings.rs
@@ -20,10 +20,13 @@
 //!   only paths bound on every branch survive, with their types
 //!   merged via [`FieldType::union`].
 //!
-//! The analyzer never rejects unknown `workspace.*` reads outright (the
-//! runtime returns `Null`), but the dataflow pass emits a warning when
-//! an output template references a workspace key that no upstream
-//! module produces.
+//! Inside a pipeline body (`process { ... }`, `if`/`switch` branches),
+//! the analyzer never rejects unknown `workspace.*` reads outright —
+//! the runtime returns `Null` for missing keys. Inside an `output`
+//! config, however, references to pipeline-mutable state
+//! (`workspace`, `egress`, `error`) are hard-rejected by
+//! [`super::outputs::check_pipeline_only_reference`] regardless of
+//! upstream binding status.
 
 use std::collections::HashMap;
 
@@ -57,9 +60,7 @@ impl Bindings {
         self.workspace.insert(path.join("."), ty);
     }
 
-    /// Get the type of a `workspace.<path>` if bound. Does not consult
-    /// the wildcard flag — callers that want "is this readable at all?"
-    /// should use [`Bindings::workspace_visible`].
+    /// Get the type of a `workspace.<path>` if bound.
     pub fn get_workspace(&self, path: &[String]) -> Option<&FieldType> {
         self.workspace.get(&path.join("."))
     }
@@ -69,18 +70,6 @@ impl Bindings {
     /// near-match candidates for unbound references.
     pub fn workspace_keys(&self) -> impl Iterator<Item = &String> {
         self.workspace.keys()
-    }
-
-    /// True when `workspace.<path>` is either explicitly bound, bound
-    /// via an ancestor (Object), or admitted by the wildcard flag.
-    pub fn workspace_visible(&self, path: &[String]) -> bool {
-        if self.wildcard {
-            return true;
-        }
-        let joined = path.join(".");
-        self.workspace
-            .keys()
-            .any(|p| p == &joined || joined.starts_with(&format!("{}.", p)))
     }
 
     /// Mark the workspace as wildcarded — the analyzer no longer knows
@@ -193,23 +182,6 @@ mod tests {
             b.get_workspace(&["workspace".into(), "x".into()]),
             Some(&FieldType::String)
         );
-        assert!(b.workspace_visible(&["workspace".into(), "x".into()]));
-    }
-
-    #[test]
-    fn workspace_ancestor_visibility() {
-        // Binding `workspace.user` as Object makes nested reads pass
-        // visibility checks — the analyzer can't know the inner shape.
-        let mut b = Bindings::new();
-        b.bind_workspace(&["workspace".into(), "user".into()], FieldType::Object);
-        assert!(b.workspace_visible(&["workspace".into(), "user".into(), "id".into()]));
-    }
-
-    #[test]
-    fn wildcard_admits_anything() {
-        let mut b = Bindings::new();
-        b.set_workspace_wildcard();
-        assert!(b.workspace_visible(&["workspace".into(), "anything".into()]));
     }
 
     #[test]

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -148,8 +148,9 @@ fn ident_type(parts: &[String], bindings: &Bindings) -> FieldType {
                 }
             }
             // Unknown leaf — Any prevents false positives in type
-            // checks. The presence check (visible-from-output) is
-            // separate and runs on `workspace_visible`.
+            // checks. Workspace references in output config are
+            // rejected at parse time, so this fallthrough handles
+            // process-body / pipeline-internal reads only.
             return FieldType::Any;
         }
         _ => {}

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -640,7 +640,10 @@ def pipeline p { input i; output o }
     }
 
     #[test]
-    fn syslog_parse_binds_known_workspace_keys() {
+    fn output_workspace_ref_is_rejected_even_when_bound_upstream() {
+        // Output config cannot reference `workspace.*` regardless of
+        // whether an upstream process bound the key. Transport-side
+        // routing must be derived from event-intrinsic fields only.
         let src = r#"
 def input i { type syslog_tcp bind "0.0.0.0:514" }
 def output o { type syslog_tcp peer { host "${workspace.msg}" port 1 } }
@@ -651,28 +654,24 @@ def pipeline p {
 }
 "#;
         let diags = analyze_str(src);
-        assert!(errors(&diags).is_empty(), "got: {:?}", diags);
-    }
-
-    #[test]
-    fn parse_json_with_defaults_narrows_to_declared_keys() {
-        let src = r#"
-def input i { type syslog_tcp bind "0.0.0.0:514" }
-def output o { type syslog_tcp peer { host "${workspace.usr}" port 1 } }
-def pipeline p {
-    input i
-    process { parse_json(ingress, {user: "anon"}) }
-    output o
-}
-"#;
-        let diags = analyze_str(src);
         let errs = errors(&diags);
         assert_eq!(errs.len(), 1, "got: {:?}", diags);
-        assert!(errs[0].message.contains("workspace.usr"));
+        assert!(errs[0].message.contains("workspace.msg"));
+        assert!(errs[0].message.contains("not addressable from output config"));
+        let help = errs[0].help.as_deref().unwrap_or("");
+        assert!(
+            help.contains("event-intrinsic"),
+            "migration hint missing: {}",
+            help
+        );
     }
 
     #[test]
-    fn parse_json_without_defaults_wildcards() {
+    fn output_workspace_ref_is_rejected_when_upstream_wildcards() {
+        // `parse_json` without defaults flips the analyzer wildcard
+        // flag, which used to admit any workspace reference. With
+        // workspace removed from output config, even wildcard
+        // contexts produce a hard reject.
         let src = r#"
 def input i { type syslog_tcp bind "0.0.0.0:514" }
 def output o { type syslog_tcp peer { host "${workspace.anything}" port 1 } }
@@ -683,7 +682,9 @@ def pipeline p {
 }
 "#;
         let diags = analyze_str(src);
-        assert!(errors(&diags).is_empty(), "got: {:?}", diags);
+        let errs = errors(&diags);
+        assert_eq!(errs.len(), 1, "got: {:?}", diags);
+        assert!(errs[0].message.contains("workspace.anything"));
     }
 
     // ----- branch intersection -------------------------------------------
@@ -709,7 +710,10 @@ def pipeline p {
     }
 
     #[test]
-    fn if_else_with_both_branches_binding_is_guaranteed() {
+    fn output_workspace_ref_is_rejected_even_when_both_branches_bind() {
+        // Both-branch binding used to qualify the reference as
+        // "guaranteed". With workspace removed from output config,
+        // even both-branch bindings produce a hard reject.
         let src = r#"
 def input i { type syslog_tcp bind "0.0.0.0:514" }
 def output o { type syslog_tcp peer { host "${workspace.tag}" port 1 } }
@@ -726,7 +730,9 @@ def pipeline p {
 }
 "#;
         let diags = analyze_str(src);
-        assert!(errors(&diags).is_empty(), "got: {:?}", diags);
+        let errs = errors(&diags);
+        assert_eq!(errs.len(), 1, "got: {:?}", diags);
+        assert!(errs[0].message.contains("workspace.tag"));
     }
 
     // ----- operator type checks ------------------------------------------
@@ -918,7 +924,68 @@ def pipeline p { input i; output o }
     }
 
     #[test]
-    fn unresolved_workspace_ref_suggests_near_match() {
+    fn output_workspace_ref_is_rejected_in_file_path_template() {
+        // The structural rule applies to every sink, not just syslog.
+        // file output's `path` template (= the historical home of
+        // workspace-dependent dynamic paths) is hard-rejected like
+        // every other output property.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type file path "/var/log/${workspace.tenant}/app.log" }
+def pipeline p {
+    input i
+    process { parse_json(ingress) }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        let errs = errors(&diags);
+        assert_eq!(errs.len(), 1, "got: {:?}", diags);
+        assert!(errs[0].message.contains("workspace.tenant"));
+    }
+
+    #[test]
+    fn output_egress_ref_is_rejected_in_path_template() {
+        // `egress` is the wire bytes pipeline body sets; allowing
+        // output config to interpolate it would re-introduce the
+        // same "pipeline body indirectly controls routing" hazard
+        // `workspace.*` removal addresses.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type file path "/var/log/${egress}.log" }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let errs = errors(&diags);
+        assert_eq!(errs.len(), 1, "got: {:?}", diags);
+        assert!(errs[0].message.contains("egress"));
+        assert!(errs[0].message.contains("pipeline-mutable state"));
+    }
+
+    #[test]
+    fn output_bare_workspace_ref_is_rejected() {
+        // `${workspace}` without a subpath used to slip past the
+        // analyzer's `path.len() < 2` guard. The rule now is
+        // "pipeline-mutable idents are not visible from output
+        // config", regardless of subpath depth.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type file path "/var/log/${to_json(workspace)}.log" }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let errs = errors(&diags);
+        assert_eq!(errs.len(), 1, "got: {:?}", diags);
+        assert!(errs[0].message.contains("workspace"));
+    }
+
+    #[test]
+    fn output_workspace_ref_help_is_migration_hint_not_suggestion() {
+        // Per-typo levenshtein suggestions (`did you mean workspace.msg?`)
+        // are gone now that workspace is structurally disallowed in
+        // output config. Every rejection carries the same migration
+        // hint pointing at event-intrinsic fields and pipeline-level
+        // routing.
         let src = r#"
 def input i { type syslog_tcp bind "0.0.0.0:514" }
 def output o { type syslog_tcp peer { host "${workspace.mssg}" port 1 } }
@@ -932,23 +999,10 @@ def pipeline p {
         let errs = errors(&diags);
         assert_eq!(errs.len(), 1, "got: {:?}", diags);
         let help = errs[0].help.as_deref().expect("should have help line");
-        assert!(help.contains("workspace.msg"), "help was: {}", help);
-    }
-
-    #[test]
-    fn unresolved_workspace_ref_silent_when_nothing_close() {
-        let src = r#"
-def input i { type syslog_tcp bind "0.0.0.0:514" }
-def output o { type syslog_tcp peer { host "${workspace.completely_unrelated_zzz}" port 1 } }
-def pipeline p { input i; output o }
-"#;
-        let diags = analyze_str(src);
-        let errs = errors(&diags);
-        assert_eq!(errs.len(), 1, "got: {:?}", diags);
         assert!(
-            errs[0].help.is_none(),
-            "should not suggest when nothing close: help={:?}",
-            errs[0].help
+            help.contains("event-intrinsic") && !help.contains("did you mean"),
+            "help was: {}",
+            help
         );
     }
 

--- a/crates/limpid/src/check/outputs.rs
+++ b/crates/limpid/src/check/outputs.rs
@@ -1,11 +1,19 @@
-//! Output-side reference checks: every `workspace.*` reference in an
-//! output property must correspond to a key produced upstream.
+//! Output-side reference checks: output config templates may only
+//! reference event-intrinsic fields (`source`, `received_at`,
+//! `ingress`). Pipeline-mutable state (`workspace`, `egress`,
+//! `error`) is structurally not addressable from output config —
+//! letting transport metadata depend on pipeline-body output would
+//! re-introduce the same hazard `workspace.*` removal addressed.
 //!
-//! Walks every property's value expression, collects the workspace
-//! references (idents, property accesses, template `${…}` interps,
-//! function-call args, binary/unary subexpressions, hash literals),
-//! and emits an Error per unresolved key. Levenshtein-based "did you
-//! mean" hints are attached when a near match exists.
+//! Walks every property's value expression, collects ident references
+//! (idents, property accesses, template `${…}` interps, function-call
+//! args, binary/unary subexpressions, hash literals), and emits a
+//! hard-reject Error per pipeline-only reference with a migration
+//! hint pointing at event-intrinsic fields and pipeline-level
+//! routing. Daemon startup and reload run the same analyzer via
+//! `compile_and_analyze` in `main.rs`, so this rule applies on every
+//! load surface — there is no "valid for daemon, rejected by
+//! --check" asymmetry.
 
 use crate::dsl::ast::{Expr, ExprKind, OutputDef, Property, walk_children};
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
@@ -15,7 +23,7 @@ use crate::modules::ModuleRegistry;
 
 use super::bindings::Bindings;
 use super::module_props::schema_declares_key;
-use super::{DiagKind, Diagnostic, expr_types, suggestions};
+use super::{DiagKind, Diagnostic, expr_types};
 
 /// When descending into a `Property::Block`, look up the inner schema
 /// for that block's key in the parent schema (if any). Returns the
@@ -150,11 +158,10 @@ fn analyze_property(
                 );
             }
             collect_workspace_refs(expr, &mut |path| {
-                check_workspace_reference(
+                check_pipeline_only_reference(
                     path,
                     output_name,
                     pipeline_name,
-                    bindings,
                     *value_span,
                     diagnostics,
                 );
@@ -183,35 +190,44 @@ fn analyze_property(
     }
 }
 
-fn check_workspace_reference(
+/// Reserved idents that the pipeline body produces or mutates. They
+/// stay invisible to output config so transport metadata can't
+/// indirectly depend on pipeline-body output.
+///
+/// `ingress`, `source`, `received_at` are intentionally absent: those
+/// are input-layer immutables that output templates may legitimately
+/// read.
+const PIPELINE_ONLY_IDENTS: &[&str] = &["workspace", "egress", "error"];
+
+fn check_pipeline_only_reference(
     path: &[String],
     output_name: &str,
     pipeline_name: &str,
-    bindings: &Bindings,
     span: Option<Span>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    // Only `workspace.*` references with at least one segment under
-    // workspace are interesting — reserved idents (ingress / source /
-    // timestamp / error / egress) are always present.
-    if path.first().map(String::as_str) != Some("workspace") || path.len() < 2 {
+    // Reject both `<reserved>.<subpath>` and the bare `<reserved>`
+    // reference (= `${workspace}` or function args like
+    // `${to_json(workspace)}`); the rule is "this ident is not visible
+    // here", not "specific subpaths are checked".
+    let Some(head) = path.first() else { return };
+    if !PIPELINE_ONLY_IDENTS.contains(&head.as_str()) {
         return;
     }
-    if !bindings.workspace_visible(path) {
-        let joined = path.join(".");
-        let mut diag = Diagnostic::error_kind(
-            DiagKind::UnknownIdent,
-            format!(
-                "[pipeline {}] output `{}` references `{}` which is not produced by any upstream module",
-                pipeline_name, output_name, joined,
-            ),
-        )
-        .with_span(span);
-        if let Some(near) = suggestions::near_workspace_path(&joined, bindings) {
-            diag = diag.with_help(format!("did you mean `{}`?", near));
-        }
-        diagnostics.push(diag);
-    }
+    let joined = path.join(".");
+    let diag = Diagnostic::error_kind(
+        DiagKind::UnknownIdent,
+        format!(
+            "[pipeline {}] output `{}` references `{}`: pipeline-mutable state is not addressable from output config",
+            pipeline_name, output_name, joined,
+        ),
+    )
+    .with_span(span)
+    .with_help(
+        "transport metadata must use event-intrinsic fields (source, received_at, ingress) only; \
+         route per-tenant or per-event traffic via separate outputs from the pipeline body".to_string(),
+    );
+    diagnostics.push(diag);
 }
 
 fn collect_workspace_refs(expr: &Expr, cb: &mut dyn FnMut(&[String])) {

--- a/crates/limpid/src/main.rs
+++ b/crates/limpid/src/main.rs
@@ -152,14 +152,60 @@ fn refuse_root_unless_overridden() -> Result<()> {
     Ok(())
 }
 
-/// Daemon mode: start the tokio runtime and run the log pipeline.
+/// Load a config file from disk and run the full compile-validate-
+/// analyze spine, returning the [`CompiledConfig`] only when every
+/// error-level analyzer diagnostic is clean.
+///
+/// Used by both daemon startup and reload so the runtime sees exactly
+/// the same valid-config contract operators get from `--check`. Without
+/// this shared spine, the daemon would accept configs that `--check`
+/// rejects — silently re-introducing the "analyzer rule not enforced
+/// in production" gap this restructure was meant to close. Adding a
+/// new analyzer rule automatically applies to the daemon here; no
+/// per-rule duplicate validator needs to be plumbed into
+/// `Runtime::start`.
+///
+/// Every diagnostic is rendered to stderr via
+/// [`check::render::render_diagnostic`] (= the same snippet+caret
+/// shape `--check` uses) so an operator who launched the daemon in
+/// the foreground sees identical diagnostic text. Errors halt the
+/// load; warnings are rendered but do not fail. Operators who want
+/// warnings to fail must run `--check --strict-warnings` (or
+/// `--ultra-strict`) as a pre-deployment gate; the daemon stays
+/// conservative about which level halts startup.
+fn compile_and_analyze(config_file: &Path) -> Result<CompiledConfig> {
+    let (config, source_map) = config::load_config_with_source_map(config_file)
+        .context("configuration error")?;
+    let compiled = CompiledConfig::from_config(config)?;
+    let mut registry = crate::modules::ModuleRegistry::new();
+    crate::modules::register_builtins(&mut registry);
+    compiled.validate(&registry)?;
+
+    let diagnostics = check::analyze(&compiled, &source_map);
+    let mut errors = 0usize;
+    for d in &diagnostics {
+        if matches!(d.level, check::Level::Error) {
+            errors += 1;
+        }
+        check::render::render_diagnostic(d, &source_map);
+    }
+    if errors > 0 {
+        anyhow::bail!(
+            "configuration rejected by analyzer: {} error(s) — fix the configuration or run \
+             `limpid --check {}` for full diagnostics",
+            errors,
+            config_file.display(),
+        );
+    }
+    Ok(compiled)
+}
+
 fn run_daemon(config_path: &str) -> Result<()> {
     refuse_root_unless_overridden()?;
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let config_file = Path::new(config_path).to_path_buf();
-        let config = config::load_config(&config_file).context("configuration error")?;
-        let compiled = CompiledConfig::from_config(config)?;
+        let compiled = compile_and_analyze(&config_file)?;
 
         let mut runtime = runtime::Runtime::start(compiled, config_file).await?;
 
@@ -178,19 +224,20 @@ fn run_daemon(config_path: &str) -> Result<()> {
                     // start.
                     let old_config = runtime.compiled_config();
 
-                    // Load and validate the new config from disk. Errors
-                    // here are recoverable: keep the running config and log.
-                    let new_compiled =
-                        match config::load_config(&file).and_then(CompiledConfig::from_config) {
-                            Ok(c) => c,
-                            Err(e) => {
-                                tracing::error!(
-                                    "reload: invalid configuration: {} — keeping current",
-                                    e
-                                );
-                                continue;
-                            }
-                        };
+                    // Load + validate + analyze the new config from disk.
+                    // Any analyzer error (= what `--check` would reject) is
+                    // a recoverable failure: log the diagnostics and keep
+                    // the running config.
+                    let new_compiled = match compile_and_analyze(&file) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::error!(
+                                "reload: invalid configuration: {} — keeping current",
+                                e
+                            );
+                            continue;
+                        }
+                    };
 
                     // Shutdown old, start new.
                     // Note: brief downtime occurs while ports are released and re-bound.

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -8,10 +8,15 @@
 //!
 //! Dynamic path templates use the DSL's native `${expr}` interpolation,
 //! e.g. `path "/var/log/${source.ip}/${strftime(timestamp, "%Y-%m-%d")}.log"`.
-//! Any DSL expression works (identifiers, function calls, string concat).
-//! Interpolations that dereference `workspace.*` are sanitised to strip
-//! `/`, `\`, and `..` so untrusted event data can't escape into sibling
-//! directories; other interpolations render verbatim.
+//! Templates may reference event-intrinsic fields (`source.*`,
+//! `received_at`, etc.) and pure functions. Pipeline-mutable state
+//! (`workspace`, `egress`, `error`) is rejected by the analyzer in
+//! `crates/limpid/src/check/outputs.rs`; daemon startup and reload
+//! invoke the same analyzer via `compile_and_analyze` in `main.rs`,
+//! so the generic expression evaluator only ever sees pre-validated
+//! references at runtime. Path components are sanitised so
+//! interpolated values can't introduce `/`, `\`, or `..` segments
+//! that would escape into sibling directories.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -322,7 +327,7 @@ impl FileOutput {
     ///
     /// 1. Per-interpolation: every `${...}` result has `/` and `\`
     ///    replaced with `_`, regardless of the wrapping expression
-    ///    (`${workspace.x}`, `${lower(workspace.x)}`, `${a + b}` —
+    ///    (`${source.ip}`, `${lower(received_at)}`, `${a + b}` —
     ///    all treated alike). An empty interpolation result is
     ///    rejected up front. The invariant is "one interpolation =
     ///    one path component"; directory structure must be expressed
@@ -336,7 +341,7 @@ impl FileOutput {
     ///
     /// 3. Trailing-slash reject: a rendered path that ends in `/`
     ///    (no filename component) errors before the auto-mkdir runs,
-    ///    so a stray template like `/var/log/${workspace.host}/`
+    ///    so a stray template like `/var/log/${source.ip}/`
     ///    cannot create empty directories silently.
     fn render_path_in(
         &self,
@@ -356,8 +361,8 @@ impl FileOutput {
                             // Pass 1: per-interp `/` `\` → `_` and reject empty.
                             // An empty interp would silently produce paths like
                             // `/foo//bar` or `/foo/.log` that almost never reflect
-                            // operator intent — usually a null workspace value or
-                            // a Pass-2 collapse of `${"..": something}`.
+                            // operator intent — usually a null event-intrinsic
+                            // value or a Pass-2 collapse of `${"..": something}`.
                             if rendered.is_empty() {
                                 anyhow::bail!(
                                     "output file: interpolation evaluated to empty string \

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -113,9 +113,13 @@ const KAFKA_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::Enum(&["0", "1", "all"]),
     },
-    // `key` accepts the magic value `source` or any user-chosen
-    // field name (`workspace.tenant` etc.). String, not Enum, since
-    // the field-name half is open.
+    // `key` accepts only the magic value `source` (= partition by
+    // event source IP). Pipeline-mutable selectors like
+    // `workspace.tenant` are rejected — see the bail in
+    // `from_properties`. Kept as String rather than Enum so the
+    // schema-level error message can match the runtime parse error
+    // (`must be 'source'`) rather than splitting it across two
+    // diagnostic categories.
     PropertySpec {
         name: "key",
         required: false,
@@ -318,11 +322,15 @@ pub struct KafkaOutput {
     metrics: Arc<OutputMetrics>,
 }
 
-/// Which event field to use as the Kafka partition key.
+/// Which event-intrinsic field to use as the Kafka partition key.
+///
+/// Only event-intrinsic fields are accepted: the partition key cannot
+/// depend on pipeline-internal workspace state. Operators who need
+/// per-tenant partition ordering must split the traffic into separate
+/// outputs at the pipeline body level, each with its own static topic.
 #[derive(Debug, Clone)]
 enum KeyField {
     Source,
-    Field(String),
 }
 
 impl Module for KafkaOutput {
@@ -370,10 +378,19 @@ impl Module for KafkaOutput {
             None => Duration::from_secs(5),
         };
 
-        let key_field = props::get_ident(properties, "key").map(|k| match k.as_str() {
-            "source" => KeyField::Source,
-            other => KeyField::Field(other.to_string()),
-        });
+        let key_field = match props::get_ident(properties, "key") {
+            Some(k) if k == "source" => Some(KeyField::Source),
+            Some(other) => anyhow::bail!(
+                "output '{}': kafka `key` must be `source` (got `{}`). \
+                 Per-tenant or per-field partitioning by pipeline-internal \
+                 workspace state is no longer supported; split the traffic \
+                 into separate kafka outputs from the pipeline body and \
+                 give each a static topic.",
+                name,
+                other,
+            ),
+            None => None,
+        };
 
         let tls = parse_tls_block(name, properties)?;
         // Pre-check before reading the password file so a broken
@@ -509,17 +526,12 @@ impl Drop for KafkaOutput {
 
 impl KafkaOutput {
     /// Compute the optional Kafka message key from `event`. Returns
-    /// `None` when no `key_field` is configured or when the referenced
-    /// workspace entry is missing / non-string. Reads owned-event
-    /// state directly after this change (no `BorrowedEvent` indirection).
+    /// `None` when no `key_field` is configured. Reads only
+    /// event-intrinsic fields (never pipeline-internal workspace).
     fn resolve_key(&self, event: &Event) -> Option<String> {
         let kf = self.key_field.as_ref()?;
         let value = match kf {
             KeyField::Source => event.source.ip().to_string(),
-            KeyField::Field(name) => event.workspace.get(name).and_then(|v| match v {
-                crate::dsl::value::OwnedValue::String(s) => Some(s.clone()),
-                _ => None,
-            })?,
         };
         Some(value)
     }
@@ -554,6 +566,40 @@ mod tests {
 
     fn ident_prop(key: &str, val: &str) -> Property {
         kv(key, ExprKind::Ident(vec![val.into()]))
+    }
+
+    fn mp(props: &[Property]) -> crate::modules::ModuleProperties {
+        crate::modules::ModuleProperties::from_parts("kafka", props.to_vec())
+    }
+
+    // ---- key field migration -----------------------------------------
+
+    #[test]
+    fn from_properties_rejects_arbitrary_key_field_with_migration_hint() {
+        // Previously the kafka output accepted any ident as `key`,
+        // looking up `event.workspace.<ident>` at send time. That
+        // capability is gone; only the event-intrinsic `source`
+        // selector remains, and any other value bails with a
+        // migration message.
+        let props = vec![
+            str_prop("brokers", "localhost:9092"),
+            str_prop("topic", "t"),
+            ident_prop("key", "user_id"),
+        ];
+        let err = KafkaOutput::from_properties(
+            "k",
+            &mp(&props),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .err()
+        .expect("constructor must reject pipeline-mutable key field");
+        let msg = err.to_string();
+        assert!(msg.contains("`source`"), "msg: {}", msg);
+        assert!(
+            msg.contains("separate kafka outputs from the pipeline body"),
+            "msg: {}",
+            msg,
+        );
     }
 
     // ---- security_protocol selector ----

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -120,6 +120,7 @@ impl CompiledConfig {
         Ok(())
     }
 
+
     fn validate_pipeline_stmt(&self, pipeline_name: &str, stmt: &PipelineStatement) -> Result<()> {
         match stmt {
             PipelineStatement::Input(input_names) => {

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -6,7 +6,8 @@
 //! path — bare unit tests on `run_check` would skip exit codes.
 
 use std::fs;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
@@ -752,4 +753,159 @@ fn check_self_inclusion_is_rejected() {
     // a24de11 unified "self-inclusion" with general cycle detection;
     // a file including itself is a cycle of length 1.
     assert!(stderr.contains("cycle"), "stderr: {}", stderr);
+}
+
+// ---- daemon startup analyzer enforcement -----------------------------
+//
+// `--check` and daemon startup share the same compile-validate-analyze
+// spine via `compile_and_analyze` in `main.rs`. These tests pin that
+// contract: an operator who skips `--check` and launches the daemon
+// directly hits the same analyzer rejection (= no "valid for daemon,
+// rejected by --check" asymmetry).
+
+fn run_daemon_attempt(config: &std::path::Path) -> std::process::Output {
+    // Drive `limpid <conf>` without `--check`. For analyzer-rejected
+    // configs the process bails at `compile_and_analyze` (= before any
+    // I/O) in milliseconds. A 5-second polling timeout guards against
+    // a future regression where the daemon accepts a config we expect
+    // to reject and proceeds to bind listeners: without this the test
+    // would block the suite indefinitely. The poll interval is short
+    // enough that the happy (= reject) path still finishes in tens of
+    // ms.
+    let mut child = Command::new(limpid_bin())
+        .arg("--config")
+        .arg(config)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn limpid");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child
+                    .wait_with_output()
+                    .expect("failed to capture daemon output");
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "daemon did not exit within 5s for config {} — analyzer regression?",
+                        config.display(),
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(e) => panic!("try_wait error: {}", e),
+        }
+    }
+}
+
+#[test]
+fn daemon_startup_rejects_workspace_in_output_config() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("daemon_workspace.conf");
+    fs::write(
+        &conf,
+        r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type syslog_tcp peer { host "${workspace.tag}" port 1 } }
+def pipeline p {
+    input i
+    process { syslog.parse(ingress) }
+    output o
+}
+"#,
+    )
+    .unwrap();
+
+    let out = run_daemon_attempt(&conf);
+    assert!(
+        !out.status.success(),
+        "daemon must reject config that `--check` would reject; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("workspace.tag"),
+        "expected analyzer-style diagnostic on daemon path; stderr: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("rejected by analyzer"),
+        "expected `compile_and_analyze` bail message; stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn daemon_startup_rejects_egress_reference_in_output_config() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("daemon_egress.conf");
+    fs::write(
+        &conf,
+        r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type file path "/var/log/${egress}.log" }
+def pipeline p { input i; output o }
+"#,
+    )
+    .unwrap();
+
+    let out = run_daemon_attempt(&conf);
+    assert!(
+        !out.status.success(),
+        "daemon must reject pipeline-mutable refs; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("egress") && stderr.contains("pipeline-mutable state"),
+        "expected pipeline-mutable diagnostic; stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn daemon_and_check_reject_same_workspace_config() {
+    // Asymmetry sentinel: if `--check` produces an error message for
+    // an output workspace reference but daemon startup happily
+    // accepts the same file (or vice versa), this test fails — making
+    // it impossible to silently regress the structural rule (= what
+    // happens when a future analyzer rule is added but daemon path
+    // forgets to re-run analyze).
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("symmetric.conf");
+    fs::write(
+        &conf,
+        r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type file path "/var/log/${workspace.tenant}.log" }
+def pipeline p {
+    input i
+    process { parse_json(ingress) }
+    output o
+}
+"#,
+    )
+    .unwrap();
+
+    let check_out = run_check(&conf);
+    let check_stderr = String::from_utf8(check_out.stderr).unwrap();
+    assert!(!check_out.status.success(), "--check must reject");
+
+    let daemon_out = run_daemon_attempt(&conf);
+    let daemon_stderr = String::from_utf8(daemon_out.stderr).unwrap();
+    assert!(!daemon_out.status.success(), "daemon must also reject");
+
+    // Both surfaces must mention the offending reference.
+    assert!(
+        check_stderr.contains("workspace.tenant") && daemon_stderr.contains("workspace.tenant"),
+        "asymmetric rejection:\n--check stderr: {}\ndaemon stderr: {}",
+        check_stderr,
+        daemon_stderr,
+    );
 }


### PR DESCRIPTION
## Summary

Output configuration templates can no longer reference pipeline-mutable state (`workspace`, `egress`, `error`). The structural invariant after this change: transport metadata may only depend on event-intrinsic fields (`source`, `received_at`, `ingress`) and sink-internal state. Per-tenant or per-event routing decisions belong in the pipeline body — split into multiple outputs via DSL conditionals — not inside a single output config.

Daemon startup and reload now run the same analyzer `--check` runs (`check::analyze`) via a shared `compile_and_analyze` helper, so the valid-config contract is symmetric across the three load surfaces. Adding a future analyzer rule automatically applies to the daemon; no per-rule duplicate validator needs to be plumbed into `Runtime::start`.

## What changed

- **Analyzer rule (`crates/limpid/src/check/outputs.rs`)**: `check_pipeline_only_reference` walks every output property's value expression and rejects any reference whose head ident is in the pipeline-only catalog (`workspace`, `egress`, `error`). Bare `workspace` (without a subpath) is rejected too — the rule is "this ident is not visible here", not "specific subpaths are checked".
- **Daemon spine (`crates/limpid/src/main.rs`)**: new `compile_and_analyze(config_file)` helper does `load_config_with_source_map → from_config → validate → analyze`, renders every diagnostic to stderr through the same snippet+caret renderer `--check` uses, and bails on any error-level diagnostic. Both initial startup and SIGHUP reload go through this helper.
- **`output kafka`**: `key` only accepts `source` now. The `KeyField::Field(String)` variant that backed the workspace-field selector is gone. Anything other than `source` fails at construction with a migration message.
- **`output file`**: docs and inline comments updated to reflect the new contract. The runtime template renderer reuses the generic expression evaluator; the analyzer gate guarantees it never sees a workspace reference at runtime.
- **Dead code cleanup**: unused `Bindings::workspace_visible` method and its tests removed.

## Breaking change for operators

Configs that referenced `workspace.*` from an output property — `path "/var/log/{workspace.tenant}/app.log"`, `key_field workspace.user_id` on kafka, `host "${workspace.msg}"` on syslog peers, etc. — are rejected at parse time. Same for `kafka` configs using `key <any-non-source-ident>`.

Both surfaces (`--check` and daemon start) produce a hard error with a migration hint pointing at event-intrinsic fields (`source`, `received_at`) and pipeline-level routing (= split into multiple outputs). The full migration note will land with the release-prep CHANGELOG net diff; the inline error messages are sufficient for operators discovering the break at deployment time.

The runtime expression evaluator keeps its `workspace.*` resolution path because process bodies and pipeline-branch conditions still reference workspace legitimately. Only output config is gated.

## Tests

- **Analyzer** (`crates/limpid/src/check/mod.rs`): six tests covering bound-upstream, upstream-wildcard, both-branch-binding, bare `workspace`, `egress`, and the file-path-template surface. Each asserts the hard-reject + migration hint shape.
- **Daemon CLI** (`crates/limpid/tests/cli_check.rs`): three tests pinning that daemon startup rejects the same configs `--check` rejects, that the rejection includes the analyzer-style diagnostic text, and the asymmetry sentinel that both surfaces produce equivalent rejection on the same config. The sentinel is the regression catcher: a future analyzer rule that forgets to flow through the daemon path makes this test fail.
- **Kafka factory** (`crates/limpid/src/modules/output/kafka.rs`): `from_properties_rejects_arbitrary_key_field_with_migration_hint` pins the migration message shape.

## CHANGELOG

Untouched. The 0.7.8 section will be rewritten as the net 0.7.7 → 0.7.8 diff at release-prep, alongside the migration note for this break and the upcoming DLQ schema work.

## Audit

push-gate 8 scopes all PASS (`uchgs verify push` summary: `would_push_succeed: true`):

- abstraction / security / ci-precheck / boundary-contract → no findings
- confidentiality (commit-gate) → no findings post label scrub
- confidentiality (push-gate) → confirmed: pre-existing base file labels in unchanged files, tracked for release-prep cleanup
- readme-current → confirmed: docs containing workspace-dependent output config descriptions deferred to the release-prep documentation sweep
- cicd-pipeline → confirmed: standing baseline (release.yml contents:write)
- rust → confirmed: standing supply-chain baseline (RUSTSEC-2026-0185 + duplicate-crate warnings)

## Test plan

- [x] `cargo check --workspace --all-targets`: clean
- [x] `cargo test --workspace`: 693 passed / 0 failed (= +9 vs prior baseline: 6 analyzer + 3 daemon CLI + 1 kafka factory; some prior workspace-admission tests removed in favour of hard-reject equivalents)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean