### PR TITLE
fix(outputs): bound shutdown drain to one attempt; never reuse retry budget

### DIFF
--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -461,8 +461,7 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
 /// has headroom inside the runtime-level shutdown budget. This is a
 /// daemon invariant tied to the runtime contract, not an operator knob —
 /// if you raise this, raise the runtime shutdown timeout in lockstep.
-pub const SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT: std::time::Duration =
-    std::time::Duration::from_secs(3);
+pub const SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Shared shutdown-time disposition for a batch whose single best-effort
 /// send attempt failed (transport error or deadline elapsed). Every

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -403,6 +403,20 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     /// ship the contents, and resolving every ack handle it has taken
     /// ownership of via `consume`.
     ///
+    /// **Contract**: every `QueueAckHandle` the output has taken
+    /// ownership of MUST be resolved (to `Delivered` or `Recovered`)
+    /// before this method returns. Any handle still parked in a local
+    /// buffer or future will be dropped when the runtime-level shutdown
+    /// timeout aborts the task, which fires `Dropped` (= silent loss
+    /// attributed to a bug). Batched outputs MUST NOT reuse their
+    /// steady-state retry budget here — the runtime caps the entire
+    /// shutdown sequence at `runtime::Daemon::SHUTDOWN_TIMEOUT` (10s),
+    /// and a retry loop that outlasts it will be killed mid-flight.
+    /// Use a single bounded attempt (e.g.
+    /// `tokio::time::timeout(SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, ...)`)
+    /// and route the unsent leftovers to the DLQ via
+    /// `route_shutdown_batch_to_dlq`.
+    ///
     /// Per-handle disposition rules mirror the steady-state contract:
     /// - successful final delivery → `resolve_delivered()`
     /// - routed to DLQ (`error_log`) after a failed final flush or a
@@ -441,37 +455,73 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     }
 }
 
