### PR TITLE
docs(comments): close cycle-wide stale-API and stale-behavior drift

### DIFF
--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -302,9 +302,9 @@ pub fn check_types(
 /// any reserved event ident, `let` binding, or `workspace.*` path.
 ///
 /// Multi-segment idents starting with `workspace` are skipped here —
-/// the dataflow check (`outputs::check_workspace_visibility`) owns the
-/// "workspace key not produced upstream" diagnostic so we don't
-/// double-flag.
+/// the output-config gate (`outputs::check_pipeline_only_reference`)
+/// owns the "pipeline-mutable state referenced from output config"
+/// diagnostic so we don't double-flag.
 ///
 /// Special-case: bare `timestamp` was the reserved Event-time ident
 /// pre-0.5; surface a targeted hint pointing at the rename rather

--- a/crates/limpid/src/check/recovery_readiness.rs
+++ b/crates/limpid/src/check/recovery_readiness.rs
@@ -13,8 +13,9 @@
 //!
 //! 1. `control { error_log "..." }` is not configured, AND
 //! 2. at least one `def output` either:
-//!    - declares a `retry { ... }` block (= invokes the
-//!      [`write_with_retry`] recovery routing path), OR
+//!    - declares a `retry { ... }` block (= enters the output's
+//!      retry-exhausted recovery path that routes the payload to
+//!      `error_log`), OR
 //!    - is a batched output type (`http`, `otlp_http`, `otlp_grpc`)
 //!      whose [`Output::shutdown`] implementation drains the buffer
 //!      to `error_log` on flush failure.
@@ -39,7 +40,7 @@ use super::{DiagKind, Diagnostic, Level};
 /// Output `type` names whose `Output::shutdown` impl drains pending
 /// batch buffers to the configured `error_log` on flush failure.
 /// Kept in lockstep with the modules that override the default
-/// no-op `shutdown` in `OutputWriter`.
+/// no-op `shutdown` on the `modules::Output` trait.
 const OUTPUT_TYPES_WITH_SHUTDOWN_DRAIN: &[&str] = &["http", "otlp_http", "otlp_grpc"];
 
 /// Returns `true` when the operator has set `control { error_log "..." }`.
@@ -59,8 +60,8 @@ fn error_log_configured(config: &CompiledConfig) -> bool {
 fn recovery_reason(output: &crate::dsl::ast::OutputDef) -> Option<&'static str> {
     let props_view = output.properties.user_properties();
 
-    // Retry block present → enters write_with_retry, which routes
-    // retry-exhausted attempts through error_log.
+    // Retry block present → enters the output's retry-exhausted
+    // recovery path, which routes the payload through error_log.
     if props::get_block(props_view, "retry").is_some() {
         return Some("retry");
     }

--- a/crates/limpid/src/config.rs
+++ b/crates/limpid/src/config.rs
@@ -2,9 +2,11 @@
 //!
 //! Includes support two source trees:
 //!
-//! 1. **Config root** — the directory of the top-level config file. All
-//!    relative `include` paths resolve here, and canonicalised results
-//!    must stay inside the root so `..` escapes are impossible.
+//! 1. **Config root** — the directory of the top-level config file.
+//!    Relative `include` paths resolve against the *including* file's
+//!    directory (so a snippet's `include "./helper"` finds a sibling
+//!    of the snippet), and every canonicalised result must stay inside
+//!    the root so `..` escapes are impossible.
 //! 2. **System snippet tree** ([`SYSTEM_SNIPPET_DIR`], default
 //!    `/usr/share/limpid/snippets`) — read-only packager-provided
 //!    library files. Absolute paths pointing under this tree are

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -2,7 +2,9 @@
 //! other management tools.
 //!
 //! Protocol: line-based over Unix stream socket.
-//! All responses except `tap` are JSON.
+//! Command-level responses are JSON, except `tap` (event-stream text)
+//! and a small set of protocol-error responses (server-too-busy,
+//! command-too-long) that fall back to a plain-text line.
 //!
 //! Commands:
 //!   health                      — {"status":"ok","uptime_seconds":N}

--- a/crates/limpid/src/dsl/eval.rs
+++ b/crates/limpid/src/dsl/eval.rs
@@ -1035,8 +1035,9 @@ mod tests {
             Value::String("42 ms")
         );
 
-        // Number + Number still numeric (no regression). numeric_op uses f64
-        // internally, so the result is Number(7.0), not Number(7).
+        // Int + Int stays numeric (no regression). numeric_op widens to
+        // f64 internally; an integer-valued finite result coerces back
+        // to Value::Int, so `as_f64()` returns the same f64 either way.
         let expr = e(ExprKind::BinOp(
             Box::new(e(ExprKind::IntLit(3))),
             BinOp::Add,

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -17,9 +17,9 @@ pub struct LimpidParser;
 /// Parse a complete configuration string into a `Config` AST.
 ///
 /// Spans in the resulting AST are tagged with `file_id = 0`. Callers
-/// that need multi-file attribution (the include loader, eventually)
-/// should use [`parse_config_with_file_id`] and feed the matching id
-/// into the [`crate::dsl::span::SourceMap`].
+/// that need multi-file attribution (e.g. the include loader in
+/// [`crate::config`]) should use [`parse_config_with_file_id`] and
+/// feed the matching id into the [`crate::dsl::span::SourceMap`].
 #[allow(dead_code)] // used extensively by tests; kept public for eventual lib surface
 pub fn parse_config(input: &str) -> Result<Config> {
     parse_config_with_file_id(input, 0)

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -7,9 +7,10 @@
 //! * `--check` (the analyzer) — to surface unknown keys, missing
 //!   required ones, type-mismatched values, and out-of-set enum values
 //!   as loud diagnostics *before* the daemon is started; and
-//! * runtime (`Module::from_properties`) — to fail fast with the same
-//!   wording when a config slips past `--check` (e.g. someone runs the
-//!   daemon directly).
+//! * runtime (the module registry's build path, before each
+//!   `Module::from_properties` factory runs) — to fail fast with the
+//!   same wording when a config slips past `--check` (e.g. someone
+//!   runs the daemon directly).
 //!
 //! Single source of truth: the validator never invents semantics the
 //! analyzer or the runtime don't share. If `framing` accepts
@@ -43,11 +44,13 @@ pub enum PropertyValueKind {
     /// idioms without forcing a config rewrite.
     Bool,
     /// String literal parseable by `props::parse_duration` (`1s`, `5m`,
-    /// `100ms`). The validator accepts any string shape and only
-    /// rejects parse failures — that keeps the rule "schema does
-    /// shape, runtime does semantics" intact.
+    /// `100ms`). Unlike the plain `String` kind, Duration accepts only
+    /// `StringLit` — `Template` and bare `Ident` are rejected, since
+    /// the parser needs a fixed literal it can hand to the duration
+    /// parser at analyzer time. Parse failures are flagged the same way.
     Duration,
     /// String literal parseable by `props::parse_size` (`1GB`, `512MB`).
+    /// Same `StringLit`-only restriction as [`Duration`].
     Size,
     /// Bare ident whose value must be one of the listed strings.
     /// `framing { octet_counting | non_transparent }`, `queue.type

--- a/crates/limpid/src/dsl/span.rs
+++ b/crates/limpid/src/dsl/span.rs
@@ -1,8 +1,9 @@
 //! Source span + multi-file source map for diagnostic rendering.
 //!
 //! A [`Span`] is a `(file_id, start, end)` byte range. The `file_id`
-//! lets the (future) include loader attribute spans across multiple
-//! physical files; in single-file usage `file_id` is always `0`.
+//! lets the include loader in [`crate::config`] attribute spans
+//! across multiple physical files; in single-file usage `file_id` is
+//! always `0`.
 //!
 //! [`SourceMap`] owns the source text for each registered file and
 //! resolves a `Span` into a [`ResolvedSpan`] (`path`, 1-based `line`,

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -74,15 +74,14 @@ use crate::dsl::value_json::{json_to_value, value_to_json};
 // for the disk-queue persist path (see below).
 //
 // Disk-queue path: when `pipeline::run_pipeline` routes an event to a disk-
-// backed output, it builds the `SinkInput::Owned` from a `BorrowedEvent::
-// to_owned()` — a freshly-constructed `OwnedEvent` with `ack: None`. So the
-// disk-queue copy does NOT extend the ack; the cursor advances when the
-// pipeline-worker channel hand-off completes, which is "memory-queue
-// enqueued / disk-queue mpsc handed-off". The remaining tail of disk
-// persistence is operator-territory: the disk-queue itself fsyncs on its own
-// cadence and surfaces its own metrics. Closing that final gap is out of
-// scope for this change — see `docs/operations/error-log.md` for the
-// recovery-readiness contract.
+// backed output, the runtime hands `QueueSender::send` a freshly-owned
+// `Event` (built via `BorrowedEvent::to_owned()` with `ack: None`). The
+// disk-queue copy does NOT extend the input-side ack; instead the queue's
+// own ack lifecycle (per `QueueAckHandle` / `ack_to`) advances the disk
+// cursor when each event's `consume` disposition resolves. The disk queue
+// flushes each segment write but does not call an explicit fsync — closing
+// that final durability gap is operator-territory (see
+// `docs/operations/error-log.md` for the recovery-readiness contract).
 
 /// Acknowledgement message sent back from the pipeline worker to the input.
 ///

--- a/crates/limpid/src/main.rs
+++ b/crates/limpid/src/main.rs
@@ -301,9 +301,10 @@ fn run_daemon(config_path: &str) -> Result<()> {
 /// - `0` — analyzer is clean (warnings allowed unless `--strict-warnings`)
 /// - `1` — at least one error-level diagnostic (including warnings
 ///   promoted by `--ultra-strict`)
-/// - `2` — `--strict-warnings` set and at least one warning was emitted
-///   (errors also exit 2 under `--strict-warnings` so CI sees a single
-///   "non-zero means investigate" signal)
+/// - `2` — `--strict-warnings` set and at least one warning was
+///   emitted (errors still exit 1; the `2` channel is reserved for
+///   the warning-only outcome so CI can tell warnings apart from
+///   hard errors)
 ///
 /// `--ultra-strict` and `--strict-warnings` are orthogonal:
 /// - `--strict-warnings` alone: exit code change only (2 on any warning)

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -2,10 +2,12 @@
 //!
 //! Wire format (LOTL — Living Off The Land):
 //! `ingress` is one journald entry serialised as a single-line UTF-8
-//! JSON object, equivalent to one line of `journalctl -o json`. The
-//! field set and values match journalctl byte-for-byte; key order
-//! within the JSON object is not guaranteed to match (JSON object
-//! ordering is a serialisation detail).
+//! JSON object, shaped to be journalctl-`-o json`-compatible for the
+//! fields libsystemd exposes. Field values match journalctl, but
+//! `__SEQNUM` / `__SEQNUM_ID` (newer journalctl) are not surfaced
+//! because the libsystemd crate doesn't expose them. Key order is
+//! insertion order from libsystemd and is not guaranteed to match
+//! journalctl's output ordering.
 //!
 //! - field names preserved as journald exposes them (`PRIORITY`,
 //!   `_PID`, `__REALTIME_TIMESTAMP`, `SYSLOG_IDENTIFIER`, `MESSAGE`, …)
@@ -253,7 +255,8 @@ fn drain_cursor_acks(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AckPosition>)
 }
 
 /// Encode one journal entry's fields into a `serde_json::Value`
-/// equivalent to `journalctl -o json` output.
+/// shaped to be journalctl-`-o json`-compatible for the fields
+/// libsystemd exposes (= see caveats below).
 ///
 /// - field name (always UTF-8 by journald spec) → JSON object key
 /// - UTF-8-clean field value → JSON string

--- a/crates/limpid/src/modules/input/tail.rs
+++ b/crates/limpid/src/modules/input/tail.rs
@@ -3,7 +3,8 @@
 //! Features:
 //! - Follows file appends (poll-based, no inotify dependency)
 //! - Detects log rotation (inode change or file truncation)
-//! - Persists read position to a state file for restart recovery
+//! - Persists the acked file offset (not the in-flight read position)
+//!   to a state file, so an unacked event is replayed on restart
 //!
 //! Properties:
 //!   path        "/var/log/auth.log"           — required

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -1,11 +1,11 @@
-//! Module system: traits, registry, and implementations for input, output,
-//! and process modules.
+//! Module system: traits, registry, and implementations for input and
+//! output modules. (Processes are DSL functions or `def process`
+//! blocks evaluated by the pipeline executor — not modules — so they
+//! live outside this layer.)
 //!
 //! `ModuleRegistry` maps type names to factory functions.
 //! Runtime resolves type names from DSL config through the registry
 //! instead of hardcoded match arms.
-//!
-//! This is the extension point for future dynamic (.so) module loading.
 
 pub mod input;
 pub mod output;
@@ -62,24 +62,24 @@ impl BuildContext {
 // (render errors bypass retry and route directly to recovery)
 // ---------------------------------------------------------------------------
 //
-// `Output::consume` returns `anyhow::Result<()>` — the consumer
-// (`write_with_retry`) used to assume every Err was a transport failure
-// and apply the retry budget. After this change each sink's `consume` runs
-// render internally (the trait no longer carries a `render` method);
-// render failures are deterministic on the event so retrying only
+// `Output::consume` returns `anyhow::Result<()>` and runs render
+// internally — the trait carries no separate `render` method.
+// Render failures are deterministic on the event, so retrying only
 // delays the DLQ landing without changing the outcome.
 //
 // `RenderError` is the in-band tag that lets sinks signal "render
 // failed permanently, skip retries" while keeping `consume`'s return
 // type a plain `Result<()>`. Sinks wrap their internal render error in
-// `RenderError::new(e)` before returning; `write_with_retry`
-// downcasts on `anyhow::Error::downcast_ref::<RenderError>()` and
-// routes straight to DLQ.
+// `RenderError::new(e)` before returning, and the consumer-side path
+// that drives retries / DLQ landing checks
+// `anyhow::Error::downcast_ref::<RenderError>()` to bypass the retry
+// budget and route straight to the error log.
 
 /// Render-error sentinel. Wraps any underlying `anyhow::Error` raised
-/// by a sink's internal render step. Detected by `write_with_retry`
-/// via `anyhow::Error::downcast_ref::<RenderError>()` so the retry
-/// budget is bypassed.
+/// by a sink's internal render step. Detected by the consumer-side
+/// retry / DLQ path via
+/// `anyhow::Error::downcast_ref::<RenderError>()` so the retry budget
+/// is bypassed and the payload is routed straight to `error_log`.
 #[derive(Debug)]
 pub struct RenderError(pub anyhow::Error);
 
@@ -92,8 +92,8 @@ impl RenderError {
 impl std::fmt::Display for RenderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Forward to the inner error so the JSONL `reason` field stays
-        // operator-friendly (`render failed: <inner>` already prefixes
-        // in `write_with_retry`).
+        // operator-friendly; the consumer-side path that catches
+        // RenderError already prefixes the `render failed:` framing.
         write!(f, "{}", self.0)
     }
 }
@@ -523,12 +523,11 @@ pub struct CreatedInput {
 
 /// Returned by output factory: the constructed sink + metrics handle.
 ///
-/// `output` is the `Arc<dyn Output>` handed to the queue consumer
-/// (which calls `Output::consume` directly — after this change there is no
-/// intermediate `OutputWriter` adapter trait). Batched outputs that
-/// need the operator-configured `error_log` receive it as a
-/// constructor argument via the factory; no post-construction setter
-/// remains on the trait.
+/// `output` is the `Arc<dyn Output>` handed to the queue consumer,
+/// which calls `Output::consume` directly — there is no intermediate
+/// adapter trait. Batched outputs that need the operator-configured
+/// `error_log` receive it as a constructor argument via the factory;
+/// no post-construction setter remains on the trait.
 pub struct CreatedOutput {
     pub output: Arc<dyn Output>,
     pub metrics: Arc<OutputMetrics>,

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -322,8 +322,10 @@ impl FileOutput {
     /// where `is_dynamic` is true when the template had any interpolated
     /// fragments (used to decide whether to `mkdir -p` the parent).
     ///
-    /// Three safety passes (each rejects rather than silently rewrites,
-    /// per Principle 1):
+    /// Three safety passes — pass 1 normalises `/` and `\` to `_`
+    /// inside each interpolation result so an injected value cannot
+    /// introduce a directory boundary; passes 2 and 3 reject (per
+    /// Principle 1) on traversal and trailing-slash shapes:
     ///
     /// 1. Per-interpolation: every `${...}` result has `/` and `\`
     ///    replaced with `_`, regardless of the wrapping expression
@@ -409,10 +411,10 @@ impl FileOutput {
     }
 }
 
-/// Pass 1: per-interpolation sanitisation. Strip `/` and `\` so an
-/// interpolation cannot expand into multiple path components or a
-/// Windows path separator. `.` is left alone — operators rely on dots
-/// for FQDN-style filenames (`web01.example.com.log`).
+/// Pass 1: per-interpolation sanitisation. Replace `/` and `\` with
+/// `_` so an interpolation cannot expand into multiple path components
+/// or a Windows path separator. `.` is left alone — operators rely on
+/// dots for FQDN-style filenames (`web01.example.com.log`).
 fn sanitize_path_component(s: &str) -> String {
     s.replace(['/', '\\'], "_")
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -47,9 +47,10 @@
 //! for `PEER_COOLDOWN` (5 s, shared with the syslog / otlp outputs)
 //! and subsequent sends rotate past it until the cooldown expires.
 //! Within a single send the rotation falls back to the cursor start
-//! when every peer is cooled (single-peer retry path) — the queue
-//! layer's per-event retry then handles re-delivery on persistent
-//! failure.
+//! when every peer is cooled (single-peer retry path) — the output's
+//! own retry loop (driven by `retry { ... }`) then handles re-delivery
+//! on persistent failure. The queue layer advances its cursor when the
+//! ack handle resolves, not when `consume` returns.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -185,7 +186,8 @@ impl Default for PeerState {
     }
 }
 
-/// Shared state between write() and the flush timer task.
+/// Shared state between `consume()` (= the queue consumer's hand-off
+/// into the buffer) and the flush timer task.
 struct Inner {
     peers: Vec<HttpPeer>,
     peer_state: Vec<PeerState>,
@@ -207,9 +209,9 @@ struct Inner {
     name: String,
     /// Per-flush retry policy. Without an internal retry, one
     /// transient ship failure would lose the whole drained batch
-    /// (the queue layer's per-event redelivery only sees the most
-    /// recent event). The retry budget for batched outputs lives
-    /// entirely here.
+    /// (the queue layer cannot re-push a buffered batch — its cursor
+    /// only advances when each event's ack handle resolves). The
+    /// retry budget for batched outputs lives entirely here.
     retry: RetryConfig,
     /// `error_log` writer injected at construction time by the
     /// runtime via `BuildContext` in `from_properties`.
@@ -617,10 +619,9 @@ impl HttpOutput {
     }
 }
 
-/// Render a single event into its HTTP body string. Mirrors the body
-/// of `HttpOutput::render` but operates on an owned `Event` so it can
-/// be called from the consumer-side flush path without setting up the
-/// borrowed-view arena.
+/// Render a single event into its HTTP body string. Called from the
+/// consumer-side flush path on an owned `Event`, so no borrowed-view
+/// arena setup is required.
 fn render_event(event: &Event) -> Result<String> {
     Ok(String::from_utf8_lossy(&event.egress).into_owned())
 }
@@ -710,8 +711,8 @@ impl Inner {
     /// next peer in round-robin order. A peer that fails the request
     /// is cooled down for `PEER_COOLDOWN` and skipped on subsequent
     /// flushes. When every peer is currently cooled the rotation falls
-    /// back to the cursor start — the queue layer's per-event retry
-    /// then handles longer-term re-delivery.
+    /// back to the cursor start — the per-flush retry loop on `Inner`
+    /// then handles longer-term re-delivery without dropping the batch.
     async fn send_batch(&self, messages: &[String]) -> Result<()> {
         let body_str = messages.join("\n");
 
@@ -1008,8 +1009,7 @@ mod tests {
     /// - `Ok(())` — Delivered, OR no disposition yet (event parked
     ///   in the in-memory batch buffer waiting for a future flush).
     /// - `Err(...)` — Recovered (= DLQ-routed; retry exhausted or
-    ///   render failure). Mirrors what tests would have seen via
-    ///   the old `write_with_retry` Err path.
+    ///   render failure).
     async fn consume(output: &HttpOutput, ev: &Event) -> Result<()> {
         let (ack, mut rx) = QueueAckHandle::for_test();
         let _ = output.consume(ev, ack).await;

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -402,7 +402,9 @@ impl Module for KafkaOutput {
 
         // message.timeout.ms: rdkafka's internal delivery timeout (includes retries to broker).
         // Separate from queue_timeout which is the wait time when the internal queue is full.
-        // If delivery fails after this timeout, limpid's queue retry mechanism handles re-delivery.
+        // If delivery fails after this timeout, the Kafka output's own `consume`
+        // path (driven by `retry { ... }`) handles re-delivery; the queue layer
+        // only advances its cursor once each ack handle resolves.
         let mut client = ClientConfig::new();
         client
             .set("bootstrap.servers", &brokers)

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -106,9 +106,9 @@ struct Inner {
     /// same `retry { max_attempts initial_wait max_wait backoff }`
     /// vocabulary as the rest of the outputs — see [`super::http`]
     /// for the batched-output rationale (without an internal retry,
-    /// one transient ship failure loses the whole drained batch
-    /// because the queue layer's per-event retry only re-pushes the
-    /// most recent Event).
+    /// one transient ship failure loses the whole drained batch —
+    /// the queue layer cannot re-push a buffered batch; its cursor
+    /// only advances when each event's ack handle resolves).
     retry_config: RetryConfig,
     /// Buffered events awaiting flush, paired with their queue ack
     /// handles. Render happens at flush time; handles resolve on
@@ -1147,9 +1147,9 @@ mod tests {
 
     #[tokio::test]
     async fn drop_aborts_pending_flush_timer() {
-        // The flush timer is armed by `consume_event` while the buffer
-        // is below `batch_size`. Drop must abort it so the spawned
-        // task doesn't leak past process exit.
+        // The flush timer is armed by `consume` while the buffer is
+        // below `batch_size`. Drop must abort it so the spawned task
+        // doesn't leak past process exit.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
@@ -1257,17 +1257,18 @@ mod tests {
         let batch_len = output.inner.batch.lock().await.len();
         assert_eq!(batch_len, 1, "event must sit in the buffer");
         let timer_armed = output.flush_handle.lock().await.is_some();
-        assert!(timer_armed, "consume_event must arm the flush timer");
+        assert!(timer_armed, "consume must arm the flush timer");
     }
 
     #[tokio::test]
     async fn shutdown_flushes_pending_batch_buffer() {
         // Regression mirror of `output http` / `otlp_http`: when
-        // batch_size > 1 the queue-side `write()` returns Ok once
-        // the event is in the buffer, so the memory queue considers
-        // it delivered. If the daemon shuts down before the batch
-        // fills, Drop alone aborts the timer and leaks the buffer.
-        // `shutdown()` aborts the timer and runs one final flush.
+        // batch_size > 1 `consume()` parks the event + ack handle in
+        // the buffer; the queue layer cannot advance its cursor until
+        // the handle resolves at flush time. If the daemon shuts down
+        // before the batch fills, Drop alone aborts the timer and
+        // leaks the buffer. `shutdown()` aborts the timer and runs
+        // one final flush (or DLQ drain).
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         listener.set_nonblocking(true).unwrap();

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -143,10 +143,10 @@ struct Inner {
     /// duplicate of the property spec.
     ///
     /// Internal retry matters for OTLP specifically because it batches
-    /// Events from multiple `write()` calls — without an internal
+    /// Events from multiple `consume()` calls — without an internal
     /// retry, a single transient ship failure would lose the whole
-    /// drained batch (the queue layer's per-event retry only re-pushes
-    /// the most recent Event).
+    /// drained batch (the queue layer cannot re-push a buffered batch;
+    /// its cursor only advances when each event's ack handle resolves).
     retry_config: RetryConfig,
     /// Buffered events awaiting flush, paired with their queue ack
     /// handles. Render happens at flush time so per-event render
@@ -618,10 +618,9 @@ impl Inner {
 }
 
 /// Render a single Event into its OTLP `ResourceLogs` proto bytes —
-/// just a refcount bump on `event.egress`. Mirrors the body of
-/// `OtlpHttpOutput::render` / `OtlpGrpcOutput::render` so the
-/// consumer-side flush path can call it directly without setting up
-/// a borrowed-view arena.
+/// just a refcount bump on `event.egress`. Called from the
+/// consumer-side flush path on an owned `Event`, so no borrowed-view
+/// arena setup is required.
 fn render_event(event: &Event) -> Result<Bytes> {
     Ok(event.egress.clone())
 }
@@ -1500,8 +1499,8 @@ mod tests {
 
     #[tokio::test]
     async fn drop_aborts_pending_flush_timer() {
-        // The flush timer is armed by `consume_event` when the buffer
-        // is below `batch_size`. Drop must abort the timer so the
+        // The flush timer is armed by `consume` when the buffer is
+        // below `batch_size`. Drop must abort the timer so the
         // process exit doesn't leak the spawned task.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
@@ -1599,12 +1598,13 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_flushes_pending_batch_buffer() {
-        // Regression mirror of `output http`: when batch_size > 1 the
-        // queue-side `write()` returns Ok once the event is in the
-        // buffer, so the memory queue considers it delivered. If the
-        // daemon shuts down before the batch fills, Drop alone aborts
-        // the timer and leaks the buffer. `shutdown()` aborts the
-        // timer and runs one final flush.
+        // Regression mirror of `output http`: when batch_size > 1
+        // `consume()` parks the event + ack handle in the buffer; the
+        // queue layer cannot advance its cursor until the handle
+        // resolves at flush time. If the daemon shuts down before the
+        // batch fills, Drop alone aborts the timer and leaks the
+        // buffer. `shutdown()` aborts the timer and runs one final
+        // flush (or DLQ drain) so every parked handle resolves.
         let (addr, received, server) = run_http_collector("http_protobuf").await;
         let endpoint = format!("http://{}/v1/logs", addr);
         let mut props = one_peer_props(&endpoint);
@@ -1620,7 +1620,7 @@ mod tests {
         )
         .unwrap();
 
-        // Drive the batched path via consume_event.
+        // Drive the batched path via consume.
         for ts in [1u64, 2u64] {
             consume(&output, &event_with_egress(singleton_bytes(ts)))
                 .await

--- a/crates/limpid/src/modules/output/persistent_conn.rs
+++ b/crates/limpid/src/modules/output/persistent_conn.rs
@@ -50,8 +50,8 @@ pub(crate) trait PersistentConn: Sync {
     async fn write_frame(&self, stream: &mut Self::Stream, payload: &Bytes) -> Result<()>;
 }
 
-/// Write `event` through a persistent stream, reconnecting once if the
-/// cached stream is stale. Bumps `events_written` on success.
+/// Write `payload` through a persistent stream, reconnecting once if
+/// the cached stream is stale. Bumps `events_written` on success.
 ///
 /// On the fast path (cached stream, write succeeds) `connect` is never
 /// invoked. A single failed write triggers one reconnect attempt; if

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -3,8 +3,10 @@
 //!
 //! The boundary between **owned** and **borrowed (arena)** event forms
 //! is drawn at [`run_pipeline`]: the function takes an [`OwnedEvent`]
-//! (which is what the input layer / channel hands over), creates a
-//! per-event [`bumpalo::Bump`], and views the event into the arena.
+//! (which is what the input layer / channel hands over) along with a
+//! caller-owned `&mut bumpalo::Bump`, and views the event into that
+//! arena. The runtime owns the bump so it can amortise allocation
+//! across many events instead of paying a fresh allocator per event.
 //! Everything inside the pipeline executor — eval, exec, function
 //! dispatch — operates on [`BorrowedEvent<'bump>`]. At each output sink
 //! and at each error path we cross back to the heap by calling
@@ -1186,10 +1188,9 @@ def pipeline p {
 
     // This restructure deleted `render_failure_falls_back_to_owned_sink_input`.
     // The pipeline-side render-Err → Owned fallback no longer exists;
-    // render now runs consumer-side inside each sink's `Output::consume`
-    // and a render failure routes straight to the DLQ via
-    // `RenderError` (see `queue::mod::write_with_retry_tests::
-    // render_err_goes_straight_to_dlq`).
+    // render now runs consumer-side inside each sink's `Output::consume`,
+    // and a render failure tagged with `RenderError` routes straight to
+    // the DLQ from the consumer loop without retrying.
 
     #[test]
     fn validate_accepts_fan_in_when_all_inputs_exist() {

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -3,12 +3,19 @@
 //! Design:
 //! - Events are serialized to JSON and appended to segment files
 //! - Each segment is a file named `seg-{sequence}.wal`
-//! - A cursor file (`cursor`) tracks the current read position
-//! - Old segments are deleted once fully consumed
-//! - Max total size is enforced; oldest unread segments are dropped if exceeded
+//! - A cursor file (`cursor`) persists the acked position — the last
+//!   byte the consumer explicitly acknowledged, not the in-flight read
+//!   position. Restart replays from this cursor for at-least-once.
+//! - Segments below the acked position are deleted once `ack_to`
+//!   advances through them; unread segments are never deleted.
+//! - Max total size is enforced by dropping the oldest consumed
+//!   segments (= those before the current read cursor); the read
+//!   cursor's own segment and any unread segments are protected even
+//!   when the cap is exceeded, so an undersized `max_size` cannot
+//!   silently drop pending events.
 //!
 //! This survives process restarts: on startup, the consumer resumes
-//! from the cursor position.
+//! from the acked cursor position.
 
 use std::collections::VecDeque;
 use std::fs;
@@ -97,8 +104,8 @@ pub struct DiskQueueReceiver {
     read_offset: u64,
     /// Persisted cursor — the last byte the consumer has explicitly
     /// acknowledged as processed. `save_cursor` is only called after
-    /// `ack()` advances this; segment files below `acked_seq` are
-    /// also deleted by `ack()`. The pre-fix code saved the read
+    /// `ack_to` advances this; segment files below `acked_seq` are
+    /// also deleted by `ack_to`. An earlier version saved the read
     /// cursor immediately on each `recv()`, which made the disk
     /// queue at-most-once: a crash mid-write lost the in-flight
     /// event because the cursor said it had been consumed.
@@ -429,7 +436,7 @@ impl DiskQueueReceiver {
             if self.read_seq < write_seq {
                 // Advance the in-memory read cursor to the next
                 // segment, but do NOT delete the current one or save
-                // the cursor yet — both are tied to `ack()`. The
+                // the cursor yet — both are tied to `ack_to`. The
                 // current segment may still hold the in-flight event
                 // (the one most recently returned by `recv()` but not
                 // yet acked); deleting it now would lose that event
@@ -850,12 +857,12 @@ mod tests {
 
     #[tokio::test]
     async fn unacked_recv_replays_on_reopen() {
-        // Regression: pre-fix the disk queue saved the cursor inside
-        // `recv()` immediately on each event, so the queue claimed
-        // events as consumed before the consumer had a chance to
-        // ship them downstream. A crash between recv and write lost
-        // the event because the on-disk cursor was already past it.
-        // The fix delays cursor persistence until `ack()`, so the
+        // Regression: an earlier disk-queue version saved the cursor
+        // inside `recv()` immediately on each event, so the queue
+        // claimed events as consumed before the consumer had a chance
+        // to ship them downstream. A crash between recv and write
+        // lost the event because the on-disk cursor was already past
+        // it. Cursor persistence is now deferred to `ack_to`, so the
         // un-acked event is replayed on the next open.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_str().unwrap();

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -150,7 +150,8 @@ pub const RETRY_PROPERTY_SPEC: PropertySpec = PropertySpec {
 #[derive(Debug, Clone)]
 pub struct QueueConfig {
     pub queue_type: QueueType,
-    /// Maximum number of events for memory queue / segment config for disk queue.
+    /// Maximum number of events for the memory queue. Ignored by the disk
+    /// queue, which is sized in bytes via `QueueType::Disk { max_size }`.
     pub capacity: usize,
 }
 

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -55,19 +55,22 @@ impl Runtime {
 
         // Optional dead-letter queue for events that fail in `process`
         // or that an output drops after exhausting retries
-        // (retry-exhausted recovery). `control { error_log "..." }` opts in to
-        // file-based recovery; when unset, the runtime falls back to a
-        // structured tracing line for the pipeline path and a plain
-        // `Dropped` disposition for the output path. The path is
-        // validated at startup (parent dir reachable) so operator typos
-        // surface before the first failure event.
+        // (retry-exhausted recovery). `control { error_log "..." }`
+        // opts in to file-based recovery; when unset, the runtime
+        // falls back to a structured `tracing::warn!` / `error!` line
+        // (pipeline path emits the full JSONL on the tracing line; the
+        // output path emits the failure summary without the full
+        // payload). The path is validated at startup (parent dir
+        // reachable) so operator typos surface before the first
+        // failure event.
         //
         // Built *before* outputs are constructed so each batched output
-        // (`http`, `otlp_http`, `otlp_grpc`) receives the handle via its
-        // constructor — no post-construction setter, no interior
+        // (`http`, `otlp_http`, `otlp_grpc`) receives the handle via
+        // its constructor — no post-construction setter, no interior
         // mutability. Non-batched outputs ignore the parameter; the
-        // queue consumer threads `error_log` in via `write_with_retry`
-        // for retry-exhausted recovery.
+        // queue consumer hands `error_log` to `run_queue_consumer`,
+        // which routes the retry-exhausted payload to the DLQ once
+        // each handle resolves.
         let error_log_path = config
             .global_blocks
             .get("control")


### PR DESCRIPTION
## Summary

A multi-reviewer comment-drift sweep across `crates/limpid/src/` closes the residual comment debt that accumulated through the 0.7.8 cycle's restructures. Independent Subagent verification narrowed Codex's 77-finding sweep to **47 confirmed fixes** in a single commit (23 files, +178 / -148).

The rewrites group into four shapes:

- **Stale-API references** — `ack()` → `ack_to`, `consume_event` → `consume`, `HttpOutput::render` / `OtlpHttpOutput::render` → `render_event` (the helper that actually exists), `OutputWriter::shutdown` → `Output::shutdown`, `outputs::check_workspace_visibility` → `outputs::check_pipeline_only_reference`, `SinkInput::Owned` → current `BorrowedEvent::to_owned()` shape.
- **Stale-behavior wording** — every batched output's "queue-layer per-event retry" framing rewritten to the current "output owns retry; queue advances when each ack handle resolves". The `RenderError` block (and its `Display` body) no longer reference the removed `write_with_retry` downcast call site. The disk-queue module rustdoc now matches the acked-position cursor contract and acknowledges the read-boundary stop in GC.
- **Operator-facing drift** — `main.rs` exit-code table (errors exit `1`, not `2`, under `--strict-warnings`); `control.rs` no longer claims every response is JSON (busy / command-too-long fall back to plain text); `config.rs` documents include resolution as relative to the *including* file, not the root.
- **Cross-cutting cleanups** — `modules/mod.rs` header drops the "input / output / process modules" framing (processes are DSL, not a module layer); `event.rs` drops the `SinkInput::Owned` reference and softens the "disk queue fsyncs" claim to "flushes each segment write" (no explicit fsync exists); the file output's path-safety paragraph fixes "all three passes reject" to "pass 1 normalises, passes 2-3 reject"; the tail / journal rustdocs replace overclaim ("byte-for-byte journalctl", "persists read position") with the actual contract.

## Verification

- Codex 8-subagent sweep produced 77 findings.
- Three independent Subagent verifiers (queue+input+output, check+dsl, pipeline+cross-cutting) adversarially reviewed each finding; **~42 CONFIRMED, ~32 NOT_DRIFT, 3 UNCERTAIN**. Codex's true-positive rate was ~55%.
- All confirmed sites are fixed here. Borderline / NOT_DRIFT sites are left in place; the rationale for each is recorded in the verifier outputs.

## Out of scope (= deferred to follow-up issues)

Two findings are potential implementation bugs, not comment drift, and are intentionally NOT addressed in this PR:

- `dsl/parser.rs:680` left-associativity comment says "rightmost" but the implementation uses `.position()` (= first match). Either the comment or the fold direction is wrong. To be triaged separately.
- `check/parser_effects.rs:43` claims "any parser defaults hash narrows wildcard" but `args.get(1)` only inspects argument index 1 — for `parse_kv(text, separator, defaults)` the defaults sit at index 2 and are missed. Implementation gap likely. To be triaged separately.

Standing push-gate items (= unchanged by this PR, tracked elsewhere):

- `RUSTSEC-2026-0185 quinn-proto 0.11.14` + `cargo-deny` duplicate warnings.
- `.github/workflows/release.yml:9` `contents: write` permission note.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace --no-fail-fast` 707 pass / 0 fail.
- [x] `cargo clippy --workspace -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean (no rustfmt drift introduced).
- [x] `grep -rnE 'ack()|write_with_retry|consume_event|OutputWriter|HttpOutput::render|OtlpHttpOutput::render|OtlpGrpcOutput::render|SinkInput::Owned|outputs::check_workspace_visibility' crates/limpid/src/` returns 0 hits in non-test prose (a handful of test-internal function names / assert strings remain and were intentionally left for a follow-up rename to keep the comment-only scope tight).