### PR TITLE
docs: operator-doc sweep — output config visibility, CLI replay surface, snippet inventory

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -19,7 +19,7 @@ It contains `include` directives and global blocks (`geoip`, `control`, `table`)
 ```
 include "inputs/*.limpid"          // glob
 include "outputs/ama.limpid"       // single file
-include "/usr/share/limpid/snippets/parsers/fortigate.limpid"   // shipped snippet
+include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"   // shipped snippet
 ```
 
 Rules:

--- a/docs/src/dsl-syntax.md
+++ b/docs/src/dsl-syntax.md
@@ -114,15 +114,18 @@ def process tag {
 
 `${expr}` accepts any expression valid in the DSL: identifiers, workspace paths (`workspace.geo.country`), function calls (`lower(workspace.host)`, `strftime(received_at, "%Y")`), string concatenation with `+`, even nested string literals (`"${"${a}${b}"}"`). To embed a literal `${`, escape with `\${`.
 
-Inside `${...}` you have access to the full event:
+**Visibility differs by surface.** Inside a process body or pipeline expression (the example above), the full event is in scope. Inside an output config (`path` on `output file`, `key` on `output kafka`, etc.) the analyzer + daemon hard-reject `workspace`, `egress`, and `error` references — output config templates may only reference event-intrinsic fields (`source`, `received_at`, `ingress`). Routing decisions that depend on pipeline-mutable state belong in the pipeline body, not the output config; see [outputs/file → Dynamic path templates](./outputs/file.md#dynamic-path-templates) for the pipeline-body routing pattern.
 
-| Name | Type | Meaning |
-|------|------|---------|
-| `received_at` | Timestamp | Wall-clock at which the event was received |
-| `source` | Object `{ ip: String, port: Int }` | Peer address. Use `source.ip` for the IP string and `source.port` for the integer port; bare `source` returns the whole object |
-| `egress`, `ingress` | String / Bytes | Event byte buffers |
-| `error` | String | Error message inside a `catch` body (otherwise null) |
-| `workspace.xxx`, `workspace.xxx.yyy` | (varies) | Named workspace values (nested lookup is supported) |
+Inside `${...}` the identifiers available are:
+
+| Name | Type | Meaning | Available in output config? |
+|------|------|---------|------------------------------|
+| `received_at` | Timestamp | Wall-clock at which the event was received | Yes |
+| `source` | Object `{ ip: String, port: Int }` | Peer address. Use `source.ip` for the IP string and `source.port` for the integer port; bare `source` returns the whole object | Yes |
+| `ingress` | String / Bytes | Raw bytes as received from the input | Yes |
+| `egress` | String / Bytes | Wire bytes assembled by the pipeline | **No** (pipeline-mutable; rejected by analyzer) |
+| `error` | String | Error message inside a `catch` body (otherwise null) | **No** (pipeline-mutable; rejected by analyzer) |
+| `workspace.xxx`, `workspace.xxx.yyy` | (varies) | Named workspace values (nested lookup is supported) | **No** (pipeline-mutable; rejected by analyzer) |
 
 All [built-in functions](./functions/expression-functions.md) — `strftime`, `lower`, `regex_extract`, `to_json`, `geoip`, and the parsers — are callable from inside `${...}`.
 

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -114,9 +114,18 @@ egress = syslog.set_pri(egress, 16, 6)   // local0.info
 Returns the leading `<PRI>` value as a number (0-191), or `null` when no valid PRI is present.
 
 ```limpid
-let pri = syslog.extract_pri(ingress)
-if pri != null and pri < 8 {
-    output alert        // emergencies and alerts
+// In a process, extract the value onto workspace …
+def process tag_pri {
+    workspace.syslog.pri = syslog.extract_pri(ingress)
+}
+
+// … then route in the pipeline body.
+def pipeline ingest {
+    input syslog_udp
+    process tag_pri
+    if workspace.syslog.pri != null and workspace.syslog.pri < 8 {
+        output alert        // emergencies and alerts
+    }
 }
 ```
 

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -33,18 +33,30 @@ The name must be a bare identifier. `def function normalize_proto { ... }` is al
 
 ## Where they can be called from
 
-Anywhere an expression is evaluated — there's no callsite restriction:
+Anywhere an expression is evaluated — there's no callsite restriction on the function dispatch itself:
 
 - **Process bodies**: `workspace.limpid.severity_id = normalize_severity(workspace.cef.severity)`.
 - **Pipeline-level conditions**: `if is_critical(workspace.limpid.severity_id) { output urgent }`.
-- **`output` templates**: `path "/var/log/limpid/${normalize_proto(workspace.cef.proto)}/events.log"`.
+- **`output` templates over event-intrinsic args**: `path "/var/log/limpid/${normalize_proto(source.port)}/events.log"` — the function call itself is fine; what *its arguments* may reference is restricted by the surrounding surface (output config rejects `workspace`, `egress`, `error`; see [DSL Syntax → String interpolation](../dsl-syntax.md#string-interpolation)). To route on a pipeline-mutable value, branch in the pipeline body and select between outputs whose own templates only reference event-intrinsic fields:
+  ```
+  def output proto_tcp { type file path "/var/log/limpid/tcp/events.log" }
+  def output proto_udp { type file path "/var/log/limpid/udp/events.log" }
+  def pipeline split {
+      input syslog_udp
+      process parse_cef                                  // sets workspace.cef.proto
+      switch normalize_proto(workspace.cef.proto) {
+          "tcp" { output proto_tcp }
+          "udp" { output proto_udp }
+      }
+  }
+  ```
 - **HashLit values**: `workspace.limpid = { severity_id: normalize_severity(...), ... }`.
 - **Function arguments**: `lower(normalize_proto(workspace.cef.proto))`.
 - **Binary operands**: `if double_score(s) > threshold { ... }`.
 
-The purity contract restricts the **body** of the function (no Event reads, no side effects). The call site is unrestricted: it operates in the surrounding expression's evaluation context, which can read the Event normally and pass concrete values into the function.
+The purity contract restricts the **body** of the function (no Event reads, no side effects). The call site is dispatch-wise unrestricted: it operates in the surrounding expression's evaluation context, which can read whatever that surface allows (full Event in process bodies / pipeline expressions; event-intrinsic only in output config templates) and pass concrete values into the function.
 
-The mental model is the same as built-in primitives: `lower()` and `regex_match()` don't care where they're called from (pipeline `if` conditions, output `path` templates, process bodies — all valid). User-defined `normalize_proto()` is no different. Both are dispatched through `FunctionRegistry::call` with already-evaluated arguments. The only operator-visible difference is that `def function` lets you ship a vendor-agnostic mapping in the DSL itself, without touching Rust.
+The mental model is the same as built-in primitives: `lower()` and `regex_match()` don't care where they're called from. User-defined `normalize_proto()` is no different. Both are dispatched through `FunctionRegistry::call` with already-evaluated arguments. The only operator-visible difference is that `def function` lets you ship a vendor-agnostic mapping in the DSL itself, without touching Rust.
 
 ## When to reach for it
 
@@ -88,7 +100,7 @@ For non-trivial computations, factor intermediate values into `let` bindings:
 
 ```
 def function normalize(s) {
-    let trimmed = trim(s)
+    let trimmed = regex_replace(s, "^\\s+|\\s+$", "")
     let lowered = lower(trimmed)
     regex_replace(lowered, "\\s+", " ")
 }
@@ -185,7 +197,7 @@ Rule of thumb: **if the result is a single value the caller wants to embed somew
 A typical vendor parser uses several small functions to canonicalise vendor-specific values into OCSF-shape:
 
 ```
-// _common/severity.limpid
+// functions/normalize_severity.limpid
 def function normalize_severity(s) {
     switch lower(s) {
         "critical" { 5 }
@@ -196,7 +208,7 @@ def function normalize_severity(s) {
     }
 }
 
-// _common/proto.limpid
+// functions/normalize_proto.limpid
 def function normalize_proto(num) {
     switch num {
         6 { "tcp" }
@@ -206,7 +218,7 @@ def function normalize_proto(num) {
     }
 }
 
-// parsers/fortigate.limpid
+// parsers/parse_fortigate_cef.limpid
 def process parse_fortigate_cef_traffic {
     workspace.limpid = {
         class_uid: 4001,

--- a/docs/src/inputs/journal.md
+++ b/docs/src/inputs/journal.md
@@ -30,9 +30,15 @@ def input system {
 
 ## Wire format
 
-`ingress` is **byte-identical to one line of `journalctl -o json`** — limpid
-invents no format here (LOTL: Living Off The Land). One journal entry → one
-`Event`, with `ingress` carrying a single-line UTF-8 JSON object.
+`ingress` is shaped to be **journalctl-`-o json`-compatible for the
+fields libsystemd exposes** — limpid invents no format here (LOTL: Living
+Off The Land). One journal entry → one `Event`, with `ingress` carrying a
+single-line UTF-8 JSON object. The shape matches `journalctl -o json` on
+field set and values, with two known divergences: `__SEQNUM` /
+`__SEQNUM_ID` (newer `journalctl`) are **not surfaced** because the
+systemd-0.10.x crate exposes no equivalent API, and JSON object key order
+is libsystemd's insertion order — not guaranteed to byte-match
+`journalctl -o json`.
 
 ```
 {"__CURSOR":"s=abc...","__REALTIME_TIMESTAMP":"1714400000000000",

--- a/docs/src/inputs/otlp-grpc.md
+++ b/docs/src/inputs/otlp-grpc.md
@@ -43,7 +43,7 @@ Identical to [`otlp_http`](./otlp-http.md): one LogRecord becomes one Event with
 
 ## Reply
 
-The handler returns an empty `ExportLogsServiceResponse` on full success. If some LogRecords could not be re-encoded (very rare), the response carries `partial_success` with `rejected_log_records` set so the sender can retry just those — matching the OTLP collector convention.
+The handler returns an empty `ExportLogsServiceResponse` on full success. If some LogRecords could not be re-encoded (very rare), the response carries `partial_success` with `rejected_log_records` set so the sender can account for the rejected records — matching the OTLP collector convention. limpid itself does not treat partial-success rejects as a selective-retry primitive (the same policy on the outbound side, documented under [otlp_grpc § Notes](../outputs/otlp_grpc.md#notes)).
 
 ```protobuf
 message ExportLogsServiceResponse {

--- a/docs/src/operations/schema-validation.md
+++ b/docs/src/operations/schema-validation.md
@@ -184,7 +184,7 @@ Anything that reads JSONL from stdin and exits non-zero on failure works. The co
 
 This approach is consistent with two existing limpid patterns:
 
-- **Record and replay.** limpid has no `limpidctl record` / `limpidctl replay`. Recording is `tap --json > file.jsonl`; replay is `inject --json --replay-timing < file.jsonl`. Two primitives, one pipe, no third subcommand. See [Debug Tap](./tap.md#replay-with-tap--inject).
+- **Record and replay.** limpid has no `limpidctl record` / `limpidctl replay`. Recording is `tap <kind> <name> --json > file.jsonl` (kind is `input` / `process` / `output`); replay is `inject input <name> --json --replay-timing < file.jsonl` (or `inject output <name>` for sink-side recovery). Two primitives, one pipe, no third subcommand. See [Debug Tap](./tap.md#replay-with-tap--inject).
 - **Principle 1 — Zero hidden behavior.** A bundled validator would run "in the background" on behalf of the user. The pipe form makes every check an explicit command with an observable exit status.
 - **Principle 3 — Domain knowledge ships as DSL snippets.** OCSF, ECS, ASIM, CIM — these are domain specifications. Their maintenance lives outside the daemon by design.
 

--- a/docs/src/operations/tap.md
+++ b/docs/src/operations/tap.md
@@ -80,7 +80,7 @@ On success, `limpidctl inject` prints the number of events injected:
 
 ### Replay with tap → inject
 
-Because `tap --json` and `inject --json` share the same Event JSON schema, you can record traffic from one daemon and replay it into another (or back into the same one):
+Because `tap <kind> <name> --json` and `inject input <name> --json` (or `inject output <name>`) share the same Event JSON schema, you can record traffic from one daemon and replay it into another (or back into the same one):
 
 ```bash
 # Capture 1000 events from a live input
@@ -94,7 +94,7 @@ This is useful for reproducing parse failures, load-testing a new pipeline, or s
 
 ### Replaying with original timing
 
-By default, `inject --json` streams events as fast as stdin allows. That is fine for reproducing a single parse failure, but it does not reproduce workloads where timing matters — rate-limit behaviour, output backpressure under spikes, or filter saturation all depend on the **cadence** of incoming events, not just their content.
+By default, `inject input <name> --json` streams events as fast as stdin allows. That is fine for reproducing a single parse failure, but it does not reproduce workloads where timing matters — rate-limit behaviour, output backpressure under spikes, or filter saturation all depend on the **cadence** of incoming events, not just their content.
 
 `--replay-timing` replays events with the same wall-clock gaps they had at capture time, using each event's top-level `received_at` field (emitted by `tap --json`):
 

--- a/docs/src/outputs/file.md
+++ b/docs/src/outputs/file.md
@@ -27,7 +27,9 @@ Permissions are applied only when the file is first created.
 
 ## Dynamic path templates
 
-`path` can contain `${...}` interpolations that are evaluated per event against the full DSL. See [DSL Syntax Basics → String interpolation](../dsl-syntax.md#string-interpolation) for the full syntax; the short version:
+`path` can contain `${...}` interpolations that are evaluated per event. Only **event-intrinsic** fields are addressable from output config: `source` (the input layer's peer address), `received_at` (ingress timestamp), and `ingress` (raw bytes). Pipeline-mutable state — `workspace`, `egress`, `error` — is **rejected at parse time** by the analyzer and the daemon both, so a template that references them never reaches runtime. (Routing decisions that depend on pipeline-internal state belong in the pipeline body — split traffic into multiple `def output` blocks, each with its own static or event-intrinsic destination, and use `if`/`switch` in the pipeline to pick which output an event goes to.)
+
+See [DSL Syntax Basics → String interpolation](../dsl-syntax.md#string-interpolation) for the full interpolation syntax. The short version:
 
 ```
 def output per_source {
@@ -35,42 +37,59 @@ def output per_source {
     path "/var/log/limpid/${source.ip}/${strftime(received_at, "%Y-%m-%d", "local")}.log"
 }
 
-def output per_host {
+def output rolled_daily {
     type file
-    path "/var/log/limpid/${workspace.hostname}.log"
+    path "/var/log/limpid/all/${strftime(received_at, "%Y-%m-%d", "local")}.log"
 }
 ```
 
-Any DSL expression is allowed inside `${...}` — identifiers (`source`, `workspace.xxx`), function calls (`strftime`, `lower`, `regex_extract`), string concatenation with `+`, and so on. There are no hardcoded placeholders; for calendar components, call `strftime(received_at, ...)` explicitly.
+Any DSL expression over event-intrinsic fields is allowed inside `${...}` — identifiers (`source.ip`, `received_at`), function calls (`strftime`, `lower`, `regex_extract`) over those identifiers, string concatenation with `+`, and so on. There are no hardcoded placeholders; for calendar components, call `strftime(received_at, ...)` explicitly.
+
+For per-tenant or per-content routing — anything that depends on what an earlier process parsed out — split into multiple outputs from the pipeline:
+
+```
+def output siem_apac { type file path "/var/log/limpid/apac.log" }
+def output siem_emea { type file path "/var/log/limpid/emea.log" }
+
+def pipeline route {
+    input syslog_udp
+    process parse_fortigate | classify_region   // sets workspace.region
+    switch workspace.region {
+        "apac" { output siem_apac }
+        "emea" { output siem_emea }
+    }
+}
+```
+
+The output configs stay static; the pipeline body decides which output each event reaches.
 
 ### Sanitisation
 
-Path interpolation goes through two safety passes that together make directory escape impossible.
+Path interpolation goes through three safety passes that together make directory escape impossible.
 
-**Pass 1 — per-interpolation slash strip + empty-result reject.** Every `${...}` interpolation in the path template — `${workspace.hostname}`, `${lower(workspace.host)}`, `${source.ip}`, `${a + "-" + b}`, all of them — has `/` and `\` in the resulting string replaced with `_`. An interpolation that evaluates to the empty string is rejected with an error (it would silently produce surprise paths like `/foo//bar` or `/foo/.log`).
+**Pass 1 — per-interpolation slash normalise + empty-result reject.** Every `${...}` interpolation in the path template — `${source.ip}`, `${strftime(received_at, "%Y-%m-%d", "local")}`, `${lower(source.ip)}`, all of them — has `/` and `\` in the resulting string replaced with `_`. An interpolation that evaluates to the empty string is rejected with an error (it would silently produce surprise paths like `/foo//bar` or `/foo/.log`).
 
 > The invariant is "**one interpolation = one non-empty path component**". Directory structure must be expressed in the literal parts of the template:
 >
 > ```
-> path "/var/log/${workspace.region}/${workspace.host}.log"   // OK — hierarchy is literal
+> path "/var/log/${source.ip}/${strftime(received_at, "%Y-%m-%d", "local")}.log"   // OK — hierarchy is literal
 > ```
 >
-> If a workspace value happens to contain a slash (e.g. `workspace.path = "asia/tokyo"`), it becomes `_` rather than spawning subdirectories. To split into directories, parse the value into pieces explicitly and place each piece in its own interpolation slot.
+> If an event-intrinsic value happens to contain a slash (rare on `source.ip`, but possible on `strftime` format strings that include path separators), it becomes `_` rather than spawning subdirectories. To split into directories, place each piece in its own interpolation slot.
 >
-> An empty interpolation result almost always reflects a config or data bug — a null workspace value, or an unintended Pass-2 collapse — so it's rejected up front rather than silently producing `/foo//bar` or `/foo/.log`. If a value is genuinely optional in your pipeline, build the final path string in a `process` first (with whatever default / fallback your case wants) and reference the resulting workspace key from the path template.
+> An empty interpolation result almost always reflects a misconfigured `strftime` format or a degenerate input (e.g. a Unix socket without a remote peer, where `source` falls back to a sentinel), so it's rejected up front rather than silently producing `/foo//bar` or `/foo/.log`. If a slot is genuinely optional in your wiring, build the literal hierarchy without it.
 >
-> Dots are NOT stripped — interpolations contributing to FQDN-style filenames work as expected (`${workspace.host}.log` → `web01.example.com.log`).
+> Dots are NOT stripped — interpolations contributing to FQDN-style filenames work as expected (`${source.ip}.log` for `10.0.0.1` produces `10.0.0.1.log`).
 
-**Pass 2 — `..` traversal strip on the fully-rendered path.** After all interpolations resolve and the literal+interpolation parts are joined into a single path string, every `../` sequence is removed (iterated to a fixpoint), a trailing `/..` is stripped, and a result of exactly `..` is emptied. This catches traversal that arises from concatenation across literals and interpolations even when no single piece contains a slash:
+**Pass 2 — `..` traversal strip on the fully-rendered path.** After all interpolations resolve and the literal+interpolation parts are joined into a single path string, every `../` sequence is removed (iterated to a fixpoint), a trailing `/..` is stripped, and a result of exactly `..` is emptied. Since Pass 1 already normalises slashes inside each interpolation, no single value can introduce a `..` segment of its own, but cross-literal patterns are still handled:
 
 ```
-path "/var/log/${workspace.parent}/x.log"   // parent="..", evaluated path="/var/log/../x.log"
-                                            // → Pass 2 strips "../" → "/var/log/x.log"
+path "/var/log/../x.log"   // → Pass 2 strips "../" → "/var/log/x.log"
 ```
 
-**Pass 3 — empty-path reject.** If Pass 2 collapsed the entire rendered path to `""` (e.g. the template was a single `${".."}`-shaped interpolation), error explicitly. Trailing-slash and directory-target cases are left to the OS — `EISDIR` / `ENOTDIR` give the same diagnostic surface either way.
+**Pass 3 — empty-path reject.** If Pass 2 collapsed the entire rendered path to `""`, error explicitly. Trailing-slash and directory-target cases are left to the OS — `EISDIR` / `ENOTDIR` give the same diagnostic surface either way.
 
-The three passes together guarantee that the final write path stays within the directory tree the operator declared in the template, with a non-empty filename component, regardless of what arrives in workspace.
+The three passes together guarantee that the final write path stays within the directory tree the operator declared in the template, with a non-empty filename component, regardless of what arrives on the wire.
 
 Parent directories are created automatically.
 

--- a/docs/src/outputs/kafka.md
+++ b/docs/src/outputs/kafka.md
@@ -61,7 +61,7 @@ def output authenticated {
 | `topic` | yes | — | Target topic name |
 | `compression` | no | `none` | `none`, `gzip`, `snappy`, `lz4`, `zstd` |
 | `acks` | no | `all` | `0` (fire-and-forget), `1` (leader only), `all` (all replicas) |
-| `key` | no | none | Event value to use as partition key |
+| `key` | no | none | Partition key. Only the literal `source` (= source IP address) is accepted; any other identifier is rejected at config-load time. See [Partition key](#partition-key). |
 | `queue_timeout` | no | `5s` | Max wait when rdkafka's internal queue is full |
 | `tls` | no | — | TLS block (see [tls block](#tls-block)). Omit for plaintext. |
 | `sasl` | no | — | SASL block (see [sasl block](#sasl-block)). Omit for no auth. |
@@ -138,14 +138,31 @@ footing.
 
 ## Partition key
 
-The `key` property determines which event field is used as the Kafka partition key. Events with the same key go to the same partition (ordering guarantee).
+The `key` property determines which event field is used as the Kafka partition key. Only the literal value `source` is accepted — events from the same source IP go to the same partition (per-source ordering). Any other identifier (including `workspace.*` paths that earlier limpid releases used for per-tenant or per-field partitioning) is rejected at config-load time with a migration message.
 
 | Value | Key source |
 |-------|------------|
-| `source` | Source IP address |
-| any other identifier | Named workspace value (must be a string) — for example `workspace.cef.device_vendor` or a custom field set by an earlier process |
+| `source` | Source IP address (event-intrinsic, always available) |
 
-If the specified field is missing or null, the event is sent without a key (round-robin across partitions).
+If `key` is omitted, the event is sent without a partition key (round-robin across partitions).
+
+For per-tenant or per-content partitioning, split traffic into separate `output kafka` blocks from the pipeline body and give each one its own `topic` (or its own broker cluster):
+
+```
+def output kafka_apac { type kafka brokers "..." topic "logs-apac" }
+def output kafka_emea { type kafka brokers "..." topic "logs-emea" }
+
+def pipeline route {
+    input syslog_udp
+    process parse_fortigate | classify_region   // sets workspace.region
+    switch workspace.region {
+        "apac" { output kafka_apac }
+        "emea" { output kafka_emea }
+    }
+}
+```
+
+Routing decisions stay in the pipeline body; the output configs stay static and addressable.
 
 ## Notes
 

--- a/docs/src/pipelines/multi-host.md
+++ b/docs/src/pipelines/multi-host.md
@@ -210,7 +210,7 @@ sudo limpidctl tap output to_relay
 # <14>1 2026-04-20T06:15:23.104Z edge01 app - - - app[12345]: {"level":"INFO","msg":"user login","user":"alice"}
 ```
 
-Replaying captured traffic into a staging relay is the same pattern: `tap --json` on one daemon, `inject --json` on the other. See [Debug Tap](../operations/tap.md#replay-with-tap--inject) for the full workflow, including `--replay-timing` for cadence-sensitive tests.
+Replaying captured traffic into a staging relay is the same pattern: `tap <kind> <name> --json` on one daemon, `inject input <name> --json` (or `inject output <name>` for sink-side replay) on the other. See [Debug Tap](../operations/tap.md#replay-with-tap--inject) for the full workflow, including `--replay-timing` for cadence-sensitive tests.
 
 This matters because pipeline correctness is a two-axis problem: *does the config express the right intent*, and *does the expressed intent work against real traffic shapes*. The first axis is covered by `limpid --check` and code review. The second is covered by `inject` + `tap` on recorded traffic, in CI, against the same DSL that runs in production.
 

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -108,7 +108,7 @@ The following shapes compile, pass tests, and are wrong. They compile because th
 
 ### Stateful processes
 
-A `def process` that carries state across events — a counter, a cache, a "last seen" timestamp — cannot be reused across pipelines safely, cannot be replayed with `inject --json`, and cannot be reasoned about without knowing the history of traffic.
+A `def process` that carries state across events — a counter, a cache, a "last seen" timestamp — cannot be reused across pipelines safely, cannot be replayed with `inject input <name> --json`, and cannot be reasoned about without knowing the history of traffic.
 
 If you need dedup, rate-limiting, or aggregation, use a primitive that limpid ships as an explicit stateful construct (e.g. `table_lookup` + `table_upsert` backed by a declared `table`), not ad-hoc mutation inside a process body. The state is then named, observable, and owned by something other than the process.
 
@@ -167,7 +167,7 @@ The question "function or process?" has a clean answer:
 
 | Situation | Write it as |
 |-----------|-------------|
-| Pure computation, no side effects, takes arguments → returns a value, vendor-agnostic | **`def function`** in the DSL (or `_common/*.limpid`) |
+| Pure computation, no side effects, takes arguments → returns a value, vendor-agnostic | **`def function`** in the DSL (or under the shipped `functions/*.limpid`) |
 | Pure computation but the daemon should ship it (built-in availability, performance) | A built-in function in Rust (contribute upstream) |
 | Depends on a specific schema spec (RFC 5424, CEF, OCSF, …) | A namespaced built-in (`syslog.xxx`) if shipping with the daemon, otherwise a `def process` in a snippet |
 | Reads or writes `egress`, `workspace`, or `ingress` directly | A `def process` |
@@ -175,7 +175,7 @@ The question "function or process?" has a clean answer:
 | Recursive | A `def process` (`def function` rejects recursion at `--check` time) |
 | Operator-specific policy (facility rewrite, vendor filter, site-specific routing) | Always a `def process`, defined close to the pipeline that uses it |
 
-A snippet library (for example, the v0.7.0 `_common/*.limpid` + `parsers/*.limpid` + `composers/*.limpid` collection that ships under `/usr/share/limpid/snippets/`) mixes the three: `def function` for vendor-agnostic mappings (severity, proto, action), `def process` for the parser / composer bodies that consume Event state and write to `workspace.limpid`, and built-in primitives (`syslog.parse`, `cef.parse`, `to_json`, `regex_*`) as the building blocks underneath.
+A snippet library (the `functions/*.limpid` + `parsers/parse_*.limpid` + `composers/compose_*.limpid` collection that ships under `/usr/share/limpid/snippets/`) mixes the three: `def function` files under `functions/` for vendor-agnostic mappings (severity, proto, action), `def process` files under `parsers/parse_*` for vendor parsers and under `composers/compose_*` for the per-class composer bodies that consume Event state and write to `workspace.limpid`, and built-in primitives (`syslog.parse`, `cef.parse`, `to_json`, `regex_*`) as the building blocks underneath.
 
 ## Writing for a snippet library
 
@@ -183,15 +183,15 @@ If your process is intended to ship in a library (vendor parsers, OCSF composers
 
 ### One schema per file
 
-The library's organising axis is the **schema** a snippet implements. For vendor parsers, a schema is a *(vendor, format)* pair — `parsers/fortigate_cef.limpid` is one schema (FortiGate's CEF field model), `parsers/fortigate_syslog.limpid` is another (FortiGate's KV-over-syslog field model). The two share a vendor name but their field shapes, dispatchers, and subtype handling are different enough that the FortiGate documentation itself splits them into separate references; the snippet library follows.
+The library's organising axis is the **schema** a snippet implements. For vendor parsers, a schema is a *(vendor, format)* pair — `parsers/parse_fortigate_cef.limpid` is one schema (FortiGate's CEF field model), `parsers/parse_fortigate_syslog.limpid` is another (FortiGate's KV-over-syslog field model). The two share a vendor name but their field shapes, dispatchers, and subtype handling are different enough that the FortiGate documentation itself splits them into separate references; the snippet library follows.
 
-For OCSF composers, the schema *is* the class — `composers/ocsf_network_activity.limpid`, `composers/ocsf_detection_finding.limpid`. OCSF is vendor- and format-independent on purpose, so per-class is the natural unit.
+For OCSF composers, the schema is the class. The library ships a single dispatcher per emit format (`composers/compose_ocsf.limpid`) that branches on the OCSF class id (`workspace.limpid.class_uid`) to assemble the right shape per event, so vendors that feed multiple OCSF classes can share one composer entry point.
 
 The contents of one file:
 
 - The leaf parsers (or the per-class composer body).
 - The dispatcher (subtype dispatcher for parsers, the schema-level `compose_ocsf` for composers).
-- Helpers that are specific to this schema. Helpers shared across multiple schemas live under `_common/` and are included as needed.
+- Helpers that are specific to this schema. Helpers shared across multiple schemas live under `functions/` and are included as needed.
 
 A vendor's "any format" entry point (e.g. `parse_fortigate` that detects format and routes to the right `(vendor, format)` parser) is a thin shim that includes both per-schema files and dispatches between them — that shim is the only place the vendor-without-format abstraction lives.
 

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -111,7 +111,7 @@ def process safe_parse_json {
 
 `try` is for **expected** failures the operator knows how to handle inline — typically a mixed stream where some events take one shape and others take another, and the process needs to record which is which on workspace and continue.
 
-When an error is **unexpected** (a bug in a wrap process, a parser hitting input it wasn't designed for, a typo'd workspace key), don't wrap it in `try`. Let it propagate: limpid sets the original event aside in the [error log](../operations/error-log.md) (DLQ) and increments `events_errored`. The operator audits the DLQ, fixes the cause, and replays via `jq | limpidctl inject --json`. Catching unexpected errors in `try` blocks would silently swallow the bug — the event would still flow downstream with whatever partial state the catch block put on workspace, and the failure signal would be lost.
+When an error is **unexpected** (a bug in a wrap process, a parser hitting input it wasn't designed for, a typo'd workspace key), don't wrap it in `try`. Let it propagate: limpid sets the original event aside in the [error log](../operations/error-log.md) (DLQ) and increments `events_errored`. The operator audits the DLQ, fixes the cause, and replays via `jq -c 'select(.kind == "process") | .event' ... | limpidctl inject input <name> --json`. Catching unexpected errors in `try` blocks would silently swallow the bug — the event would still flow downstream with whatever partial state the catch block put on workspace, and the failure signal would be lost.
 
 Rule of thumb: if the catch block has nothing useful to do besides stamp `workspace.failed = true`, you don't want `try` — you want the DLQ.
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -9,10 +9,12 @@ a vendor adds a field (the snippet is plain DSL: edit the file and
 SIGHUP).
 
 > **Status:** the snippet library was introduced in v0.7.0 and has
-> expanded across the 0.7.x line. It currently ships 24 vendor
-> parsers (plus 2 transport parsers — `parse_syslog` and
-> `parse_journald`), the OCSF 1.3.0 27-class composer, the RFC 5424 and
-> replay-shape composers, one filter, and several reusable
+> expanded across the 0.7.x line. It currently ships 31 parser files
+> (vendor parsers — FortiGate / ASA / Checkpoint / Palo Alto / Sysmon /
+> CloudTrail / Okta / Azure Activity / K8s audit / AWS GuardDuty /
+> VPC Flow / … — plus the transport parsers `parse_syslog` and
+> `parse_journald`), the OCSF 1.3.0 27-class composer, the RFC 5424
+> and replay-shape composers, one filter, and several reusable
 > functions. Coverage continues to grow on the 0.7.x cadence.
 
 ## Snippet library

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -215,7 +215,7 @@ def pipeline main {
 
 The pipeline body itself is unchanged from Step 3 — only the surrounding files moved.
 
-(The `include "processes/*.limpid"` line is reserved for Step 6 — we don't have any user-defined processes to drop in there yet. Glob includes resolve to zero files quietly, so the line is harmless until Step 6 populates the directory.)
+(The `include "processes/*.limpid"` line is reserved for Step 6 — we don't have any user-defined processes to drop in there yet. The current loader **errors** if a glob matches zero files, so add the line only after Step 6 has placed at least one `.limpid` file in `processes/`.)
 
 Glob includes resolve relative to the main config file's directory. The directory layout is a convention; you could put everything in one file (and we did, until now). See [Main Configuration](./configuration.md) for the global blocks and include rules.
 
@@ -315,7 +315,7 @@ Pipelines:
   main                        278941 received     10117 finished    268824 dropped         0 discarded
 ```
 
-`tap --json` and `inject --json` are symmetric — every Event captured by one is consumable by the other, with `received_at` and `source` preserved. Add `--replay-timing` to play back at the original cadence, or `--replay-timing=10x` to compress an hour of traffic into six minutes. This makes "what would this config change have done last Tuesday?" a routine question.
+`tap <kind> <name> --json` and `inject input <name> --json` (or `inject output <name>` for sink-side replay) are symmetric — every Event captured by one is consumable by the other, with `received_at` and `source` preserved. Add `--replay-timing` to play back at the original cadence, or `--replay-timing=10x` to compress an hour of traffic into six minutes. This makes "what would this config change have done last Tuesday?" a routine question.
 
 ## Where to next
 
@@ -330,7 +330,7 @@ And along the way you've picked up the operator-side tools that come with limpid
 
 - `limpidctl tap` and `limpidctl stats` for seeing what is flowing where, live, with no redeploy,
 - `limpid --check` for catching configuration mistakes before they reach the daemon, with automatic rollback if a reload fails anyway,
-- `limpidctl tap --json` + `limpidctl inject --json --replay-timing` for capturing real traffic and replaying it through any configuration after the fact.
+- `limpidctl tap <kind> <name> --json` + `limpidctl inject input <name> --json --replay-timing` (or `inject output <name>` for sink-side replay) for capturing real traffic and replaying it through any configuration after the fact.
 
 From here:
 


### PR DESCRIPTION
## Summary

The previous DLQ-schema doc rewrite closed the operator-facing schema gap. This PR closes the remaining drift the docs-sweep review surfaced, in three clusters.

**Output config visibility** — the 0.7.8 hard-reject of `workspace`, `egress`, and `error` from output config still had operator-facing examples that would now fail at parse time.

- `docs/src/outputs/file.md` — the dynamic-path-template section is rewritten head-on: only event-intrinsic fields (`source`, `received_at`, `ingress`) are addressable from `path`; `${workspace.*}` examples are replaced with `${source.ip}` / `${strftime(received_at, ...)}` shapes, and a pipeline-body routing pattern (split into multiple `def output` blocks and `switch` on workspace state from the pipeline) is documented as the replacement for the old workspace-in-template recipe. The three-pass sanitisation block is reworded for the same reason.
- `docs/src/dsl-syntax.md` — the string-interpolation reference table gains an "available in output config" column so the asymmetric visibility is documented at the syntax-reference layer, not only per sink.
- `docs/src/outputs/kafka.md` — the `key` property is corrected to "only the literal `source`"; the per-tenant partitioning example is moved to the pipeline-body routing pattern.
- `docs/src/functions/user-defined.md` — the output-template example that passed `workspace.cef.proto` is replaced with an event-intrinsic argument, and a pipeline-body routing example is added for the workspace-input case.

**`limpidctl` CLI replay surface** — every recipe still wrote `inject --json` / `tap --json`. The current surface requires `tap <kind> <name> --json` and `inject input <name> --json` / `inject output <name> --json`.

- `docs/src/operations/schema-validation.md`, `docs/src/processing/user-defined.md`, `docs/src/tutorial.md`, `docs/src/operations/tap.md`, `docs/src/pipelines/multi-host.md`, `docs/src/processing/design-guide.md` — every replay / record recipe is updated to the kind-explicit form, and the choice between `inject input` (Process-flavor DLQ replay; full pipeline re-run) and `inject output` (Output-flavor DLQ replay; sink `consume()` re-route) is called out where the surrounding context makes it relevant.

**Snippet inventory and stale syntax** — the 0.7.x parser-snippet expansion overran the docs counts and tree references; one example was syntactically invalid; one stale `trim()` reference; one outdated include path.

- `docs/src/snippets/README.md` — "24 vendor parsers" updated to the current 31-file inventory (AWS GuardDuty / VPC Flow, Azure Activity, K8s audit, Okta System Log and others landed during 0.7.x).
- `docs/src/configuration.md` — the include example pointed at `parsers/fortigate.limpid`, which never existed; updated to `parsers/parse_fortigate_cef.limpid`.
- `docs/src/processing/design-guide.md` — the snippet-tree wording predated the 0.7.x reorganisation (`_common/`, `parsers/fortigate_cef.limpid`, per-class composer files); rewritten to match the shipped `functions/`, `parsers/parse_*`, single-dispatch `composers/compose_ocsf.limpid` layout.
- `docs/src/functions/user-defined.md` — example file-path comments (`_common/severity.limpid`, `_common/proto.limpid`, `parsers/fortigate.limpid`) updated to `functions/normalize_severity.limpid`, `functions/normalize_proto.limpid`, `parsers/parse_fortigate_cef.limpid`. The `normalize(s)` example replaced its `trim(s)` call (no such primitive) with `regex_replace(s, "^\\s+|\\s+$", "")`.
- `docs/src/functions/expression-functions.md` — the `extract_pri` example showed `let pri = ...; if pri != null { output alert }` inside a single block; that shape parses in neither a process body (no `output`) nor a pipeline body (no `let`). Split into the two correct scopes.
- `docs/src/tutorial.md` — "Glob includes resolve to zero files quietly" → "errors", reflecting the current loader.
- `docs/src/inputs/journal.md` — `ingress` was described as "byte-identical to `journalctl -o json`"; libsystemd doesn't expose `__SEQNUM*` and key order is insertion-order, not byte-stable. Reworded to "journalctl-compatible for the fields libsystemd exposes" with the two known divergences spelled out.
- `docs/src/inputs/otlp-grpc.md` — the `partial_success` reply note claimed senders could "retry just those" rejected records; limpid does not treat selective retry as a primitive on either side. Softened to "account for rejected records" with a cross-reference to the matching outbound-side note.

## Verification

Adversarially reviewed by Codex with two passes; both rounds of findings (snippet-tree references in `functions/user-defined.md` and `processing/design-guide.md`) are now closed. Push-gate (`uchgs verify push`) clean — only the two standing baseline `confirmed=false` scopes remain (`cicd-pipeline` Info on `release.yml:9 contents: write`, `rust` for `RUSTSEC-2026-0185 quinn-proto 0.11.14` + `cargo-deny` duplicate-crate warnings; neither is PR-derived).

## Test plan

- [x] `cargo build --workspace`, `cargo test --workspace --no-fail-fast` (714 pass), `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check` all clean.
- [x] No daemon-side change; pure operator-facing prose.
- [ ] After merge, render the mdbook and spot-check the rewritten sections (`outputs/file.md` dynamic-path template, `dsl-syntax.md` interpolation table, `functions/user-defined.md` snippet examples) render as expected.