-/// Shared helper: walk the leftover `(Event, QueueAckHandle)` entries
-/// from a failed batched-output shutdown flush. Each event becomes one
-/// DLQ record (carrying the real `source`, `ingress`, `received_at`)
-/// and its handle is resolved as `Recovered`. On per-record write
-/// failure we warn and continue, then still resolve the handle so the
-/// queue cursor can advance — staying parked at a broken `error_log`
-/// path would block the queue forever.
-pub async fn write_shutdown_events_to_error_log(
-    writer: &Arc<crate::error_log::ErrorLogWriter>,
+/// Per-attempt deadline for the single shutdown flush a batched output
+/// is allowed. Deliberately shorter than `runtime::Daemon::SHUTDOWN_TIMEOUT`
+/// (10s) so the DLQ drain that follows a failed / timed-out send still
+/// has headroom inside the runtime-level shutdown budget. This is a
+/// daemon invariant tied to the runtime contract, not an operator knob —
+/// if you raise this, raise the runtime shutdown timeout in lockstep.
+pub const SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(3);
+
+/// Shared shutdown-time disposition for a batch whose single best-effort
+/// send attempt failed (transport error or deadline elapsed). Every
+/// `(Event, QueueAckHandle)` entry is:
+///
+/// 1. Counted in `events_failed`.
+/// 2. Routed to the DLQ when `error_log` is `Some` (per-record write
+///    failure → warn and continue; the cursor must keep advancing).
+/// 3. Resolved as `Recovered` so the queue's ack-handle invariant holds
+///    and the handle's `Drop` does NOT fire `Dropped` (which would be
+///    silent loss attributed to a bug).
+///
+/// When `error_log` is `None` we log loudly and resolve `Recovered`
+/// anyway — keeping the handle parked is strictly worse than an
+/// explicit, logged best-effort recovery.
+pub async fn route_shutdown_batch_to_dlq(
+    error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
+    metrics: &OutputMetrics,
     output_name: &str,
     events: Vec<(Event, crate::queue::QueueAckHandle)>,
     flush_err: &anyhow::Error,
 ) {
-    let reason = format!("shutdown flush failed: {}", flush_err);
-    for (ev, ack) in events {
-        let ctx = crate::pipeline::ErroredEventContext::Output {
-            timestamp: chrono::Utc::now(),
-            pipeline: String::new(),
-            site: format!("{} shutdown", output_name),
-            reason: reason.clone(),
-            output_name: output_name.to_string(),
-            event: crate::pipeline::OutputEvent::from_owned(&ev),
-        };
-        if let Err(write_err) = writer.write(&ctx).await {
-            tracing::warn!(
-                "output '{}': error_log write during shutdown failed: {} — dropping event",
-                output_name,
-                write_err
-            );
+    use std::sync::atomic::Ordering;
+
+    if events.is_empty() {
+        return;
+    }
+    if let Some(writer) = error_log {
+        let reason = format!("shutdown flush failed: {}", flush_err);
+        for (ev, ack) in events {
+            let ctx = crate::pipeline::ErroredEventContext::Output {
+                timestamp: chrono::Utc::now(),
+                pipeline: String::new(),
+                site: format!("{} shutdown", output_name),
+                reason: reason.clone(),
+                output_name: output_name.to_string(),
+                event: crate::pipeline::OutputEvent::from_owned(&ev),
+            };
+            if let Err(write_err) = writer.write(&ctx).await {
+                tracing::warn!(
+                    "output '{}': error_log write during shutdown failed: {} — dropping event",
+                    output_name,
+                    write_err
+                );
+            }
+            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_recovered();
         }
-        ack.resolve_recovered();
+    } else {
+        tracing::warn!(
+            "output '{}': {} events dropped at shutdown (no error_log): {}",
+            output_name,
+            events.len(),
+            flush_err
+        );
+        for (_, ack) in events {
+            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_recovered();
+        }
     }
 }
 

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -1914,6 +1914,195 @@ mod tests {
         assert_eq!(output.inner.batch.lock().await.len(), 0);
     }
 
+    /// Counts every POST the failing collector receives so the test
+    /// can assert how many attempts the shutdown actually made.
+    async fn run_counting_failing_collector() -> (
+        SocketAddr,
+        Arc<std::sync::atomic::AtomicUsize>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use axum::{
+            Router, extract::State, http::StatusCode, response::IntoResponse, routing::post,
+        };
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+        #[derive(Clone)]
+        struct AppState {
+            count: Arc<AtomicUsize>,
+        }
+        async fn handle(State(s): State<AppState>) -> impl IntoResponse {
+            s.count.fetch_add(1, AtomicOrdering::Relaxed);
+            (StatusCode::INTERNAL_SERVER_ERROR, "")
+        }
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let count = Arc::new(AtomicUsize::new(0));
+        let app = Router::new().route("/", post(handle)).with_state(AppState {
+            count: Arc::clone(&count),
+        });
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (addr, count, server)
+    }
+
+    /// Regression for the 0.7.8 shutdown panic / silent loss: at shutdown
+    /// the batched flush MUST NOT consume the steady-state retry budget.
+    /// We configure `max_attempts=5` with `200ms` waits — a budget that,
+    /// if reused, would clearly visit the peer five times. The shutdown
+    /// must POST exactly once, complete promptly, drain the buffer to
+    /// the DLQ, and resolve every handle as `Recovered`.
+    #[tokio::test]
+    async fn shutdown_does_not_burn_steady_state_retry_budget() {
+        let (addr, post_count, server) = run_counting_failing_collector().await;
+        let url = format!("http://{}/", addr);
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let retry = Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 5),
+                prop_str("initial_wait", "200ms"),
+                prop_str("max_wait", "200ms"),
+                Property::KeyValue {
+                    key: "backoff".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
+                    value_span: None,
+                },
+            ],
+        };
+        let output = HttpOutput::from_properties(
+            "myout",
+            &mp(&[
+                peer_block(&url),
+                prop_int("batch_size", 100),
+                prop_str("batch_timeout", "30s"),
+                retry,
+            ]),
+            &ctx,
+        )
+        .unwrap();
+
+        consume(&output, &event_with("ev1")).await.unwrap();
+        consume(&output, &event_with("ev2")).await.unwrap();
+
+        let started = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(2), output.shutdown(Some(&writer)))
+            .await
+            .expect("shutdown must complete inside the runtime budget")
+            .unwrap();
+        let elapsed = started.elapsed();
+        server.abort();
+
+        let posts = post_count.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            posts, 1,
+            "shutdown reused the steady-state retry budget ({} attempts); expected exactly 1",
+            posts
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "shutdown took {:?} — must be bounded by SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT",
+            elapsed
+        );
+        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        let body = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(
+            body.lines().count(),
+            2,
+            "both buffered events must land in the DLQ"
+        );
+    }
+
+    /// Bind a TCP listener that completes the handshake but never reads
+    /// the request body or sends a response — the closest in-process
+    /// reproduction of the bug repro's unreachable peer. Held connections
+    /// are kept alive in the spawned task until it is aborted.
+    async fn run_stalled_listener() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                held.push(sock);
+            }
+        });
+        (addr, server)
+    }
+
+    /// Regression for the panic root cause: at shutdown the single send
+    /// attempt MUST be wrapped in a bounded timeout, otherwise an
+    /// unreachable peer (TCP accepts but never replies) outlasts the
+    /// runtime's 10s shutdown deadline, the task is aborted, and the
+    /// in-flight `shippable: Vec<(Event, QueueAckHandle)>` is dropped
+    /// without resolving — firing `QueueAckHandle::Drop` and silently
+    /// losing the events.
+    ///
+    /// Asserts that the elapsed deadline branch routes every event to
+    /// the DLQ and resolves `Recovered`, and that shutdown returns
+    /// inside `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` plus a small margin.
+    #[tokio::test]
+    async fn shutdown_bounded_by_attempt_timeout_against_stalled_peer() {
+        let (addr, server) = run_stalled_listener().await;
+        let url = format!("http://{}/", addr);
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = HttpOutput::from_properties(
+            "myout",
+            &mp(&[
+                peer_block(&url),
+                prop_int("batch_size", 100),
+                prop_str("batch_timeout", "30s"),
+                fast_retry_block(),
+            ]),
+            &ctx,
+        )
+        .unwrap();
+
+        consume(&output, &event_with("ev1")).await.unwrap();
+        consume(&output, &event_with("ev2")).await.unwrap();
+
+        let started = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT + Duration::from_secs(2),
+            output.shutdown(Some(&writer)),
+        )
+        .await;
+        let elapsed = started.elapsed();
+        server.abort();
+
+        result
+            .expect("shutdown must return before runtime would have aborted us")
+            .unwrap();
+        assert!(
+            elapsed < crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT + Duration::from_secs(1),
+            "shutdown took {:?} — must be bounded by SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT",
+            elapsed
+        );
+        assert_eq!(output.inner.batch.lock().await.len(), 0);
+
+        let body = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2, "both events must reach the DLQ");
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("deadline exceeded"),
+            "DLQ records must carry the elapsed-deadline reason, got: {joined}"
+        );
+    }
+
     /// Constructor-time error_log injection (replaces the prior
     /// `attach_error_log(&self, ...)` setter). The runtime always
     /// goes through `from_properties` with a `BuildContext` carrying

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -476,41 +476,18 @@ impl Output for HttpOutput {
 
     async fn shutdown(
         &self,
-        error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
+        _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
+        // Order: cancel the timer first so it cannot race in another
+        // flush, then take the buffer in one shot, then run the
+        // shutdown-mode flush which owns the entire disposition
+        // (Delivered on success, DLQ + Recovered otherwise). The
+        // queue consumer has already stopped pushing into us by the
+        // time `shutdown` is called, so there is no re-entrant-push
+        // race to defend against here.
         self.cancel_timer().await;
-        // Run one final flush. The flush is infallible from the
-        // caller's POV — it either ships and resolves Delivered, or
-        // routes-to-DLQ and resolves Recovered for each leftover.
-        self.flush().await;
-        // Anything still sitting in the buffer (race with timer, or
-        // a re-entrant push) is sent through the shutdown DLQ helper.
-        let leftovers = std::mem::take(&mut *self.inner.batch.lock().await);
-        if !leftovers.is_empty() {
-            let err = anyhow::anyhow!("shutdown leftover after final flush");
-            if let Some(writer) = error_log {
-                crate::modules::write_shutdown_events_to_error_log(
-                    writer,
-                    &self.inner.name,
-                    leftovers,
-                    &err,
-                )
-                .await;
-            } else {
-                tracing::warn!(
-                    "output '{}': {} events dropped at shutdown (no error_log)",
-                    self.inner.name,
-                    leftovers.len()
-                );
-                for (_, ack) in leftovers {
-                    self.inner
-                        .metrics
-                        .events_failed
-                        .fetch_add(1, Ordering::Relaxed);
-                    ack.resolve_recovered();
-                }
-            }
-        }
+        let batch = std::mem::take(&mut *self.inner.batch.lock().await);
+        self.inner.flush_events_at_shutdown(batch).await;
         Ok(())
     }
 }
