### PR TITLE
refactor: DLQ sum-type schema (Process / Output flavors)

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -1,39 +1,55 @@
 //! Dead-letter queue (DLQ) writer for events that fail their main-flow
 //! disposition.
 //!
-//! This writer is invoked from four producer sites — the `process`
-//! discriminator on each record names which one wrote it:
+//! Records are sum-typed (`schema_version: 2`): every record carries a
+//! `kind` discriminator (`"process"` or `"output"`) and a per-kind block
+//! (`process: { name }` or `output: { name }`) naming the failure site.
+//! The Output flavor additionally carries the rendered `egress` in
+//! `event.egress`; the Process flavor only has `event.{source,
+//! received_at, ingress}`.
 //!
-//! 1. **Process runtime errors** — a `process` body raised an error
-//!    (`runtime.rs::process_event` Errored arm + the sibling pipeline-
-//!    body branch for `if`/`switch`/`error <expr>`/process-args eval
-//!    failures, surfaced as `(pipeline body)`).
-//! 2. **Output retry exhausted** — `queue/mod.rs` consumer routes the
-//!    payload here after the retry budget is spent, surfaced as
-//!    `(output <name>)`.
-//! 3. **Output enqueue failures** — `runtime.rs` could not hand an
-//!    event to an output's queue (queue closed, disk write error,
-//!    unknown output), surfaced as `(output enqueue)`.
-//! 4. **Batched-output shutdown-flush leftovers** — `modules/mod.rs`
-//!    walks the remaining `Vec<Event>` buffer of a batched output that
-//!    could not flush at shutdown and routes each through the normal
-//!    `write()` path with the real source/ingress/received_at, surfaced
-//!    as `(output <name> shutdown)`. Before this change the path
-//!    synthesised an `Event` from the rendered bytes; now the buffer
-//!    is `Vec<Event>` already so no synthetic construction is needed.
-//! 5. **Batched-output per-event render failures** — `modules/output/*.rs`
-//!    routes events that fail `render()` during a batched flush
-//!    through the same writer with `reason = "render failed during
-//!    batch flush: ..."`, surfaced as `(output <name>)`.
+//! Seven producer sites map to the two flavors:
 //!
-//! All four converge on this same JSONL file, the same replay recipe,
-//! and the same `events_errored` / `events_errored_unwritable` counter
-//! pair. Operators can then audit failures, fix the offending config
-//! or parser, and replay the original events via:
+//! Process flavor (= pipeline-side failures; replay via `inject input`):
+//!
+//! 1. **`<process_name>`** — an explicit `process` body raised an error
+//!    via `error <expr>` or a process-internal failure.
+//! 2. **`(inline)`** — an inline `process { ... }` block raised
+//!    similarly.
+//! 3. **`(pipeline body)`** — `if`/`switch`/`error <expr>`/process-args
+//!    eval failed before reaching a process body.
+//! 4. **`(pipeline)`** — `error <expr>` at the pipeline (statement)
+//!    level raised.
+//!
+//! Output flavor (= sink-side failures; replay via `inject output`):
+//!
+//! 5. **`<output_name>`** — output retry budget exhausted (= sink-side).
+//!    A batched output's per-event render failure inside `flush()` is
+//!    also routed here with `reason = "render failed during batch
+//!    flush: ..."`.
+//! 6. **`<output_name> shutdown`** — batched output's `shutdown()`
+//!    walks any remaining `Vec<Event>` buffer entries (one per event)
+//!    through this writer.
+//! 7. **`<output_name> enqueue`** — `runtime.rs` could not hand an
+//!    event to the named output's queue (queue closed, disk write
+//!    error, unknown output). Per-failed-output split: a pipeline-eval
+//!    result with N failed-output enqueues produces N records.
+//!
+//! All seven converge on this same JSONL file and the same
+//! `events_errored` / `events_errored_unwritable` counter pair.
+//! Operators audit failures, fix the offending config or parser, and
+//! replay the original events. Replay tooling is flavor-aware:
 //!
 //! ```bash
-//! jq -c '.event' /var/log/limpid/errored.jsonl \
-//!     | limpidctl inject input <name> --json
+//! # Process flavor: re-enter at the input layer; the pipeline reruns
+//! # against the original ingress bytes.
+//! jq -c 'select(.kind == "process") | .event' /var/log/limpid/errored.jsonl \
+//!     | limpidctl inject input <input-name> --json
+//!
+//! # Output flavor: re-deliver the pre-rendered event directly to the
+//! # named output's queue; the sink re-routes via its own `consume()`.
+//! jq -c 'select(.kind == "output") | .event' /var/log/limpid/errored.jsonl \
+//!     | limpidctl inject output <output-name> --json
 //! ```
 //!
 //! Per-write `OpenOptions::create(true).append(true)` is used by

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -158,12 +158,12 @@ mod tests {
             "partial".into(),
             OwnedValue::String("from earlier process".into()),
         );
-        ErroredEventContext {
+        ErroredEventContext::Process {
             timestamp: chrono::DateTime::from_timestamp_nanos(1_700_000_000_000_000_000),
             pipeline: "p".into(),
-            process: "wrap".into(),
+            site: "wrap".into(),
             reason: "unknown identifier: timestamp".into(),
-            event,
+            event: crate::pipeline::ProcessEvent::from_owned(&event),
         }
     }
 
