### PR TITLE
docs(operations,outputs): rewrite DLQ schema docs to v2 sum-type

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -45,7 +45,7 @@ control {
 | Property | Default | Effect |
 |----------|---------|--------|
 | `socket` | `/var/run/limpid/control.sock` | Unix socket path consumed by `limpidctl` and `limpid-prometheus`. |
-| `error_log` | *(unset)* | JSONL file appended to when a `process` raises a runtime error. When unset, the runtime falls back to a structured `tracing::error!` line so the failure data is never silently lost. Strongly recommended when any output declares `retry` or is a batched OTLP/HTTP output — `--check` warns (see [Error Log → recovery dependency](./operations/error-log.md)). See [Error Log (DLQ)](./operations/error-log.md) for the record format and replay recipe. |
+| `error_log` | *(unset)* | JSONL file appended to when an event terminates at a producer site that needs replay — pipeline-side process / pipeline-skeleton runtime errors and sink-side retry exhaustion / shutdown-drain / enqueue failures (see [Error Log → Producer sites](./operations/error-log.md#producer-sites)). When unset, Process-flavor records fall back to a `tracing::error!` line with the full JSONL inline (still recoverable from journald), but Output-flavor records degrade to a name-only warn line that does **not** carry the event payload — Output failures are effectively dropped without `error_log`. Strongly recommended when any output declares `retry` or is a batched OTLP/HTTP output — `--check` warns (see [Error Log → Recovery readiness check](./operations/error-log.md#recovery-readiness-check---check)). See [Error Log (DLQ)](./operations/error-log.md) for the v2 record format and flavor-aware replay recipes. |
 
 The whole block is optional — daemon starts with the defaults if it's omitted.
 

--- a/docs/src/inputs/otlp-http.md
+++ b/docs/src/inputs/otlp-http.md
@@ -79,7 +79,7 @@ def process unpack_otlp {
 }
 ```
 
-See [`otlp.decode_resourcelog_protobuf`](../functions/expression-functions.md#otlp).
+See [`otlp.decode_resourcelog_protobuf`](../functions/expression-functions.md#otlpdecode_resourcelog_protobufbytes--object).
 
 ## Splitting policy
 

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -2,7 +2,9 @@
 
 When a `process` statement raises a runtime error — unknown identifier, type mismatch, regex compile failure, parser blowup on malformed input — the event is set aside in a **dead-letter queue (DLQ)** rather than forwarded with the original `ingress` unchanged. The same DLQ also receives events routed by an explicit [`error` statement](../pipelines/drop-finish-error.md#error): a snippet parser dispatcher hitting an unsupported subtype, or a process detecting a missing-required-field contract violation, can call `error "..."` to land the event in the DLQ with an operator-authored reason. Operators audit the failures, fix the offending config or parser, and replay the events.
 
-This page covers the on-disk format, the `control { error_log "..." }` opt-in, and the replay recipe. The corresponding metrics (`events_errored`, `events_errored_unwritable`) are documented under [Metrics](./metrics.md).
+Output-side failures (retry budget exhausted, shutdown-drain leftovers, enqueue failures) land in the same file, with a different record shape that preserves the pre-rendered wire payload — so the replay tooling can hand them straight back to the sink without re-running the whole pipeline.
+
+This page covers the on-disk format, the `control { error_log "..." }` opt-in, and the replay recipes. The corresponding metrics (`events_errored`, `events_errored_unwritable`) are documented under [Metrics](./metrics.md).
 
 ## Why a DLQ instead of forwarding or discarding
 
@@ -18,7 +20,7 @@ Three behaviours were considered:
 - **Discard** makes the bug visible (counter goes up) but is itself a strong failure mode: a security telemetry pipeline that drops events to a config typo is the wrong default.
 - **DLQ** preserves the data and the bug signal: `events_errored` ticks up *and* the original event is recoverable. This is the Logstash / Fluentd `@ERROR` pattern.
 
-The runtime cannot guess what the operator intended at the failure point — `egress` may have been partially rewritten by earlier processes in the chain, the next process expected a workspace key that was never produced, etc. So the DLQ deliberately preserves only the *original* event (ingress / source / received_at) and lets the operator re-run from scratch after the fix.
+The runtime cannot guess what the operator intended at the failure point — `egress` may have been partially rewritten by earlier processes in the chain, the next process expected a workspace key that was never produced, etc. So the DLQ deliberately preserves only the *original* event (ingress / source / received_at) for the Process flavor, and the pre-rendered wire payload (with `egress`) for the Output flavor, and lets the operator re-run from the appropriate boundary after the fix.
 
 ## Configuring the DLQ
 
@@ -31,27 +33,18 @@ control {
 }
 ```
 
-When `error_log` is **unset**, the same record is emitted as a structured `tracing::error!` line — operators using `systemd` can still recover via `journalctl -u limpid -o json | jq …`. The data is never silently lost.
+When unset, the fallback differs by flavor:
 
-The recommended deployment is the explicit file path: a dedicated DLQ file is easier to monitor, easier to rotate, and decouples replay volume from journald rate limits.
+- **Process flavor** — the daemon emits a `tracing::error!` line that includes the full failure JSONL inline, so the data is still preserved on the standard log channel. Replay is awkward (you have to `jq` over journald, no `limpidctl inject` shortcut) but the original event is recoverable.
+- **Output flavor** — the daemon emits a `tracing::warn!` / `error!` line that names the output and the reason, but **does not serialize the event payload**. The record is effectively dropped; it is not recoverable from journald. The retry-exhaustion, shutdown-drain, and enqueue-failure paths all behave this way when `error_log` is unset.
 
-### Startup validation
+For any pipeline that uses `retry { ... }` or a batched output (`http`, `otlp_http`, `otlp_grpc`), `limpid --check` raises a recovery-readiness warning when `error_log` is not configured; see [Recovery readiness check](#recovery-readiness-check---check) below.
 
-At daemon start (and on `SIGHUP` reload), limpid stat()s the parent directory of `error_log` and refuses to start if it doesn't exist or isn't a directory. Operator typos surface before any event hits the failure path, not after the first runtime error. The file itself does not need to exist — the daemon creates it on the first failure.
-
-If the directory is reachable but the daemon can't *write* to it (wrong owner, read-only filesystem), startup still succeeds; the failure surfaces as `events_errored_unwritable` increments at runtime. See [When the DLQ write itself fails](#when-the-dlq-write-itself-fails) for the diagnosis path.
-
-### Permissions and rotation
-
-The daemon opens the file with `OpenOptions::create(true).append(true)` per write, so:
-
-- The file is created on first failure if it doesn't exist (parent directory must exist and be writable by the daemon user — checked at startup).
-- `logrotate` with `copytruncate` works without a SIGHUP handshake — the daemon picks up the new inode on the next failure.
-- Concurrent failures from multiple pipeline workers serialise through an in-process `Mutex` inside the writer. POSIX `O_APPEND` only guarantees atomic append for writes ≤ `PIPE_BUF` (Linux: 4 KiB), and DLQ records carrying base64-encoded binary ingress easily exceed that — so limpid does not rely on the kernel-level guarantee.
+The path must be in a directory the daemon user can write to. limpid validates this at startup (`--check` and daemon start both fail with a clear message if the parent directory is missing or non-writable).
 
 ### Recommended `logrotate` configuration
 
-The DLQ has no in-process size cap; sustained failures can fill the disk. Pair it with a `logrotate` entry:
+A typical operator setup keeps the live file capped and the rotated archives compressed:
 
 ```
 /var/log/limpid/errored.jsonl {
@@ -77,14 +70,20 @@ Operators with stricter retention needs (compliance: hold N days of forensic-qua
 
 ## Record format
 
-One JSON object per line:
+Each line is a sum-typed JSON record. Since 0.7.8 the record carries an explicit `schema_version: 2` and a `kind` discriminator (`"process"` or `"output"`) that selects a per-kind block at the top level. Process flavor records carry `process: { name }` and a minimal event (ingress only); Output flavor records carry `output: { name }` and the pre-rendered `event.egress`.
+
+### Process flavor
+
+A pipeline-side failure (process body raised, pipeline-skeleton eval failed, explicit `error <expr>`) emits a Process record. Replay re-enters at the input layer — the pipeline is re-run from scratch against the original ingress bytes.
 
 ```json
 {
+  "schema_version": 2,
   "timestamp": "2026-04-27T03:28:39.178046123Z",
   "reason": "unknown identifier: timestamp",
-  "process": "wrap_journal",
   "pipeline": "journal_forward",
+  "kind": "process",
+  "process": { "name": "wrap_journal" },
   "event": {
     "source": {"ip": "10.0.0.1", "port": 514},
     "received_at": 1745719719178046000,
@@ -93,125 +92,202 @@ One JSON object per line:
 }
 ```
 
+### Output flavor
+
+A sink-side failure (retry budget exhausted, batched-output shutdown drain, runtime-side enqueue failure) emits an Output record. Replay hands the pre-rendered payload directly to the named output's queue — the sink re-routes via its own `consume()` path, no pipeline re-run.
+
+```json
+{
+  "schema_version": 2,
+  "timestamp": "2026-04-27T03:31:02.998742000Z",
+  "reason": "output write failed after 5 attempts: connection refused",
+  "pipeline": "",
+  "kind": "output",
+  "output": { "name": "mysink" },
+  "event": {
+    "source": {"ip": "10.0.0.1", "port": 514},
+    "received_at": 1745719719178046000,
+    "ingress": "<134>1 2026-04-27T03:28:39Z host app 1234 - - hello",
+    "egress": "<134>1 2026-04-27T03:28:39Z host app 1234 - - hello\n"
+  }
+}
+```
+
+### Common fields
+
 | Field | Meaning |
 |-------|---------|
-| `timestamp` | RFC3339 with nanosecond precision; wall-clock at which the error was raised. |
-| `reason` | Stringified `ProcessError`. Stable enough for `grep` / classification but not a stable API. |
-| `process` | Failed process or recovery-path discriminator. A named `def process` invocation surfaces its name; an inline `process { ... }` block surfaces `(inline)`. For records originating from an output's or pipeline-skeleton's recovery path the value is one of five discriminators: `(output <name>)` — retry exhausted; `(output <name> shutdown)` — batched output's shutdown drain; `(pipeline)` — explicit `error` statement from pipeline routing; `(pipeline body)` — pipeline-skeleton expression eval failure (`if` condition, `switch` discriminant, `error <expr>` arg, or `process` function args); `(output enqueue)` — output enqueue failure. |
-| `pipeline` | Pipeline name (`def pipeline <name>`). Empty for output-originated retry / shutdown records (`(output <name>)`, `(output <name> shutdown)`). Populated for the in-pipeline shapes: process runtime errors, `(pipeline)`, `(pipeline body)`, and `(output enqueue)` — the latter carries the name of the pipeline that failed to hand the event off. |
+| `schema_version` | Integer `2`. Identifies the v2 sum-typed shape; v1 is a hard break (see [Schema migration v1 → v2](#schema-migration-v1--v2) below). |
+| `timestamp` | RFC3339 with nanosecond precision; wall-clock at which the failure was raised. |
+| `reason` | Stringified failure reason. Stable enough for `grep` / classification but not a stable API. The runbook below maps reason patterns back to producer sites. |
+| `pipeline` | Pipeline name (`def pipeline <name>`). Populated for every Process record; for Output records it carries the originating pipeline only when the failure happened *at the pipeline → output boundary* (= enqueue failure). Retry-exhausted and shutdown-drain Output records have an empty `pipeline` field because the event had already left its source pipeline by then. |
+| `kind` | Discriminator: `"process"` or `"output"`. Selects which per-kind block is present and which `event.*` fields are populated. |
 | `event.source` | Originating peer as `{ip, port}` object. Same shape as `tap --json` and as the DSL `source` ident. |
 | `event.received_at` | i64 unix nanoseconds (matches OTLP `time_unix_nano`). Same shape as `tap --json`. |
 | `event.ingress` | Original wire bytes. UTF-8-clean payloads serialise as a JSON string; non-UTF-8 payloads use the `$bytes_b64` marker the rest of the JSON layer already uses for `tap --json`. |
 
-Example `reason` values across the discriminators: `"unknown identifier: timestamp"` (process runtime error), `"output retry exhausted after 5 attempts: connection refused"` (`(output <name>)`), `"output shutting down; draining queue"` (`(output <name> shutdown)`), `"unsupported subtype: vpc-flow-v3"` (`(pipeline)` — explicit `error <expr>`), `"unknown identifier: workspace.cef.severityy"` (`(pipeline body)` — expression eval in an `if`/`switch`/process-args slot), `"output enqueue failed for: mysink (queue closed, disk write error, or unknown output)"` (`(output enqueue)`).
+### Process-flavor extras
 
-## Recovery paths into the DLQ
+| Field | Meaning |
+|-------|---------|
+| `process` | `{ "name": "<site>" }` block. `name` is the failing `def process` name, `(inline)` for an inline `process { ... }` block, `(pipeline)` for a pipeline-statement `error <expr>`, or `(pipeline body)` for a pipeline-skeleton expression failure (`if` / `switch` / `error <expr>` arg / `process` function args). |
 
-The DLQ receives records from five distinct paths. The `process` field above is the discriminator:
+`event` carries only `{ source, received_at, ingress }` — no `egress`, no `workspace`. Replay re-runs the pipeline from scratch on `ingress`.
 
-1. **Process runtime error / explicit `error`** — a `process` statement raised an error, or pipeline routing executed `error <expr?>`. `process` is the failed `def process` name (or `(inline)`), or `(pipeline)` for pipeline-level `error`. `pipeline` is populated. (Original behaviour.)
-2. **Pipeline-skeleton eval failure** — an expression embedded in the pipeline skeleton itself raised an error: an `if` condition, a `switch` discriminant, the argument of an explicit `error <expr>` statement, or one of the arguments passed to a `process` function call. These eval slots run outside of any `process { ... }` body, so the existing process-error path does not catch them; the orchestrator routes them through the same DLQ writer with `process = "(pipeline body)"`. `pipeline` is populated. The reason carries the underlying expression error verbatim.
-3. **Output retry exhausted** — an output exhausted its `retry` budget against the destination. `process = "(output <name>)"`, `pipeline` empty. The event carries the post-pipeline `egress` that the output attempted to deliver.
-4. **Batched output shutdown drain** — a batched output (`otlp_*`, `http`) was shut down while events were still buffered and could not flush them. `process = "(output <name> shutdown)"`, `pipeline` empty. Synthetic-event metadata constraints apply: `received_at` reflects the shutdown moment for events that never carried their own; per-event source / workspace state may be a representative of the batch rather than per-record.
-5. **Output enqueue failure** — the pipeline could not hand an event to an output's queue (queue full, unknown output, disk-queue write error). `process = "(output enqueue)"`, and `pipeline` is the name of the pipeline that failed to enqueue — the only output-discriminator shape that keeps the originating pipeline name. The record preserves the event as it was at the pipeline → output boundary.
+### Output-flavor extras
 
-All five paths converge on the same JSONL file and the same replay recipe — `jq` on the `process` field selects which recovery path you are replaying.
+| Field | Meaning |
+|-------|---------|
+| `output` | `{ "name": "<output_name>" }` block. `name` is the `def output` name. The flavor is intentionally address-free — no peer, endpoint, partition, topic, path, URL, target, or workspace fragment leaks into the record. Replay hands the event back to the sink via `limpidctl inject output <name>`, and the sink re-routes via its own `consume()` path. |
+| `event.egress` | Pre-rendered wire bytes (= what the sink attempted to deliver). Same UTF-8 / `$bytes_b64` encoding rules as `ingress`. The sink interprets `egress` as already-encoded payload (no re-render). |
+
+`workspace` is intentionally **not** serialised on Output records — sink-side routing state is forbidden from the recovery record by design. See [Address-free Output records](#address-free-output-records) below for the rationale.
+
+### Producer sites
+
+Seven producer sites map to the two flavors. The runbook section below maps each one to its triage signal (`reason` pattern) and most common causes.
+
+Process flavor (4 sites — replay via `inject input`):
+
+1. **`<process_name>`** — an explicit `process` body raised via `error <expr>` or a process-internal failure.
+2. **`(inline)`** — an inline `process { ... }` block raised the same way.
+3. **`(pipeline body)`** — an `if` condition / `switch` discriminant / explicit `error <expr>` argument / `process` function argument failed to evaluate before reaching a process body.
+4. **`(pipeline)`** — `error <expr>` at the pipeline (statement) level raised, including the dispatcher pattern where a snippet routes on an unrecognised subtype.
+
+Output flavor (3 sites — replay via `inject output`):
+
+5. **`<output_name>`** — the output exhausted its `retry { ... }` budget against the destination. A batched output's per-event render failure inside `flush()` is also routed here with `reason = "render failed during batch flush: ..."`. `pipeline` is empty.
+6. **`<output_name> shutdown`** — a batched output (`http`, `otlp_http`, `otlp_grpc`) was shut down with events still buffered and the final flush failed. The `shutdown()` impl walks the remaining `(Event, QueueAckHandle)` buffer entries (one record per parked event) through this writer. `pipeline` is empty. The per-event `source`, `received_at`, `ingress`, and `egress` come from the original `Event` that was parked in the buffer at `consume()` time; nothing is synthesised. (Earlier 0.7.7 drafts of this flavor carried synthetic shutdown-time metadata; the 0.7.8 ack-lifecycle work parks the source `Event` alongside the ack handle so each shutdown-drain record now reflects the real per-event provenance.)
+7. **`<output_name> enqueue`** — `runtime.rs` could not hand an event to the named output's queue (queue closed, disk-queue write error, unknown output). `pipeline` is the name of the originating pipeline — the only Output-flavor site that keeps it populated. Per-failed-output split: a single pipeline-eval result with N failed-output enqueues produces N records (one per failing output).
+
+The `reason` field distinguishes sites 5 / 6 / 7 within a single output name: retry exhaustion uses `"output write failed after N attempts: ..."`, shutdown drain uses `"shutdown flush failed: ..."`, enqueue failure uses `"output enqueue failed (queue closed, disk write error, or unknown output)"`. A batched output's per-event render failure inside `flush()` uses `"render failed during batch flush: ..."`. The runbook's [root-cause heuristics table](#step-3--root-cause-heuristics-by-site) lists the full patterns.
+
+### Address-free Output records
+
+The Output record carries `output: { name }` and nothing more. No peer address, endpoint URL, partition, topic, path, target, key, or workspace fragment leaks into the recovery record.
+
+Why: replay calls `limpidctl inject output <name>`, which hands the event back to the sink. The sink re-routes via the same `consume()` path it uses for live traffic — round-robin peer selection, retry budget, batching, headers, all of it. There is no "send this exact record to this exact peer" mode; the sink owns routing. Carrying address details on the record would create two failure modes: (a) replay vs. live diverging when the operator updates the sink config between failure and replay, and (b) sensitive routing metadata (peer hostnames, internal endpoint URLs) leaking into the DLQ file.
+
+The trade-off: an operator who needs to know *which peer failed* for an `<output_name>` retry-exhaustion record reads the daemon log (`journalctl -u limpid` around the timestamp), not the DLQ record.
+
+### Schema stability
+
+`schema_version: 2` is the operator-visible discriminator. Pre-1.0, the schema may add fields to existing kinds, or add new kinds, both of which bump `schema_version`. Field renames within an existing kind also bump it. After 1.0 the format will be locked under semantic versioning.
+
+`event.source` changed shape from a flat `"ip:port"` string to a `{ip, port}` object in v0.5.6 (independent of `schema_version`, but worth knowing if you're reading captures from that era).
 
 ### Recovery readiness check (`--check`)
 
-Since 0.7.8, `limpid --check` emits a recovery-readiness warning when any output declares `retry` or is a batched OTLP/HTTP output and the `control { error_log }` is unset. Without `error_log`, recovery paths 3–5 above fall back to a `tracing::warn!`/`error!` line that names the output but **does not serialize the event payload** — the record itself is dropped and is not recoverable from journald. (Paths 1–2 are different: `write_errored_to_dlq` does emit the full JSONL on a tracing line when `error_log` is unset, so for process errors `journalctl | jq` still works as a fallback — just harder to replay than a dedicated file.) The warning catches the missing configuration before the first failure.
+Since 0.7.8, `limpid --check` emits a recovery-readiness warning when any output declares `retry` or is a batched OTLP/HTTP output and `control { error_log }` is unset. Without `error_log`, the Output-flavor recovery paths (retry exhausted, shutdown drain, enqueue failure) fall back to a `tracing::warn!` / `error!` line that names the output but **does not serialize the event payload** — the record itself is dropped and is not recoverable from journald. (Process-flavor records are different: the runtime emits the full JSONL on the tracing line when `error_log` is unset, so for process errors `journalctl | jq` still works as a fallback — just harder to replay than a dedicated file.) The warning catches the missing configuration before the first failure.
 
 Since 0.7.8, the cursor a `tail` / `journal` input persists to its `state_file` advances on **pipeline-worker completion**, not on channel hand-off. A crash mid-processing now leaves the on-disk cursor pointing to the last *processed* line, so the next start re-reads any events that were in flight — closing the previous at-most-once gap and moving recovery toward at-least-once.
 
-The five DLQ paths above are not a full safety net for output-side in-flight loss, though: path 4 only covers the shutdown-drain of a batched output, and path 5 only covers an *enqueue* failure. An event that was *successfully* enqueued to a memory queue and is still sitting in that queue (or being processed by the output worker) at the moment the process crashes is **not** recovered by either path — memory queues are not a durability layer, and the input cursor has already moved past the event because the pipeline worker acked it before the output queue handed it off. For full at-least-once across a process restart with in-flight queued events, configure a per-output **disk queue** — disk queues survive the crash and replay on restart. Memory-queue events in flight at crash time are lost.
-
-`event.egress` and `event.workspace` are intentionally **not** included — at the failure point they may hold partial state from earlier processes in the chain, which would confuse `inject --json` replay. The replay path re-runs the pipeline from scratch on `ingress`.
-
-Format stability: pre-1.0 we may add new top-level fields, and existing keys may still be reshaped if the underlying DSL changes (the `event.source` field changed from a flat `"ip:port"` string to a `{ip, port}` object in v0.5.6, alongside the corresponding DSL change). After 1.0 the format will be locked.
+The seven producer sites above are not a full safety net for output-side in-flight loss. Sites 5 / 6 only cover the events the output explicitly resolved as failures; an event that was *successfully* enqueued to a memory queue and is still sitting in that queue (or being processed by the output worker) at the moment the process crashes is **not** recovered by any of them — memory queues are not a durability layer. For full at-least-once across a process restart with in-flight queued events, configure a per-output **disk queue** — disk queues survive the crash and replay on restart. Memory-queue events in flight at crash time are lost.
 
 ## Replay
 
-Once the offending config or parser is fixed, replay errored events with `jq` + `limpidctl inject --json`:
+Once the offending config or parser is fixed, replay errored records with `jq` + `limpidctl inject`. The recipe depends on the flavor: Process records replay through the input layer (full pipeline re-run), Output records replay through the named output's queue (sink re-route only).
+
+### Process flavor — replay via `inject input`
 
 ```bash
 # Replay all errored events for one pipeline:
-jq -c 'select(.pipeline == "journal_forward") | .event' \
+jq -c 'select(.kind == "process" and .pipeline == "journal_forward") | .event' \
     /var/log/limpid/errored.jsonl \
     | limpidctl inject input <input_name> --json
 
-# Replay everything:
-jq -c '.event' /var/log/limpid/errored.jsonl \
+# Replay all Process-flavor records (any pipeline):
+jq -c 'select(.kind == "process") | .event' /var/log/limpid/errored.jsonl \
     | limpidctl inject input <input_name> --json
 
-# Replay only failures of a specific process:
-jq -c 'select(.process == "wrap_journal") | .event' \
+# Replay only failures of a specific process site:
+jq -c 'select(.kind == "process" and .process.name == "wrap_journal") | .event' \
     /var/log/limpid/errored.jsonl \
     | limpidctl inject input <input_name> --json
 
 # Replay events where the failure reason matches a pattern:
-jq -c 'select(.reason | test("parse_json")) | .event' \
+jq -c 'select(.kind == "process" and (.reason | test("parse_json"))) | .event' \
     /var/log/limpid/errored.jsonl \
     | limpidctl inject input <input_name> --json
 ```
 
-The `event` sub-object is exactly what `Event::from_json` (and therefore `inject --json`) needs to reconstruct a fresh Event: `egress` defaults to `ingress`, `workspace` starts empty. Replay is "as if the event just arrived for the first time" — no risk of partial-state confusion.
+The `event` sub-object is exactly what `Event::from_json` (and therefore `inject input --json`) needs to reconstruct a fresh Event: `egress` defaults to `ingress`, `workspace` starts empty. Replay is "as if the event just arrived for the first time" — no risk of partial-state confusion.
+
+### Output flavor — replay via `inject output`
+
+```bash
+# Replay all retry-exhausted records for one output:
+jq -c 'select(.kind == "output" and .output.name == "mysink") | .event' \
+    /var/log/limpid/errored.jsonl \
+    | limpidctl inject output mysink --json
+
+# Replay all Output-flavor records, fanned out by output name:
+jq -c 'select(.kind == "output") | "\(.output.name)\t\(.event | @json)"' \
+    /var/log/limpid/errored.jsonl \
+    | while IFS=$'\t' read -r name event_json; do
+        echo "$event_json" | limpidctl inject output "$name" --json
+    done
+```
+
+The `event` sub-object for Output records carries `egress` (the pre-rendered wire bytes the sink had tried to deliver). `inject output --json` hands this straight to the sink's `consume()` — no re-rendering, no pipeline re-run. The sink applies its current peer/retry/batching configuration as if the event had just been enqueued normally.
+
+### Archive after replaying
 
 After replay, archive the DLQ file so the next failure window starts clean:
 
 ```bash
 mv /var/log/limpid/errored.jsonl \
-   /var/log/limpid/errored.jsonl.replayed-$(date +%Y%m%dT%H%M%S)
+   /var/log/limpid/errored.jsonl.replayed-$(date -u +%Y%m%dT%H%M%SZ)
 ```
 
 (Recreating the file is unnecessary — the daemon will recreate it on the next failure.)
 
 ## Replay and triage runbook
 
-The basic `jq | limpidctl inject` recipe above is enough when you already know which records to replay and why they failed. In an incident — DLQ growth alert just fired, you don't yet know which of the four recovery paths is dominating, and the file has tens of thousands of lines — work through this runbook instead. It walks from "what is in the file" to "what to replay and what to fix first."
+The recipes above are enough when you already know which records to replay and why they failed. In an incident — DLQ growth alert just fired, you don't yet know which producer site is dominating, and the file has tens of thousands of lines — work through this runbook instead. It walks from "what is in the file" to "what to replay and what to fix first."
 
 ### 1. Reading the DLQ
 
 Tail the live file with `jq` to watch new failures arrive:
 
 ```bash
-tail -F /var/log/limpid/errored.jsonl | jq -c '{ts: .timestamp, process, reason}'
+tail -F /var/log/limpid/errored.jsonl | jq -c '{ts: .timestamp, kind, name: (.process.name // .output.name), reason}'
 ```
 
-The `process` field is the single discriminator that tells you which of the five [recovery paths](#recovery-paths-into-the-dlq) emitted the record. A representative line per path:
+The `kind` field + the per-kind `name` together identify the producer site at a glance.
+
+A representative line per site, condensed:
 
 ```jsonc
-// 1. Process runtime error / explicit `error` — `pipeline` is populated.
-{"process":"wrap_journal","pipeline":"journal_forward","reason":"unknown identifier: timestamp", ...}
-{"process":"(inline)","pipeline":"fortinet_in","reason":"parse_json failed: expected `}` at line 1 column 87", ...}
-{"process":"(pipeline)","pipeline":"audit_in","reason":"unsupported subtype: vpc-flow-v3", ...}
+// Process flavor (kind="process", populated `pipeline`, ingress-only event)
+{"kind":"process","process":{"name":"wrap_journal"},"pipeline":"journal_forward","reason":"unknown identifier: timestamp", ...}
+{"kind":"process","process":{"name":"(inline)"},"pipeline":"fortinet_in","reason":"parse_json failed: expected `}` at line 1 column 87", ...}
+{"kind":"process","process":{"name":"(pipeline)"},"pipeline":"audit_in","reason":"unsupported subtype: vpc-flow-v3", ...}
+{"kind":"process","process":{"name":"(pipeline body)"},"pipeline":"journal_forward","reason":"unknown identifier: workspace.cef.severityy", ...}
 
-// 2. Pipeline-skeleton eval failure — `pipeline` is populated.
-{"process":"(pipeline body)","pipeline":"journal_forward","reason":"unknown identifier: workspace.cef.severityy", ...}
-
-// 3. Output retry exhausted — `pipeline` empty.
-{"process":"(output mysink)","pipeline":"","reason":"output write failed after 5 attempts: connection refused", ...}
-
-// 4. Batched output shutdown drain — `pipeline` empty.
-{"process":"(output otlp_main shutdown)","pipeline":"","reason":"shutdown flush failed: deadline exceeded", ...}
-
-// 5. Output enqueue failure — `pipeline` carries the originating pipeline.
-{"process":"(output mysink)","pipeline":"mypipe","reason":"output enqueue failed for: mysink (queue closed, disk write error, or unknown output)", ...}
+// Output flavor (kind="output", pipeline empty for retry / shutdown, populated for enqueue, egress present)
+{"kind":"output","output":{"name":"mysink"},"pipeline":"","reason":"output write failed after 5 attempts: connection refused", ...}
+{"kind":"output","output":{"name":"otlp_main"},"pipeline":"","reason":"shutdown flush failed: deadline exceeded", ...}
+{"kind":"output","output":{"name":"mysink"},"pipeline":"mypipe","reason":"output enqueue failed (queue closed, disk write error, or unknown output)", ...}
 ```
 
-Note the asymmetry: paths 3 and 4 have an empty `pipeline` field, because by the time the event reached the output it had already left its source pipeline. Paths 1, 2, and 5 keep `pipeline` populated. For path-3/4 records, filter on `process` (not `pipeline`). For path-5 records, either filter is valid — `process == "(output enqueue)"` scopes by the recovery shape, `pipeline == "<name>"` scopes by the originating pipeline.
+Note the asymmetry on `pipeline`: Process records always populate it; Output records populate it only for enqueue failures (the originating pipeline is known at that boundary), and leave it empty for retry exhaustion and shutdown drain (the event had already left its source pipeline).
 
 ### 2. Triage flow
 
-**Step 1 — aggregate by path.** The first question is always "what is dominating the file?":
+**Step 1 — aggregate by site.** The first question is always "what is dominating the file?":
 
 ```bash
-jq -r '.process' /var/log/limpid/errored.jsonl | sort | uniq -c | sort -rn
+# Group by (kind, name, reason-pattern) — the three things that uniquely identify a site.
+jq -r '[.kind, (.process.name // .output.name), (.reason | split(":")[0])] | @tsv' \
+    /var/log/limpid/errored.jsonl \
+    | sort | uniq -c | sort -rn | head
 ```
 
-Pair it with a reason breakdown for the top offender:
+Pair it with a per-site reason breakdown for the top offender:
 
 ```bash
-jq -r 'select(.process == "(output mysink)") | .reason' \
+jq -r 'select(.kind == "output" and .output.name == "mysink") | .reason' \
     /var/log/limpid/errored.jsonl | sort | uniq -c | sort -rn | head
 ```
 
@@ -227,17 +303,18 @@ jq -r '.timestamp[:16]' /var/log/limpid/errored.jsonl \
 
 A flat curve over the last 5 minutes means the upstream issue resolved itself — you are now only dealing with cleanup. A still-climbing curve means fix the root cause before you replay anything, or you will land the same events back in the DLQ.
 
-**Step 3 — root-cause heuristics by path.**
+**Step 3 — root-cause heuristics by site.**
 
-| Discriminator | Most common causes | First place to look |
-|---|---|---|
-| `(output <name>)` (retry exhausted) | backend down, network partition, auth expired, sustained backpressure | downstream health, `events_failed` / `retries` on the output ([Metrics](./metrics.md)) |
-| `(output <name> shutdown)` | daemon `kill -9` or restart while a batched output (`otlp_*`, `http`) still had buffered events | `journalctl -u limpid` around the shutdown window |
-| `(output enqueue)` | output queue full, output task stopped, disk-backed queue write error | output `events_received` vs. `events_written`, disk space, queue config |
-| `(pipeline body)` | typo in an `if` condition / `switch` discriminant, undefined workspace key referenced from a `process` arg or an `error <expr>` slot | the `reason` string + the pipeline DSL around the failing expression |
-| `<pipeline_process_name>` / `(inline)` / `(pipeline)` | DSL bug, parser blowup on a new input shape, missing-required-field contract violation | the `reason` string + the offending `event.ingress` payload |
+| `kind` | `name` | `reason` pattern | Most common causes | First place to look |
+|---|---|---|---|---|
+| `output` | `<output_name>` | `output write failed after N attempts: …` | backend down, network partition, auth expired, sustained backpressure | downstream health, `events_failed` / `retries` on the output ([Metrics](./metrics.md)) |
+| `output` | `<output_name>` | `render failed during batch flush: …` | render bug, missing workspace key the renderer depended on (rare; deterministic) | the failing process / template, not the output |
+| `output` | `<output_name>` | `shutdown flush failed: …` | daemon `kill -9` or restart while a batched output (`otlp_*`, `http`) still had buffered events | `journalctl -u limpid` around the shutdown window |
+| `output` | `<output_name>` | `output enqueue failed (queue closed, disk write error, or unknown output)` | output queue full, output task stopped, disk-backed queue write error, unknown output name in the pipeline body | output `events_received` vs `events_written`, disk space, queue config |
+| `process` | `(pipeline body)` | varies | typo in an `if` condition / `switch` discriminant, undefined workspace key referenced from a `process` arg or an `error <expr>` slot | the `reason` string + the pipeline DSL around the failing expression |
+| `process` | `<process_name>` / `(inline)` / `(pipeline)` | varies | DSL bug, parser blowup on a new input shape, missing-required-field contract violation | the `reason` string + the offending `event.ingress` payload |
 
-**Step 4 — transient vs. permanent.** Replay is only safe for *transient* causes — the kind where re-running the pipeline now will succeed. Apply this rule:
+**Step 4 — transient vs. permanent.** Replay is only safe for *transient* causes — the kind where re-running now will succeed. Apply this rule:
 
 - **Transient (replay fixes it):** backend was down and is back, daemon was restarted, queue was full and has drained, a config typo was corrected.
 - **Permanent (fix config first, then replay):** DSL bug, parser cannot handle a new vendor format, output points at the wrong destination. Replaying without the fix just re-fills the DLQ.
@@ -246,45 +323,39 @@ If you cannot tell, pull *one* record, run it through `limpid --test-pipeline` (
 
 ### 3. Replay
 
-The [basic recipes](#replay) above cover the common shape. A few patterns worth calling out for incident use:
+The [basic recipes](#replay) above cover the common shapes. A few patterns worth calling out for incident use:
 
 ```bash
-# Path-scoped replay: only retry-exhausted records for one output.
-jq -c 'select(.process == "(output mysink)") | .event' \
+# Site-scoped replay: only retry-exhausted records for one output.
+jq -c 'select(.kind == "output" and .output.name == "mysink") | .event' \
     /var/log/limpid/errored.jsonl \
-    | limpidctl inject input <input_name> --json
+    | limpidctl inject output mysink --json
 
 # Time-windowed replay: only failures after the fix landed at 14:05 UTC.
-jq -c 'select(.timestamp >= "2026-04-27T14:05:00Z") | .event' \
+jq -c 'select(.kind == "process" and .timestamp >= "2026-04-27T14:05:00Z") | .event' \
     /var/log/limpid/errored.jsonl \
     | limpidctl inject input <input_name> --json
 
 # Reason-pattern replay: only the specific bug class you just fixed.
-jq -c 'select(.reason | test("parse_json")) | .event' \
+jq -c 'select(.kind == "process" and (.reason | test("parse_json"))) | .event' \
     /var/log/limpid/errored.jsonl \
     | limpidctl inject input <input_name> --json
 ```
 
-**Shutdown-drain caveat.** Records with `process` ending in `shutdown` carry partly synthetic metadata: `event.source` is `127.0.0.1:0` and `event.received_at` is the shutdown wall-clock, not the original arrival time. The `event.ingress` field on these records is the *rendered* batched-output payload (already wrapped, encoded, batched), not the wire bytes that originally entered the pipeline. Re-injecting them:
-
-- stamps a new `received_at` from the inject time,
-- replaces the original source IP/port with `127.0.0.1:0` (or whatever the receiving input synthesizes),
-- and runs the pipeline again *on the already-rendered payload*, which is almost never what you want for a stateful wrap/format process.
-
-For shutdown-drain records, prefer `limpidctl inject output <name>` (direct queue inject, bypassing the pipeline) so the payload goes straight back to the downstream destination as captured. Use input replay only when you are sure the pipeline is idempotent on its own output.
+**Shutdown-drain caveat.** Output-flavor records with `reason` starting with `shutdown flush failed: ...` are *per-event* records, not per-batch — the batched output's shutdown helper walks every still-buffered `(Event, QueueAckHandle)` entry and writes one record per parked event, so `event.source`, `event.received_at`, `event.ingress`, and `event.egress` all reflect the original per-event provenance (no synthetic shutdown-time metadata). `event.egress` carries the per-event pre-rendered payload (= the bytes the output had built for the wire on each event, before the unsent batch wrapper was applied), so `inject output <name>` is the correct replay path — the sink takes the per-event pre-rendered bytes and re-routes via its `consume()` path, applying the current batch wrapper / headers / compression as if the event had just been enqueued. Do **not** route shutdown-drain records through `inject input <name>`: doing so feeds the per-event pre-rendered payload back into the pipeline as raw `ingress`, which is almost never what you want.
 
 **Fail-fast pilot.** Before any large replay, validate the fix on a single record:
 
 ```bash
-jq -c 'select(.process == "(output mysink)") | .event' \
+jq -c 'select(.kind == "output" and .output.name == "mysink") | .event' \
     /var/log/limpid/errored.jsonl \
     | head -1 \
-    | limpidctl inject input <input_name> --json
+    | limpidctl inject output mysink --json
 ```
 
-Tap the input or the failing process ([Debug Tap](./tap.md)) in another shell to watch what happens. If the one record succeeds, fan out to the full file; if it fails the same way, stop and fix the root cause before continuing.
+Tap the output ([Debug Tap](./tap.md)) in another shell to watch what happens. If the one record succeeds, fan out to the full file; if it fails the same way, stop and fix the root cause before continuing.
 
-**Archive before replaying again.** Always rotate or move the DLQ file after a replay batch — otherwise the next replay will double-process everything that was already replayed and succeeded:
+**Archive before replaying again.** Always rotate or move the DLQ file after a replay batch — otherwise the next replay rerun re-processes everything, including the records you just successfully replayed:
 
 ```bash
 mv /var/log/limpid/errored.jsonl \
@@ -302,24 +373,29 @@ wc -l /var/log/limpid/errored.jsonl
 
 For rotation, see the [Recommended `logrotate` configuration](#recommended-logrotate-configuration) above. A retention policy on the rotated archives — for example, compress after 1 day, ship to long-term storage at 7 days, delete at 30 — sits on top of that `logrotate` block via a separate cron / archival job; it is intentionally not embedded in `logrotate` itself because retention is environment-specific (compliance hold, cold-storage budget, replay window) and should not be coupled to in-process rotation.
 
-**Alerting on DLQ growth.** The metric to alert on is `events_errored` (pipeline metric), and `events_errored_unwritable` is the secondary alarm that the DLQ writer itself is failing — see [Metrics](./metrics.md) for the full list. A Prometheus rule:
+**Alerting on DLQ growth.** Two counters together cover both flavors: pipeline-side failures (Process records + the enqueue-failure subset of Output records) bump `events_errored` on the pipeline, while sink-side failures (retry exhausted, shutdown drain, batched-output per-event render failures) bump `events_failed` on the originating output. `events_errored_unwritable` is the secondary alarm that the DLQ writer itself is failing — see [Metrics](./metrics.md) for the full list. A Prometheus rule:
 
 ```promql
-# Sustained failure: more than 10 events/sec into the DLQ for 5 minutes.
+# Sustained pipeline-side failure (Process flavor + output enqueue):
+# more than 10 events/sec into the DLQ for 5 minutes.
 rate(limpid_pipeline_events_errored_total[5m]) > 10
+
+# Sustained sink-side failure (Output flavor retry / shutdown / render):
+# any single output averaging > 10 failures/sec for 5 minutes.
+rate(limpid_output_events_failed_total[5m]) > 10
 
 # Alarm: the DLQ writer itself can't write — replay is partial.
 increase(limpid_pipeline_events_errored_unwritable_total[5m]) > 0
 ```
 
-(Confirm the exact exported metric names against your `limpid-prometheus` exporter; the in-process counter names are `events_errored` and `events_errored_unwritable`.)
+(Confirm the exact exported metric names against your `limpid-prometheus` exporter; the in-process counter names are `events_errored`, `events_failed` (per output), and `events_errored_unwritable`.)
 
-**Multi-instance DLQ aggregation.** When several limpid daemons each write their own `error_log` file, central triage means shipping each file to a single host and replaying from there. The simple shape: a `filebeat` / `vector` / `rsyslog` collector tails each daemon's DLQ and forwards the lines into a central archive bucket; replay runs against a `jq` query over the aggregated archive and injects back into the daemon whose `pipeline` field matches. Detailed multi-instance topology is deferred to a separate runbook.
+**Multi-instance DLQ aggregation.** When several limpid daemons each write their own `error_log` file, central triage means shipping each file to a single host and replaying from there. The simple shape: a `filebeat` / `vector` / `rsyslog` collector tails each daemon's DLQ and forwards the lines into a central archive bucket; replay runs against a `jq` query over the aggregated archive and injects back into the daemon whose `pipeline` (Process flavor) or `output.name` (Output flavor) matches. Detailed multi-instance topology is deferred to a separate runbook.
 
 ### 5. Anti-patterns and pitfalls
 
 - **Do not use the DLQ as a general log channel.** It exists for replayable failures. Routing successful events into it (via `error "..."` on the happy path, or by mis-configuring a process to always raise) makes the file grow without bound and buries the real failures.
-- **Do not blind-replay shutdown-drain records into an input.** The metadata is synthetic and the `ingress` is the rendered batched-output payload (see the caveat under [Replay](#3-replay)). Use `limpidctl inject output <name>` for those, or verify the downstream is in a state where pipeline re-processing of the rendered payload is safe.
+- **Do not feed Output-flavor records into `inject input`.** The `event.egress` is already-rendered batched-output bytes — re-running the pipeline on it almost never produces a useful result. Use `inject output <name>` for Output records and `inject input <name>` for Process records.
 - **Do not replay before you fix the root cause.** A still-broken pipeline turns a 10 000-line DLQ into a 20 000-line DLQ — `events_errored` keeps climbing because every replayed event fails the same way it did the first time.
 - **Do not skip the pilot.** Even a "trivial" config fix has rolled back into the DLQ at scale because something downstream — a quota, a stale auth token, a per-IP rate limit — kicks in only on the bulk traffic. One-record pilot, then fan out.
 - **Do not replay without archiving the source file.** Without `mv`-ing it aside, the next replay rerun re-processes everything, including the records you just successfully replayed; you cannot tell from the DLQ alone which records have already been re-injected.
@@ -336,10 +412,10 @@ $ echo 'sample event' \
 [input] → ingress: <134>sample event
 [process]  wrap_journal → error: process failed: unknown identifier: timestamp (event → error_log)
 
-[error_log]  {"timestamp":"...","reason":"...","process":"wrap_journal","pipeline":"journal_forward","event":{"source":{"ip":"127.0.0.1","port":0},"received_at":...,"ingress":"<134>sample event"}}
+[error_log]  {"schema_version":2,"timestamp":"...","reason":"...","pipeline":"journal_forward","kind":"process","process":{"name":"wrap_journal"},"event":{"source":{"ip":"127.0.0.1","port":0},"received_at":...,"ingress":"<134>sample event"}}
 ```
 
-This is useful for confirming the JSONL shape, the `pipeline` / `process` labels, and that the original ingress is captured correctly — all without booting the daemon or touching any file.
+This is useful for confirming the JSONL shape, the `kind` / per-kind name discriminator, and that the original ingress is captured correctly — all without booting the daemon or touching any file. The Output-flavor shape can be observed by triggering a sink retry exhaustion against an unroutable peer; `--test-pipeline` does not directly emit Output records (it stops at pipeline-side disposition).
 
 ## When the DLQ write itself fails
 
@@ -353,3 +429,77 @@ Investigate immediately:
 - Is the file path on a network filesystem with intermittent connectivity?
 
 Once the underlying issue is fixed, the next errored event lands in the file again and the counter stops increasing; existing records are unaffected.
+
+## Schema migration v1 → v2
+
+The 0.7.8 release introduces `schema_version: 2` as a **hard break**. v1 records (no `schema_version`, top-level `process` string field as the discriminator, no `kind`, no per-kind block) are not readable by v2 tooling, and v2 records are not readable by v1 tooling.
+
+The break was necessary because v1 conflated two unrelated failure shapes into one `process` field — pipeline-side failures (`wrap_journal`, `(inline)`, `(pipeline body)`, `(pipeline)`) and sink-side failures (`(output mysink)`, `(output mysink shutdown)`, and the special enqueue form `(output enqueue)` whose output name lived only inside the `reason` string). Operators replaying the file had to special-case the `(output ...)` prefix and pick a different `limpidctl inject` flag for each, with no machine-readable signal — just an in-band string convention. v2 lifts the flavor into a `kind` discriminator and gives each flavor its own block, so replay tooling can `select(.kind == "output")` and route to `inject output` deterministically.
+
+### What to do with pre-0.7.8 captures
+
+The recommended path is **archive, don't migrate**. v1 capture files predate the recovery-readiness gates, the unified `event.egress` carry, and (for Output-flavor records) the `inject output` replay command itself — so replaying them under the new daemon is operationally weaker than letting the 0.7.8 daemon re-fail any still-affected events into the new v2 file.
+
+```bash
+# At upgrade time: rotate the existing v1 file aside.
+mv /var/log/limpid/errored.jsonl \
+   /var/log/limpid/errored.jsonl.v1.archived-$(date -u +%Y%m%dT%H%M%SZ)
+```
+
+The 0.7.8 daemon recreates `errored.jsonl` on the first v2 failure.
+
+### If you must replay a v1 capture
+
+When a specific incident requires replaying a v1 file (e.g. a known-good backend that was down during the upgrade window has come back), you can split it into Process and Output halves with `jq` and translate each:
+
+v1 used three different `process`-field encodings for the three sink-side sites:
+
+- `(output <name>)` — retry exhausted; the bare output name is recoverable from the parenthetical.
+- `(output <name> shutdown)` — shutdown drain; same, with a `" shutdown"` suffix.
+- `(output enqueue)` — enqueue failure; **the output name does not appear in `process`**. It is buried inside the `reason` string (`output enqueue failed for: <names> (queue closed, disk write error, or unknown output)`), and a single pipeline-eval result with multiple failing outputs would produce one v1 record naming every failed output in `reason`, not one record per failing output. v2 records each failing output separately, so a faithful round-trip means parsing the `reason` string and splitting.
+
+The recipes below cover retry-exhausted and shutdown-drain; v1 enqueue records need manual handling and are skipped.
+
+```bash
+# v1 → v2 Process-flavor translation.
+# (v1 records whose `process` field does NOT start with "(output ".)
+jq -c 'select((.process | startswith("(output ")) | not) | {
+    schema_version: 2,
+    timestamp,
+    reason,
+    pipeline,
+    kind: "process",
+    process: { name: .process },
+    event: { source: .event.source, received_at: .event.received_at, ingress: .event.ingress }
+}' /var/log/limpid/errored.jsonl.v1.archived-* \
+    > /tmp/v1-process.jsonl
+
+# v1 → v2 Output-flavor translation — retry-exhausted + shutdown-drain ONLY.
+# (v1 `(output enqueue)` records are skipped; see the manual paragraph below.)
+jq -c 'select(.process | startswith("(output ") and .process != "(output enqueue)") | {
+    schema_version: 2,
+    timestamp,
+    reason,
+    pipeline,
+    kind: "output",
+    # Strip the "(output " prefix and the trailing " shutdown)" / ")" suffix
+    # to recover the bare output name. (No " enqueue)" handling — those are
+    # filtered out above.)
+    output: { name: (.process
+                     | sub("^\\(output\\s+"; "")
+                     | sub("\\s+shutdown\\)$"; "")
+                     | sub("\\)$"; "")) },
+    event: .event  # v1 already carried egress on output records
+}' /var/log/limpid/errored.jsonl.v1.archived-* \
+    > /tmp/v1-output.jsonl
+
+# Spot-check the v1 enqueue records that need manual handling.
+jq -c 'select(.process == "(output enqueue)")' \
+    /var/log/limpid/errored.jsonl.v1.archived-* \
+    > /tmp/v1-enqueue-manual.jsonl
+wc -l /tmp/v1-enqueue-manual.jsonl
+```
+
+The translation is lossy in two ways: (a) the v1 `(output <name>)` and `(output <name> shutdown)` site distinctions are flattened to the same `output.name`, surviving only in `reason`; (b) v1 records that do not match either prefix shape (older daemon variants) are silently dropped. v1 enqueue records are written to a separate file because reconstructing the output name (or names) from the `reason` string is fragile — operators who genuinely need to replay enqueue-failure captures should read the file by hand, identify the intended output(s), and `inject output <name>` the events one cohort at a time. Both translated halves (`/tmp/v1-process.jsonl`, `/tmp/v1-output.jsonl`) can be fed straight through the v2 replay recipes above (`inject input` for the Process file, `inject output` per name for the Output file).
+
+Re-archive the translated halves alongside the original v1 file once replay is complete.

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -10,12 +10,12 @@ limpid tracks metrics at every level of the pipeline. Each component counts its 
 | `finished` | Events that reached at least one output |
 | `dropped` | Events explicitly discarded by `drop` |
 | `discarded` | Events that completed without reaching any output |
-| `errored` | Events whose `process` raised a runtime error — routed to the [error log](./error-log.md) for inspection and replay |
+| `errored` | Events that failed at any pipeline-side producer site — process / pipeline-skeleton runtime errors and runtime-side output enqueue failures — routed to the [error log](./error-log.md) for inspection and replay |
 | `errored_unwritable` | Subset of `errored` where the configured `error_log` write itself failed (disk full / permissions / rotation race) |
 
 **`events_discarded`** is a signal of possible misconfiguration — the event went through the entire pipeline but was never sent anywhere.
 
-**`events_errored`** is a signal of a pipeline-runtime bug — a process statement raised an error. The original event is preserved in the [error log](./error-log.md) so it can be replayed via `jq | limpidctl inject --json` once the bug is fixed.
+**`events_errored`** is the pipeline-side rollup of every event that ended in a Process flavor DLQ record (process body raised, pipeline-skeleton eval failed, explicit `error <expr>`) plus runtime-side output enqueue failures. Sink-side terminal failures (retry exhausted, shutdown drain, batched render failure, OTLP partial-success rejects) are counted separately under the per-output `events_failed`. The original event is preserved in the [error log](./error-log.md) for replay — `jq -c 'select(.kind == "process") | .event' /var/log/limpid/errored.jsonl | limpidctl inject input <name> --json` for Process records, `jq -c 'select(.kind == "output") | .event' ... | limpidctl inject output <name> --json` for Output records (see [Error Log → Replay](./error-log.md#replay)).
 
 **`events_errored_unwritable`** is alarm-level — non-zero means some errored events fell back to the `tracing::error!` channel because the configured `error_log` file couldn't be written (disk full, permissions, rotation race). Investigate before assuming replay coverage is complete; see [Error Log → When the DLQ write itself fails](./error-log.md#when-the-dlq-write-itself-fails).
 
@@ -36,12 +36,12 @@ The split between `received` and `injected` keeps "real" traffic distinguishable
 | `received` | Total events that entered this output's queue (from pipelines + injects) |
 | `injected` | Events pushed into this output's queue via `limpidctl inject` |
 | `written` | Events successfully written to the destination |
-| `failed` | Events that failed after all retry attempts. For the OTLP outputs (`otlp_grpc` / `otlp_http`), the receiver's `partial_success.rejected_log_records` is also routed here — those are events the server *accepted at the transport layer* but refused at the validation layer, dropped per the [`partial_success` policy](../otlp.md#56-retry-transport-level-only), and surfaced via this counter so dashboards see the loss. |
+| `failed` | Events whose final state on this output was a terminal failure. Includes retry-budget exhaustion, per-event render failures on batched outputs' `flush()`, shutdown-drain leftovers when the final flush fails, and — for the OTLP outputs (`otlp_grpc` / `otlp_http`) — the receiver's `partial_success.rejected_log_records`, which are events the server *accepted at the transport layer* but refused at the validation layer (dropped per the [`partial_success` policy](../otlp.md#56-retry-transport-level-only)). |
 | `retries` | Total retry attempts across all events |
 
 `received - injected` = events delivered via pipelines. `received - written - failed` ≈ events pending in the queue (useful for disk queues).
 
-`events_failed` counts every event whose final state was retry-exhausted (including OTLP `partial_success.rejected_log_records`). Of those, the ones actually lost are only the records that hit a DLQ write failure or had no DLQ configured — when `control { error_log }` is set, exhausted events are persisted into the DLQ for replay. Evaluate `events_failed` in combination with the DLQ contents (and `events_errored_unwritable`); the `--check` recovery-readiness warning (see [Error Log → Recovery readiness check](./error-log.md#recovery-readiness-check---check)) flags the no-`error_log` case at configuration time so the interpretation of `events_failed` stays unambiguous in production.
+`events_failed` is the per-output rollup of every terminal sink-side failure (retry exhausted, render failure, shutdown-drain leftover, OTLP `partial_success.rejected_log_records`). Of those, the ones actually lost are only the records that hit a DLQ write failure or had no DLQ configured — when `control { error_log }` is set, exhausted events are persisted into the DLQ for replay as Output-flavor records (see [Error Log → Producer sites](./error-log.md#producer-sites)). Evaluate `events_failed` in combination with the DLQ contents (and `events_errored_unwritable`); the `--check` recovery-readiness warning (see [Error Log → Recovery readiness check](./error-log.md#recovery-readiness-check---check)) flags the no-`error_log` case at configuration time so the interpretation of `events_failed` stays unambiguous in production.
 
 ## Viewing metrics
 

--- a/docs/src/outputs/README.md
+++ b/docs/src/outputs/README.md
@@ -57,12 +57,15 @@ Events are persisted to a Write-Ahead Log (WAL) on disk. Survives process restar
 
 ### Recovery (error_log)
 
-The daemon-wide [`control { error_log "..." }`](../operations/error-log.md) block names a JSONL file that catches payloads the queue/retry chain could not place. Two paths feed it:
+The daemon-wide [`control { error_log "..." }`](../operations/error-log.md) block names a JSONL file that catches payloads the queue/retry chain could not place. Three sink-side paths feed it as Output-flavor records (`kind: "output"`):
 
-- the retry budget was exhausted,
-- a batched output (e.g. `http`, `otlp_http`, `otlp_grpc`) failed to flush its remaining buffer at shutdown.
+- the output's `retry { ... }` budget was exhausted,
+- a batched output (`http`, `otlp_http`, `otlp_grpc`) failed to flush its remaining buffer at shutdown (one record per still-parked event),
+- the runtime could not hand an event to the output's queue at the pipeline → output boundary (queue closed, disk-queue write error, unknown output).
 
-Each line is one rendered payload. When `error_log` is unset the daemon falls back to 0.7.7-compatible behaviour (warn + drop), and `limpid --check` emits a warning so the operator notices the silent drop path.
+Each line is one per-event record carrying `event.egress` (= the pre-rendered bytes the sink had built). Replay via `limpidctl inject output <name> --json` hands the event back to the sink's `consume()` path — no pipeline re-run, no re-render. See [Error Log → Output flavor](../operations/error-log.md#output-flavor) for the full record shape and producer-site catalog.
+
+When `error_log` is unset, Output-flavor records fall back to a name-only `tracing::warn!` / `error!` line that does **not** serialize the event payload — the data is effectively dropped. `limpid --check` emits a recovery-readiness warning so the operator notices the silent drop path before the first failure.
 
 ## Usage in pipelines
 

--- a/docs/src/outputs/http.md
+++ b/docs/src/outputs/http.md
@@ -70,7 +70,7 @@ Each `peer` block configures one target endpoint:
 | `tls.ca` | no | Custom CA certificate file (PEM) for this peer. Falls back to the system root store if omitted. |
 | `tls.cert`, `tls.key` | no (paired) | Client certificate and private key for mTLS, as separate PEM files (chmod 600 the key). Both must be present together. |
 
-On each send the rotation picks the next available peer (cooldown expired) and tries it. On failure that peer is marked cooled-down for ~5 s and subsequent sends rotate past it until the cooldown expires. When every peer is currently cooled the rotation falls back to the cursor start — the queue layer's per-event retry then handles re-delivery.
+On each send the rotation picks the next available peer (cooldown expired) and tries it. On failure that peer is marked cooled-down for ~5 s and subsequent sends rotate past it until the cooldown expires. When every peer is currently cooled the rotation falls back to the cursor start — the output's per-flush retry budget (driven inside `consume()`) then handles re-delivery without dropping the drained batch.
 
 ### headers block
 
@@ -92,11 +92,11 @@ When `batch_size > 1`, events are buffered and sent in a single HTTP request bod
 - `batch_size` events have accumulated, or
 - `batch_timeout` has elapsed since the last event (debounce timer)
 
-On flush failure, events are returned to the buffer for retry by the queue.
+On flush failure the events are returned to the in-memory buffer; the output's per-flush retry loop drives re-delivery on the next `batch_timeout` tick (the queue layer cannot re-push a buffered batch — its cursor only advances when each event's ack handle resolves at flush time).
 
 ### Shutdown
 
-When the daemon stops, a final flush is attempted for any partial batch. If that flush fails unrecoverably, the buffered request body is drained to `control { error_log "..." }`, one DLQ record per rendered body. Without `error_log` configured, behaviour matches 0.7.7 (warn + drop). Because the in-memory queue drops the source `Event` envelope as soon as `write()` returns `Ok`, the original metadata cannot be reconstructed at shutdown — DLQ records emitted on this path carry a synthetic source and the shutdown time as `received_at`.
+When the daemon stops, a final flush is attempted for any partial batch. If that flush fails unrecoverably, the buffered events are drained to `control { error_log "..." }` as one Output-flavor DLQ record per still-parked event — `event.source`, `event.received_at`, `event.ingress`, and `event.egress` reflect the original per-event provenance because the batched output parks the source `Event` alongside its `QueueAckHandle` until the flush resolves. Without `error_log` configured, behaviour matches 0.7.7 (warn + drop without serialising the payload).
 
 - Common queue / retry properties — see [Queue and retry](./README.md#queue-and-retry).
 - Recovery / DLQ behaviour for shutdown-flush leftovers — see [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).

--- a/docs/src/outputs/kafka.md
+++ b/docs/src/outputs/kafka.md
@@ -151,7 +151,7 @@ If the specified field is missing or null, the event is sent without a key (roun
 
 - rdkafka handles batching and compression internally — no manual batch configuration needed (unlike [http](./http.md)).
 - On shutdown, the producer flushes pending messages (up to 5 seconds).
-- The internal delivery timeout (`message.timeout.ms`) is 30 seconds. If a message can't be delivered within that time, it's returned as an error and limpid's [queue retry](./README.md#queue-and-retry) handles re-delivery.
+- The internal delivery timeout (`message.timeout.ms`) is 30 seconds. If a message can't be delivered within that time, it's returned as an error and the output's `retry { ... }` budget (driven inside `consume()`) handles re-delivery. On retry exhaustion the payload routes to `control { error_log "..." }` as an Output-flavor DLQ record; see [Outputs → Recovery (error_log)](./README.md#recovery-error_log).
 
 ## Example
 

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -2,7 +2,7 @@
 
 Forwards events to one or more OpenTelemetry collectors / OTLP-compatible SaaS backends over OTLP/gRPC. Multiple peers are tried in round-robin order with per-peer cooldown on failure.
 
-Each Event's `egress` is expected to be the singleton ResourceLogs protobuf bytes produced by [`otlp.encode_resourcelog_protobuf`](../functions/expression-functions.md#otlp). The output buffers these per-Event ResourceLogs, flushes on `batch_size` or `batch_timeout`, wraps the batch in an `ExportLogsServiceRequest`, and ships it.
+Each Event's `egress` is expected to be the singleton ResourceLogs protobuf bytes produced by [`otlp.encode_resourcelog_protobuf`](../functions/expression-functions.md#otlpencode_resourcelog_protobufhashlit--bytes). The output buffers these per-Event ResourceLogs, flushes on `batch_size` or `batch_timeout`, wraps the batch in an `ExportLogsServiceRequest`, and ships it.
 
 > Why limpid's OTLP behaves the way it does — Resource attributes are user-authored not auto-detected, `partial_success` is not retried selectively, `batch_level` is wire-only and semantically null — is documented in [OTLP — design rationale](../otlp.md). The reference table below covers *how* to configure; the design page covers *why* the defaults are what they are.
 
@@ -88,7 +88,7 @@ Identical semantics to the [otlp_http batch_level](./otlp_http.md#batch_level) �
 
 - `partial_success` on the response (rejected log records) is logged as a warning. The internal `retry { … }` block does not branch on `partial_success` — it retries the whole batch on transport failures only. A finer "retry just the rejects" policy is queued for a later release.
 - On a transport error during a partial-success flush, the drained batch is restored to the in-memory buffer so the rejected records are not lost to the next attempt.
-- At shutdown, if a final flush fails unrecoverably, the remaining buffered ResourceLogs are drained to `control { error_log "..." }` — one DLQ record per rendered request body. Without `error_log` the daemon falls back to 0.7.7 behaviour (warn + drop); shutdown-path DLQ records carry a synthetic source and the shutdown time as `received_at` because the envelope `Event` is dropped at `write()` Ok. See [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).
+- At shutdown, if a final flush fails unrecoverably, the buffered events are drained to `control { error_log "..." }` as one Output-flavor DLQ record per still-parked event — `event.source`, `event.received_at`, `event.ingress`, and `event.egress` reflect the original per-event provenance because the batched output parks the source `Event` alongside its `QueueAckHandle` until the flush resolves. Without `error_log` the daemon falls back to 0.7.7 behaviour (warn + drop without serialising the payload). See [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).
 - Common queue / retry properties — see [Queue and retry](./README.md#queue-and-retry).
 - Server TLS uses rustls (aws-lc-rs provider). System root certificates are loaded via tonic's `tls-roots`; supply `tls { ca }` to add a custom CA on top.
 - For HTTP transport see [otlp_http](./otlp_http.md).

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -2,7 +2,7 @@
 
 Forwards events to one or more OpenTelemetry collectors / OTLP-compatible SaaS backends over OTLP/HTTP, in either `http_protobuf` (default) or `http_json` wire format. Multiple peers are tried in round-robin order with per-peer cooldown on failure.
 
-Each Event's `egress` is expected to be the singleton ResourceLogs protobuf bytes produced by [`otlp.encode_resourcelog_protobuf`](../functions/expression-functions.md#otlp). The output buffers these per-Event ResourceLogs, flushes on `batch_size` or `batch_timeout`, wraps the batch in an `ExportLogsServiceRequest`, and ships it.
+Each Event's `egress` is expected to be the singleton ResourceLogs protobuf bytes produced by [`otlp.encode_resourcelog_protobuf`](../functions/expression-functions.md#otlpencode_resourcelog_protobufhashlit--bytes). The output buffers these per-Event ResourceLogs, flushes on `batch_size` or `batch_timeout`, wraps the batch in an `ExportLogsServiceRequest`, and ships it.
 
 > Why limpid's OTLP behaves the way it does — Resource attributes are user-authored not auto-detected, `partial_success` is not retried selectively, `batch_level` is wire-only and semantically null — is documented in [OTLP — design rationale](../otlp.md). The reference table below covers *how* to configure; the design page covers *why* the defaults are what they are.
 
@@ -138,6 +138,6 @@ The merging modes are wire-efficiency optimisations; if your batch sizes are mod
 
 - `http_protobuf` is the canonical OTLP wire form; `http_json` serializes per the OTLP/JSON canonical mapping (camelCase, u64-as-string, bytes-as-hex).
 - `verify false` skips certificate verification — development only. limpid emits a `tracing::warn!` once per `https://` peer at startup when `verify false` is in effect so the misconfiguration is greppable in the daemon log. Has no effect on `http://` endpoints (no TLS to verify).
-- At shutdown, if a final flush of the remaining buffered ResourceLogs fails unrecoverably, the buffer is drained to `control { error_log "..." }`, one DLQ record per rendered request body. Without `error_log` the daemon falls back to 0.7.7 behaviour (warn + drop); because the in-memory queue drops the source `Event` envelope at `write()` Ok, shutdown-path DLQ records carry a synthetic source and the shutdown time as `received_at`. See [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).
+- At shutdown, if a final flush of the remaining buffered ResourceLogs fails unrecoverably, the buffered events are drained to `control { error_log "..." }` as one Output-flavor DLQ record per still-parked event — `event.source`, `event.received_at`, `event.ingress`, and `event.egress` reflect the original per-event provenance because the batched output parks the source `Event` alongside its `QueueAckHandle` until the flush resolves. Without `error_log` the daemon falls back to 0.7.7 behaviour (warn + drop without serialising the payload). See [Queue and retry → Recovery (error_log)](./README.md#recovery-error_log).
 - Common queue / retry properties — see [Queue and retry](./README.md#queue-and-retry).
 - For gRPC transport see [otlp_grpc](./otlp_grpc.md).

--- a/docs/src/outputs/syslog-tcp.md
+++ b/docs/src/outputs/syslog-tcp.md
@@ -123,9 +123,10 @@ after expiry, the peer is reconnected and the cooldown is cleared on
 success or extended on failure.
 
 If every peer is cooled-down (or fails within the same write call), the
-write returns an error and the queued retry path handles the rest. See
-the [queue](../outputs/README.md#queue-and-retry) section for retry
-behaviour.
+write returns an error and the output's `retry { ... }` budget (driven
+inside `consume()`) handles re-delivery. On retry exhaustion the payload
+routes to `control { error_log "..." }` as an Output-flavor DLQ record;
+see [Outputs → Recovery (error_log)](../outputs/README.md#recovery-error_log).
 
 ## Notes
 


### PR DESCRIPTION
## Summary

`docs/src/operations/error-log.md` and its operator-facing cross-references still described the v1 DLQ shape — a top-level `process` string field acting as the only discriminator across five recovery paths, with no `schema_version`, no per-kind block, and a single ambiguous `event.egress` carry. After the cycle's α / PR-B rewrite the record is sum-typed (`schema_version: 2`, `kind: "process" | "output"`, per-kind `process: { name }` or `output: { name }`, Process-flavor events ingress-only, Output-flavor events carrying the pre-rendered per-event `event.egress`), and the operator-facing replay tooling split into `inject input <name>` and `inject output <name>`.

This PR rewrites the operator docs to match what the daemon actually serialises.

- **`docs/src/operations/error-log.md`** — full rewrite. Process and Output flavor sections with concrete examples, flavor-aware field tables, seven producer sites listed across the two flavors, address-free Output records rationale, recovery-readiness check, flavor-aware replay recipes, runbook discriminator table keyed on `kind` + per-kind `name` + `reason` pattern, Output-flavor shutdown-drain prose that says records carry real per-event provenance (the batched outputs park `(Event, QueueAckHandle)` pairs in their buffer; `shutdown()` walks each one under its original `source` / `received_at` / `ingress` / `egress`), and a v1 → v2 migration section covering both the recommended "archive, don't migrate" path and a `jq` translation for the cases that genuinely need replay across the boundary. v1 enqueue records — which encoded the output name only inside `reason` — are intentionally split out into a manual-handling file so the automatic recipe cannot misclassify them.
- **`docs/src/operations/metrics.md`** — `events_failed` is described as the per-output rollup of every terminal sink-side failure (retry exhausted, render-during-flush, shutdown-drain leftover, OTLP partial-success rejects); `events_errored` is the pipeline-side rollup covering Process flavor records plus enqueue failures, with explicit `inject input` vs `inject output` replay recipes.
- **`docs/src/configuration.md`** — the `error_log` row no longer says "process runtime error" only. Both flavors are listed, with the asymmetric `tracing` fallback (Process keeps the full JSONL inline; Output degrades to a name-only warn line that drops the payload) called out so operators understand why batched outputs need `error_log`.
- **`docs/src/outputs/README.md` → Recovery (error_log)** — "two paths" → three sink-side producer sites (retry exhaustion / shutdown drain / enqueue failure); each line is re-described as a per-event record carrying `event.egress` rather than a single rendered batch envelope.
- **`docs/src/outputs/{http,otlp_http,otlp_grpc,kafka,syslog-tcp}.md`** — the "queue-layer per-event retry handles re-delivery" framing is rewritten to "output owns retry; queue cursor only advances when each event's ack handle resolves". The shutdown-drain prose on the batched outputs now says one DLQ record per still-parked Event with real per-event provenance, not "one record per rendered request body with a synthetic source".
- **`docs/src/inputs/otlp-http.md`** + **`docs/src/outputs/{otlp_http,otlp_grpc}.md`** — the broken `#otlp` anchor on `expression-functions.md` is repointed at the per-function section that has a stable rendered id.

No daemon behaviour change.

## Verification

Adversarially reviewed by Codex with two passes (= one on the original draft, one on the amended `(output enqueue)` migration recipe); both rounds of findings (`reason` string drift at L313, the v1 `(output enqueue)` shape error and its overview leak at L437) are now closed. Push-gate (`uchgs verify push`) clean — only the two standing baseline `confirmed=false` scopes remain (`cicd-pipeline` Info on `release.yml:9 contents: write`, `rust` for the standing `RUSTSEC-2026-0185 quinn-proto 0.11.14` advisory and the `cargo-deny` duplicate-crate warnings; neither is PR-D1 derived).

## Test plan

- [x] `cargo build --workspace`, `cargo test --workspace --no-fail-fast`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check` all clean.
- [x] No daemon-side change; pure operator-facing prose.
- [ ] After merge, regenerate the mdbook output and spot-check the anchored cross-references (the rendered `#otlpencode_resourcelog_protobufhashlit--bytes` / `#otlpdecode_resourcelog_protobufbytes--object` anchors) resolve as expected.