@@ -704,6 +681,82 @@ impl Inner {
                 .await;
             self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
             ack.resolve_recovered();
+        }
+    }
+
+    /// Shutdown single-attempt flush; never uses the steady-state retry
+    /// budget. Render failures route per-event to DLQ as before; the
+    /// shippable subset gets one `send_batch` call wrapped in
+    /// `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The `shippable` vector is held
+    /// in this frame across the `timeout()` boundary so an `Elapsed`
+    /// outcome does NOT drop it — otherwise the inner handles would
+    /// fire `QueueAckHandle::Drop` and be counted as silent loss.
+    async fn flush_events_at_shutdown(&self, batch: Vec<(Event, QueueAckHandle)>) {
+        if batch.is_empty() {
+            return;
+        }
+        let mut messages: Vec<String> = Vec::with_capacity(batch.len());
+        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
+        let mut render_failures: Vec<(Event, QueueAckHandle, anyhow::Error)> = Vec::new();
+        for (ev, ack) in batch {
+            match render_event(&ev) {
+                Ok(m) => {
+                    messages.push(m);
+                    shippable.push((ev, ack));
+                }
+                Err(e) => render_failures.push((ev, ack, e)),
+            }
+        }
+        for (ev, ack, err) in render_failures {
+            let reason = format!("render failed during shutdown flush: {}", err);
+            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
+                .await;
+            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_recovered();
+        }
+        if messages.is_empty() {
+            return;
+        }
+        let count = shippable.len() as u64;
+        let send_outcome = tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            self.send_batch(&messages),
+        )
+        .await;
+        match send_outcome {
+            Ok(Ok(())) => {
+                self.metrics
+                    .events_written
+                    .fetch_add(count, Ordering::Relaxed);
+                for (_, ack) in shippable {
+                    ack.resolve_delivered();
+                }
+            }
+            Ok(Err(send_err)) => {
+                let err = anyhow::anyhow!("transport error: {}", send_err);
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
+            }
+            Err(_elapsed) => {
+                let err = anyhow::anyhow!(
+                    "deadline exceeded after {:?} during shutdown flush",
+                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+                );
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
+            }
         }
     }
 

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -364,38 +364,17 @@ impl Output for OtlpGrpcOutput {
 
     async fn shutdown(
         &self,
-        error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
+        _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
+        // Order: abort the deferred flush timer, take the buffer in one
+        // shot, then run the shutdown-mode flush which owns the entire
+        // disposition. The queue consumer has stopped pushing by the
+        // time `shutdown` is called, so no re-entrant-push race.
         if let Some(h) = self.flush_handle.lock().await.take() {
             h.abort();
         }
-        self.flush().await;
-        let leftovers = std::mem::take(&mut *self.inner.batch.lock().await);
-        if !leftovers.is_empty() {
-            let err = anyhow::anyhow!("shutdown leftover after final flush");
-            if let Some(writer) = error_log {
-                crate::modules::write_shutdown_events_to_error_log(
-                    writer,
-                    &self.inner.name,
-                    leftovers,
-                    &err,
-                )
-                .await;
-            } else {
-                tracing::warn!(
-                    "output '{}': {} events dropped at shutdown (no error_log)",
-                    self.inner.name,
-                    leftovers.len()
-                );
-                for (_, ack) in leftovers {
-                    self.inner
-                        .metrics
-                        .events_failed
-                        .fetch_add(1, Ordering::Relaxed);
-                    ack.resolve_recovered();
-                }
-            }
-        }
+        let batch = std::mem::take(&mut *self.inner.batch.lock().await);
+        self.inner.flush_events_at_shutdown(batch).await;
         Ok(())
     }
 }
