### PR TITLE
fix(queue): commit disk cursor at per-event ack position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@ Two High pipeline-side error-path gaps closed together. (1) `run_pipeline_with_o
 High-severity audit finding. The disk queue saved its read cursor inside `recv()` immediately after each event was returned, so from the queue's POV the event was consumed before the queue consumer even handed it off downstream. A crash between `recv` and the output write lost the event: on restart the persisted cursor sat past the un-shipped record and it was never replayed — defeating the "retry / restart re-delivers" contract the disk queue exists for. The queue now follows the standard durable-queue contract (Kafka/RabbitMQ shape): `recv()` only advances an in-memory cursor, and a new `ack()` hook persists progress + reclaims consumed segments. The queue consumer calls `ack()` after every event's disposition is decided — delivered, routed to secondary, or retries exhausted — so the on-disk cursor only moves once the event has reached a terminal state. Memory-queue's `ack()` is a no-op. This shifts the disk queue from at-most-once to at-least-once; downstream sinks that can't tolerate duplicates need idempotent ingestion.
 
 
+### Fixed — `queue`: disk cursor uses per-event ack position (regression fix)
+
+The `DiskQueueReceiver::ack()` method introduced in this cycle saved the
+receiver's current `read_seq` / `read_offset` instead of the position of the
+event whose handle was being acked. With batched outputs holding multiple
+`(Event, QueueAckHandle)` pairs in flight, a single event ack advanced the
+cursor past **all** buffered events; a crash before the remaining events
+flushed silently lost them — defeating the at-least-once guarantee the same
+cycle's "disk cursor commits on consumer ack" entry advertised.
+`QueueAckHandle` now carries its position, the receiver tracks an in-flight
+position queue, and the persisted cursor only advances through the contiguous
+acked prefix from the front. Memory queue is unaffected (no persistent cursor).
+
+
 ### Fixed — `queue`: retry-exhausted and unrecoverable payloads now flow to `error_log`
 
 Output retry exhausted with no usable secondary path previously dropped the payload silently — the consumer ack'd, the event left the disk queue's replay window, and only a `tracing::warn!` plus an `events_failed` increment remained. Same shape when a secondary was configured but its enqueue also failed: the original event was already consumed and the failure was log-only. Retry exhaustion (and failed-secondary fall-through) now write the payload as a JSONL record to the configured `control { error_log "..." }` — the same DLQ that pipeline / process eval errors flow into. Output-failed records ride the same writer with `pipeline=""` and `process="(output <name>)"` as the discriminator, so operators reading the DLQ stream see them alongside pipeline failures. When no `error_log` is configured the previous warn-only fallback is preserved (no regression).

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -986,9 +986,11 @@ mod tests {
         let (ack, mut rx) = QueueAckHandle::for_test();
         let _ = output.consume(ev, ack).await;
         match rx.try_recv() {
-            Ok(crate::queue::AckDisposition::Delivered) => Ok(()),
-            Ok(crate::queue::AckDisposition::Recovered) => Err(anyhow::anyhow!("recovered to DLQ")),
-            Ok(crate::queue::AckDisposition::Dropped) => Err(anyhow::anyhow!("dropped")),
+            Ok((_, crate::queue::AckDisposition::Delivered)) => Ok(()),
+            Ok((_, crate::queue::AckDisposition::Recovered)) => {
+                Err(anyhow::anyhow!("recovered to DLQ"))
+            }
+            Ok((_, crate::queue::AckDisposition::Dropped)) => Err(anyhow::anyhow!("dropped")),
             // No disposition yet — event is parked in the buffer.
             // Treated as Ok for test purposes; tests that need to
             // observe the eventual flush dispose separately.
@@ -1474,8 +1476,14 @@ mod tests {
         output.consume(&event_with("e2"), ack2).await.unwrap();
         server.abort();
 
-        assert_eq!(rx1.recv().await, Some(crate::queue::AckDisposition::Recovered));
-        assert_eq!(rx2.recv().await, Some(crate::queue::AckDisposition::Recovered));
+        assert!(matches!(
+            rx1.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        assert!(matches!(
+            rx2.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
         assert_eq!(
             output.inner.batch.lock().await.len(),
             0,
@@ -1515,8 +1523,14 @@ mod tests {
         // Fill the batch → flush fires → ack resolves Delivered.
         let (ack2, mut rx2) = QueueAckHandle::for_test();
         output.consume(&event_with("e2"), ack2).await.unwrap();
-        assert_eq!(rx.recv().await, Some(crate::queue::AckDisposition::Delivered));
-        assert_eq!(rx2.recv().await, Some(crate::queue::AckDisposition::Delivered));
+        assert!(matches!(
+            rx.recv().await,
+            Some((_, crate::queue::AckDisposition::Delivered))
+        ));
+        assert!(matches!(
+            rx2.recv().await,
+            Some((_, crate::queue::AckDisposition::Delivered))
+        ));
         for _ in 0..50 {
             if !received.lock().await.is_empty() {
                 break;

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -916,9 +916,11 @@ mod tests {
         let (ack, mut rx) = QueueAckHandle::for_test();
         let _ = output.consume(ev, ack).await;
         match rx.try_recv() {
-            Ok(crate::queue::AckDisposition::Delivered) => Ok(()),
-            Ok(crate::queue::AckDisposition::Recovered) => Err(anyhow::anyhow!("recovered to DLQ")),
-            Ok(crate::queue::AckDisposition::Dropped) => Err(anyhow::anyhow!("dropped")),
+            Ok((_, crate::queue::AckDisposition::Delivered)) => Ok(()),
+            Ok((_, crate::queue::AckDisposition::Recovered)) => {
+                Err(anyhow::anyhow!("recovered to DLQ"))
+            }
+            Ok((_, crate::queue::AckDisposition::Dropped)) => Err(anyhow::anyhow!("dropped")),
             Err(_) => Ok(()),
         }
     }
@@ -1284,8 +1286,14 @@ mod tests {
             .consume(&event_with_egress(singleton_bytes(2)), ack2)
             .await
             .unwrap();
-        assert_eq!(rx1.recv().await, Some(crate::queue::AckDisposition::Recovered));
-        assert_eq!(rx2.recv().await, Some(crate::queue::AckDisposition::Recovered));
+        assert!(matches!(
+            rx1.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        assert!(matches!(
+            rx2.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
         assert_eq!(output.inner.batch.lock().await.len(), 0);
     }
 

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -1023,9 +1023,11 @@ mod tests {
         let (ack, mut rx) = QueueAckHandle::for_test();
         let _ = output.consume(ev, ack).await;
         match rx.try_recv() {
-            Ok(crate::queue::AckDisposition::Delivered) => Ok(()),
-            Ok(crate::queue::AckDisposition::Recovered) => Err(anyhow::anyhow!("recovered to DLQ")),
-            Ok(crate::queue::AckDisposition::Dropped) => Err(anyhow::anyhow!("dropped")),
+            Ok((_, crate::queue::AckDisposition::Delivered)) => Ok(()),
+            Ok((_, crate::queue::AckDisposition::Recovered)) => {
+                Err(anyhow::anyhow!("recovered to DLQ"))
+            }
+            Ok((_, crate::queue::AckDisposition::Dropped)) => Err(anyhow::anyhow!("dropped")),
             Err(_) => Ok(()),
         }
     }
@@ -1483,8 +1485,14 @@ mod tests {
             .consume(&event_with_egress(singleton_bytes(2)), ack2)
             .await
             .unwrap();
-        assert_eq!(rx1.recv().await, Some(crate::queue::AckDisposition::Recovered));
-        assert_eq!(rx2.recv().await, Some(crate::queue::AckDisposition::Recovered));
+        assert!(matches!(
+            rx1.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        assert!(matches!(
+            rx2.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
         assert_eq!(
             output.inner.batch.lock().await.len(),
             0,

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -10,6 +10,7 @@
 //! This survives process restarts: on startup, the consumer resumes
 //! from the cursor position.
 
+use std::collections::VecDeque;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -19,9 +20,24 @@ use std::sync::{Arc, Mutex};
 use tracing::{debug, error, warn};
 
 use crate::event::Event;
+use crate::queue::AckPosition;
 
 const SEGMENT_MAX_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB per segment
 const NEWLINE: u8 = b'\n';
+
+/// One in-flight (read but not yet acked) event tracked by
+/// [`DiskQueueReceiver`]. `start_*` is the position the
+/// [`AckPosition::Disk`] handle quotes; `end_*` is the position the
+/// persisted cursor lands on once this event reaches the front of the
+/// contiguous acked prefix and is popped.
+#[derive(Debug, Clone, Copy)]
+struct InFlight {
+    start_seq: u64,
+    start_offset: u64,
+    end_seq: u64,
+    end_offset: u64,
+    acked: bool,
+}
 
 /// Shared state for disk queue.
 struct DiskQueueState {
@@ -88,6 +104,22 @@ pub struct DiskQueueReceiver {
     /// event because the cursor said it had been consumed.
     acked_seq: u64,
     acked_offset: u64,
+    /// In-flight position tracker. Each entry carries the event's
+    /// `(start_seq, start_offset)` — the position the
+    /// [`AckPosition::Disk`] handle quotes back to identify *which*
+    /// event is being acked — alongside the `(end_seq, end_offset)`
+    /// the persisted cursor must land on once that event is done
+    /// (= the position of the NEXT event after it). Cursor only
+    /// advances through the contiguous `acked=true` prefix popped
+    /// from the front, so an out-of-order ack (= batched output
+    /// resolving handles in flush order, not in receive order) holds
+    /// the cursor back until the earlier in-flight events also
+    /// resolve. Pre-fix this state did not exist; ack saved
+    /// `self.read_seq` / `self.read_offset` — the position of the
+    /// NEXT event to read — and any single ack from anywhere in the
+    /// in-flight batch silently advanced past every still-pending
+    /// event.
+    in_flight_positions: VecDeque<InFlight>,
     dir: PathBuf,
 }
 
@@ -132,6 +164,7 @@ pub fn create_disk_queue(
             // what `recover_state` returned).
             acked_seq: read_seq,
             acked_offset: read_offset,
+            in_flight_positions: VecDeque::new(),
             dir,
         },
     ))
@@ -175,7 +208,7 @@ impl DiskQueueSender {
 }
 
 impl DiskQueueReceiver {
-    pub async fn recv(&mut self) -> Option<Event> {
+    pub async fn recv(&mut self) -> Option<(Event, AckPosition)> {
         loop {
             // Register for notification BEFORE checking — prevents missed-wakeup race.
             // Clone the Arc to avoid borrowing self across the await.
@@ -183,8 +216,8 @@ impl DiskQueueReceiver {
             let notified = notify.notified();
             tokio::pin!(notified);
 
-            if let Some(event) = self.try_read_next() {
-                return Some(event);
+            if let Some(pair) = self.try_read_next() {
+                return Some(pair);
             }
             if self.closed.load(Ordering::Acquire) {
                 return self.try_read_next();
@@ -193,29 +226,72 @@ impl DiskQueueReceiver {
         }
     }
 
-    pub fn try_recv(&mut self) -> Option<Event> {
+    pub fn try_recv(&mut self) -> Option<(Event, AckPosition)> {
         self.try_read_next()
     }
 
-    /// Commit progress to disk: persist the cursor and reclaim fully-
-    /// consumed segments. Called by the queue consumer after each
-    /// event's disposition is decided (delivered or dropped — both
-    /// are "done from this queue's POV").
+    /// Commit a specific event's position to the in-flight tracker
+    /// and, if it completes the contiguous acked prefix from the
+    /// front, advance the persisted cursor through that prefix and
+    /// reclaim fully-consumed segments.
     ///
-    /// Before this hook existed the disk queue was at-most-once on
-    /// crashes: `recv()` advanced and persisted the cursor in one
-    /// shot, so a crash between the event being read and the consumer
-    /// actually writing it downstream lost the event. The contract is
-    /// now at-least-once — a crash mid-write replays the un-acked
-    /// event on restart (matches Kafka/RabbitMQ). Downstreams that
-    /// can't tolerate duplicates need idempotent ingestion; the
-    /// queue documents this.
-    pub fn ack(&mut self) {
-        if self.acked_seq == self.read_seq && self.acked_offset == self.read_offset {
-            // Idempotent ack — nothing new to commit. Cheap no-op
-            // path so callers can ack defensively after every event
-            // even if a prior ack already covered the position
-            // (e.g. drain-loop polling the empty tail).
+    /// Pre-fix the receiver had `ack(&mut self)` that just saved
+    /// `self.read_seq` / `self.read_offset` — but those fields point
+    /// at the NEXT event to read, not the event being acked. With
+    /// batched outputs holding multiple `(Event, QueueAckHandle)`
+    /// pairs in flight, a single event's ack would advance the
+    /// persisted cursor past every still-in-flight event in the
+    /// buffer; a crash before flush silently lost the rest, defeating
+    /// the at-least-once contract. Position is now captured at recv
+    /// time and threaded through the handle, so ack_to commits the
+    /// right position regardless of resolve order.
+    pub fn ack_to(&mut self, seq: u64, offset: u64) {
+        // Look up the position in the in-flight queue and mark it
+        // acked. A miss means the consumer fed us a position we never
+        // handed out (or one we have already advanced past) — both
+        // shapes are bugs; warn and refuse to advance the cursor so
+        // we cannot accidentally widen a cursor jump on bad input.
+        let mut found = false;
+        for entry in self.in_flight_positions.iter_mut() {
+            if entry.start_seq == seq && entry.start_offset == offset {
+                entry.acked = true;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            warn!(
+                "disk queue: ack_to for unknown position seq={} offset={} \
+                 (already advanced past, or never issued); cursor unchanged",
+                seq, offset,
+            );
+            return;
+        }
+
+        // Pop the contiguous acked prefix from the front; the last
+        // entry popped wins the cursor advance — and we land on its
+        // *end* position (= the next byte to read after that event),
+        // not its start position. Landing on the start would replay
+        // the acked event on next open.
+        let mut advanced = None;
+        while let Some(front) = self.in_flight_positions.front() {
+            if !front.acked {
+                break;
+            }
+            let popped = self.in_flight_positions.pop_front().unwrap();
+            advanced = Some((popped.end_seq, popped.end_offset));
+        }
+
+        let Some((new_seq, new_offset)) = advanced else {
+            // The acked position was not at the front and no
+            // contiguous prefix completed; cursor stays put until
+            // the earlier in-flight entries also ack.
+            return;
+        };
+
+        if new_seq == self.acked_seq && new_offset == self.acked_offset {
+            // Idempotent — defensive no-op (matches the pre-fix
+            // contract for drain-loop polling against the empty tail).
             return;
         }
 
@@ -223,7 +299,7 @@ impl DiskQueueReceiver {
         // below the new acked seq. We held them through recv() so
         // crash-replay could find the in-flight event; once ack
         // advances past them they're permanently consumed.
-        for stale_seq in self.acked_seq..self.read_seq {
+        for stale_seq in self.acked_seq..new_seq {
             let seg_path = segment_path(&self.dir, stale_seq);
             if let Err(e) = fs::remove_file(&seg_path) {
                 // Missing file is acceptable (segment may have been
@@ -243,12 +319,12 @@ impl DiskQueueReceiver {
             }
         }
 
-        self.acked_seq = self.read_seq;
-        self.acked_offset = self.read_offset;
+        self.acked_seq = new_seq;
+        self.acked_offset = new_offset;
         save_cursor(&self.dir, self.acked_seq, self.acked_offset);
     }
 
-    fn try_read_next(&mut self) -> Option<Event> {
+    fn try_read_next(&mut self) -> Option<(Event, AckPosition)> {
         loop {
             let seg_path = segment_path(&self.dir, self.read_seq);
             if !seg_path.exists() {
@@ -299,18 +375,43 @@ impl DiskQueueReceiver {
                     continue;
                 }
 
+                // Capture the position of THIS event (= the position
+                // BEFORE we advance past it) so the ack handle can be
+                // matched back to the contiguous-prefix tracker.
+                // Pre-fix the receiver acked using `read_seq` /
+                // `read_offset` AFTER the advance, which named the
+                // NEXT event's position, not this one's — and under
+                // batched outputs that mismatch silently advanced the
+                // cursor past in-flight events.
+                let start_seq = self.read_seq;
+                let start_offset = self.read_offset;
                 self.read_offset += bytes_read as u64;
+                let end_seq = self.read_seq;
+                let end_offset = self.read_offset;
                 // Do NOT save_cursor here. The cursor on disk only
-                // advances when the consumer calls `ack()`, after the
-                // event has been successfully handed off downstream.
-                // Returning here with the in-memory `read_offset`
-                // already moved gives the recv side an in-flight
-                // position; if the process crashes before `ack()`,
-                // restart re-reads from `acked_offset` and replays
-                // this event.
+                // advances when the consumer calls `ack_to`, after
+                // the event has been successfully handed off
+                // downstream. Returning here with the in-memory
+                // `read_offset` already moved gives the recv side an
+                // in-flight position; if the process crashes before
+                // ack, restart re-reads from `acked_offset` and
+                // replays this event.
 
                 if let Some(event) = Event::from_json(trimmed) {
-                    return Some(event);
+                    self.in_flight_positions.push_back(InFlight {
+                        start_seq,
+                        start_offset,
+                        end_seq,
+                        end_offset,
+                        acked: false,
+                    });
+                    return Some((
+                        event,
+                        AckPosition::Disk {
+                            seq: start_seq,
+                            offset: start_offset,
+                        },
+                    ));
                 }
 
                 warn!(
@@ -575,10 +676,10 @@ mod tests {
         tx.send(make_event("<134>msg1")).await.unwrap();
         tx.send(make_event("<134>msg2")).await.unwrap();
 
-        let e1 = rx.recv().await.unwrap();
+        let (e1, _p1) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>msg1");
 
-        let e2 = rx.recv().await.unwrap();
+        let (e2, _p2) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>msg2");
     }
 
@@ -603,9 +704,9 @@ mod tests {
             let (_tx, mut rx) = create_disk_queue(path, 0).unwrap();
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
-                let e1 = rx.recv().await.unwrap();
+                let (e1, _) = rx.recv().await.unwrap();
                 assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>persist1");
-                let e2 = rx.recv().await.unwrap();
+                let (e2, _) = rx.recv().await.unwrap();
                 assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>persist2");
             });
         }
@@ -765,22 +866,29 @@ mod tests {
             tx.send(make_event("<134>e2")).await.unwrap();
             // Receive e1 but don't ack — simulates a process that
             // started shipping it and crashed before completing.
-            let e1 = rx.recv().await.unwrap();
+            let (e1, _) = rx.recv().await.unwrap();
             assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>e1");
-            // rx is dropped here without `ack()`.
+            // rx is dropped here without `ack_to`.
         }
 
         {
             let (_tx, mut rx) = create_disk_queue(path, 0).unwrap();
-            let e1 = rx.recv().await.unwrap();
+            let (e1, _) = rx.recv().await.unwrap();
             assert_eq!(
                 String::from_utf8_lossy(&e1.ingress),
                 "<134>e1",
                 "unacked event must replay on reopen (at-least-once contract)",
             );
             // And e2 follows in order.
-            let e2 = rx.recv().await.unwrap();
+            let (e2, _) = rx.recv().await.unwrap();
             assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>e2");
+        }
+    }
+
+    fn unwrap_disk_position(p: AckPosition) -> (u64, u64) {
+        match p {
+            AckPosition::Disk { seq, offset } => (seq, offset),
+            AckPosition::Memory => panic!("expected Disk position, got Memory"),
         }
     }
 
@@ -796,16 +904,17 @@ mod tests {
             let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
             tx.send(make_event("<134>e1")).await.unwrap();
             tx.send(make_event("<134>e2")).await.unwrap();
-            let e1 = rx.recv().await.unwrap();
+            let (e1, p1) = rx.recv().await.unwrap();
             assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>e1");
-            rx.ack();
+            let (seq, off) = unwrap_disk_position(p1);
+            rx.ack_to(seq, off);
             // Now drop without acking e2.
         }
 
         {
             let (_tx, mut rx) = create_disk_queue(path, 0).unwrap();
             // Cursor is past e1, so the next recv starts at e2.
-            let next = rx.recv().await.unwrap();
+            let (next, _) = rx.recv().await.unwrap();
             assert_eq!(
                 String::from_utf8_lossy(&next.ingress),
                 "<134>e2",
@@ -816,18 +925,160 @@ mod tests {
 
     #[tokio::test]
     async fn ack_is_idempotent_when_nothing_new_to_commit() {
-        // ack() is a no-op when acked == read. The drain loop and
+        // ack_to is a no-op when acked == read. The drain loop and
         // any defensive consumer-side double-ack should incur no
         // disk write and no error.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_str().unwrap();
         let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
         tx.send(make_event("<134>only")).await.unwrap();
-        let _ = rx.recv().await.unwrap();
-        rx.ack();
-        // Second ack with nothing new to commit must be a clean
-        // no-op (no double-delete attempts, no panic).
-        rx.ack();
-        rx.ack();
+        let (_e, p) = rx.recv().await.unwrap();
+        let (seq, off) = unwrap_disk_position(p);
+        rx.ack_to(seq, off);
+        // Second ack with the same position is unknown (already
+        // popped from in_flight), warns, and does not advance.
+        rx.ack_to(seq, off);
+        rx.ack_to(seq, off);
+    }
+
+    // ---------- positional ack regression tests ----------
+
+    #[tokio::test]
+    async fn disk_ack_out_of_order_advances_only_contiguous_prefix() {
+        // Receive A, B, C, then ack C, then B, then A.
+        // Cursor must stay put after C-ack and B-ack (front not yet
+        // acked), then jump straight past C once A — the front — is
+        // acked. This is the regression: pre-fix any single ack
+        // would have saved `read_seq`/`read_offset`, which after
+        // three recvs already pointed past C.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
+        tx.send(make_event("<134>A")).await.unwrap();
+        tx.send(make_event("<134>B")).await.unwrap();
+        tx.send(make_event("<134>C")).await.unwrap();
+
+        let (_a, pa) = rx.recv().await.unwrap();
+        let (_b, pb) = rx.recv().await.unwrap();
+        let (_c, pc) = rx.recv().await.unwrap();
+
+        let (a_seq, a_off) = unwrap_disk_position(pa);
+        let (b_seq, b_off) = unwrap_disk_position(pb);
+        let (c_seq, c_off) = unwrap_disk_position(pc);
+
+        // Snapshot the end position of C (= the read cursor after
+        // recv returned C) so we can compare the persisted cursor
+        // after A is acked.
+        let c_end_seq = rx.read_seq;
+        let c_end_offset = rx.read_offset;
+
+        // ack C → cursor stays at boot value (front is A, not acked).
+        rx.ack_to(c_seq, c_off);
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!(
+            (seq, off),
+            (0, 0),
+            "ack C with A,B still in flight must not advance cursor",
+        );
+
+        // ack B → still no advance.
+        rx.ack_to(b_seq, b_off);
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!(
+            (seq, off),
+            (0, 0),
+            "ack B with A still in flight must not advance cursor",
+        );
+
+        // ack A → cursor jumps past C (the end of the contiguous
+        // acked prefix), so a reopen would resume past C.
+        rx.ack_to(a_seq, a_off);
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!(
+            (seq, off),
+            (c_end_seq, c_end_offset),
+            "front ack must advance through the full contiguous prefix",
+        );
+        assert!(rx.in_flight_positions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn disk_ack_in_order_advances_immediately() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
+
+        for i in 0..3 {
+            tx.send(make_event(&format!("<134>e{i}"))).await.unwrap();
+        }
+
+        for _ in 0..3 {
+            let (_e, p) = rx.recv().await.unwrap();
+            let (seq, off) = unwrap_disk_position(p);
+            // Cursor must land on the END of the just-acked event
+            // (= where the next read would resume), not its start.
+            let expected_end = (rx.read_seq, rx.read_offset);
+            rx.ack_to(seq, off);
+            let (cseq, coff) = load_cursor(dir.path());
+            assert_eq!((cseq, coff), expected_end);
+        }
+        assert!(rx.in_flight_positions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_acks_bounded_under_sustained_load() {
+        // After every event is acked, the in-flight tracker must be
+        // empty — a leak there would grow O(N) with sustained load.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
+
+        for i in 0..1000 {
+            tx.send(make_event(&format!("<134>e{i}"))).await.unwrap();
+        }
+        let mut positions = Vec::with_capacity(1000);
+        for _ in 0..1000 {
+            let (_e, p) = rx.recv().await.unwrap();
+            positions.push(unwrap_disk_position(p));
+        }
+        // Ack in receive order — the simplest fast path.
+        for (seq, off) in positions {
+            rx.ack_to(seq, off);
+        }
+        assert!(
+            rx.in_flight_positions.is_empty(),
+            "in_flight_positions leaked: {} entries left",
+            rx.in_flight_positions.len(),
+        );
+    }
+
+    #[tokio::test]
+    async fn ack_for_unknown_position_warns_not_advances() {
+        // A position the receiver never handed out (or already
+        // popped) must NOT advance the cursor — it's a no-op + warn.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let (tx, mut rx) = create_disk_queue(path, 0).unwrap();
+
+        tx.send(make_event("<134>e1")).await.unwrap();
+        let (_e, p) = rx.recv().await.unwrap();
+        let (real_seq, real_off) = unwrap_disk_position(p);
+        let expected_end = (rx.read_seq, rx.read_offset);
+
+        // Ack a position no recv ever produced.
+        rx.ack_to(real_seq + 999, 42);
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!(
+            (seq, off),
+            (0, 0),
+            "unknown-position ack must not advance the cursor",
+        );
+
+        // The real one still works — and lands on the END of the
+        // event, not its start.
+        rx.ack_to(real_seq, real_off);
+        let (seq, off) = load_cursor(dir.path());
+        assert_eq!((seq, off), expected_end);
     }
 }

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -307,6 +307,22 @@ impl QueueSender {
     }
 }
 
+/// Position of an event in its queue, captured at `recv()` time and
+/// carried through the event's lifetime on a [`QueueAckHandle`]. The
+/// consumer feeds it back to the receiver via `ack_to`, which uses it
+/// to advance the on-disk cursor only through the contiguous prefix of
+/// acked positions — so out-of-order acks from a batched output do not
+/// silently advance past still-in-flight events.
+///
+/// Memory queues have no persistent cursor, so the [`AckPosition::Memory`]
+/// variant carries no data — it exists only so the handle's type does
+/// not need to know which backend produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AckPosition {
+    Memory,
+    Disk { seq: u64, offset: u64 },
+}
+
 /// Handle for receiving events from a queue.
 pub struct QueueReceiver {
     inner: ReceiverInner,
@@ -319,35 +335,60 @@ enum ReceiverInner {
 }
 
 impl QueueReceiver {
-    pub async fn recv(&mut self) -> Option<Event> {
+    /// Receive the next event, paired with the position that must be
+    /// fed back via `ack_to` once the event reaches a terminal
+    /// disposition. The position is captured at the moment of read,
+    /// not at ack time — that distinction is what makes the disk
+    /// cursor correct under batched, out-of-order acks.
+    pub async fn recv(&mut self) -> Option<(Event, AckPosition)> {
         match &mut self.inner {
-            ReceiverInner::Memory(rx) => rx.recv().await,
+            ReceiverInner::Memory(rx) => rx.recv().await.map(|e| (e, AckPosition::Memory)),
             ReceiverInner::Disk(rx) => rx.recv().await,
         }
     }
 
-    pub fn try_recv(&mut self) -> Option<Event> {
+    pub fn try_recv(&mut self) -> Option<(Event, AckPosition)> {
         match &mut self.inner {
-            ReceiverInner::Memory(rx) => rx.try_recv().ok(),
+            ReceiverInner::Memory(rx) => rx.try_recv().ok().map(|e| (e, AckPosition::Memory)),
             ReceiverInner::Disk(rx) => rx.try_recv(),
         }
     }
 
-    /// Commit the most recent `recv()` as processed. For the disk
-    /// backend this advances the persisted cursor and reclaims
-    /// fully-consumed segments — the actual durability hook. For the
-    /// memory backend this is a no-op (mpsc removes events on
-    /// `recv()`; there is no separate persistent cursor to advance).
+    /// Commit a specific event's position as processed. For the disk
+    /// backend this records the ack against the in-flight position
+    /// queue and, when the position is the front of the queue (or
+    /// completes a contiguous acked prefix from the front), advances
+    /// the persisted cursor through that prefix and reclaims
+    /// fully-consumed segments. For the memory backend this is a
+    /// no-op (mpsc removes events on `recv()`; there is no separate
+    /// persistent cursor to advance).
     ///
-    /// The consumer is expected to call `ack()` after every event's
-    /// final disposition is decided — delivered or given up on
-    /// (= "dropped" with retries exhausted). Both dispositions mean
-    /// the event no longer needs to live in the queue. Skipping the
-    /// call is safe (= the next call's progress covers it) but
-    /// unnecessarily defers cursor commits.
-    pub fn ack(&mut self) {
-        if let ReceiverInner::Disk(rx) = &mut self.inner {
-            rx.ack();
+    /// The consumer is expected to call `ack_to(position)` after
+    /// every event's final disposition is decided — delivered, routed
+    /// to recovery, or dropped. Calling out of order is safe: the
+    /// disk receiver only persists through positions that are
+    /// contiguously acked from the front, so a late-arriving early
+    /// ack will still hold the cursor back correctly.
+    pub fn ack_to(&mut self, position: AckPosition) {
+        match (&mut self.inner, position) {
+            (ReceiverInner::Memory(_), AckPosition::Memory) => {}
+            (ReceiverInner::Disk(rx), AckPosition::Disk { seq, offset }) => {
+                rx.ack_to(seq, offset);
+            }
+            (ReceiverInner::Memory(_), AckPosition::Disk { .. }) => {
+                debug_assert!(
+                    false,
+                    "ack_to: Disk position fed to memory receiver — backend mismatch",
+                );
+                warn!("queue: ack_to received Disk position on a memory receiver (ignored)");
+            }
+            (ReceiverInner::Disk(_), AckPosition::Memory) => {
+                debug_assert!(
+                    false,
+                    "ack_to: Memory position fed to disk receiver — backend mismatch",
+                );
+                warn!("queue: ack_to received Memory position on a disk receiver (ignored)");
+            }
         }
     }
 }
@@ -495,7 +536,16 @@ pub enum AckDisposition {
 /// `debug_assert!`s the contract was met.
 #[derive(Debug)]
 pub struct QueueAckHandle {
-    tx: Option<tokio::sync::mpsc::UnboundedSender<AckDisposition>>,
+    tx: Option<tokio::sync::mpsc::UnboundedSender<(AckPosition, AckDisposition)>>,
+    /// Position the handle's event occupied in the source queue,
+    /// captured at `recv()` time. Pre-fix the disk receiver advanced
+    /// its cursor to `self.read_*` at ack time, which under batched
+    /// outputs meant "all in-flight events", not "this event" — a
+    /// single ack from anywhere in the batch could advance the cursor
+    /// past still-in-flight events and silently lose them on crash.
+    /// Carrying the position on the handle decouples cursor commit
+    /// from in-flight order.
+    position: AckPosition,
     /// True once an explicit `resolve_*` ran. Read in `Drop` to
     /// distinguish "resolved cleanly" (silence the debug_assert) from
     /// "dropped without resolve" (fire the assert + send `Dropped`).
@@ -503,18 +553,34 @@ pub struct QueueAckHandle {
 }
 
 impl QueueAckHandle {
-    pub fn new(tx: tokio::sync::mpsc::UnboundedSender<AckDisposition>) -> Self {
+    pub fn new(
+        tx: tokio::sync::mpsc::UnboundedSender<(AckPosition, AckDisposition)>,
+        position: AckPosition,
+    ) -> Self {
         Self {
             tx: Some(tx),
+            position,
             resolved: false,
         }
+    }
+
+    /// The position this handle's event occupies in the source queue.
+    /// Returned alongside the [`AckDisposition`] when the handle
+    /// resolves, so the queue consumer can drive `ack_to(position)`
+    /// on the matching receiver. Currently only used in tests; kept
+    /// public so a future output that wants to log / route on
+    /// position (e.g. structured tracing of disk-cursor pressure)
+    /// does not have to add a new accessor.
+    #[allow(dead_code)]
+    pub fn position(&self) -> AckPosition {
+        self.position
     }
 
     /// Signal that the event was durably delivered. Consumes the handle.
     pub fn resolve_delivered(mut self) {
         self.resolved = true;
         if let Some(tx) = self.tx.take() {
-            let _ = tx.send(AckDisposition::Delivered);
+            let _ = tx.send((self.position, AckDisposition::Delivered));
         }
     }
 
@@ -523,16 +589,31 @@ impl QueueAckHandle {
     pub fn resolve_recovered(mut self) {
         self.resolved = true;
         if let Some(tx) = self.tx.take() {
-            let _ = tx.send(AckDisposition::Recovered);
+            let _ = tx.send((self.position, AckDisposition::Recovered));
         }
     }
 
     /// Test-only constructor returning the handle and the receiving
     /// half of its ack channel, so tests can assert on the disposition.
     #[cfg(test)]
-    pub fn for_test() -> (Self, tokio::sync::mpsc::UnboundedReceiver<AckDisposition>) {
+    pub fn for_test() -> (
+        Self,
+        tokio::sync::mpsc::UnboundedReceiver<(AckPosition, AckDisposition)>,
+    ) {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        (Self::new(tx), rx)
+        (Self::new(tx, AckPosition::Memory), rx)
+    }
+
+    /// Test-only constructor that also sets the carried position.
+    #[cfg(test)]
+    pub fn for_test_with_position(
+        position: AckPosition,
+    ) -> (
+        Self,
+        tokio::sync::mpsc::UnboundedReceiver<(AckPosition, AckDisposition)>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (Self::new(tx, position), rx)
     }
 }
 
@@ -544,7 +625,7 @@ impl Drop for QueueAckHandle {
              — bug: outputs MUST explicitly resolve their disposition"
         );
         if let Some(tx) = self.tx.take() {
-            let _ = tx.send(AckDisposition::Dropped);
+            let _ = tx.send((self.position, AckDisposition::Dropped));
         }
     }
 }
@@ -572,7 +653,7 @@ pub async fn run_queue_consumer(
     let name = Arc::clone(&receiver.name);
     info!("output '{}': queue consumer started", name);
     let (ack_tx, mut ack_rx) =
-        tokio::sync::mpsc::unbounded_channel::<AckDisposition>();
+        tokio::sync::mpsc::unbounded_channel::<(AckPosition, AckDisposition)>();
     let mut in_flight: usize = 0;
     let mut accepting = true;
 
@@ -593,11 +674,11 @@ pub async fn run_queue_consumer(
                     // (which drains batched buffers and resolves the
                     // handles parked inside them) and only then
                     // draining the ack channel.
-                    while let Some(event) = receiver.try_recv() {
+                    while let Some((event, position)) = receiver.try_recv() {
                         if let Some(tap) = &tap {
                             tap.emit(&format!("output {}", name), &event).await;
                         }
-                        let handle = QueueAckHandle::new(ack_tx.clone());
+                        let handle = QueueAckHandle::new(ack_tx.clone(), position);
                         in_flight += 1;
                         if let Err(e) = writer.consume(&event, handle).await {
                             tracing::error!(
@@ -613,9 +694,13 @@ pub async fn run_queue_consumer(
                 }
             }
 
-            Some(disposition) = ack_rx.recv() => {
+            Some((position, disposition)) = ack_rx.recv() => {
                 handle_ack_disposition(disposition, &name, &metrics);
-                receiver.ack();
+                // Dropped disposition advances the cursor the same as Delivered:
+                // panic-mid-handle event loss is the pre-0.7.7 semantic and is
+                // out of scope for this regression fix; full panic recovery is
+                // a separate cycle.
+                receiver.ack_to(position);
                 in_flight = in_flight.saturating_sub(1);
                 // Natural queue-closure exit: the receiver returned
                 // None, we stopped accepting, and the last in-flight
@@ -631,11 +716,11 @@ pub async fn run_queue_consumer(
 
             input = receiver.recv(), if accepting => {
                 match input {
-                    Some(event) => {
+                    Some((event, position)) => {
                         if let Some(tap) = &tap {
                             tap.emit(&format!("output {}", name), &event).await;
                         }
-                        let handle = QueueAckHandle::new(ack_tx.clone());
+                        let handle = QueueAckHandle::new(ack_tx.clone(), position);
                         in_flight += 1;
                         if let Err(e) = writer.consume(&event, handle).await {
                             // Reaching here means the output returned an
@@ -678,9 +763,9 @@ pub async fn run_queue_consumer(
         warn!("output '{}': shutdown flush failed: {}", name, e);
     }
     drop(ack_tx);
-    while let Some(disposition) = ack_rx.recv().await {
+    while let Some((position, disposition)) = ack_rx.recv().await {
         handle_ack_disposition(disposition, &name, &metrics);
-        receiver.ack();
+        receiver.ack_to(position);
         in_flight = in_flight.saturating_sub(1);
     }
     if in_flight != 0 {
@@ -836,7 +921,10 @@ mod consumer_lifecycle_tests {
     async fn ack_handle_resolve_delivered_sends_delivered() {
         let (handle, mut rx) = QueueAckHandle::for_test();
         handle.resolve_delivered();
-        assert_eq!(rx.recv().await, Some(AckDisposition::Delivered));
+        assert_eq!(
+            rx.recv().await,
+            Some((AckPosition::Memory, AckDisposition::Delivered))
+        );
         assert_eq!(rx.recv().await, None);
     }
 
@@ -844,8 +932,26 @@ mod consumer_lifecycle_tests {
     async fn ack_handle_resolve_recovered_sends_recovered() {
         let (handle, mut rx) = QueueAckHandle::for_test();
         handle.resolve_recovered();
-        assert_eq!(rx.recv().await, Some(AckDisposition::Recovered));
+        assert_eq!(
+            rx.recv().await,
+            Some((AckPosition::Memory, AckDisposition::Recovered))
+        );
         assert_eq!(rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn ack_handle_carries_position_through_resolve() {
+        // Positions captured at recv time must travel back unchanged
+        // through `resolve_delivered` — this is the core of the
+        // positional-ack fix.
+        let position = AckPosition::Disk {
+            seq: 7,
+            offset: 4242,
+        };
+        let (handle, mut rx) = QueueAckHandle::for_test_with_position(position);
+        assert_eq!(handle.position(), position);
+        handle.resolve_delivered();
+        assert_eq!(rx.recv().await, Some((position, AckDisposition::Delivered)));
     }
 
     /// Dropping a handle without resolving sends `Dropped` so the
@@ -857,7 +963,10 @@ mod consumer_lifecycle_tests {
     async fn ack_handle_drop_without_resolve_sends_dropped_in_release() {
         let (handle, mut rx) = QueueAckHandle::for_test();
         drop(handle);
-        assert_eq!(rx.recv().await, Some(AckDisposition::Dropped));
+        assert_eq!(
+            rx.recv().await,
+            Some((AckPosition::Memory, AckDisposition::Dropped))
+        );
     }
 
     #[cfg(debug_assertions)]
@@ -1097,6 +1206,30 @@ mod consumer_lifecycle_tests {
         // metrics stay at 0 and the writer's is at 3.
         assert_eq!(writer.metrics.events_failed.load(Ordering::Relaxed), 3);
         assert_eq!(metrics.events_failed.load(Ordering::Relaxed), 0);
+    }
+
+    /// `ack_to(AckPosition::Memory)` on a memory-backed receiver is a
+    /// silent no-op: the mpsc channel already consumed the event on
+    /// recv, there is no persistent cursor to advance. This is the
+    /// contract every memory-queue consumer relies on; a regression
+    /// that, e.g., panicked here would break every non-disk output
+    /// the moment the consumer loop tried to commit an ack.
+    #[tokio::test]
+    async fn memory_queue_ack_to_is_noop() {
+        let (sender, mut receiver) = create_queue(
+            "mem".into(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 4,
+            },
+        )
+        .unwrap();
+        sender.send(owned_event()).await.unwrap();
+        let (_e, position) = receiver.recv().await.unwrap();
+        assert_eq!(position, AckPosition::Memory);
+        receiver.ack_to(position);
+        // A second ack on the same position is still a clean no-op.
+        receiver.ack_to(AckPosition::Memory);
     }
 }
 


### PR DESCRIPTION
## Summary

- The `DiskQueueReceiver::ack()` introduced by BCZ-1 persisted `self.read_seq` / `self.read_offset` (= the NEXT event to read). Under the batched outputs landing in the same cycle (http / otlp_http / otlp_grpc), a single in-flight ack would advance the on-disk cursor past every still-buffered event; a crash before flush silently lost them all, defeating the at-least-once contract the cycle's earlier "cursor commits on consumer ack" entry advertised.
- `AckPosition` enum is now carried on `QueueAckHandle`, captured at `recv()` time and fed back to the receiver via `ack_to(position)`. The disk receiver keeps an `in_flight_positions: VecDeque<InFlight { start, end, acked }>` in read order, pops the contiguous acked prefix from the front, and `save_cursor`s the **end position** of the last popped entry. Landing on `end` rather than `start` also prevents the acked event from replaying.
- Memory queue is a no-op (no persistent cursor). The old `receiver.ack()` API is removed outright (0 grep hits across the tree). Future `Kafka { partition, offset }` and similar variants get compile-error-driven enforcement of every `ack_to` implementation.

## Reviewers

- Owner agent: PASS.
- Sibling Claude reviewer: PASS — judged the deviation from the sketch (`VecDeque<(pos, acked)>` → `InFlight { start, end, acked }`) as a justified refinement that closes the second cursor-correctness axis (= land position) the sketch missed.
- Codex: PASS — verified `try_read_next` advance timing, `ack_to` unknown-position warn + cursor unchanged, shutdown ordering, segment GC range, and `AckPosition` extensibility. Ran `cargo test -p limpid disk_ack` and related targeted tests; all pass.

## Test plan

- [x] `cargo test -p limpid` 697 pass / 0 fail. New tests: `disk_ack_out_of_order_advances_only_contiguous_prefix`, `disk_ack_in_order_advances_immediately`, `ack_persists_cursor_so_acked_event_does_not_replay`, `pending_acks_bounded_under_sustained_load`, `ack_for_unknown_position_warns_not_advances`, `memory_queue_ack_to_is_noop`, `ack_handle_carries_position_through_resolve`.
- [x] `cargo clippy -p limpid --all-targets -- -D warnings` clean.
- [x] `receiver.ack()` / `rx.ack(` grep returns 0 hits (= old API fully removed).
- [ ] After rebase-merge, re-run the BCZ-1 ack-lifecycle test suite on release/0.7.8 to confirm no regression.