### PR TITLE
fix(dsl/parser): fold same-precedence operators left-associatively

### DIFF
--- a/crates/limpid/src/dsl/eval.rs
+++ b/crates/limpid/src/dsl/eval.rs
@@ -1063,6 +1063,55 @@ mod tests {
     }
 
     #[test]
+    fn test_eval_text_to_value_left_associative_div() {
+        // End-to-end regression: parse `10 / 2 / 5` from source text and
+        // confirm the *value* is 1, not 25. The pre-fix parser produced a
+        // right-associative tree that evaluated to `10 / (2 / 5) = 25` —
+        // the existing chained-add test built the AST by hand and missed
+        // this whole path. Div is non-commutative, so the tree shape is
+        // visible in the final scalar.
+        use crate::dsl::parser::parse_config;
+        let src = r#"
+def pipeline p {
+    input a
+    process inline | {
+        workspace.x = 10 / 2 / 5
+    }
+    drop
+}
+"#;
+        let config = parse_config(src).unwrap();
+        let pipeline = match &config.definitions[0] {
+            Definition::Pipeline(def) => def,
+            _ => panic!("expected Pipeline"),
+        };
+        let chain = match &pipeline.body[1] {
+            PipelineStatement::ProcessChain(chain) => chain,
+            _ => panic!("expected ProcessChain"),
+        };
+        let stmts = match &chain[1] {
+            ProcessChainElement::Inline(stmts) => stmts,
+            _ => panic!("expected Inline"),
+        };
+        let expr = match &stmts[0] {
+            ProcessStatement::Assign(_, expr) => expr,
+            _ => panic!("expected Assign"),
+        };
+
+        let _bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&_bump);
+        let ev = make_event();
+        let bev = ev.view_in(&arena);
+        let f = make_funcs();
+        let result = eval_expr(expr, &bev, &f, &arena).unwrap();
+        assert_eq!(
+            result.as_f64(),
+            Some(1.0),
+            "10 / 2 / 5 must be (10/2)/5 = 1, not 10/(2/5) = 25"
+        );
+    }
+
+    #[test]
     fn test_eval_binop_logical() {
         let _bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&_bump);

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -677,16 +677,17 @@ fn fold_by_precedence(operands: &mut Vec<Expr>, operators: &mut Vec<BinOp>) -> R
         );
     }
 
-    // Find lowest precedence operator (rightmost for left-associativity)
+    // Split at the rightmost operator of minimum precedence so the left side
+    // folds first — that yields a left-associative tree, e.g. `1 - 2 - 3`
+    // becomes `(1 - 2) - 3`, not `1 - (2 - 3)`.
     let min_prec = operators
         .iter()
         .map(precedence)
         .min()
         .expect("operators non-empty: caller only enters this branch with >= 1 operator");
-    // Find the *last* operator with that precedence (left-associative: fold left, so find first)
     let idx = operators
         .iter()
-        .position(|op| precedence(op) == min_prec)
+        .rposition(|op| precedence(op) == min_prec)
         .expect("min_prec was just computed from operators, so at least one matches");
 
     let op = operators.remove(idx);
@@ -1265,6 +1266,57 @@ def pipeline test {
             },
             _ => panic!("expected Pipeline definition"),
         }
+    }
+
+    #[test]
+    fn test_parse_binop_left_associative_same_precedence() {
+        // `1 - 2 - 3` must parse as `(1 - 2) - 3`, not `1 - (2 - 3)`.
+        // The eval-side numeric ops are non-commutative for Sub/Div, so the
+        // tree shape is observable in the final value.
+        let src = r#"
+def pipeline p {
+    input a
+    process inline | {
+        workspace.x = 1 - 2 - 3
+    }
+    drop
+}
+"#;
+        let config = parse_config(src).unwrap();
+        let pipeline = match &config.definitions[0] {
+            Definition::Pipeline(def) => def,
+            _ => panic!("expected Pipeline"),
+        };
+        let chain = match &pipeline.body[1] {
+            PipelineStatement::ProcessChain(chain) => chain,
+            _ => panic!("expected ProcessChain"),
+        };
+        let stmts = match &chain[1] {
+            ProcessChainElement::Inline(stmts) => stmts,
+            _ => panic!("expected Inline"),
+        };
+        let rhs = match &stmts[0] {
+            ProcessStatement::Assign(_, expr) => expr,
+            _ => panic!("expected Assign"),
+        };
+        // Expect: BinOp(BinOp(1, Sub, 2), Sub, 3)
+        let (outer_l, outer_op, outer_r) = match &rhs.kind {
+            ExprKind::BinOp(l, op, r) => (l, op, r),
+            other => panic!("expected outer BinOp, got {:?}", other),
+        };
+        assert_eq!(*outer_op, BinOp::Sub);
+        assert!(
+            matches!(&outer_r.kind, ExprKind::IntLit(3)),
+            "right child must be the trailing literal 3, got {:?}",
+            outer_r.kind
+        );
+        let (inner_l, inner_op, inner_r) = match &outer_l.kind {
+            ExprKind::BinOp(l, op, r) => (l, op, r),
+            other => panic!("expected inner BinOp on the left, got {:?}", other),
+        };
+        assert_eq!(*inner_op, BinOp::Sub);
+        assert!(matches!(&inner_l.kind, ExprKind::IntLit(1)));
+        assert!(matches!(&inner_r.kind, ExprKind::IntLit(2)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`fold_by_precedence` picked the leftmost minimum-precedence operator as the split point, producing a **right-associative AST** for chains like `1 - 2 - 3` or `10 / 2 / 5`. With `.rposition`, the rightmost operator becomes the split point, the left side folds first, and the AST matches the left-associative convention expected for arithmetic and consistent with the surrounding comment.

Originally flagged during the comment-drift review (PR #74) as a potential implementation bug rather than a documentation issue; the fix is the smallest local change that resolves the contradiction.

## Test plan

The existing chained-binop eval test built the AST by hand, so the parser-side regression was invisible. Two new tests close the gap:

- [x] parser: AST-shape assertion on `1 - 2 - 3` confirms `((1-2)-3)`.
- [x] eval: text → parse → eval on `10 / 2 / 5 == 1` (not `4` — which is what right-associative `(10 / (2 / 5))` produces under integer rounding).
- [x] `cargo build --workspace`, `cargo test --workspace --no-fail-fast` (709 pass), `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check` all clean.