@@ -497,6 +476,93 @@ impl Inner {
                     self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_recovered();
                 }
+            }
+        }
+    }
+
+    /// Shutdown single-attempt flush; never uses the steady-state retry
+    /// budget. Partial successes are honoured (the rejected tail goes to
+    /// DLQ with the `partial_success` reason — distinct from transport
+    /// failure), and the shippable subset gets one `send_batch` call
+    /// wrapped in `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The `shippable`
+    /// vector is held in this frame across the `timeout()` boundary so
+    /// an `Elapsed` outcome does NOT drop it — otherwise the inner
+    /// handles would fire `QueueAckHandle::Drop` and be counted as
+    /// silent loss.
+    async fn flush_events_at_shutdown(&self, batch: Vec<(Event, QueueAckHandle)>) {
+        if batch.is_empty() {
+            return;
+        }
+        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
+        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
+        for (ev, ack) in batch {
+            payloads.push(ev.egress.clone());
+            shippable.push((ev, ack));
+        }
+        if payloads.is_empty() {
+            return;
+        }
+        let count = shippable.len() as u64;
+        let send_outcome = tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            send_batch(self, payloads),
+        )
+        .await;
+        match send_outcome {
+            Ok(Ok(outcome)) => {
+                let rejected = outcome.rejected.min(count);
+                let written = count - rejected;
+                if written > 0 {
+                    self.metrics
+                        .events_written
+                        .fetch_add(written, Ordering::Relaxed);
+                }
+                if rejected > 0 {
+                    self.metrics
+                        .events_failed
+                        .fetch_add(rejected, Ordering::Relaxed);
+                }
+                let split = (count - rejected) as usize;
+                let mut iter = shippable.into_iter();
+                for (_, ack) in iter.by_ref().take(split) {
+                    ack.resolve_delivered();
+                }
+                for (ev, ack) in iter {
+                    let reason = "collector reported partial_success rejection".to_string();
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        &ev,
+                        &reason,
+                    )
+                    .await;
+                    ack.resolve_recovered();
+                }
+            }
+            Ok(Err(send_err)) => {
+                let err = anyhow::anyhow!("transport error: {}", send_err);
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
+            }
+            Err(_elapsed) => {
+                let err = anyhow::anyhow!(
+                    "deadline exceeded after {:?} during shutdown flush",
+                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+                );
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
             }
         }
     }

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -455,38 +455,17 @@ impl Output for OtlpHttpOutput {
 
     async fn shutdown(
         &self,
-        error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
+        _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
+        // Order: abort the deferred flush timer, take the buffer in one
+        // shot, then run the shutdown-mode flush which owns the entire
+        // disposition. The queue consumer has stopped pushing by the
+        // time `shutdown` is called, so no re-entrant-push race.
         if let Some(h) = self.flush_handle.lock().await.take() {
             h.abort();
         }
-        self.flush().await;
-        let leftovers = std::mem::take(&mut *self.inner.batch.lock().await);
-        if !leftovers.is_empty() {
-            let err = anyhow::anyhow!("shutdown leftover after final flush");
-            if let Some(writer) = error_log {
-                crate::modules::write_shutdown_events_to_error_log(
-                    writer,
-                    &self.inner.name,
-                    leftovers,
-                    &err,
-                )
-                .await;
-            } else {
-                tracing::warn!(
-                    "output '{}': {} events dropped at shutdown (no error_log)",
-                    self.inner.name,
-                    leftovers.len()
-                );
-                for (_, ack) in leftovers {
-                    self.inner
-                        .metrics
-                        .events_failed
-                        .fetch_add(1, Ordering::Relaxed);
-                    ack.resolve_recovered();
-                }
-            }
-        }
+        let batch = std::mem::take(&mut *self.inner.batch.lock().await);
+        self.inner.flush_events_at_shutdown(batch).await;
         Ok(())
     }
 }
@@ -612,6 +591,106 @@ impl Inner {
                     self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_recovered();
                 }
+            }
+        }
+    }
+
+    /// Shutdown single-attempt flush; never uses the steady-state retry
+    /// budget. Render failures route per-event to DLQ as before, partial
+    /// successes are honoured (the rejected tail goes to DLQ with the
+    /// `partial_success` reason — distinct from transport failure),
+    /// and the shippable subset gets one `send_batch` call wrapped in
+    /// `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The `shippable` vector is held
+    /// in this frame across the `timeout()` boundary so an `Elapsed`
+    /// outcome does NOT drop it — otherwise the inner handles would
+    /// fire `QueueAckHandle::Drop` and be counted as silent loss.
+    async fn flush_events_at_shutdown(&self, batch: Vec<(Event, QueueAckHandle)>) {
+        if batch.is_empty() {
+            return;
+        }
+        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
+        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
+        let mut render_failures: Vec<(Event, QueueAckHandle, anyhow::Error)> = Vec::new();
+        for (ev, ack) in batch {
+            match render_event(&ev) {
+                Ok(p) => {
+                    payloads.push(p);
+                    shippable.push((ev, ack));
+                }
+                Err(e) => render_failures.push((ev, ack, e)),
+            }
+        }
+        for (ev, ack, err) in render_failures {
+            let reason = format!("render failed during shutdown flush: {}", err);
+            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
+                .await;
+            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_recovered();
+        }
+        if payloads.is_empty() {
+            return;
+        }
+        let count = shippable.len() as u64;
+        let send_outcome = tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            send_batch(self, payloads),
+        )
+        .await;
+        match send_outcome {
+            Ok(Ok(outcome)) => {
+                let rejected = outcome.rejected.min(count);
+                let written = count - rejected;
+                if written > 0 {
+                    self.metrics
+                        .events_written
+                        .fetch_add(written, Ordering::Relaxed);
+                }
+                if rejected > 0 {
+                    self.metrics
+                        .events_failed
+                        .fetch_add(rejected, Ordering::Relaxed);
+                }
+                let split = (count - rejected) as usize;
+                let mut iter = shippable.into_iter();
+                for (_, ack) in iter.by_ref().take(split) {
+                    ack.resolve_delivered();
+                }
+                for (ev, ack) in iter {
+                    let reason = "collector reported partial_success rejection".to_string();
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        &ev,
+                        &reason,
+                    )
+                    .await;
+                    ack.resolve_recovered();
+                }
+            }
+            Ok(Err(send_err)) => {
+                let err = anyhow::anyhow!("transport error: {}", send_err);
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
+            }
+            Err(_elapsed) => {
+                let err = anyhow::anyhow!(
+                    "deadline exceeded after {:?} during shutdown flush",
+                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+                );
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
             }
         }
     }


### PR DESCRIPTION
## Summary

The 0.7.8 batched-output shutdown path called `self.flush().await`,
which reuses the steady-state retry budget. With an unreachable peer
and reqwest's default 30s request timeout, a single attempt outlasts
the runtime-level 10s shutdown deadline. The runtime then aborts the
task, dropping the in-flight `shippable: Vec<(Event, QueueAckHandle)>`
parked inside `Inner::flush_events` — every handle's `Drop` fires
`Dropped`, which is a `debug_assert` panic in debug builds and silent
data loss in release (events skip the DLQ, `events_failed` is bumped
without an operator-visible recovery record).

The fix tightens the shutdown contract so this category of bug cannot
recur:

- `Output::shutdown` MUST resolve every `QueueAckHandle` it has taken
  ownership of, and MUST NOT reuse the steady-state retry budget.
  Documented in the trait doc.
- `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT = 3s` — daemon invariant (not an
  operator knob), deliberately under the runtime's 10s shutdown
  deadline so the DLQ drain that follows a failed attempt still has
  headroom.
- New shared helper `route_shutdown_batch_to_dlq` owns the
  shutdown-time disposition: `events_failed` bump, route to DLQ when
  `error_log` is `Some`, log loudly when `None`, and resolve every
  handle as `Recovered`.
- Each batched output (`http`, `otlp/http`, `otlp/grpc`) drops its
  steady-state retry loop at shutdown for a single `send_batch`
  attempt wrapped in `tokio::time::timeout(SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, …)`.
  Failure paths route distinct reasons (`render failed during shutdown
  flush: …` / `transport error: …` / `deadline exceeded after 3s
  during shutdown flush`) so operator triage stays unambiguous.
- The `shippable: Vec<(Event, QueueAckHandle)>` vector is held in
  the parent stack frame, never moved into the `timeout()` future,
  so an `Elapsed` outcome surfaces the still-owned handles to the
  DLQ helper. This is the lifecycle invariant the previous shape got
  wrong.

## Verification

- `cargo test -p limpid` — all 27 integration tests pass.
- `cargo test -p limpid --bin limpid modules::output` — 146 tests pass
  (existing + 2 new regression tests).
- `cargo clippy -p limpid --bin limpid --tests -- -D warnings` clean.
- `cargo fmt --all --check` clean.

End-to-end repro (syslog UDP input + unreachable HTTP peer + SIGTERM):

```
exit=0 shutdown_elapsed=3s
INFO limpid::runtime: shutdown complete
DLQ: 5 records, reason="shutdown flush failed: deadline exceeded after 3s during shutdown flush"
```

- No panic, no abort, no `shutdown timed out` log.
- Shutdown completes at exactly `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` (3s),
  well inside the runtime's 10s budget.
- All 5 buffered events land in the DLQ with the operator-readable
  elapsed-deadline reason.

## Tests

Two new regressions in `crates/limpid/src/modules/output/http.rs`:

- `shutdown_does_not_burn_steady_state_retry_budget` — pins
  `max_attempts=5, initial_wait=200ms` retry-budget bypass: shutdown
  POSTs exactly once and returns inside 2s. If `Output::shutdown` ever
  reaches back into the steady-state retry budget again, this test
  fires.
- `shutdown_bounded_by_attempt_timeout_against_stalled_peer` — pins
  the `tokio::time::Elapsed` branch directly via a `TcpListener` that
  accepts but never replies (in-process mirror of the bug repro's
  unreachable peer). Asserts shutdown returns inside
  `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT + 1s` and DLQ records carry the
  `deadline exceeded` reason.

OTLP HTTP / gRPC outputs reuse the same `flush_events_at_shutdown`
shape and rely on their existing `shutdown_*` coverage for behavioural
regression. A `Daemon::shutdown` E2E that exercises the runtime-level
10s deadline directly is left as a follow-up — the unit composition
above pins the invariant the runtime depends on.

## Test plan

- [ ] `cargo test -p limpid` on CI
- [ ] `cargo clippy --workspace -- -D warnings` on CI
- [ ] Manual repro: `udp_in syslog → http output (unreachable peer)` + SIGTERM
  - no panic / abort in stderr
  - shutdown completes inside ~3s
  - all in-flight events land in `error_log`