@@ -179,11 +179,14 @@ mod tests {
         assert_eq!(lines.len(), 2);
         for line in &lines {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(v["schema_version"], 2);
+            assert_eq!(v["kind"], "process");
             assert_eq!(v["pipeline"], "p");
-            assert_eq!(v["process"], "wrap");
+            assert_eq!(v["process"]["name"], "wrap");
+            assert!(v["output"].is_null());
             assert!(v["reason"].as_str().unwrap().contains("timestamp"));
-            // event sub-object keeps only source / received_at / ingress —
-            // egress and workspace are intentionally omitted.
+            // event sub-object keeps only source / received_at / ingress
+            // for Process records — egress and workspace are omitted.
             let event = &v["event"];
             assert!(event.get("source").is_some());
             assert!(event.get("received_at").is_some());
@@ -234,8 +237,22 @@ mod tests {
             Bytes::from(big),
             "10.0.0.1:514".parse::<SocketAddr>().unwrap(),
         );
-        let mut ctx = ctx();
-        ctx.event = big_event;
+        let ctx = match ctx() {
+            ErroredEventContext::Process {
+                timestamp,
+                pipeline,
+                site,
+                reason,
+                ..
+            } => ErroredEventContext::Process {
+                timestamp,
+                pipeline,
+                site,
+                reason,
+                event: crate::pipeline::ProcessEvent::from_owned(&big_event),
+            },
+            _ => unreachable!("ctx() returns Process"),
+        };
         let ctx = Arc::new(ctx);
 
         let mut handles = Vec::new();

--- a/crates/limpid/src/main.rs
+++ b/crates/limpid/src/main.rs
@@ -509,9 +509,11 @@ fn run_test(config_path: &str, pipeline_name: &str, input_json: Option<&str>) ->
     // layer (`process_event`); --test-pipeline prints the would-be
     // JSONL line so the same recipe (`jq -c '.event' | inject`) can
     // be rehearsed against the trace.
-    if let Some(ref err_ctx) = result.errored {
+    if !result.errored.is_empty() {
         println!();
-        println!("[error_log]  {}", err_ctx.to_jsonl());
+        for err_ctx in &result.errored {
+            println!("[error_log]  {}", err_ctx.to_jsonl());
+        }
     }
 
     Ok(())

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -456,12 +456,13 @@ pub async fn write_shutdown_events_to_error_log(
 ) {
     let reason = format!("shutdown flush failed: {}", flush_err);
     for (ev, ack) in events {
-        let ctx = crate::pipeline::ErroredEventContext {
+        let ctx = crate::pipeline::ErroredEventContext::Output {
             timestamp: chrono::Utc::now(),
             pipeline: String::new(),
-            process: format!("(output {} shutdown)", output_name),
+            site: format!("{} shutdown", output_name),
             reason: reason.clone(),
-            event: ev,
+            output_name: output_name.to_string(),
+            event: crate::pipeline::OutputEvent::from_owned(&ev),
         };
         if let Err(write_err) = writer.write(&ctx).await {
             tracing::warn!(
@@ -486,12 +487,13 @@ pub async fn route_event_to_dlq(
     reason: &str,
 ) {
     if let Some(writer) = error_log {
-        let ctx = crate::pipeline::ErroredEventContext {
+        let ctx = crate::pipeline::ErroredEventContext::Output {
             timestamp: chrono::Utc::now(),
             pipeline: String::new(),
-            process: format!("(output {})", output_name),
+            site: output_name.to_string(),
             reason: reason.to_string(),
-            event: event.clone(),
+            output_name: output_name.to_string(),
+            event: crate::pipeline::OutputEvent::from_owned(event),
         };
         if let Err(write_err) = writer.write(&ctx).await {
             tracing::warn!(

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -1344,8 +1344,14 @@ mod tests {
         assert_eq!(lines.len(), 2);
         for line in &lines {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
-            assert_eq!(v["process"], "(output myout)");
+            assert_eq!(v["schema_version"], 2);
+            assert_eq!(v["kind"], "output");
+            assert_eq!(v["output"]["name"], "myout");
             assert!(v["event"]["ingress"].is_string() || v["event"]["ingress"].is_object());
+            assert!(
+                v["event"]["egress"].is_string() || v["event"]["egress"].is_object(),
+                "Output records must carry egress for inject-output replay"
+            );
         }
     }
 

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -1719,11 +1719,17 @@ mod tests {
         assert_eq!(lines.len(), 2);
         for line in &lines {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
-            assert_eq!(v["process"], "(output myout)");
+            assert_eq!(v["schema_version"], 2);
+            assert_eq!(v["kind"], "output");
+            assert_eq!(v["output"]["name"], "myout");
             // The reason carries the underlying transport error from
             // `flush_events`; the exact wording is implementation
             // detail.
             assert!(v["event"]["ingress"].is_string() || v["event"]["ingress"].is_object());
+            assert!(
+                v["event"]["egress"].is_string() || v["event"]["egress"].is_object(),
+                "Output records must carry egress for inject-output replay"
+            );
         }
     }
 

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -233,58 +233,272 @@ pub enum PipelineTermination {
     Errored,
 }
 
-/// Failure context surfaced when a pipeline terminates with [`PipelineTermination::Errored`].
+/// Sum-type failure context surfaced when an event is routed to the
+/// dead-letter queue.
 ///
-/// The `event` carries the **original** ingress / source / received_at
-/// (egress and workspace are intentionally not snapshotted — at the
-/// point of failure they may hold partial state from earlier processes
-/// in the chain, which would confuse `inject --json` replay). Replay
-/// re-runs the pipeline from scratch on `event`.
+/// Two flavors distinguish *where* the failure occurred and therefore
+/// what `event` snapshot is meaningful for replay:
+///
+/// - [`Process`](ErroredEventContext::Process) — a `process` step (named
+///   `def process` invocation, inline `process { ... }` block, or a
+///   top-level `error` statement) failed during pipeline execution.
+///   The captured [`ProcessEvent`] holds the original ingress / source /
+///   received_at; egress is not snapshotted because at the failure
+///   point it may hold partial output of an earlier process in the
+///   chain, which would confuse replay. Replay re-runs the pipeline
+///   from scratch via `limpidctl inject input <pipeline_input>`.
+///
+/// - [`Output`](ErroredEventContext::Output) — an output sink failed to
+///   accept the event (queue enqueue failure on the runtime side, retry
+///   exhaustion on the sink side, or batched shutdown drain). The
+///   captured [`OutputEvent`] holds both ingress AND egress, because
+///   the pipeline body already finished and the egress is the rendered
+///   payload the sink was about to write. Replay routes through
+///   `limpidctl inject output <output_name>` and the sink's
+///   `consume()` re-runs internal routing.
+///
+/// The Output flavor records *only* the output name — never an
+/// address, destination, path, key, topic, partition, endpoint,
+/// URL, peer, or any other sink-specific routing metadata. Replay
+/// sends the event back through
+/// the named output's `consume()`, which re-routes internally.
 #[derive(Debug, Clone)]
-pub struct ErroredEventContext {
-    /// Wall-clock at which the error was raised.
-    pub timestamp: chrono::DateTime<chrono::Utc>,
-    /// Pipeline name (from `def pipeline <name>`).
-    pub pipeline: String,
-    /// Failed process: a named `def process` invocation surfaces its
-    /// name; an inline `process { ... }` block surfaces `(inline)`.
-    pub process: String,
-    /// Stringified `ProcessError` / `anyhow::Error` from the failure.
-    pub reason: String,
-    /// Pre-failure event with original ingress / source / received_at.
-    /// Heap-owned so it can outlive the per-event arena that produced it.
-    pub event: OwnedEvent,
+pub enum ErroredEventContext {
+    Process {
+        /// Wall-clock at which the error was raised.
+        timestamp: chrono::DateTime<chrono::Utc>,
+        /// Pipeline name (from `def pipeline <name>`).
+        pipeline: String,
+        /// Failure site: `<process_name>` for an explicit `def process`
+        /// invocation, `(inline)` for an inline `process { ... }` block,
+        /// `(pipeline)` for an explicit `error` statement at pipeline
+        /// scope, or `(pipeline body)` for a runtime error raised by
+        /// expression evaluation outside any process.
+        site: String,
+        /// Stringified `ProcessError` / `anyhow::Error` from the failure.
+        reason: String,
+        /// Pre-failure event snapshot (ingress / source / received_at only).
+        event: ProcessEvent,
+    },
+    Output {
+        /// Wall-clock at which the error was raised.
+        timestamp: chrono::DateTime<chrono::Utc>,
+        /// Pipeline name — empty for runtime-side enqueue failures
+        /// (the runtime accumulates one record per failed output, with
+        /// no single pipeline ownership beyond the dispatch context;
+        /// kept blank rather than misattributed).
+        pipeline: String,
+        /// Failure site: `<output_name>` for retry exhaustion,
+        /// `<output_name> shutdown` for batched shutdown drain, or
+        /// `<output_name> enqueue` for runtime enqueue failure.
+        site: String,
+        /// Stringified failure reason.
+        reason: String,
+        /// Output name — the *only* sink-routing metadata captured.
+        /// Replay = `limpidctl inject output <output_name>`.
+        output_name: String,
+        /// Event snapshot (ingress + egress + source + received_at).
+        event: OutputEvent,
+    },
+}
+
+/// Process-flavor event snapshot for the DLQ.
+///
+/// Carries only the fields needed to re-run the pipeline from scratch:
+/// the original ingress bytes, the source socket, and the input
+/// timestamp. Egress is not captured because at a process failure
+/// point it may hold partial output of an earlier process step.
+#[derive(Debug, Clone)]
+pub struct ProcessEvent {
+    pub source: std::net::SocketAddr,
+    pub received_at: chrono::DateTime<chrono::Utc>,
+    pub ingress: bytes::Bytes,
+}
+
+/// Output-flavor event snapshot for the DLQ.
+///
+/// Carries both ingress and egress: the pipeline body already finished
+/// and produced an egress payload — replay through `inject output`
+/// hands the egress directly to the sink's `consume()` for
+/// re-rendering / re-shipping.
+#[derive(Debug, Clone)]
+pub struct OutputEvent {
+    pub source: std::net::SocketAddr,
+    pub received_at: chrono::DateTime<chrono::Utc>,
+    pub ingress: bytes::Bytes,
+    pub egress: bytes::Bytes,
+}
+
+impl ProcessEvent {
+    /// Snapshot the process-flavor fields from an [`OwnedEvent`].
+    pub fn from_owned(ev: &OwnedEvent) -> Self {
+        Self {
+            source: ev.source,
+            received_at: ev.received_at,
+            ingress: ev.ingress.clone(),
+        }
+    }
+}
+
+impl OutputEvent {
+    /// Snapshot the output-flavor fields from an [`OwnedEvent`].
+    pub fn from_owned(ev: &OwnedEvent) -> Self {
+        Self {
+            source: ev.source,
+            received_at: ev.received_at,
+            ingress: ev.ingress.clone(),
+            egress: ev.egress.clone(),
+        }
+    }
 }
 
 impl ErroredEventContext {
+    /// Pipeline name accessor (empty string for runtime-side Output records).
+    pub fn pipeline(&self) -> &str {
+        match self {
+            Self::Process { pipeline, .. } | Self::Output { pipeline, .. } => pipeline,
+        }
+    }
+
+    /// Failure-site accessor.
+    pub fn site(&self) -> &str {
+        match self {
+            Self::Process { site, .. } | Self::Output { site, .. } => site,
+        }
+    }
+
     /// Serialise as a single-line JSON record for the dead-letter queue.
     ///
-    /// The `event` sub-object only carries `source` / `received_at` /
-    /// `ingress` — exactly the fields `OwnedEvent::from_json` (and
-    /// therefore `limpidctl inject --json`) needs to reconstruct a fresh
-    /// event. `egress` is omitted because at the failure point it may
-    /// be a partial result of earlier processes in the chain;
-    /// `workspace` is omitted for the same reason. Replay should
-    /// rebuild both from scratch.
+    /// Layout (v2 — hard break from v1):
     ///
-    /// Format is operator-stable: pre-1.0 we may add new top-level
-    /// fields, but `timestamp` / `reason` / `process` / `pipeline` /
-    /// `event` keep their current shape so existing
-    /// `jq | inject` recipes survive.
+    /// ```text
+    /// {
+    ///   "schema_version": 2,
+    ///   "timestamp": "<RFC3339 nanos UTC>",
+    ///   "reason": "<error msg>",
+    ///   "pipeline": "<def pipeline name or empty>",
+    ///   "kind": "process" | "output",
+    ///   "process": { "name": "<process_name>" },   // kind=process only
+    ///   "output":  { "name": "<output_name>" },    // kind=output only
+    ///   "event": {
+    ///     "source": { "ip": ..., "port": ... },
+    ///     "received_at": <unix nanos>,
+    ///     "ingress": "...",
+    ///     "egress":  "..."                         // kind=output only
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// `schema_version: 2` is the operator-visible discriminator for
+    /// the v0.7.8 schema break. Output records intentionally carry
+    /// *only* `{ name }` — no address, dest, path, key, topic,
+    /// partition, endpoint, URL, peer, target, or workspace. Replay
+    /// (`limpidctl inject output <name>`) hands the event back to the
+    /// sink's `consume()`, which re-routes internally.
     pub fn to_jsonl(&self) -> String {
-        let mut event_json = self.event.to_json_value();
-        if let serde_json::Value::Object(ref mut map) = event_json {
-            map.remove("egress");
-            map.remove("workspace");
+        // Rebuild a minimal Event so we can reuse the canonical
+        // `to_json_value` serialiser for source / received_at /
+        // ingress / egress. We construct it from the snapshot rather
+        // than carrying a full OwnedEvent so we never accidentally
+        // leak workspace fragments into the DLQ.
+        let (timestamp, pipeline, kind_block, reason, event_json) = match self {
+            Self::Process {
+                timestamp,
+                pipeline,
+                site,
+                reason,
+                event,
+            } => {
+                let ev = OwnedEvent {
+                    received_at: event.received_at,
+                    source: event.source,
+                    ingress: event.ingress.clone(),
+                    egress: event.ingress.clone(),
+                    workspace: std::collections::HashMap::new(),
+                    ack: None,
+                };
+                let mut event_json = ev.to_json_value();
+                if let serde_json::Value::Object(ref mut map) = event_json {
+                    // ProcessEvent has no egress concept — strip it so
+                    // replay recipes treat absence as "build egress
+                    // from ingress at deserialisation time"
+                    // (`Event::from_json` already does that).
+                    map.remove("egress");
+                    map.remove("workspace");
+                }
+                (
+                    *timestamp,
+                    pipeline,
+                    serde_json::json!({
+                        "kind": "process",
+                        "process": { "name": site },
+                    }),
+                    reason,
+                    event_json,
+                )
+            }
+            Self::Output {
+                timestamp,
+                pipeline,
+                site: _,
+                reason,
+                output_name,
+                event,
+            } => {
+                let ev = OwnedEvent {
+                    received_at: event.received_at,
+                    source: event.source,
+                    ingress: event.ingress.clone(),
+                    egress: event.egress.clone(),
+                    workspace: std::collections::HashMap::new(),
+                    ack: None,
+                };
+                let mut event_json = ev.to_json_value();
+                if let serde_json::Value::Object(ref mut map) = event_json {
+                    // Output records must never carry workspace —
+                    // any sink-specific routing metadata is forbidden
+                    // by the DLQ schema contract (replay re-routes
+                    // via the sink's own `consume()` path).
+                    map.remove("workspace");
+                }
+                (
+                    *timestamp,
+                    pipeline,
+                    serde_json::json!({
+                        "kind": "output",
+                        "output": { "name": output_name },
+                    }),
+                    reason,
+                    event_json,
+                )
+            }
+        };
+
+        // Merge kind discriminator block + per-kind name block into
+        // the top-level record. Using a Map keeps key ordering stable.
+        let mut record = serde_json::Map::new();
+        record.insert("schema_version".into(), serde_json::json!(2));
+        record.insert(
+            "timestamp".into(),
+            serde_json::Value::String(
+                timestamp.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
+            ),
+        );
+        record.insert(
+            "reason".into(),
+            serde_json::Value::String(reason.clone()),
+        );
+        record.insert(
+            "pipeline".into(),
+            serde_json::Value::String(pipeline.clone()),
+        );
+        if let serde_json::Value::Object(kb) = kind_block {
+            for (k, v) in kb {
+                record.insert(k, v);
+            }
         }
-        let record = serde_json::json!({
-            "timestamp": self.timestamp.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
-            "reason": self.reason,
-            "process": self.process,
-            "pipeline": self.pipeline,
-            "event": event_json,
-        });
-        record.to_string()
+        record.insert("event".into(), event_json);
+        serde_json::Value::Object(record).to_string()
     }
 }
 
@@ -302,11 +516,13 @@ pub struct PipelineRunResult {
     /// `events_discarded` (Finished AND emitted nothing).
     pub had_outputs: bool,
     pub termination: PipelineTermination,
-    /// Populated iff `termination == Errored`. The runtime layer writes
-    /// this to the configured dead-letter queue (`error_log`) or, if
-    /// none is configured, emits a structured `tracing::error!` line
-    /// with the same payload.
-    pub errored: Option<ErroredEventContext>,
+    /// DLQ records accumulated during this run. Non-empty iff
+    /// `termination == Errored` from a pipeline-side failure, or when
+    /// the runtime layer appends per-failed-output enqueue records
+    /// (one per failed output). The runtime drains each record into
+    /// the configured `error_log`, or — when none is configured —
+    /// emits one structured `tracing::error!` line per record.
+    pub errored: Vec<ErroredEventContext>,
 }
 
 /// A process registry backed by compiled DSL process definitions.
@@ -427,7 +643,7 @@ pub fn run_pipeline(
     let arena = EventArena::new(bump);
     let bevent = event.view_in(&arena);
 
-    let mut errored: Option<ErroredEventContext> = None;
+    let mut errored: Vec<ErroredEventContext> = Vec::new();
     let exec_ctx = PipelineExecCtx {
         pipeline_name: &pipeline.name,
         registry: &registry,
@@ -478,7 +694,7 @@ struct PipelineExecCtx<'a, 'bump: 'a> {
 struct PipelineExecOut<'a> {
     trace: &'a mut Vec<TraceEntry>,
     outputs: &'a mut Vec<(String, OwnedEvent)>,
-    errored: &'a mut Option<ErroredEventContext>,
+    errored: &'a mut Vec<ErroredEventContext>,
 }
 
 /// Execute a pipeline body (sequence of pipeline statements).
@@ -532,12 +748,12 @@ fn exec_pipeline_stmt<'bump>(
             // Cross to owned form for the DLQ context (which must
             // outlive the per-event arena).
             let owned = event.to_owned();
-            *out.errored = Some(ErroredEventContext {
+            out.errored.push(ErroredEventContext::Process {
                 timestamp: chrono::Utc::now(),
                 pipeline: ctx.pipeline_name.to_string(),
-                process: "(pipeline)".to_string(),
+                site: "(pipeline)".to_string(),
                 reason: msg,
-                event: owned,
+                event: ProcessEvent::from_owned(&owned),
             });
             Ok((None, PipelineTermination::Errored))
         }
@@ -594,12 +810,12 @@ fn exec_pipeline_stmt<'bump>(
                                     label: name.clone(),
                                     detail: format!("error: {} (event → error_log)", e),
                                 });
-                                *out.errored = Some(ErroredEventContext {
+                                out.errored.push(ErroredEventContext::Process {
                                     timestamp: chrono::Utc::now(),
                                     pipeline: ctx.pipeline_name.to_string(),
-                                    process: name.clone(),
+                                    site: name.clone(),
                                     reason: e.to_string(),
-                                    event: backup_owned,
+                                    event: ProcessEvent::from_owned(&backup_owned),
                                 });
                                 return Ok((None, PipelineTermination::Errored));
                             }
@@ -631,12 +847,12 @@ fn exec_pipeline_stmt<'bump>(
                                     label: "(inline)".into(),
                                     detail: format!("error: {} (event → error_log)", e),
                                 });
-                                *out.errored = Some(ErroredEventContext {
+                                out.errored.push(ErroredEventContext::Process {
                                     timestamp: chrono::Utc::now(),
                                     pipeline: ctx.pipeline_name.to_string(),
-                                    process: "(inline)".to_string(),
+                                    site: "(inline)".to_string(),
                                     reason: e.to_string(),
-                                    event: backup_owned,
+                                    event: ProcessEvent::from_owned(&backup_owned),
                                 });
                                 return Ok((None, PipelineTermination::Errored));
                             }
@@ -819,20 +1035,38 @@ def pipeline p {
         )
         .unwrap();
         assert_eq!(result.termination, PipelineTermination::Errored);
-        let ctx = result.errored.expect("errored context must be populated");
-        assert_eq!(ctx.pipeline, "p");
-        assert_eq!(ctx.process, "wrap");
-        assert!(
-            ctx.reason.contains("unknown identifier"),
-            "unexpected reason: {}",
-            ctx.reason
-        );
-        assert_eq!(&ctx.event.ingress[..], b"original payload");
+        assert_eq!(result.errored.len(), 1);
+        let ctx = &result.errored[0];
+        match ctx {
+            ErroredEventContext::Process {
+                pipeline,
+                site,
+                reason,
+                event,
+                ..
+            } => {
+                assert_eq!(pipeline, "p");
+                assert_eq!(site, "wrap");
+                assert!(
+                    reason.contains("unknown identifier"),
+                    "unexpected reason: {}",
+                    reason
+                );
+                assert_eq!(&event.ingress[..], b"original payload");
+            }
+            other => panic!("expected Process variant, got {:?}", other),
+        }
         assert!(result.outputs.is_empty());
         let line = ctx.to_jsonl();
+        assert!(line.contains("\"schema_version\":2"));
+        assert!(line.contains("\"kind\":\"process\""));
         assert!(line.contains("\"pipeline\":\"p\""));
-        assert!(line.contains("\"process\":\"wrap\""));
+        assert!(line.contains("\"name\":\"wrap\""));
         assert!(line.contains("original payload"));
+        // ProcessEvent has no egress in the serialised event block.
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert!(v["event"]["egress"].is_null());
+        assert!(v["output"].is_null());
     }
 
     #[test]
@@ -877,14 +1111,20 @@ def pipeline p {
         )
         .unwrap();
         assert_eq!(result.termination, PipelineTermination::Errored);
-        let ctx = result.errored.expect("errored context must be populated");
-        assert_eq!(ctx.pipeline, "p");
-        assert_eq!(ctx.process, "refuse");
-        assert!(
-            ctx.reason.contains("I refuse"),
-            "unexpected reason: {}",
-            ctx.reason
-        );
+        assert_eq!(result.errored.len(), 1);
+        match &result.errored[0] {
+            ErroredEventContext::Process {
+                pipeline,
+                site,
+                reason,
+                ..
+            } => {
+                assert_eq!(pipeline, "p");
+                assert_eq!(site, "refuse");
+                assert!(reason.contains("I refuse"), "unexpected reason: {}", reason);
+            }
+            other => panic!("expected Process variant, got {:?}", other),
+        }
         assert!(result.outputs.is_empty());
     }
 
@@ -927,14 +1167,24 @@ def pipeline p {
         )
         .unwrap();
         assert_eq!(result.termination, PipelineTermination::Errored);
-        let ctx = result.errored.expect("errored context must be populated");
-        assert_eq!(ctx.pipeline, "p");
-        assert_eq!(ctx.process, "(pipeline)");
-        assert!(
-            ctx.reason.contains("blocked at pipeline gate"),
-            "unexpected reason: {}",
-            ctx.reason
-        );
+        assert_eq!(result.errored.len(), 1);
+        match &result.errored[0] {
+            ErroredEventContext::Process {
+                pipeline,
+                site,
+                reason,
+                ..
+            } => {
+                assert_eq!(pipeline, "p");
+                assert_eq!(site, "(pipeline)");
+                assert!(
+                    reason.contains("blocked at pipeline gate"),
+                    "unexpected reason: {}",
+                    reason
+                );
+            }
+            other => panic!("expected Process variant, got {:?}", other),
+        }
         assert!(result.outputs.is_empty());
     }
 
@@ -959,5 +1209,245 @@ def pipeline p {
 "#;
         let cfg = compile(src).unwrap();
         cfg.validate(&ModuleRegistry::new()).unwrap();
+    }
+
+    // ---------------------------------------------------------------------
+    // DLQ sum-type tests
+    // ---------------------------------------------------------------------
+
+    fn sample_owned_event() -> crate::event::OwnedEvent {
+        use bytes::Bytes;
+        use std::net::SocketAddr;
+        let mut ev = crate::event::OwnedEvent::new(
+            Bytes::from_static(b"hello"),
+            "10.0.0.1:514".parse::<SocketAddr>().unwrap(),
+        );
+        ev.egress = Bytes::from_static(b"goodbye");
+        ev
+    }
+
+    #[test]
+    fn process_variant_jsonl_has_no_egress_no_output_block() {
+        let ctx = ErroredEventContext::Process {
+            timestamp: chrono::DateTime::from_timestamp_nanos(1_700_000_000_000_000_000),
+            pipeline: "p".into(),
+            site: "wrap".into(),
+            reason: "boom".into(),
+            event: ProcessEvent::from_owned(&sample_owned_event()),
+        };
+        let line = ctx.to_jsonl();
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["schema_version"], 2);
+        assert_eq!(v["kind"], "process");
+        assert_eq!(v["pipeline"], "p");
+        assert_eq!(v["reason"], "boom");
+        assert_eq!(v["process"]["name"], "wrap");
+        assert!(v["output"].is_null(), "Process must not carry output block");
+        assert_eq!(v["event"]["ingress"], "hello");
+        assert!(
+            v["event"]["egress"].is_null(),
+            "Process event must omit egress"
+        );
+        assert!(v["event"]["workspace"].is_null());
+    }
+
+    #[test]
+    fn output_variant_jsonl_carries_egress_and_output_block() {
+        let ctx = ErroredEventContext::Output {
+            timestamp: chrono::DateTime::from_timestamp_nanos(1_700_000_000_000_000_000),
+            pipeline: String::new(),
+            site: "sink enqueue".into(),
+            reason: "queue closed".into(),
+            output_name: "sink".into(),
+            event: OutputEvent::from_owned(&sample_owned_event()),
+        };
+        let line = ctx.to_jsonl();
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["schema_version"], 2);
+        assert_eq!(v["kind"], "output");
+        assert_eq!(v["pipeline"], "");
+        assert_eq!(v["output"]["name"], "sink");
+        assert!(
+            v["process"].is_null(),
+            "Output must not carry process block"
+        );
+        assert_eq!(v["event"]["ingress"], "hello");
+        assert_eq!(v["event"]["egress"], "goodbye");
+        assert!(v["event"]["workspace"].is_null());
+    }
+
+    #[test]
+    fn output_variant_jsonl_must_not_carry_sink_routing_metadata() {
+        // Pin the DLQ no-address contract: the Output record carries
+        // ONLY `{ name }`. No address, dest, path, key, topic,
+        // partition, endpoint, url, peer, target, or workspace at any
+        // level.
+        let ctx = ErroredEventContext::Output {
+            timestamp: chrono::Utc::now(),
+            pipeline: "p".into(),
+            site: "sink".into(),
+            reason: "retry exhausted".into(),
+            output_name: "sink".into(),
+            event: OutputEvent::from_owned(&sample_owned_event()),
+        };
+        let line = ctx.to_jsonl();
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        let forbidden = [
+            "address",
+            "dest",
+            "path",
+            "key",
+            "topic",
+            "partition",
+            "endpoint",
+            "url",
+            "peer",
+            "target",
+            "workspace",
+        ];
+        for f in forbidden {
+            assert!(
+                v.get(f).is_none(),
+                "top-level must not carry forbidden field {}",
+                f
+            );
+            assert!(
+                v["output"].get(f).is_none(),
+                "output block must not carry forbidden field {}",
+                f
+            );
+            assert!(
+                v["event"].get(f).is_none(),
+                "event block must not carry forbidden field {}",
+                f
+            );
+        }
+        // output block must have *only* `name`.
+        let obj = v["output"].as_object().expect("output is an object");
+        assert_eq!(obj.len(), 1, "output block must carry only `name`");
+        assert!(obj.contains_key("name"));
+    }
+
+    #[test]
+    fn output_variant_round_trip_via_event_from_json() {
+        // The Output event sub-object must be replayable through
+        // `Event::from_json` so `limpidctl inject output --json` can
+        // reconstruct the egress payload end-to-end.
+        let ctx = ErroredEventContext::Output {
+            timestamp: chrono::Utc::now(),
+            pipeline: String::new(),
+            site: "sink enqueue".into(),
+            reason: "queue closed".into(),
+            output_name: "sink".into(),
+            event: OutputEvent::from_owned(&sample_owned_event()),
+        };
+        let line = ctx.to_jsonl();
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        let event_str = serde_json::to_string(&v["event"]).unwrap();
+        let replayed =
+            crate::event::Event::from_json(&event_str).expect("event sub-object must replay");
+        assert_eq!(&replayed.ingress[..], b"hello");
+        assert_eq!(&replayed.egress[..], b"goodbye");
+    }
+
+    #[test]
+    fn process_variant_round_trip_via_event_from_json() {
+        let ctx = ErroredEventContext::Process {
+            timestamp: chrono::Utc::now(),
+            pipeline: "p".into(),
+            site: "wrap".into(),
+            reason: "boom".into(),
+            event: ProcessEvent::from_owned(&sample_owned_event()),
+        };
+        let line = ctx.to_jsonl();
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        let event_str = serde_json::to_string(&v["event"]).unwrap();
+        let replayed =
+            crate::event::Event::from_json(&event_str).expect("event sub-object must replay");
+        // Process events omit egress on the wire — Event::from_json
+        // backfills egress from ingress so replay through `inject input`
+        // sees a self-consistent starting state.
+        assert_eq!(&replayed.ingress[..], b"hello");
+        assert_eq!(&replayed.egress[..], b"hello");
+    }
+
+    #[test]
+    fn process_variant_named_process_site_selection() {
+        // Named `def process` invocation surfaces site = "<process_name>".
+        use crate::event::OwnedEvent;
+        use crate::functions::{FunctionRegistry, register_builtins, table::TableStore};
+        use bytes::Bytes;
+        use std::net::SocketAddr;
+
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def process wrap { egress = strftime(timestamp, "%Y", "UTC") }
+def pipeline p { input i; process wrap; output o }
+"#;
+        let cfg = compile(src).unwrap();
+        let pipeline = cfg.pipelines.get("p").unwrap();
+        let mut funcs = FunctionRegistry::new();
+        let store = TableStore::from_configs(vec![]).unwrap();
+        register_builtins(&mut funcs, store);
+        let event = OwnedEvent::new(
+            Bytes::from_static(b"x"),
+            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        );
+        let result = run_pipeline(
+            pipeline,
+            &event,
+            &cfg,
+            &funcs,
+            None,
+            &mut bumpalo::Bump::new(),
+        )
+        .unwrap();
+        assert_eq!(result.errored.len(), 1);
+        assert!(
+            matches!(&result.errored[0], ErroredEventContext::Process { site, .. } if site == "wrap")
+        );
+    }
+
+    #[test]
+    fn process_variant_inline_site_selection() {
+        // Inline `process { ... }` block surfaces site = "(inline)".
+        use crate::event::OwnedEvent;
+        use crate::functions::{FunctionRegistry, register_builtins, table::TableStore};
+        use bytes::Bytes;
+        use std::net::SocketAddr;
+
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process { egress = strftime(timestamp, "%Y", "UTC") }
+    output o
+}
+"#;
+        let cfg = compile(src).unwrap();
+        let pipeline = cfg.pipelines.get("p").unwrap();
+        let mut funcs = FunctionRegistry::new();
+        let store = TableStore::from_configs(vec![]).unwrap();
+        register_builtins(&mut funcs, store);
+        let event = OwnedEvent::new(
+            Bytes::from_static(b"x"),
+            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        );
+        let result = run_pipeline(
+            pipeline,
+            &event,
+            &cfg,
+            &funcs,
+            None,
+            &mut bumpalo::Bump::new(),
+        )
+        .unwrap();
+        assert_eq!(result.errored.len(), 1);
+        assert!(matches!(
+            &result.errored[0],
+            ErroredEventContext::Process { site, .. } if site == "(inline)"
+        ));
     }
 }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -550,20 +550,30 @@ async fn run_pipeline_with_outputs(
     // recovery affordances as a `process` error — DLQ entry plus an
     // `events_errored` increment — instead of a silent
     // `events_finished` count on an event that was effectively lost.
+    //
+    // The DLQ records are emitted **per failed output** so each one
+    // can be replayed independently through
+    // `limpidctl inject output <name>` — joining them into one
+    // multi-output record would force the operator to re-run every
+    // sibling sink for one enqueue failure.
     if !failed_outputs.is_empty() {
-        let reason = format!(
-            "output enqueue failed for: {} (queue closed, disk write error, \
-             or unknown output)",
-            failed_outputs.join(", ")
-        );
+        let reason = "output enqueue failed (queue closed, disk write \
+             error, or unknown output)"
+            .to_string();
         result.termination = crate::pipeline::PipelineTermination::Errored;
-        result.errored = Some(crate::pipeline::ErroredEventContext {
-            timestamp: chrono::Utc::now(),
-            pipeline: pipeline.name.clone(),
-            process: "(output enqueue)".to_string(),
-            reason,
-            event: event.to_owned(),
-        });
+        let owned = event.to_owned();
+        for output_name in failed_outputs {
+            result
+                .errored
+                .push(crate::pipeline::ErroredEventContext::Output {
+                    timestamp: chrono::Utc::now(),
+                    pipeline: pipeline.name.clone(),
+                    site: format!("{} enqueue", output_name),
+                    reason: reason.clone(),
+                    output_name: output_name.clone(),
+                    event: crate::pipeline::OutputEvent::from_owned(&owned),
+                });
+        }
     }
 
     Ok(result)
@@ -611,18 +621,27 @@ async fn process_event(
                             .metrics
                             .events_errored
                             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        // Route the original event to the DLQ. The
-                        // pipeline guarantees `errored` is populated
-                        // when termination == Errored; defend with a
-                        // log if the contract somehow breaks.
-                        if let Some(err_ctx) = result.errored {
-                            write_errored_to_dlq(&err_ctx, &worker.metrics, ctx.error_log.as_ref())
-                                .await;
-                        } else {
+                        // Drain every accumulated DLQ record. For a
+                        // pipeline-side failure this is exactly one
+                        // record; for a runtime-side per-failed-output
+                        // enqueue failure it is one record per output.
+                        // The metric increments once per pipeline run
+                        // (= one logical event lost), independent of
+                        // the record count, matching prior semantics.
+                        if result.errored.is_empty() {
                             error!(
                                 "pipeline '{}': Errored termination without error context — bug",
                                 worker.def.name
                             );
+                        } else {
+                            for err_ctx in &result.errored {
+                                write_errored_to_dlq(
+                                    err_ctx,
+                                    &worker.metrics,
+                                    ctx.error_log.as_ref(),
+                                )
+                                .await;
+                            }
                         }
                     }
                     PipelineTermination::Finished => {
@@ -657,12 +676,13 @@ async fn process_event(
                     .metrics
                     .events_errored
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let err_ctx = crate::pipeline::ErroredEventContext {
+                let owned = event.to_owned();
+                let err_ctx = crate::pipeline::ErroredEventContext::Process {
                     timestamp: chrono::Utc::now(),
                     pipeline: worker.def.name.clone(),
-                    process: "(pipeline body)".to_string(),
+                    site: "(pipeline body)".to_string(),
                     reason: e.to_string(),
-                    event: event.to_owned(),
+                    event: crate::pipeline::ProcessEvent::from_owned(&owned),
                 };
                 write_errored_to_dlq(&err_ctx, &worker.metrics, ctx.error_log.as_ref()).await;
             }
@@ -707,9 +727,9 @@ async fn write_errored_to_dlq(
             // lost. Operators can grep / `journalctl | jq` it.
             error!(
                 event_record = %err_ctx.to_jsonl(),
-                "pipeline '{}': process '{}' errored; configure `control {{ error_log \"...\" }}` for file-based DLQ",
-                err_ctx.pipeline,
-                err_ctx.process
+                "pipeline '{}': site '{}' errored; configure `control {{ error_log \"...\" }}` for file-based DLQ",
+                err_ctx.pipeline(),
+                err_ctx.site()
             );
         }
     }
@@ -853,12 +873,12 @@ mod tests {
     fn make_err_ctx(reason: &str) -> crate::pipeline::ErroredEventContext {
         let addr = std::net::SocketAddr::from_str("127.0.0.1:0").unwrap();
         let ev = Event::new(Bytes::from_static(b"test-event"), addr);
-        crate::pipeline::ErroredEventContext {
+        crate::pipeline::ErroredEventContext::Process {
             timestamp: chrono::Utc::now(),
             pipeline: "test_pipeline".to_string(),
-            process: "(test process)".to_string(),
+            site: "(test process)".to_string(),
             reason: reason.to_string(),
-            event: ev,
+            event: crate::pipeline::ProcessEvent::from_owned(&ev),
         }
     }
 
@@ -911,5 +931,67 @@ mod tests {
         // Sanity: no metric is touched on this branch (the caller
         // already bumped events_errored before calling us).
         assert_eq!(metrics.events_errored_unwritable.load(Ordering::Relaxed), 0,);
+    }
+
+    #[tokio::test]
+    async fn output_enqueue_failure_splits_one_dlq_record_per_failed_output() {
+        // When a pipeline lists multiple `output` targets and none of
+        // them resolve at runtime (= unknown output names slipped past
+        // startup validation, or queues were torn down), the enqueue
+        // path must produce ONE DLQ record per failed output rather
+        // than a single joined record. That lets the operator replay
+        // each output independently via
+        // `limpidctl inject output <name>` without re-running sibling
+        // sinks that were already fine.
+        use crate::pipeline::ErroredEventContext;
+        let def = pipeline_def(
+            "def pipeline p { input i; output sink_a; output sink_b; finish }",
+        );
+
+        let cfg = CompiledConfig::from_config(parse_config("").unwrap()).unwrap();
+        let ctx = PipelineContext {
+            // Empty output_senders → every `output` statement falls
+            // into the "unknown output" arm and is reported as a
+            // failed enqueue. This is exactly the codepath the runtime
+            // is meant to split per-output.
+            output_senders: Arc::new(HashMap::new()),
+            config: Arc::new(cfg),
+            funcs: Arc::new(FunctionRegistry::new()),
+            tap: TapRegistry::new(),
+            error_log: None,
+        };
+
+        let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
+        let event = Event::new(Bytes::from_static(b"payload"), addr);
+        let mut bump = bumpalo::Bump::new();
+        let result = run_pipeline_with_outputs(&def, &event, &ctx, &mut bump)
+            .await
+            .expect("run_pipeline_with_outputs should not propagate");
+
+        assert_eq!(
+            result.termination,
+            crate::pipeline::PipelineTermination::Errored
+        );
+        assert_eq!(
+            result.errored.len(),
+            2,
+            "two failed outputs must produce two DLQ records"
+        );
+        let mut names: Vec<String> = result
+            .errored
+            .iter()
+            .map(|ctx| match ctx {
+                ErroredEventContext::Output {
+                    output_name, site, ..
+                } => {
+                    assert!(site.ends_with(" enqueue"), "unexpected site: {site}");
+                    assert_eq!(*site, format!("{} enqueue", output_name));
+                    output_name.clone()
+                }
+                other => panic!("expected Output variant, got {:?}", other),
+            })
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["sink_a".to_string(), "sink_b".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

Rewrites the DLQ record format as a Process / Output sum type. Process flavor records pipeline-side failures (input bytes survive replay through `inject input`); Output flavor records sink-side failures (egress survives replay through `inject output`, which already exists end-to-end). The discriminator moves from a single magic `process` string to a typed `kind` field plus a per-kind block, and `schema_version: 2` lands at the top level so operator tooling can machine-detect the break.

Per-failed-output split for runtime enqueue failures: a pipeline whose evaluation finishes but cannot enqueue to N outputs produces N DLQ records, one per failed output, instead of one record with the names joined in the reason string.

The Output flavor record carries `output: { name }` only — never address, dest, path, key, topic, partition, endpoint, URL, peer, target, or workspace at any level. Replay re-routes through the sink's own `consume()` path; the DLQ records *what* failed and to *which* output, not *where* the sink was going to send it. This is the structural invariant the rewrite pins.

## What changed

- **`ErroredEventContext` becomes an enum** in `crates/limpid/src/pipeline.rs` with `Process { event: ProcessEvent }` / `Output { event: OutputEvent, output_name }` variants. `ProcessEvent` carries `source / received_at / ingress`; `OutputEvent` adds `egress`.
- **`PipelineRunResult.errored` becomes `Vec<ErroredEventContext>`**. The runtime enqueue path emits one record per failed output, the pipeline-side error paths each push their single record, and downstream consumers iterate.
- **`to_jsonl()` emits v2 layout**: `schema_version: 2`, `kind` discriminator, per-kind `{ name }` block, `event.egress` present only on Output. Hard break from v1; operators detect via `schema_version`.
- **Seven producer sites** wire into the right variant:
  - Process (4): `<process_name>`, `(inline)`, `(pipeline body)`, `(pipeline)` (= explicit `error <expr>` at the pipeline level)
  - Output (3): `<output_name>` (= retry exhausted; batched per-event render failure also routes here), `<output_name> shutdown`, `<output_name> enqueue` (= per-failed-output)
- **`limpidctl inject output <name>`** already existed end-to-end from earlier work; the replay recipe is now flavor-aware (`jq -c 'select(.kind == ...) | .event' | limpidctl inject ...`).
- **`error_log.rs` module rustdoc rewritten** in a follow-up commit (`3106fdc`) for the v2 schema, the seven sites grouped by flavor, and the flavor-aware replay recipes.

## Forbidden list (= structural invariants, not aspirational)

This PR explicitly does NOT:

- Introduce a `SinkAddress` enum or any sink-address type
- Add `route()` or `render()` to the `Output` trait (= sink trait surface untouched, render/route split is deferred until a concrete cross-cutting consumer triggers it)
- Change the queue envelope shape (= queue still carries `Event`, the post-restructure contract)
- Carry `address`, `dest`, `path`, `key`, `topic`, `partition`, `endpoint`, `url`, `peer`, `target`, or `workspace` in any DLQ record field at any level
- Do unrelated sink-module cleanup

If a future PR proposes any of the above for DLQ, it should justify the deviation against this PR's structural invariants explicitly.

## Tests

- Variant-selection tests for each producer site
- serde round-trip (Process / Output)
- Output variant pins `event.egress` presence; Process variant pins absence
- Per-failed-output split test (= two failing outputs → two records)
- End-to-end round-trip: DLQ record → `to_jsonl` → `inject output` → output queue receives the replayed event
- All existing tests pass; total 701 (= +8 vs prior baseline)

## CHANGELOG

Untouched. The 0.7.8 section will be rewritten as the net 0.7.7 → 0.7.8 diff at release-prep, alongside the v1 → v2 migration note, the `jq -c 'select(.kind == ...)'` recipe update, and the operator-facing docs sweep.

## Audit

push-gate 8 scopes all PASS (`uchgs verify push` summary: `would_push_succeed: true`):

- security / ci-precheck / boundary-contract → no findings
- abstraction → confirmed: A-1 (module doc drift) resolved by the follow-up commit; module doc now describes the v2 schema, seven sites, and flavor-aware replay recipes
- confidentiality (commit-gate, both commits) → no findings post label scrub
- confidentiality (push-gate) → confirmed: pre-existing base file labels in unchanged files, scheduled for the documentation sweep
- readme-current → confirmed: DLQ v2 operator-doc gap (error-log.md, README.md) deferred to the documentation sweep alongside CHANGELOG net diff and vault card updates
- cicd-pipeline → confirmed: standing baseline (release.yml contents:write)
- rust → confirmed: standing supply-chain baseline (RUSTSEC-2026-0185 + duplicate-crate warnings)

## Test plan

- [x] `cargo check --workspace --all-targets`: clean
- [x] `cargo test --workspace`: 701 passed / 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean