### PR TITLE
fix(otlp): preserve Timestamp values in u64 fields

### DIFF
--- a/crates/limpid/src/functions/otlp/encode.rs
+++ b/crates/limpid/src/functions/otlp/encode.rs
@@ -270,6 +270,7 @@ fn u64_field(entries: Entries<'_>, key: &str) -> Option<u64> {
     lookup(entries, key).and_then(|v| match v {
         Value::Int(n) if n >= 0 => Some(n as u64),
         Value::Float(f) if f.is_finite() && f >= 0.0 && f.fract() == 0.0 => Some(f as u64),
+        Value::Timestamp(dt) => dt.timestamp_nanos_opt().and_then(|n| u64::try_from(n).ok()),
         _ => None,
     })
 }
@@ -479,4 +480,38 @@ fn anyvalue_to_hashlit<'bump>(arena: &EventArena<'bump>, av: &AnyValue) -> Value
         }
     }
     b.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, TimeZone, Utc};
+
+    #[test]
+    fn u64_field_accepts_timestamp_value() {
+        let dt: DateTime<Utc> = Utc.timestamp_opt(1_700_000_000, 123_456_789).unwrap();
+        let expected = dt.timestamp_nanos_opt().unwrap() as u64;
+        let entries: &[(&str, Value<'_>)] = &[("time_unix_nano", Value::Timestamp(dt))];
+        assert_eq!(u64_field(entries, "time_unix_nano"), Some(expected));
+    }
+
+    #[test]
+    fn u64_field_rejects_pre_epoch_timestamp() {
+        let dt: DateTime<Utc> = Utc.timestamp_opt(-1, 0).unwrap();
+        let entries: &[(&str, Value<'_>)] = &[("time_unix_nano", Value::Timestamp(dt))];
+        assert_eq!(u64_field(entries, "time_unix_nano"), None);
+    }
+
+    #[test]
+    fn log_record_carries_timestamp_nanos_on_wire() {
+        let dt: DateTime<Utc> = Utc.timestamp_opt(1_700_000_000, 123_456_789).unwrap();
+        let expected = dt.timestamp_nanos_opt().unwrap() as u64;
+        let entries: &[(&str, Value<'_>)] = &[
+            ("time_unix_nano", Value::Timestamp(dt)),
+            ("observed_time_unix_nano", Value::Timestamp(dt)),
+        ];
+        let lr = hashlit_to_log_record(&Value::Object(entries)).unwrap();
+        assert_eq!(lr.time_unix_nano, expected);
+        assert_eq!(lr.observed_time_unix_nano, expected);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a silent timestamp loss in the OTLP log-record encoder: the documented operator pattern `time_unix_nano: received_at` encoded a wire-level `0` because `received_at` evaluates to `Value::Timestamp(DateTime<Utc>)`, but `u64_field` only matched `Value::Int` / `Value::Float`. Both call sites in `hashlit_to_log_record` (`time_unix_nano`, `observed_time_unix_nano`) fell through to `.unwrap_or(0)`, so the proto default suppressed the field on the wire with no warning.

A `Value::Timestamp` arm is added to `u64_field` and converts via `timestamp_nanos_opt()` — returning `None` outside the 1677-2262 representable range (matching OTLP's u64-nanos-since-epoch contract) and rejecting pre-1970 instants through `u64::try_from`. `u64_field` is the single source of truth for u64 fields in this encoder, so the one-line fix covers every affected path.

## Test plan

- [x] `cargo test -p limpid --bins` — 681 passed (includes 3 new regression tests in `functions::otlp::encode::tests`)
- [x] `cargo clippy -p limpid --bins -- -D warnings` — clean
- [x] Regression coverage: `u64_field` happy path with `Value::Timestamp`, pre-epoch rejection, and end-to-end `hashlit_to_log_record` assertion that the encoded `LogRecord` carries the correct nanos for both `time_unix_nano` and `observed_time_unix_nano`
- [ ] Operator-facing re-verify pass for `docs/src/operations/otlp.md` compose patterns — deferred to a follow-up PR after this lands
- [ ] Encoder-side warning when `time_unix_nano` is unset (silent → loud) — deferred to a separate issue; collides with the legitimate server-side timestamp delegation use case