### PR TITLE
fix(shutdown): close handle-leak vectors via consume_shutdown trait + flusher actor

### DIFF
--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -397,6 +397,42 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     /// error and the handle's `Drop` impl fires `Dropped`.
     async fn consume(&self, event: &Event, ack: crate::queue::QueueAckHandle) -> Result<()>;
 
+    /// Drain-time variant of `consume`: called by the queue consumer
+    /// for events still buffered in the receiver AFTER the shutdown
+    /// signal was observed. Unlike `consume`, this MUST NOT use the
+    /// steady-state retry budget — the runtime caps the entire
+    /// shutdown sequence at `runtime::Daemon::SHUTDOWN_TIMEOUT` (10s),
+    /// and a retry loop (`consume_singleton` / `flush_events` with
+    /// exponential backoff) that outlasts it gets killed mid-flight,
+    /// dropping `QueueAckHandle`s unresolved.
+    ///
+    /// Contract:
+    /// - Unbatched outputs: single bounded send attempt (wrap
+    ///   transport in `tokio::time::timeout(SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, ...)`
+    ///   when blocking I/O is possible), no retry, no exponential
+    ///   backoff `sleep`.
+    /// - Batched outputs: push the `(event, ack)` pair into the
+    ///   buffer that the post-loop `shutdown()` call will drain
+    ///   bounded. Do NOT trigger a steady-state flush (`flush_events`
+    ///   with retry budget) from here — buffer only, defer the
+    ///   bounded final flush to `shutdown()`.
+    /// - On successful delivery (unbatched only): `ack.resolve_delivered()`.
+    /// - On failure (transport / timeout / render): route to DLQ via
+    ///   `route_event_to_dlq` and `ack.resolve_recovered()`.
+    /// - `Ok(())` signals the output took lifecycle ownership; actual
+    ///   disposition flows through the handle.
+    ///
+    /// This is a required method (no default) deliberately: a default
+    /// that forwarded to `consume` would silently re-introduce the
+    /// steady-state retry path the shutdown contract forbids. Forcing
+    /// every output to implement it is the compile-error-driven
+    /// guarantee that the drain path stays bounded.
+    async fn consume_shutdown(
+        &self,
+        event: &Event,
+        ack: crate::queue::QueueAckHandle,
+    ) -> Result<()>;
+
     /// Called once when the daemon is shutting down, before the queue
     /// consumer exits. The output is responsible for draining any
     /// internal buffer it still holds, making a best-effort attempt to
@@ -462,6 +498,42 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
 /// daemon invariant tied to the runtime contract, not an operator knob —
 /// if you raise this, raise the runtime shutdown timeout in lockstep.
 pub const SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Helper for unbatched `Output::consume_shutdown` implementations: given
+/// the result of a single bounded send attempt, finalize the event's
+/// disposition under the shutdown contract (no retry, no backoff).
+///
+/// - `Ok(())` → `events_written++`, ack `Delivered`.
+/// - `Err(e)` → DLQ via `route_event_to_dlq`, `events_failed++`, ack
+///   `Recovered`. Never `Dropped` — the handle is always resolved.
+///
+/// Callers are responsible for wrapping their send in
+/// `tokio::time::timeout(SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, ...)` when the
+/// transport can block (TCP / TLS / HTTPS / Unix socket) and folding the
+/// `Elapsed` error into `Err`. Sync writes (`stdout`) and best-effort
+/// fire-and-forget transports may pass the raw result directly.
+pub async fn finalize_shutdown_singleton_disposition(
+    result: Result<()>,
+    error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
+    metrics: &OutputMetrics,
+    output_name: &str,
+    event: &Event,
+    ack: crate::queue::QueueAckHandle,
+) {
+    use std::sync::atomic::Ordering;
+    match result {
+        Ok(()) => {
+            metrics.events_written.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_delivered();
+        }
+        Err(e) => {
+            let reason = format!("shutdown send failed: {}", e);
+            route_event_to_dlq(error_log, output_name, event, &reason).await;
+            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_recovered();
+        }
+    }
+}
 
 /// Shared shutdown-time disposition for a batch whose single best-effort
 /// send attempt failed (transport error or deadline elapsed). Every

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -402,9 +402,9 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     /// signal was observed. Unlike `consume`, this MUST NOT use the
     /// steady-state retry budget — the runtime caps the entire
     /// shutdown sequence at `runtime::Daemon::SHUTDOWN_TIMEOUT` (10s),
-    /// and a retry loop (`consume_singleton` / `flush_events` with
-    /// exponential backoff) that outlasts it gets killed mid-flight,
-    /// dropping `QueueAckHandle`s unresolved.
+    /// and a steady-state retry loop (e.g. `flush_events`'s
+    /// exponential backoff path) that outlasts it gets killed
+    /// mid-flight, dropping `QueueAckHandle`s unresolved.
     ///
     /// Contract:
     /// - Unbatched outputs: single bounded send attempt (wrap

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -250,6 +250,73 @@ impl Output for FileOutput {
             }
         }
     }
+
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let payload_res = {
+            let bump = bumpalo::Bump::new();
+            let arena = EventArena::new(&bump);
+            let bevent = event.view_in(&arena);
+            self.render_path_in(&bevent, &arena)
+        };
+        let payload = match payload_res {
+            Ok((resolved, is_dynamic)) => FilePayload {
+                egress: event.egress.clone(),
+                path: resolved,
+                is_dynamic,
+            },
+            Err(e) => {
+                let reason = format!("render failed: {}", RenderError::new(e));
+                crate::modules::route_event_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.name,
+                    event,
+                    &reason,
+                )
+                .await;
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                ack.resolve_recovered();
+                return Ok(());
+            }
+        };
+        match tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            self.write_payload(payload),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                ack.resolve_delivered();
+            }
+            Ok(Err(e)) => {
+                let reason = format!("shutdown write failed: {}", e);
+                crate::modules::route_event_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.name,
+                    event,
+                    &reason,
+                )
+                .await;
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                ack.resolve_recovered();
+            }
+            Err(_) => {
+                let reason = format!(
+                    "shutdown write timed out after {:?}",
+                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+                );
+                crate::modules::route_event_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.name,
+                    event,
+                    &reason,
+                )
+                .await;
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                ack.resolve_recovered();
+            }
+        }
+        Ok(())
+    }
 }
 
 impl FileOutput {

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -694,6 +694,31 @@ impl Inner {
     /// (resolve_recovered); the rest proceed to the HTTP send loop.
     /// Transport failures consume the per-flush retry budget; on
     /// exhaust the whole shippable subset is routed to DLQ.
+    /// Yield when the cooperative shutdown signal is observed. Used
+    /// in `tokio::select!` to race the transport `send_batch` future
+    /// so a stalled peer cannot trap the actor task with the batch on
+    /// its stack past the runtime shutdown deadline.
+    ///
+    /// The double-check around `notified()` closes the lost-wake race:
+    /// if `is_shutting_down` flips between our load and the call to
+    /// `notified()`, the re-check catches it; otherwise the next
+    /// `notify_waiters()` (from `shutdown()`) wakes us.
+    async fn wait_until_shutdown(&self) {
+        loop {
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            let notified = self.flush_notify.notified();
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+            // After the notify wake, the next iteration's `load`
+            // decides whether to return (shutdown observed) or loop
+            // (spurious wake from a threshold-driven flush nudge).
+        }
+    }
+
     async fn flush_events(&self, batch: Vec<(Event, QueueAckHandle)>) {
         if batch.is_empty() {
             return;
@@ -724,8 +749,22 @@ impl Inner {
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
         let final_err = loop {
-            match self.send_batch(&messages).await {
-                Ok(()) => {
+            // Race the transport against the shutdown signal. A
+            // stalled peer (= TCP accepted but never responds) holds
+            // `send_batch().await` past the runtime shutdown deadline
+            // — the actor task gets aborted with the stack-local
+            // shippable Vec, dropping every parked QueueAckHandle
+            // unresolved (the audited bug). With the race, a
+            // `shutdown()` mid-flight cancels the send future
+            // (reqwest cancels the connection on drop) and falls
+            // through to the DLQ + Recovered path below.
+            let send_outcome = tokio::select! {
+                biased;
+                res = self.send_batch(&messages) => Some(res),
+                _ = self.wait_until_shutdown() => None,
+            };
+            match send_outcome {
+                Some(Ok(())) => {
                     self.metrics
                         .events_written
                         .fetch_add(count, Ordering::Relaxed);
@@ -734,7 +773,12 @@ impl Inner {
                     }
                     return;
                 }
-                Err(e) => {
+                None => {
+                    break anyhow::anyhow!(
+                        "shutdown cancelled in-flight send (collapsed retry budget)"
+                    );
+                }
+                Some(Err(e)) => {
                     attempt += 1;
                     self.metrics.retries.fetch_add(1, Ordering::Relaxed);
                     if attempt >= self.retry.max_attempts {
@@ -2459,5 +2503,106 @@ mod tests {
         // when the output drops at end-of-test. The peer is unreachable,
         // so all three route to the test-DLQ-recovery path.
         let _ = tokio::time::timeout(Duration::from_secs(2), output.shutdown(None)).await;
+    }
+
+    /// Audit-identified leak (2026-06-27 follow-up): the flusher actor
+    /// was mid-`send_batch().await` against a stalled peer when
+    /// `shutdown()` signalled. The previous fix collapsed retry sleeps
+    /// but not the transport call itself, so the actor sat on its
+    /// stack-local `shippable` Vec until the runtime aborted it,
+    /// dropping every parked `QueueAckHandle` unresolved (debug:
+    /// panic; release: silent loss).
+    ///
+    /// This test sets up that exact race — actor wakes via
+    /// `batch_timeout`, enters `send_batch` against a TCP listener
+    /// that accepts but never responds, `shutdown()` fires — and
+    /// asserts every handle resolves to `Recovered` (via DLQ) inside
+    /// the bounded shutdown budget.
+    #[tokio::test]
+    async fn actor_send_in_flight_cancels_on_shutdown_against_stalled_peer() {
+        let (addr, server) = run_stalled_listener().await;
+        let url = format!("http://{}/", addr);
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        // Short timer wake + large batch_size so the actor (not
+        // consume itself) is the path that calls `send_batch`.
+        let output = Arc::new(
+            HttpOutput::from_properties(
+                "test",
+                &mp(&[
+                    peer_block(&url),
+                    prop_int("batch_size", 100),
+                    prop_str("batch_timeout", "100ms"),
+                    fast_retry_block(),
+                ]),
+                &ctx,
+            )
+            .unwrap(),
+        );
+
+        // One sub-threshold event — buffered, actor will pick it up
+        // when the timer fires. We must drive consume via the trait
+        // method (not the test shim) so the ack stays unresolved
+        // until the actor's flush_events resolves it.
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        <HttpOutput as Output>::consume(&output, &event_with("ev"), ack)
+            .await
+            .unwrap();
+
+        // Give the actor time to wake, take the batch, and enter
+        // `send_batch` against the stalled peer. 200ms > batch_timeout
+        // (100ms) plus a small margin for actor wake + transport
+        // handshake. The reqwest client's 30s read timeout would be
+        // the dominant wait without our cooperative cancel.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Now call shutdown. With the cooperative transport cancel,
+        // the actor's `send_batch` future is dropped, the loop falls
+        // through to the DLQ + Recovered path, the actor exits
+        // cleanly, and shutdown joins it well within
+        // SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT.
+        let started = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(5), output.shutdown(Some(&writer)))
+            .await
+            .expect("shutdown must complete inside the bounded budget")
+            .unwrap();
+        let elapsed = started.elapsed();
+        server.abort();
+
+        // The runtime budget for the whole shutdown sequence is 10s;
+        // we want this case to fit well within the per-attempt
+        // bound (3s) plus a small post-actor drain margin.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "shutdown took {:?} — transport cancel did not collapse the in-flight send",
+            elapsed
+        );
+
+        // The handle must resolve (not drop). Recovered (DLQ-routed)
+        // is the expected disposition since the peer never responded.
+        let (_pos, disposition) =
+            rx.try_recv().expect("ack must resolve, not drop unresolved");
+        assert!(
+            matches!(disposition, crate::queue::AckDisposition::Recovered),
+            "expected Recovered (DLQ), got {:?}",
+            disposition
+        );
+
+        // DLQ must have the event.
+        assert!(
+            path.exists(),
+            "DLQ file must be written when transport cancel collapses the send"
+        );
+        let body = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(
+            body.lines().count(),
+            1,
+            "the single buffered event must land in the DLQ"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -236,13 +236,29 @@ pub struct HttpOutput {
     inner: Arc<Inner>,
     batch_size: usize,
     /// Long-lived flusher actor handle. The actor task owns the
-    /// timer + flush-driven flush lifecycle. It is deliberately
-    /// NEVER `abort()`-ed — the audit found that abort()ing a task
-    /// that holds the batch on its stack across an `.await` boundary
-    /// drops every parked `QueueAckHandle` unresolved (debug panic,
-    /// release silent loss). `shutdown()` signals the actor via
-    /// `is_shutting_down` + `flush_notify.notify_waiters()` and
-    /// joins it bounded by `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`.
+    /// timer + flush-driven flush lifecycle.
+    ///
+    /// **Lifecycle contract**:
+    /// - **Normal operation (`shutdown()`)**: NEVER aborts the
+    ///   actor. It signals cooperative shutdown via
+    ///   `is_shutting_down` + `flush_notify.notify_waiters()` and
+    ///   joins it bounded by `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The
+    ///   actor resolves every stack-local handle (Delivered /
+    ///   Recovered via DLQ) before exiting.
+    /// - **`Drop` fallback (last-resort)**: sync `Drop` cannot
+    ///   `.await` the actor, so it signals first then calls
+    ///   `abort()` as a last resort. This path is for teardown
+    ///   scenarios where `shutdown()` was not invoked (e.g. config
+    ///   reload in tests). The signal gives the actor a chance to
+    ///   exit cleanly before the abort lands; in practice the
+    ///   runtime calls `shutdown()` before drop in production.
+    ///
+    /// The audit (2026-06-27) found that prior versions abort()-ed
+    /// a per-flush *timer* task that held the stack-local batch
+    /// across `flush_events.await` — dropping every parked
+    /// `QueueAckHandle` unresolved. The structural fix moves the
+    /// abort surface to this single actor handle and keeps `abort()`
+    /// off the `shutdown()` path entirely.
     actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     metrics: Arc<OutputMetrics>,
 }
@@ -478,15 +494,20 @@ impl Module for HttpOutput {
 /// triggers: threshold-driven `flush_notify`, timer-driven
 /// `batch_timeout` sleep, or shutdown via `is_shutting_down`.
 ///
-/// **Never `abort()`-ed**. The audit (2026-06-27) found that prior
-/// versions spawned a per-flush timer task that held a stack-local
-/// `Vec<(Event, QueueAckHandle)>` across `flush_events.await`, and
-/// `shutdown()` would `abort()` that task — dropping every parked
-/// handle unresolved (debug `debug_assert!(resolved)` panic, release
-/// silent `Dropped` loss). The actor here owns the entire batched
-/// lifecycle; abort surface is one handle for the whole output, and
-/// `shutdown()` joins it gracefully via `is_shutting_down` +
-/// `notify_waiters()`.
+/// **`shutdown()` never aborts this actor** — it signals
+/// cooperative shutdown and joins bounded. `Drop` is a last-resort
+/// fallback that signals then aborts, since sync `Drop` cannot
+/// `.await`. See `HttpOutput::actor_handle` for the full lifecycle
+/// contract.
+///
+/// The audit (2026-06-27) found that prior versions abort()-ed a
+/// per-flush *timer* task that held a stack-local
+/// `Vec<(Event, QueueAckHandle)>` across `flush_events.await`,
+/// dropping every parked handle unresolved
+/// (debug `debug_assert!(resolved)` panic, release silent `Dropped`
+/// loss). Consolidating the timer + flush lifecycle into this single
+/// actor and keeping `abort()` off the `shutdown()` path is the
+/// structural fix.
 async fn flusher_actor_loop(inner: Arc<Inner>) {
     loop {
         if inner.is_shutting_down.load(Ordering::Acquire) {

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -53,11 +53,11 @@
 //! ack handle resolves, not when `consume` returns.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::dsl::ast::Property;
 use crate::dsl::props;
@@ -187,7 +187,7 @@ impl Default for PeerState {
 }
 
 /// Shared state between `consume()` (= the queue consumer's hand-off
-/// into the buffer) and the flush timer task.
+/// into the buffer) and the flusher actor task.
 struct Inner {
     peers: Vec<HttpPeer>,
     peer_state: Vec<PeerState>,
@@ -221,12 +221,29 @@ struct Inner {
     /// the flush path then falls back to a `tracing::error!` line.
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    /// Threshold-driven flush trigger. `consume()` calls
+    /// `notify_one()` when the buffer crosses `batch_size`; the
+    /// flusher actor's `select!` wakes and drains.
+    flush_notify: Notify,
+    /// Co-operative cancel flag. `shutdown()` sets this to true
+    /// before notifying the actor; both the actor loop and the
+    /// in-flight `flush_events` retry loop check it so they exit
+    /// without burning the full retry budget.
+    is_shutting_down: AtomicBool,
 }
 
 pub struct HttpOutput {
     inner: Arc<Inner>,
     batch_size: usize,
-    flush_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Long-lived flusher actor handle. The actor task owns the
+    /// timer + flush-driven flush lifecycle. It is deliberately
+    /// NEVER `abort()`-ed — the audit found that abort()ing a task
+    /// that holds the batch on its stack across an `.await` boundary
+    /// drops every parked `QueueAckHandle` unresolved (debug panic,
+    /// release silent loss). `shutdown()` signals the actor via
+    /// `is_shutting_down` + `flush_notify.notify_waiters()` and
+    /// joins it bounded by `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`.
+    actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     metrics: Arc<OutputMetrics>,
 }
 
@@ -413,26 +430,89 @@ impl Module for HttpOutput {
 
         let retry = RetryConfig::from_output_properties(properties)?;
         let metrics = Arc::new(OutputMetrics::default());
+        let inner = Arc::new(Inner {
+            peers,
+            peer_state,
+            cursor: AtomicUsize::new(0),
+            method,
+            content_type,
+            headers,
+            batch_timeout,
+            compress,
+            batch: Mutex::new(Vec::with_capacity(batch_size.max(1))),
+            name: name.to_string(),
+            retry,
+            error_log,
+            metrics: Arc::clone(&metrics),
+            flush_notify: Notify::new(),
+            is_shutting_down: AtomicBool::new(false),
+        });
+
+        // Spawn the flusher actor only for true batching mode. For
+        // `batch_size <= 1` (single-event ship), `consume()` routes
+        // straight to `consume_singleton` and the buffer is unused —
+        // an actor would do nothing but consume a task slot.
+        let actor_handle = if batch_size > 1 {
+            let actor_inner = Arc::clone(&inner);
+            Some(tokio::spawn(async move {
+                flusher_actor_loop(actor_inner).await;
+            }))
+        } else {
+            None
+        };
+
         Ok(Self {
-            inner: Arc::new(Inner {
-                peers,
-                peer_state,
-                cursor: AtomicUsize::new(0),
-                method,
-                content_type,
-                headers,
-                batch_timeout,
-                compress,
-                batch: Mutex::new(Vec::with_capacity(batch_size.max(1))),
-                name: name.to_string(),
-                retry,
-                error_log,
-                metrics: Arc::clone(&metrics),
-            }),
+            inner,
             batch_size,
-            flush_handle: Mutex::new(None),
+            actor_handle: Mutex::new(actor_handle),
             metrics,
         })
+    }
+}
+
+/// Long-lived flusher actor. Drains the buffer on either of three
+/// triggers: threshold-driven `flush_notify`, timer-driven
+/// `batch_timeout` sleep, or shutdown via `is_shutting_down`.
+///
+/// **Never `abort()`-ed**. The audit (2026-06-27) found that prior
+/// versions spawned a per-flush timer task that held a stack-local
+/// `Vec<(Event, QueueAckHandle)>` across `flush_events.await`, and
+/// `shutdown()` would `abort()` that task — dropping every parked
+/// handle unresolved (debug `debug_assert!(resolved)` panic, release
+/// silent `Dropped` loss). The actor here owns the entire batched
+/// lifecycle; abort surface is one handle for the whole output, and
+/// `shutdown()` joins it gracefully via `is_shutting_down` +
+/// `notify_waiters()`.
+async fn flusher_actor_loop(inner: Arc<Inner>) {
+    loop {
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        // Race the three triggers. `biased` makes shutdown the
+        // priority arm so a `notify_waiters()` race with a
+        // threshold notify still exits cleanly.
+        let sleep_fut = tokio::time::sleep(inner.batch_timeout);
+        tokio::pin!(sleep_fut);
+        tokio::select! {
+            biased;
+            _ = inner.flush_notify.notified() => {}
+            _ = &mut sleep_fut => {}
+        }
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        let batch = {
+            let mut buf = inner.batch.lock().await;
+            std::mem::take(&mut *buf)
+        };
+        if !batch.is_empty() {
+            // `flush_events` resolves every handle (Delivered on
+            // success, Recovered on retry-exhausted DLQ). It checks
+            // `is_shutting_down` between retry attempts so a
+            // shutdown signal collapses the retry budget to one
+            // attempt instead of burning the full backoff window.
+            inner.flush_events(batch).await;
+        }
     }
 }
 
@@ -460,17 +540,15 @@ impl Output for HttpOutput {
             buf.len() >= self.batch_size
         };
         if should_flush {
-            self.cancel_timer().await;
-            self.flush().await;
-            // After flush, the buffer should be empty (flush_events
-            // resolved every handle). Defensive: re-arm if anything
-            // raced its way back in.
-            if !self.inner.batch.lock().await.is_empty() {
-                self.reset_timer().await;
-            }
-        } else {
-            self.reset_timer().await;
+            // Threshold reached: nudge the flusher actor. The actor
+            // does the take + flush; this `consume` returns
+            // immediately. No `flush()` inline here — that would
+            // make `consume` itself the abort target the timer task
+            // used to be.
+            self.inner.flush_notify.notify_one();
         }
+        // No timer reset — the actor's `select!` already races the
+        // batch_timeout sleep.
         Ok(())
     }
 
@@ -492,16 +570,44 @@ impl Output for HttpOutput {
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // Order: cancel the timer first so it cannot race in another
-        // flush, then take the buffer in one shot, then run the
-        // shutdown-mode flush which owns the entire disposition
-        // (Delivered on success, DLQ + Recovered otherwise). The
-        // queue consumer has already stopped pushing into us by the
-        // time `shutdown` is called, so there is no re-entrant-push
-        // race to defend against here.
-        self.cancel_timer().await;
-        let batch = std::mem::take(&mut *self.inner.batch.lock().await);
-        self.inner.flush_events_at_shutdown(batch).await;
+        // 1. Signal cooperative shutdown so the actor's `select!`
+        //    wakes (via `notify_waiters`) and any in-flight
+        //    `flush_events` retry sleep exits early via the
+        //    `is_shutting_down` check.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+
+        // 2. Bounded join of the flusher actor. If the actor is
+        //    currently mid-`flush_events`, the cooperative-cancel in
+        //    the retry loop collapses its retry to one attempt;
+        //    `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` (3s) is the deadline.
+        //    Critical: do NOT `abort()` on timeout — the actor's
+        //    stack-local batch would drop handles unresolved (the
+        //    audited bug). On timeout we just leave the actor task
+        //    to finish naturally; whatever it has not yet flushed is
+        //    still in the buffer (events queued via
+        //    `consume_shutdown` after the actor exited) and step 3
+        //    handles those.
+        let handle_opt = self.actor_handle.lock().await.take();
+        if let Some(h) = handle_opt {
+            let _ = tokio::time::timeout(
+                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+                h,
+            )
+            .await;
+        }
+
+        // 3. Drain whatever the actor did not pick up — anything
+        //    pushed via `consume_shutdown` after the actor exited,
+        //    plus any in-flight batch the actor was unable to flush
+        //    (those handles are still held by the actor task's
+        //    stack frame; we cannot reach them from here, so we
+        //    accept that narrow loss window in exchange for not
+        //    abort()-ing the actor). `flush_events_at_shutdown`
+        //    does one bounded send attempt then routes the rest to
+        //    DLQ + Recovered.
+        let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
+        self.inner.flush_events_at_shutdown(leftover).await;
         Ok(())
     }
 }
@@ -568,46 +674,6 @@ impl HttpOutput {
         }
     }
 
-    /// Drain the buffer and run one flush. Returns nothing — every
-    /// dispatched event has its disposition resolved internally,
-    /// either via successful delivery or via DLQ routing.
-    async fn flush(&self) {
-        let batch = {
-            let mut buf = self.inner.batch.lock().await;
-            if buf.is_empty() {
-                return;
-            }
-            std::mem::take(&mut *buf)
-        };
-        self.inner.flush_events(batch).await;
-    }
-
-    async fn cancel_timer(&self) {
-        let mut handle = self.flush_handle.lock().await;
-        if let Some(h) = handle.take() {
-            h.abort();
-        }
-    }
-
-    async fn reset_timer(&self) {
-        let mut handle = self.flush_handle.lock().await;
-        if let Some(h) = handle.take() {
-            h.abort();
-        }
-        let inner = Arc::clone(&self.inner);
-        let timeout = self.inner.batch_timeout;
-        *handle = Some(tokio::spawn(async move {
-            tokio::time::sleep(timeout).await;
-            let batch = {
-                let mut buf = inner.batch.lock().await;
-                if buf.is_empty() {
-                    return;
-                }
-                std::mem::take(&mut *buf)
-            };
-            inner.flush_events(batch).await;
-        }));
-    }
 }
 
 /// Render a single event into its HTTP body string. Called from the
@@ -669,6 +735,16 @@ impl Inner {
                     attempt += 1;
                     self.metrics.retries.fetch_add(1, Ordering::Relaxed);
                     if attempt >= self.retry.max_attempts {
+                        break e;
+                    }
+                    // Cooperative shutdown cancel: if `shutdown()`
+                    // signalled mid-retry, abandon the budget and
+                    // route the shippable batch straight to DLQ.
+                    // Burning the full backoff window would outlast
+                    // the runtime's 10s shutdown timeout and leak
+                    // the stack-local handles when the task is
+                    // aborted by the runtime.
+                    if self.is_shutting_down.load(Ordering::Acquire) {
                         break e;
                     }
                     tracing::warn!(
@@ -876,7 +952,18 @@ async fn send_once(peer: &HttpPeer, inner: &Inner, body: &[u8]) -> Result<()> {
 
 impl Drop for HttpOutput {
     fn drop(&mut self) {
-        if let Some(h) = self.flush_handle.get_mut().take() {
+        // Signal the actor cooperatively before falling back to
+        // abort — `shutdown()` should have already done this and
+        // joined, but Drop is the last-resort path (Output dropped
+        // without an explicit `shutdown()` call, e.g. config
+        // teardown in tests). The actor's stack-local batch on a
+        // bare abort would drop handles unresolved; calling
+        // `is_shutting_down` and `notify_waiters` here gives it a
+        // chance to exit cleanly first, even though we cannot await
+        // its completion from a sync Drop.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+        if let Some(h) = self.actor_handle.get_mut().take() {
             h.abort();
         }
         // Best-effort warn on leaked buffered events. Holding an Arc
@@ -1560,8 +1647,11 @@ mod tests {
             batch_len, 0,
             "singleton path must not land the event in the batch"
         );
-        let timer_armed = output.flush_handle.lock().await.is_some();
-        assert!(!timer_armed, "singleton path must not arm the flush timer");
+        let actor_spawned = output.actor_handle.lock().await.is_some();
+        assert!(
+            !actor_spawned,
+            "singleton path (batch_size <= 1) must not spawn the flusher actor"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -1858,14 +1858,14 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_flushes_pending_batch_buffer() {
-        // Regression: under batch_size > 1 the queue-side `write()`
-        // returns Ok once the event is in the buffer, so the memory
-        // queue considers it delivered. If the daemon shuts down
-        // before the batch fills or the timer fires, Drop alone
-        // aborts the timer and leaks the buffered events. The fix
-        // gives Output a `shutdown()` method that the queue consumer
-        // calls once the consume loop exits, and HttpOutput
-        // overrides it to cancel the timer and run one final flush.
+        // Regression: under batch_size > 1 `consume()` parks the
+        // (event, ack) pair in the output buffer; the queue cursor
+        // cannot advance until that handle resolves. If shutdown
+        // happens before the batch fills or before the actor's
+        // batch_timeout wake, `shutdown()` must signal/join the
+        // actor and final-drain the buffer so every parked handle
+        // resolves (Delivered on flush success, Recovered on DLQ
+        // route).
         let (addr, received, server) = run_echo_collector().await;
         let url = format!("http://{}/", addr);
         let output = HttpOutput::from_properties(
@@ -2449,8 +2449,9 @@ mod tests {
             .unwrap(),
         );
 
-        // Threshold-trigger an inline flush. The peer 5xx-fails;
-        // flush_events enters its retry loop with a 5s sleep.
+        // Threshold-trigger an actor flush. The peer 5xx-fails;
+        // the actor's flush_events enters its retry loop with a 5s
+        // sleep.
         let (ack1, _rx1) = QueueAckHandle::for_test();
         let (ack2, _rx2) = QueueAckHandle::for_test();
         let _ = output.consume(&event_with("a"), ack1).await;
@@ -2460,11 +2461,11 @@ mod tests {
             let _ = output_clone.consume(&event, ack2).await;
         });
 
-        // Let the consume task enter the retry sleep.
+        // Let the actor task enter the retry sleep.
         tokio::time::sleep(Duration::from_millis(300)).await;
 
         // Shutdown signals cooperative cancel; the retry sleep
-        // bails out via is_shutting_down and the inline flush
+        // bails out via is_shutting_down and the actor flush
         // collapses to DLQ + Recovered for both events.
         let started = std::time::Instant::now();
         tokio::time::timeout(Duration::from_secs(4), output.shutdown(Some(&writer)))

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -540,15 +540,18 @@ impl Output for HttpOutput {
             buf.len() >= self.batch_size
         };
         if should_flush {
-            // Threshold reached: nudge the flusher actor. The actor
-            // does the take + flush; this `consume` returns
-            // immediately. No `flush()` inline here — that would
-            // make `consume` itself the abort target the timer task
-            // used to be.
-            self.inner.flush_notify.notify_one();
+            // Threshold reached: flush inline, on the queue
+            // consumer's own task. Not a leak surface — the queue
+            // consumer drives the lifecycle and is never `abort()`-ed
+            // in normal operation. Preserves the prior contract that
+            // a threshold-triggered flush has resolved every ack
+            // before `consume` returns.
+            let batch = std::mem::take(&mut *self.inner.batch.lock().await);
+            self.inner.flush_events(batch).await;
         }
-        // No timer reset — the actor's `select!` already races the
-        // batch_timeout sleep.
+        // No timer reset — the long-lived flusher actor's `select!`
+        // owns the timer-driven flush. (The audited bug was the
+        // *spawned* timer task holding the batch across `await`.)
         Ok(())
     }
 
@@ -755,7 +758,20 @@ impl Inner {
                         e,
                         wait
                     );
-                    tokio::time::sleep(wait).await;
+                    // Race the sleep against a shutdown wake. The
+                    // bare check before the sleep only catches a
+                    // shutdown that arrived between attempts; a
+                    // shutdown that fires *during* the sleep would
+                    // otherwise be stuck until the sleep elapses
+                    // (5s+ in practice, longer than the runtime
+                    // shutdown budget). `flush_notify.notify_waiters`
+                    // is called by `shutdown()`, so the sleep arm
+                    // here wakes immediately and the next iteration
+                    // sees `is_shutting_down=true` and breaks.
+                    tokio::select! {
+                        _ = tokio::time::sleep(wait) => {}
+                        _ = self.flush_notify.notified() => {}
+                    }
                     wait = self.retry.next_wait(wait);
                 }
             }
@@ -2242,5 +2258,206 @@ mod tests {
             Arc::ptr_eq(stored, &writer),
             "constructor must store the exact Arc passed in"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Regression tests for the 2026-06-27 shutdown-lifecycle audit
+    // (consume_shutdown trait dispatch + cooperative cancel + actor
+    // model). These pin the new contracts so future refactors don't
+    // silently re-introduce the leak.
+    // -----------------------------------------------------------------
+
+    /// `Output::consume_shutdown` on a batched http output MUST park
+    /// the (event, ack) into the buffer without touching the
+    /// steady-state retry / consume_singleton path. The follow-up
+    /// `shutdown()` is the only place handles resolve.
+    #[tokio::test]
+    async fn consume_shutdown_buffers_for_batched_http() {
+        // Unreachable peer: the goal is to verify *no* network call
+        // happens on `consume_shutdown` itself; if it accidentally
+        // routed to `consume_singleton`, the retry sleep would burn
+        // attempts here.
+        let dir = tempfile::TempDir::new().unwrap();
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(
+            dir.path().join("errored.jsonl"),
+        ));
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = HttpOutput::from_properties(
+            "test",
+            &mp(&[
+                peer_block("http://127.0.0.1:1/"),
+                prop_int("batch_size", 100),
+                prop_str("batch_timeout", "30s"),
+                fast_retry_block(),
+            ]),
+            &ctx,
+        )
+        .unwrap();
+
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        let started = std::time::Instant::now();
+        <HttpOutput as Output>::consume_shutdown(&output, &event_with("ev"), ack)
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "consume_shutdown returned in {:?} — must be a buffer push, not the retry path",
+            elapsed
+        );
+        assert_eq!(
+            output.inner.batch.lock().await.len(),
+            1,
+            "event must land in the buffer"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "ack must NOT resolve in consume_shutdown — only in the post-loop shutdown drain"
+        );
+
+        // The follow-up shutdown drains it. Unreachable peer → DLQ + Recovered.
+        let _ = tokio::time::timeout(Duration::from_secs(2), output.shutdown(Some(&writer))).await;
+        let disposition = rx.try_recv().expect("ack must resolve after shutdown");
+        assert!(
+            matches!(disposition.1, crate::queue::AckDisposition::Recovered),
+            "ack must resolve as Recovered (DLQ route), got {:?}",
+            disposition.1
+        );
+    }
+
+    /// In-flight `flush_events` retry MUST exit early when
+    /// `is_shutting_down` is set — burning the full retry budget
+    /// outlasts the runtime's 10s shutdown deadline and the abort
+    /// drops the stack-local batch with handles unresolved (= the
+    /// audited bug). With `max_attempts=5` + `initial_wait=1s` (long
+    /// enough to span the runtime budget), shutdown must still
+    /// complete inside `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` and every ack
+    /// must resolve.
+    #[tokio::test]
+    async fn cooperative_cancel_collapses_retry_during_shutdown() {
+        let (addr, _post_count, server) = run_counting_failing_collector().await;
+        let url = format!("http://{}/", addr);
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        // Long retry waits so a non-cancelled budget would clearly
+        // exceed SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT (3s).
+        let retry = Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 5),
+                prop_str("initial_wait", "5s"),
+                prop_str("max_wait", "5s"),
+                Property::KeyValue {
+                    key: "backoff".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
+                    value_span: None,
+                },
+            ],
+        };
+        let output = Arc::new(
+            HttpOutput::from_properties(
+                "test",
+                &mp(&[
+                    peer_block(&url),
+                    prop_int("batch_size", 2),
+                    prop_str("batch_timeout", "30s"),
+                    retry,
+                ]),
+                &ctx,
+            )
+            .unwrap(),
+        );
+
+        // Threshold-trigger an inline flush. The peer 5xx-fails;
+        // flush_events enters its retry loop with a 5s sleep.
+        let (ack1, _rx1) = QueueAckHandle::for_test();
+        let (ack2, _rx2) = QueueAckHandle::for_test();
+        let _ = output.consume(&event_with("a"), ack1).await;
+        let output_clone = Arc::clone(&output);
+        let event = event_with("b");
+        let flush_task = tokio::spawn(async move {
+            let _ = output_clone.consume(&event, ack2).await;
+        });
+
+        // Let the consume task enter the retry sleep.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // Shutdown signals cooperative cancel; the retry sleep
+        // bails out via is_shutting_down and the inline flush
+        // collapses to DLQ + Recovered for both events.
+        let started = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(4), output.shutdown(Some(&writer)))
+            .await
+            .expect("shutdown must complete inside SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT + budget")
+            .unwrap();
+        let elapsed = started.elapsed();
+        let _ = tokio::time::timeout(Duration::from_secs(1), flush_task).await;
+        server.abort();
+
+        assert!(
+            elapsed < Duration::from_secs(4),
+            "shutdown took {:?} — cooperative cancel did not collapse the retry budget",
+            elapsed
+        );
+        assert!(
+            path.exists(),
+            "DLQ must have been written after the cooperative cancel"
+        );
+    }
+
+    /// The flusher actor is spawned exactly once at construction (for
+    /// `batch_size > 1`) and is the same handle for the lifetime of
+    /// the output — there is no per-flush respawn that would re-open
+    /// the abort surface the timer task used to expose.
+    #[tokio::test]
+    async fn flusher_actor_spawned_once_at_construction() {
+        let output = HttpOutput::from_properties(
+            "test",
+            &mp(&[
+                peer_block("http://127.0.0.1:1/"),
+                prop_int("batch_size", 100),
+                prop_str("batch_timeout", "30s"),
+                fast_retry_block(),
+            ]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let handle_id_before = {
+            let guard = output.actor_handle.lock().await;
+            guard
+                .as_ref()
+                .map(|h| h.id())
+                .expect("batched output must spawn the actor")
+        };
+        // Multiple consumes (sub-threshold) must not respawn the actor.
+        consume(&output, &event_with("a")).await.unwrap();
+        consume(&output, &event_with("b")).await.unwrap();
+        consume(&output, &event_with("c")).await.unwrap();
+        let handle_id_after = {
+            let guard = output.actor_handle.lock().await;
+            guard
+                .as_ref()
+                .map(|h| h.id())
+                .expect("actor must still be the same handle")
+        };
+        assert_eq!(
+            handle_id_before, handle_id_after,
+            "the flusher actor must be the same task across consumes — no per-flush respawn"
+        );
+        // Drain the buffer so the (a,b,c) handles do not leak unresolved
+        // when the output drops at end-of-test. The peer is unreachable,
+        // so all three route to the test-DLQ-recovery path.
+        let _ = tokio::time::timeout(Duration::from_secs(2), output.shutdown(None)).await;
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -253,12 +253,12 @@ pub struct HttpOutput {
     ///   exit cleanly before the abort lands; in practice the
     ///   runtime calls `shutdown()` before drop in production.
     ///
-    /// The audit (2026-06-27) found that prior versions abort()-ed
-    /// a per-flush *timer* task that held the stack-local batch
-    /// across `flush_events.await` — dropping every parked
-    /// `QueueAckHandle` unresolved. The structural fix moves the
-    /// abort surface to this single actor handle and keeps `abort()`
-    /// off the `shutdown()` path entirely.
+    /// Earlier versions of this output spawned a per-flush *timer*
+    /// task that held the stack-local batch across
+    /// `flush_events.await`; when `shutdown()` abort()-ed that task
+    /// every parked `QueueAckHandle` dropped unresolved. The
+    /// structural fix moves the abort surface to this single actor
+    /// handle and keeps `abort()` off the `shutdown()` path entirely.
     actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     metrics: Arc<OutputMetrics>,
 }
@@ -500,10 +500,10 @@ impl Module for HttpOutput {
 /// `.await`. See `HttpOutput::actor_handle` for the full lifecycle
 /// contract.
 ///
-/// The audit (2026-06-27) found that prior versions abort()-ed a
-/// per-flush *timer* task that held a stack-local
-/// `Vec<(Event, QueueAckHandle)>` across `flush_events.await`,
-/// dropping every parked handle unresolved
+/// Earlier versions spawned a per-flush *timer* task that held a
+/// stack-local `Vec<(Event, QueueAckHandle)>` across
+/// `flush_events.await`, and `shutdown()` would abort()-ing it
+/// dropped every parked handle unresolved
 /// (debug `debug_assert!(resolved)` panic, release silent `Dropped`
 /// loss). Consolidating the timer + flush lifecycle into this single
 /// actor and keeping `abort()` off the `shutdown()` path is the
@@ -561,9 +561,10 @@ impl Output for HttpOutput {
         // `batch_timeout`, or on `is_shutting_down`. The queue
         // consumer's task is NEVER held in a `send_batch.await`
         // here — that separation is what makes shutdown observable
-        // independently of the consumer (the prior audit caught
-        // that an inline flush on the consumer's task blocked it
-        // from reaching its own shutdown observation). Works for
+        // independently of the consumer. (An earlier implementation
+        // performed an inline flush on the consumer's task and
+        // blocked the consumer from reaching its own shutdown
+        // observation.) Works for
         // both batched (`batch_size > 1`) and singleton
         // (`batch_size <= 1`) modes — for the latter the actor
         // flushes a one-element batch on each notify.
@@ -713,12 +714,13 @@ impl Inner {
             // Race the transport against the shutdown signal. A
             // stalled peer (= TCP accepted but never responds) holds
             // `send_batch().await` past the runtime shutdown deadline
-            // — the actor task gets aborted with the stack-local
-            // shippable Vec, dropping every parked QueueAckHandle
-            // unresolved (the audited bug). With the race, a
-            // `shutdown()` mid-flight cancels the send future
-            // (reqwest cancels the connection on drop) and falls
-            // through to the DLQ + Recovered path below.
+            // — without the race the actor task gets aborted with
+            // the stack-local shippable Vec, dropping every parked
+            // QueueAckHandle unresolved (the unresolved-handle
+            // regression). With the race, a `shutdown()` mid-flight
+            // cancels the send future (reqwest cancels the connection
+            // on drop) and falls through to the DLQ + Recovered path
+            // below.
             let send_outcome = tokio::select! {
                 biased;
                 res = self.send_batch(&messages) => Some(res),
@@ -1707,7 +1709,7 @@ mod tests {
         // `batch_size <= 1` no longer takes a separate inline path —
         // every event flows through the flusher actor, which keeps
         // the queue consumer's task off the transport `await` (the
-        // 0.7.8 audit blocker). Each consume pushes one event,
+        // shutdown lifecycle regression). Each consume pushes one event,
         // notifies the actor (threshold=1), the actor takes the
         // 1-element batch and ships. The peer is unreachable so the
         // disposition lands as Recovered via the DLQ path.
@@ -2331,9 +2333,9 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // Regression tests for the 2026-06-27 shutdown-lifecycle audit
+    // Regression tests for shutdown lifecycle handle ownership
     // (consume_shutdown trait dispatch + cooperative cancel + actor
-    // model). These pin the new contracts so future refactors don't
+    // model). These pin the contracts so future refactors don't
     // silently re-introduce the leak.
     // -----------------------------------------------------------------
 
@@ -2403,10 +2405,10 @@ mod tests {
     /// `is_shutting_down` is set — burning the full retry budget
     /// outlasts the runtime's 10s shutdown deadline and the abort
     /// drops the stack-local batch with handles unresolved (= the
-    /// audited bug). With `max_attempts=5` + `initial_wait=1s` (long
-    /// enough to span the runtime budget), shutdown must still
-    /// complete inside `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` and every ack
-    /// must resolve.
+    /// unresolved-handle regression). With `max_attempts=5` +
+    /// `initial_wait=1s` (long enough to span the runtime budget),
+    /// shutdown must still complete inside
+    /// `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` and every ack must resolve.
     #[tokio::test]
     async fn cooperative_cancel_collapses_retry_during_shutdown() {
         let (addr, _post_count, server) = run_counting_failing_collector().await;
@@ -2714,13 +2716,14 @@ mod tests {
         );
     }
 
-    /// Singleton (`batch_size <= 1`) actor + shutdown race. After
-    /// the audit, batch_size=1 no longer goes through an inline
-    /// retry path on the queue consumer's task — every event flows
-    /// through the actor, so the same bounded-shutdown contract
-    /// applies. consume() pushes one event (threshold reached at
-    /// 1), the actor wakes, enters send_batch, shutdown signals,
-    /// the handle resolves to Recovered via DLQ.
+    /// Singleton (`batch_size <= 1`) actor + shutdown race. In
+    /// the current implementation batch_size=1 no longer takes a
+    /// separate inline retry path on the queue consumer's task —
+    /// every event flows through the actor, so the same bounded-
+    /// shutdown contract applies. consume() pushes one event
+    /// (threshold reached at 1), the actor wakes, enters
+    /// send_batch, shutdown signals, the handle resolves to
+    /// Recovered via DLQ.
     #[tokio::test]
     async fn singleton_actor_send_cancels_on_shutdown_against_stalled_peer() {
         let (addr, server) = run_stalled_listener().await;

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -474,6 +474,20 @@ impl Output for HttpOutput {
         Ok(())
     }
 
+    /// Drain-time per-event entry: park the `(event, ack)` pair in the
+    /// buffer that the post-loop `shutdown()` call will drain bounded.
+    /// Deliberately does NOT trigger a flush from here — that would
+    /// re-enter the steady-state retry path (`consume_singleton` /
+    /// `flush_events` exponential backoff) which the shutdown contract
+    /// forbids. The buffer holds the handle until `shutdown()` resolves
+    /// it via `flush_events_at_shutdown`'s bounded single attempt + DLQ
+    /// route.
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let mut buf = self.inner.batch.lock().await;
+        buf.push((event.clone(), ack));
+        Ok(())
+    }
+
     async fn shutdown(
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -602,11 +602,7 @@ impl Output for HttpOutput {
         //    re-open the leak this commit set closes.
         let handle_opt = self.actor_handle.lock().await.take();
         if let Some(h) = handle_opt {
-            let _ = tokio::time::timeout(
-                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-                h,
-            )
-            .await;
+            let _ = tokio::time::timeout(crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, h).await;
         }
 
         // 3. Final drain. The buffer holds only events pushed via
@@ -1368,26 +1364,20 @@ mod tests {
         .unwrap();
         // First send goes to A (cursor 0), fails. With max_attempts=1
         // the failure routes to Recovered (DLQ). A is cooled down.
-        let disp1 = consume_and_wait_disposition(
-            &output,
-            &event_with("rr-fail"),
-            Duration::from_secs(2),
-        )
-        .await
-        .unwrap();
+        let disp1 =
+            consume_and_wait_disposition(&output, &event_with("rr-fail"), Duration::from_secs(2))
+                .await
+                .unwrap();
         assert!(
             matches!(disp1, crate::queue::AckDisposition::Recovered),
             "first attempt should fail (peer A is 500) → Recovered, got {:?}",
             disp1
         );
         // Second event goes to peer B (next in rotation, A cooled).
-        let disp2 = consume_and_wait_disposition(
-            &output,
-            &event_with("rr-ok"),
-            Duration::from_secs(2),
-        )
-        .await
-        .unwrap();
+        let disp2 =
+            consume_and_wait_disposition(&output, &event_with("rr-ok"), Duration::from_secs(2))
+                .await
+                .unwrap();
         assert!(
             matches!(disp2, crate::queue::AckDisposition::Delivered),
             "second send should hit peer B → Delivered, got {:?}",
@@ -1668,12 +1658,8 @@ mod tests {
         )
         .unwrap();
         let pre_call = Instant::now();
-        let _ = consume_and_wait_disposition(
-            &output,
-            &event_with("hello"),
-            Duration::from_secs(5),
-        )
-        .await;
+        let _ = consume_and_wait_disposition(&output, &event_with("hello"), Duration::from_secs(5))
+            .await;
         let cooldown_until = output.inner.peer_state[0]
             .cooldown_until
             .lock()
@@ -1713,13 +1699,10 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        let disp = consume_and_wait_disposition(
-            &output,
-            &event_with("singleton"),
-            Duration::from_secs(2),
-        )
-        .await
-        .unwrap();
+        let disp =
+            consume_and_wait_disposition(&output, &event_with("singleton"), Duration::from_secs(2))
+                .await
+                .unwrap();
         assert!(
             matches!(disp, crate::queue::AckDisposition::Recovered),
             "send must fail against unreachable peer → Recovered, got {:?}",
@@ -1728,10 +1711,7 @@ mod tests {
         // After the actor drains the 1-element batch, the buffer
         // must be empty again.
         let batch_len = output.inner.batch.lock().await.len();
-        assert_eq!(
-            batch_len, 0,
-            "actor must drain the singleton batch"
-        );
+        assert_eq!(batch_len, 0, "actor must drain the singleton batch");
         let actor_spawned = output.actor_handle.lock().await.is_some();
         assert!(
             actor_spawned,
@@ -2610,8 +2590,9 @@ mod tests {
 
         // The handle must resolve (not drop). Recovered (DLQ-routed)
         // is the expected disposition since the peer never responded.
-        let (_pos, disposition) =
-            rx.try_recv().expect("ack must resolve, not drop unresolved");
+        let (_pos, disposition) = rx
+            .try_recv()
+            .expect("ack must resolve, not drop unresolved");
         assert!(
             matches!(disposition, crate::queue::AckDisposition::Recovered),
             "expected Recovered (DLQ), got {:?}",

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -448,11 +448,15 @@ impl Module for HttpOutput {
             is_shutting_down: AtomicBool::new(false),
         });
 
-        // Spawn the flusher actor only for true batching mode. For
-        // `batch_size <= 1` (single-event ship), `consume()` routes
-        // straight to `consume_singleton` and the buffer is unused —
-        // an actor would do nothing but consume a task slot.
-        let actor_handle = if batch_size > 1 {
+        // The flusher actor owns every send — both batched flushes
+        // and singleton (`batch_size <= 1`) — so the queue
+        // consumer's task is never blocked in a `send_batch.await`.
+        // That separation is what makes the actor's
+        // `wait_until_shutdown` race effective: shutdown can be
+        // observed independently of whatever the consumer is doing.
+        // Spawn unconditionally except when there is no runtime (=
+        // parsing-only unit tests outside `#[tokio::test]`).
+        let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
             let actor_inner = Arc::clone(&inner);
             Some(tokio::spawn(async move {
                 flusher_actor_loop(actor_inner).await;
@@ -531,27 +535,27 @@ impl Output for HttpOutput {
     /// recovered) — not now. Returning `Ok(())` only signals that
     /// the output took ownership of the lifecycle.
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        if self.batch_size <= 1 {
-            return self.consume_singleton(event, ack).await;
-        }
+        // Hand the (event, ack) off to the actor and return. The
+        // actor drains the buffer on `flush_notify`, on
+        // `batch_timeout`, or on `is_shutting_down`. The queue
+        // consumer's task is NEVER held in a `send_batch.await`
+        // here — that separation is what makes shutdown observable
+        // independently of the consumer (the prior audit caught
+        // that an inline flush on the consumer's task blocked it
+        // from reaching its own shutdown observation). Works for
+        // both batched (`batch_size > 1`) and singleton
+        // (`batch_size <= 1`) modes — for the latter the actor
+        // flushes a one-element batch on each notify.
         let should_flush = {
             let mut buf = self.inner.batch.lock().await;
             buf.push((event.clone(), ack));
             buf.len() >= self.batch_size
         };
         if should_flush {
-            // Threshold reached: flush inline, on the queue
-            // consumer's own task. Not a leak surface — the queue
-            // consumer drives the lifecycle and is never `abort()`-ed
-            // in normal operation. Preserves the prior contract that
-            // a threshold-triggered flush has resolved every ack
-            // before `consume` returns.
-            let batch = std::mem::take(&mut *self.inner.batch.lock().await);
-            self.inner.flush_events(batch).await;
+            self.inner.flush_notify.notify_one();
         }
-        // No timer reset — the long-lived flusher actor's `select!`
-        // owns the timer-driven flush. (The audited bug was the
-        // *spawned* timer task holding the batch across `await`.)
+        // The actor's `select!` already races the `batch_timeout`
+        // sleep — no separate timer to arm.
         Ok(())
     }
 
@@ -617,70 +621,6 @@ impl Output for HttpOutput {
         self.inner.flush_events_at_shutdown(leftover).await;
         Ok(())
     }
-}
-
-impl HttpOutput {
-    /// Render + ship one event inline (used when `batch_size <= 1`).
-    /// Drives the retry budget internally; resolves the ack based on
-    /// final disposition.
-    async fn consume_singleton(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        let msg = match render_event(event) {
-            Ok(m) => m,
-            Err(e) => {
-                let reason = format!("render failed: {}", e);
-                crate::modules::route_event_to_dlq(
-                    self.inner.error_log.as_ref(),
-                    &self.inner.name,
-                    event,
-                    &reason,
-                )
-                .await;
-                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                ack.resolve_recovered();
-                return Ok(());
-            }
-        };
-        let mut attempt = 0u32;
-        let mut wait = self.inner.retry.initial_wait;
-        loop {
-            match self.inner.send_batch(std::slice::from_ref(&msg)).await {
-                Ok(()) => {
-                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                    ack.resolve_delivered();
-                    return Ok(());
-                }
-                Err(e) => {
-                    attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
-                    if attempt >= self.inner.retry.max_attempts {
-                        let reason =
-                            format!("output write failed after {} attempts: {}", attempt, e);
-                        crate::modules::route_event_to_dlq(
-                            self.inner.error_log.as_ref(),
-                            &self.inner.name,
-                            event,
-                            &reason,
-                        )
-                        .await;
-                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                        ack.resolve_recovered();
-                        return Ok(());
-                    }
-                    tracing::warn!(
-                        "output '{}': send failed (attempt {}/{}): {} — retrying in {:?}",
-                        self.inner.name,
-                        attempt,
-                        self.inner.retry.max_attempts,
-                        e,
-                        wait
-                    );
-                    tokio::time::sleep(wait).await;
-                    wait = self.inner.retry.next_wait(wait);
-                }
-            }
-        }
-    }
-
 }
 
 /// Render a single event into its HTTP body string. Called from the
@@ -1222,12 +1162,13 @@ mod tests {
     }
 
     /// Test shim mirroring the queue consumer's call into
-    /// `Output::consume`. Synthesises a 0.7.x-style `Result<()>` for
-    /// the test bodies that already speak that vocabulary:
-    /// - `Ok(())` — Delivered, OR no disposition yet (event parked
-    ///   in the in-memory batch buffer waiting for a future flush).
-    /// - `Err(...)` — Recovered (= DLQ-routed; retry exhausted or
-    ///   render failure).
+    /// `Output::consume`. Since the actor refactor `consume`
+    /// just buffers + notifies and returns immediately; the eventual
+    /// ack disposition surfaces from the flusher actor. This shim
+    /// captures the "ownership-accepted" return value only and
+    /// reports `Ok(())` regardless of whether a disposition has
+    /// landed yet — tests that need the disposition (delivered /
+    /// recovered) should use `consume_and_wait_disposition` instead.
     async fn consume(output: &HttpOutput, ev: &Event) -> Result<()> {
         let (ack, mut rx) = QueueAckHandle::for_test();
         let _ = output.consume(ev, ack).await;
@@ -1237,11 +1178,51 @@ mod tests {
                 Err(anyhow::anyhow!("recovered to DLQ"))
             }
             Ok((_, crate::queue::AckDisposition::Dropped)) => Err(anyhow::anyhow!("dropped")),
-            // No disposition yet — event is parked in the buffer.
-            // Treated as Ok for test purposes; tests that need to
-            // observe the eventual flush dispose separately.
             Err(_) => Ok(()),
         }
+    }
+
+    /// Push an event via `consume()` then await the flusher actor's
+    /// resolution. Returns Delivered / Recovered / Dropped as
+    /// surfaced by the ack handle. Bounded by `timeout` — tests
+    /// that need to drive paused virtual time should advance time
+    /// before calling this (or use the lower-level
+    /// `consume_with_handle` helper to interleave their own time
+    /// advances).
+    async fn consume_and_wait_disposition(
+        output: &HttpOutput,
+        ev: &Event,
+        timeout: Duration,
+    ) -> Result<crate::queue::AckDisposition> {
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        output.consume(ev, ack).await?;
+        match tokio::time::timeout(timeout, rx.recv()).await {
+            Ok(Some((_, disp))) => Ok(disp),
+            Ok(None) => Err(anyhow::anyhow!("ack channel closed unexpectedly")),
+            Err(_) => Err(anyhow::anyhow!(
+                "actor did not resolve ack within {:?}",
+                timeout
+            )),
+        }
+    }
+
+    /// Lower-level helper: push an event, return the ack receiver
+    /// for the test to await/poll directly. Used by paused-virtual-
+    /// time tests that need to advance time between `consume()` and
+    /// the disposition recv.
+    #[allow(dead_code)]
+    async fn consume_with_handle(
+        output: &HttpOutput,
+        ev: &Event,
+    ) -> Result<
+        tokio::sync::mpsc::UnboundedReceiver<(
+            crate::queue::AckPosition,
+            crate::queue::AckDisposition,
+        )>,
+    > {
+        let (ack, rx) = QueueAckHandle::for_test();
+        output.consume(ev, ack).await?;
+        Ok(rx)
     }
 
     async fn run_echo_collector() -> (
@@ -1321,19 +1302,27 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
+        // Drive each event end-to-end before pushing the next, so
+        // batch_size=1 → one event per send_batch → cursor advances
+        // once per event (= the round-robin invariant). With the
+        // actor refactor, a fast sequence of `consume()` calls can
+        // otherwise batch multiple events into one flush; awaiting
+        // the per-event disposition keeps the test deterministic
+        // without needing larger sleeps.
         for i in 0..9 {
-            consume(&output, &event_with(&format!("rr-{}", i)))
-                .await
-                .unwrap();
-        }
-        for _ in 0..50 {
-            let na = r_a.lock().await.len();
-            let nb = r_b.lock().await.len();
-            let nc = r_c.lock().await.len();
-            if na + nb + nc == 9 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            let disp = consume_and_wait_disposition(
+                &output,
+                &event_with(&format!("rr-{}", i)),
+                Duration::from_secs(2),
+            )
+            .await
+            .unwrap();
+            assert!(
+                matches!(disp, crate::queue::AckDisposition::Delivered),
+                "event {} must Deliver, got {:?}",
+                i,
+                disp
+            );
         }
         s_a.abort();
         s_b.abort();
@@ -1379,14 +1368,31 @@ mod tests {
         .unwrap();
         // First send goes to A (cursor 0), fails. With max_attempts=1
         // the failure routes to Recovered (DLQ). A is cooled down.
-        let first = consume(&output, &event_with("rr-fail")).await;
+        let disp1 = consume_and_wait_disposition(
+            &output,
+            &event_with("rr-fail"),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
         assert!(
-            first.is_err(),
-            "first attempt should fail (peer A is 500): {:?}",
-            first
+            matches!(disp1, crate::queue::AckDisposition::Recovered),
+            "first attempt should fail (peer A is 500) → Recovered, got {:?}",
+            disp1
         );
         // Second event goes to peer B (next in rotation, A cooled).
-        consume(&output, &event_with("rr-ok")).await.unwrap();
+        let disp2 = consume_and_wait_disposition(
+            &output,
+            &event_with("rr-ok"),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(disp2, crate::queue::AckDisposition::Delivered),
+            "second send should hit peer B → Delivered, got {:?}",
+            disp2
+        );
         s_a.abort();
         s_b.abort();
     }
@@ -1662,7 +1668,12 @@ mod tests {
         )
         .unwrap();
         let pre_call = Instant::now();
-        let _ = consume(&output, &event_with("hello")).await;
+        let _ = consume_and_wait_disposition(
+            &output,
+            &event_with("hello"),
+            Duration::from_secs(5),
+        )
+        .await;
         let cooldown_until = output.inner.peer_state[0]
             .cooldown_until
             .lock()
@@ -1685,11 +1696,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn singleton_batch_size_ships_inline_without_buffering() {
-        // When `batch_size <= 1`, `consume` short-circuits through the
-        // singleton path that renders + ships in one shot (no buffer,
-        // no timer). Mirrors the prior `write_owned` bypass behaviour
-        // but for the unified queue path.
+    async fn singleton_batch_size_ships_via_actor() {
+        // `batch_size <= 1` no longer takes a separate inline path —
+        // every event flows through the flusher actor, which keeps
+        // the queue consumer's task off the transport `await` (the
+        // 0.7.8 audit blocker). Each consume pushes one event,
+        // notifies the actor (threshold=1), the actor takes the
+        // 1-element batch and ships. The peer is unreachable so the
+        // disposition lands as Recovered via the DLQ path.
         let mut props = vec![peer_block("http://127.0.0.1:1/")];
         props.push(prop_int("batch_size", 1));
         props.push(fast_retry_block());
@@ -1699,22 +1713,29 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        let err = consume(&output, &event_with("singleton"))
-            .await
-            .expect_err("send must fail against unreachable peer");
-        // With the new lifecycle the underlying transport message
-        // is consumed by the DLQ-routing path, so we only check that
-        // the disposition surfaced as Recovered (= test-shim Err).
-        assert!(err.to_string().contains("recovered"), "got: {err}");
+        let disp = consume_and_wait_disposition(
+            &output,
+            &event_with("singleton"),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Recovered),
+            "send must fail against unreachable peer → Recovered, got {:?}",
+            disp
+        );
+        // After the actor drains the 1-element batch, the buffer
+        // must be empty again.
         let batch_len = output.inner.batch.lock().await.len();
         assert_eq!(
             batch_len, 0,
-            "singleton path must not land the event in the batch"
+            "actor must drain the singleton batch"
         );
         let actor_spawned = output.actor_handle.lock().await.is_some();
         assert!(
-            !actor_spawned,
-            "singleton path (batch_size <= 1) must not spawn the flusher actor"
+            actor_spawned,
+            "the flusher actor is spawned for every batch_size (singleton included)"
         );
     }
 
@@ -2607,6 +2628,153 @@ mod tests {
             body.lines().count(),
             1,
             "the single buffered event must land in the DLQ"
+        );
+    }
+
+    /// Threshold-triggered actor flush + shutdown race. The previous
+    /// drop-cancel test exercised the timer-driven path; this one
+    /// exercises the `batch.len() >= batch_size` notify path. Both
+    /// must resolve every handle inside the bounded shutdown budget.
+    #[tokio::test]
+    async fn actor_threshold_flush_cancels_on_shutdown_against_stalled_peer() {
+        let (addr, server) = run_stalled_listener().await;
+        let url = format!("http://{}/", addr);
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = Arc::new(
+            HttpOutput::from_properties(
+                "test",
+                &mp(&[
+                    peer_block(&url),
+                    prop_int("batch_size", 2),
+                    prop_str("batch_timeout", "30s"),
+                    fast_retry_block(),
+                ]),
+                &ctx,
+            )
+            .unwrap(),
+        );
+
+        // Push two events: the second hits the threshold, fires
+        // flush_notify, the actor wakes and enters send_batch
+        // against the stalled peer.
+        let (ack1, mut rx1) = QueueAckHandle::for_test();
+        let (ack2, mut rx2) = QueueAckHandle::for_test();
+        <HttpOutput as Output>::consume(&output, &event_with("a"), ack1)
+            .await
+            .unwrap();
+        <HttpOutput as Output>::consume(&output, &event_with("b"), ack2)
+            .await
+            .unwrap();
+
+        // Let the actor reach the in-flight send.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let started = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(5), output.shutdown(Some(&writer)))
+            .await
+            .expect("shutdown must complete inside the bounded budget")
+            .unwrap();
+        let elapsed = started.elapsed();
+        server.abort();
+
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "shutdown took {:?} — threshold-flush in-flight send was not cancelled",
+            elapsed
+        );
+
+        let (_, d1) = rx1.try_recv().expect("ack1 must resolve, not drop");
+        let (_, d2) = rx2.try_recv().expect("ack2 must resolve, not drop");
+        assert!(
+            matches!(d1, crate::queue::AckDisposition::Recovered),
+            "ack1 expected Recovered, got {:?}",
+            d1
+        );
+        assert!(
+            matches!(d2, crate::queue::AckDisposition::Recovered),
+            "ack2 expected Recovered, got {:?}",
+            d2
+        );
+
+        // Both events land in the DLQ.
+        let body = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(
+            body.lines().count(),
+            2,
+            "both threshold-flushed events must land in the DLQ"
+        );
+    }
+
+    /// Singleton (`batch_size <= 1`) actor + shutdown race. After
+    /// the audit, batch_size=1 no longer goes through an inline
+    /// retry path on the queue consumer's task — every event flows
+    /// through the actor, so the same bounded-shutdown contract
+    /// applies. consume() pushes one event (threshold reached at
+    /// 1), the actor wakes, enters send_batch, shutdown signals,
+    /// the handle resolves to Recovered via DLQ.
+    #[tokio::test]
+    async fn singleton_actor_send_cancels_on_shutdown_against_stalled_peer() {
+        let (addr, server) = run_stalled_listener().await;
+        let url = format!("http://{}/", addr);
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
+        let ctx = crate::modules::BuildContext {
+            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            error_log: Some(Arc::clone(&writer)),
+        };
+        let output = Arc::new(
+            HttpOutput::from_properties(
+                "test",
+                &mp(&[
+                    peer_block(&url),
+                    prop_int("batch_size", 1),
+                    fast_retry_block(),
+                ]),
+                &ctx,
+            )
+            .unwrap(),
+        );
+
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        <HttpOutput as Output>::consume(&output, &event_with("singleton"), ack)
+            .await
+            .unwrap();
+
+        // Let the actor reach the in-flight send.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let started = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(5), output.shutdown(Some(&writer)))
+            .await
+            .expect("shutdown must complete inside the bounded budget")
+            .unwrap();
+        let elapsed = started.elapsed();
+        server.abort();
+
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "shutdown took {:?} — singleton in-flight send was not cancelled",
+            elapsed
+        );
+
+        let (_, disp) = rx.try_recv().expect("ack must resolve, not drop");
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Recovered),
+            "singleton ack expected Recovered, got {:?}",
+            disp
+        );
+        let body = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(
+            body.lines().count(),
+            1,
+            "the singleton event must land in the DLQ"
         );
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -573,24 +573,29 @@ impl Output for HttpOutput {
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // 1. Signal cooperative shutdown so the actor's `select!`
-        //    wakes (via `notify_waiters`) and any in-flight
-        //    `flush_events` retry sleep exits early via the
-        //    `is_shutting_down` check.
+        // 1. Signal cooperative shutdown. `is_shutting_down`
+        //    propagates to the actor's outer `select!`, to the
+        //    retry sleep race, and (via the transport-cancel race
+        //    in `flush_events`) to the in-flight `send_batch` call
+        //    itself. `notify_waiters` wakes every current `.notified()`
+        //    awaiter so a stalled peer's transport future is dropped
+        //    immediately rather than blocking until its read timeout.
         self.inner.is_shutting_down.store(true, Ordering::Release);
         self.inner.flush_notify.notify_waiters();
 
-        // 2. Bounded join of the flusher actor. If the actor is
-        //    currently mid-`flush_events`, the cooperative-cancel in
-        //    the retry loop collapses its retry to one attempt;
-        //    `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` (3s) is the deadline.
-        //    Critical: do NOT `abort()` on timeout — the actor's
-        //    stack-local batch would drop handles unresolved (the
-        //    audited bug). On timeout we just leave the actor task
-        //    to finish naturally; whatever it has not yet flushed is
-        //    still in the buffer (events queued via
-        //    `consume_shutdown` after the actor exited) and step 3
-        //    handles those.
+        // 2. Bounded join of the flusher actor. The actor's invariant
+        //    is that EVERY stack-local `(Event, QueueAckHandle)` it
+        //    has taken is resolved (Delivered on success, Recovered on
+        //    transport cancel / retry exhaustion / DLQ recovery)
+        //    before `flush_events` returns and before the actor exits.
+        //    The cooperative cancels above guarantee the actor reaches
+        //    that exit promptly even when a peer stalls — so a healthy
+        //    actor finishes well inside `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`.
+        //    The timeout here is a defensive guard against a future
+        //    bug (e.g. a new transport path that forgets the cancel
+        //    race); it is NOT a contract that allows unresolved
+        //    handles. We deliberately do NOT `abort()` — abort would
+        //    re-open the leak this commit set closes.
         let handle_opt = self.actor_handle.lock().await.take();
         if let Some(h) = handle_opt {
             let _ = tokio::time::timeout(
@@ -600,13 +605,12 @@ impl Output for HttpOutput {
             .await;
         }
 
-        // 3. Drain whatever the actor did not pick up — anything
-        //    pushed via `consume_shutdown` after the actor exited,
-        //    plus any in-flight batch the actor was unable to flush
-        //    (those handles are still held by the actor task's
-        //    stack frame; we cannot reach them from here, so we
-        //    accept that narrow loss window in exchange for not
-        //    abort()-ing the actor). `flush_events_at_shutdown`
+        // 3. Final drain. The buffer holds only events pushed via
+        //    `consume_shutdown` (the queue consumer's drain path
+        //    after shutdown signal) plus anything that arrived too
+        //    late for the actor's last iteration. The actor's own
+        //    in-flight batch was already resolved by `flush_events`
+        //    before the actor exited. `flush_events_at_shutdown`
         //    does one bounded send attempt then routes the rest to
         //    DLQ + Recovered.
         let leftover = std::mem::take(&mut *self.inner.batch.lock().await);

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -583,11 +583,11 @@ impl Output for HttpOutput {
     /// Drain-time per-event entry: park the `(event, ack)` pair in the
     /// buffer that the post-loop `shutdown()` call will drain bounded.
     /// Deliberately does NOT trigger a flush from here — that would
-    /// re-enter the steady-state retry path (`consume_singleton` /
-    /// `flush_events` exponential backoff) which the shutdown contract
-    /// forbids. The buffer holds the handle until `shutdown()` resolves
-    /// it via `flush_events_at_shutdown`'s bounded single attempt + DLQ
-    /// route.
+    /// re-enter the steady-state retry path (the old inline-singleton /
+    /// `flush_events` exponential backoff loops) which the shutdown
+    /// contract forbids. The buffer holds the handle until `shutdown()`
+    /// resolves it via `flush_events_at_shutdown`'s bounded single
+    /// attempt + DLQ route.
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         let mut buf = self.inner.batch.lock().await;
         buf.push((event.clone(), ack));
@@ -2339,13 +2339,13 @@ mod tests {
 
     /// `Output::consume_shutdown` on a batched http output MUST park
     /// the (event, ack) into the buffer without touching the
-    /// steady-state retry / consume_singleton path. The follow-up
-    /// `shutdown()` is the only place handles resolve.
+    /// steady-state retry path. The follow-up `shutdown()` is the
+    /// only place handles resolve.
     #[tokio::test]
     async fn consume_shutdown_buffers_for_batched_http() {
         // Unreachable peer: the goal is to verify *no* network call
-        // happens on `consume_shutdown` itself; if it accidentally
-        // routed to `consume_singleton`, the retry sleep would burn
+        // happens on `consume_shutdown` itself; any accidental
+        // routing to the steady-state send + retry loop would burn
         // attempts here.
         let dir = tempfile::TempDir::new().unwrap();
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -498,6 +498,31 @@ impl Output for KafkaOutput {
             }
         }
     }
+
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let result = match tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            self.try_send(event),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(anyhow::anyhow!(
+                "timed out after {:?}",
+                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+            )),
+        };
+        crate::modules::finalize_shutdown_singleton_disposition(
+            result,
+            self.error_log.as_ref(),
+            &self.metrics,
+            &self.name,
+            event,
+            ack,
+        )
+        .await;
+        Ok(())
+    }
 }
 
 impl KafkaOutput {

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -362,6 +362,15 @@ impl Output for OtlpGrpcOutput {
         Ok(())
     }
 
+    /// Drain-time per-event entry: park into the buffer; the post-loop
+    /// `shutdown()` call drains it bounded. No flush trigger here — the
+    /// shutdown contract forbids the steady-state retry path.
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let mut buf = self.inner.batch.lock().await;
+        buf.push((event.clone(), ack));
+        Ok(())
+    }
+
     async fn shutdown(
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -453,6 +453,20 @@ impl Output for OtlpGrpcOutput {
 
 
 impl Inner {
+    /// Yield on cooperative shutdown — see `http::Inner::wait_until_shutdown`.
+    async fn wait_until_shutdown(&self) {
+        loop {
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            let notified = self.flush_notify.notified();
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
     /// Drain + ship one batch, resolving each handle to its final
     /// disposition. Mirrors the http counterpart's ack-handle
     /// semantics: infallible to the caller, per-event DLQ routing on
@@ -475,7 +489,19 @@ impl Inner {
             return;
         }
         let count = shippable.len() as u64;
-        match send_batch(self, payloads).await {
+        // Race the transport against shutdown — see http.rs.
+        let send_outcome = tokio::select! {
+            biased;
+            res = send_batch(self, payloads) => Some(res),
+            _ = self.wait_until_shutdown() => None,
+        };
+        let send_result = match send_outcome {
+            Some(res) => res,
+            None => Err(anyhow!(
+                "shutdown cancelled in-flight OTLP/gRPC send"
+            )),
+        };
+        match send_result {
             Ok(outcome) => {
                 let rejected = outcome.rejected.min(count);
                 let written = count - rejected;

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -684,7 +684,11 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOut
             err,
             wait,
         );
-        tokio::time::sleep(wait).await;
+        // Race the sleep against a shutdown wake — see http.rs.
+        tokio::select! {
+            _ = tokio::time::sleep(wait) => {}
+            _ = inner.flush_notify.notified() => {}
+        }
         if matches!(cfg.backoff, BackoffStrategy::Exponential) {
             wait = wait.saturating_mul(2).min(cfg.max_wait);
         }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -403,21 +403,16 @@ impl HasMetrics for OtlpGrpcOutput {
 #[async_trait::async_trait]
 impl Output for OtlpGrpcOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        // Hand the (event, ack) off to the actor — see
+        // `http::HttpOutput::consume` for rationale.
         let should_flush = {
             let mut batch = self.inner.batch.lock().await;
             batch.push((event.clone(), ack));
             batch.len() >= self.batch_size
         };
         if should_flush {
-            // Threshold-triggered flush runs on the queue consumer's
-            // own task (not abort-prone); preserves the prior
-            // contract that handles are resolved before `consume`
-            // returns when a full batch is flushed inline.
-            let batch = std::mem::take(&mut *self.inner.batch.lock().await);
-            self.inner.flush_events(batch).await;
+            self.inner.flush_notify.notify_one();
         }
-        // Timer-driven flush is owned by the long-lived flusher
-        // actor's `select!`. No spawned per-flush timer task.
         Ok(())
     }
 
@@ -1119,6 +1114,39 @@ mod tests {
         }
     }
 
+    #[allow(dead_code)]
+    async fn consume_and_wait_disposition(
+        output: &OtlpGrpcOutput,
+        ev: &Event,
+        timeout: Duration,
+    ) -> Result<crate::queue::AckDisposition> {
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        output.consume(ev, ack).await?;
+        match tokio::time::timeout(timeout, rx.recv()).await {
+            Ok(Some((_, disp))) => Ok(disp),
+            Ok(None) => Err(anyhow::anyhow!("ack channel closed unexpectedly")),
+            Err(_) => Err(anyhow::anyhow!(
+                "actor did not resolve ack within {:?}",
+                timeout
+            )),
+        }
+    }
+
+    #[allow(dead_code)]
+    async fn consume_with_handle(
+        output: &OtlpGrpcOutput,
+        ev: &Event,
+    ) -> Result<
+        tokio::sync::mpsc::UnboundedReceiver<(
+            crate::queue::AckPosition,
+            crate::queue::AckDisposition,
+        )>,
+    > {
+        let (ack, rx) = QueueAckHandle::for_test();
+        output.consume(ev, ack).await?;
+        Ok(rx)
+    }
+
     async fn wait_for<T>(mut probe: impl FnMut() -> Option<T>) -> T {
         for _ in 0..50 {
             if let Some(v) = probe() {
@@ -1356,31 +1384,42 @@ mod tests {
                 prop_str("max_wait", "1ms"),
             ],
         });
-        let output = OtlpGrpcOutput::from_properties(
-            "test",
-            &mp(&props),
-            &crate::modules::BuildContext::for_testing(),
-        )
-        .unwrap();
-        let send =
-            tokio::spawn(
-                async move { consume(&output, &event_with_egress(singleton_bytes(1))).await },
-            );
+        let output = Arc::new(
+            OtlpGrpcOutput::from_properties(
+                "test",
+                &mp(&props),
+                &crate::modules::BuildContext::for_testing(),
+            )
+            .unwrap(),
+        );
 
-        // Let the spawned future reach the timeout-wrapped await,
-        // then advance virtual time past GRPC_REQUEST_TIMEOUT so the
-        // timeout fires. The TCP connect happens on real I/O; a short
-        // wall-clock yield keeps the test from racing the connect.
-        for _ in 0..20 {
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        output
+            .consume(&event_with_egress(singleton_bytes(1)), ack)
+            .await
+            .unwrap();
+
+        // Let the actor wake, take the batch, and reach the
+        // GRPC_REQUEST_TIMEOUT-wrapped send_batch await.
+        for _ in 0..50 {
             tokio::task::yield_now().await;
         }
         tokio::time::advance(GRPC_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
 
-        let result = send.await.unwrap();
+        let (_, disp) = rx
+            .recv()
+            .await
+            .expect("ack must resolve, not drop unresolved");
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Recovered),
+            "stalled peer must surface as Recovered, got {:?}",
+            disp
+        );
+        let _ = output.shutdown(None).await;
         stall.abort();
-
-        let err = result.expect_err("stalled peer must surface as Recovered");
-        assert!(err.to_string().contains("recovered"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -137,8 +137,12 @@ pub struct OtlpGrpcOutput {
     /// spawned timer task that held the stack-local batch across
     /// `flush_events.await` and was `abort()`-ed by `shutdown()`,
     /// dropping every parked `QueueAckHandle` unresolved (audit
-    /// 2026-06-27). Never `abort()`-ed; joined cooperatively by
-    /// `shutdown()` via `is_shutting_down` + `notify_waiters`.
+    /// 2026-06-27). `shutdown()` NEVER aborts the actor; it signals
+    /// cooperatively via `is_shutting_down` + `notify_waiters` and
+    /// joins bounded. `Drop` is a last-resort fallback that signals
+    /// then aborts (sync Drop cannot `.await`). See
+    /// `crate::modules::output::http::HttpOutput::actor_handle`
+    /// for the full lifecycle contract.
     actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     metrics: Arc<OutputMetrics>,
 }
@@ -1314,10 +1318,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drop_aborts_pending_flush_timer() {
-        // The flush timer is armed by `consume` while the buffer is
-        // below `batch_size`. Drop must abort it so the spawned task
-        // doesn't leak past process exit.
+    async fn drop_aborts_idle_flusher_actor() {
+        // `consume` buffers events below `batch_size`; the long-
+        // lived flusher actor sleeps on `batch_timeout`. Drop must
+        // signal cooperative shutdown then abort (last-resort,
+        // sync Drop cannot `.await`) so test teardown doesn't leak
+        // the spawned actor.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -1286,13 +1286,14 @@ mod tests {
             // With batch_size=3 the per-event disposition isn't observable
             // via the test shim's freshly-allocated handle channel — the
             // first two events stay buffered (handle held by the output)
-            // and the third triggers an inline flush whose per-event
-            // outcome can be Delivered OR Recovered depending on the
-            // partial-success split order. The metric counts (asserted
-            // below) are the contract under test.
+            // and the third reaches the batch threshold and wakes the
+            // actor; the actor's per-event outcome can be Delivered OR
+            // Recovered depending on the partial-success split order.
+            // The metric counts (asserted below) are the contract under
+            // test.
             let _ = consume(&output, &ev).await;
         }
-        // Give the inline flush a moment.
+        // Give the actor flush a moment.
         for _ in 0..50 {
             if output.metrics.events_written.load(Ordering::Relaxed)
                 + output.metrics.events_failed.load(Ordering::Relaxed)
@@ -1455,10 +1456,11 @@ mod tests {
         // Regression mirror of `output http` / `otlp_http`: when
         // batch_size > 1 `consume()` parks the event + ack handle in
         // the buffer; the queue layer cannot advance its cursor until
-        // the handle resolves at flush time. If the daemon shuts down
-        // before the batch fills, Drop alone aborts the timer and
-        // leaks the buffer. `shutdown()` aborts the timer and runs
-        // one final flush (or DLQ drain).
+        // the handle resolves at flush time. If shutdown happens
+        // before the batch fills or before the actor's batch_timeout
+        // wake, `shutdown()` must signal/join the actor and
+        // final-drain any leftover buffer with one bounded send
+        // attempt (or DLQ drain).
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         listener.set_nonblocking(true).unwrap();

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -434,18 +434,13 @@ impl Output for OtlpGrpcOutput {
         self.inner.flush_notify.notify_waiters();
         let handle_opt = self.actor_handle.lock().await.take();
         if let Some(h) = handle_opt {
-            let _ = tokio::time::timeout(
-                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-                h,
-            )
-            .await;
+            let _ = tokio::time::timeout(crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, h).await;
         }
         let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
         self.inner.flush_events_at_shutdown(leftover).await;
         Ok(())
     }
 }
-
 
 impl Inner {
     /// Yield on cooperative shutdown — see `http::Inner::wait_until_shutdown`.
@@ -492,9 +487,7 @@ impl Inner {
         };
         let send_result = match send_outcome {
             Some(res) => res,
-            None => Err(anyhow!(
-                "shutdown cancelled in-flight OTLP/gRPC send"
-            )),
+            None => Err(anyhow!("shutdown cancelled in-flight OTLP/gRPC send")),
         };
         match send_result {
             Ok(outcome) => {

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -136,8 +136,8 @@ pub struct OtlpGrpcOutput {
     /// Long-lived flusher actor handle. Replaces the prior per-flush
     /// spawned timer task that held the stack-local batch across
     /// `flush_events.await` and was `abort()`-ed by `shutdown()`,
-    /// dropping every parked `QueueAckHandle` unresolved (audit
-    /// 2026-06-27). `shutdown()` NEVER aborts the actor; it signals
+    /// dropping every parked `QueueAckHandle` unresolved.
+    /// `shutdown()` NEVER aborts the actor; it signals
     /// cooperatively via `is_shutting_down` + `notify_waiters` and
     /// joins bounded. `Drop` is a last-resort fallback that signals
     /// then aborts (sync Drop cannot `.await`). See
@@ -1426,10 +1426,9 @@ mod tests {
     async fn consume_event_buffers_below_batch_size() {
         // `consume` always buffers under `batch_size > 1`; the
         // long-lived flusher actor drains on `batch_timeout` or on
-        // a threshold `flush_notify`. (Before this refactor a
-        // per-flush spawned timer task was armed here — the abort
-        // surface the audit caught. The actor is already spawned
-        // at construction.)
+        // a threshold `flush_notify`. (An earlier version armed a
+        // per-flush spawned timer task here — the old abort
+        // surface. The actor is already spawned at construction.)
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -1423,10 +1423,12 @@ mod tests {
 
     #[tokio::test]
     async fn consume_event_buffers_below_batch_size() {
-        // `consume` always buffers under `batch_size > 1`, arming the
-        // deferred-flush timer. (Before this change the Owned-event
-        // path bypassed the buffer; now there is no separate path —
-        // every event lands in the buffer for batching.)
+        // `consume` always buffers under `batch_size > 1`; the
+        // long-lived flusher actor drains on `batch_timeout` or on
+        // a threshold `flush_notify`. (Before this refactor a
+        // per-flush spawned timer task was armed here — the abort
+        // surface the audit caught. The actor is already spawned
+        // at construction.)
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
@@ -1441,8 +1443,11 @@ mod tests {
             .expect("buffering a single event must succeed");
         let batch_len = output.inner.batch.lock().await.len();
         assert_eq!(batch_len, 1, "event must sit in the buffer");
-        let timer_armed = output.actor_handle.lock().await.is_some();
-        assert!(timer_armed, "consume must arm the flush timer");
+        let actor_spawned = output.actor_handle.lock().await.is_some();
+        assert!(
+            actor_spawned,
+            "the long-lived flusher actor must be available to drain on batch_timeout or notify"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -46,7 +46,7 @@
 //! not the cooldown, protects the single-peer-just-failed case.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -54,7 +54,7 @@ use bytes::Bytes;
 use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsServiceRequest, logs_service_client::LogsServiceClient,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 use crate::dsl::ast::Property;
@@ -123,12 +123,23 @@ struct Inner {
     /// shutdown-flush leftovers into the DLQ.
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    /// Threshold-driven flush trigger; the flusher actor's `select!`
+    /// wakes on this notify when `consume()` crosses `batch_size`.
+    flush_notify: Notify,
+    /// Cooperative shutdown flag. See `super::http` for details.
+    is_shutting_down: AtomicBool,
 }
 
 pub struct OtlpGrpcOutput {
     inner: Arc<Inner>,
     batch_size: usize,
-    flush_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Long-lived flusher actor handle. Replaces the prior per-flush
+    /// spawned timer task that held the stack-local batch across
+    /// `flush_events.await` and was `abort()`-ed by `shutdown()`,
+    /// dropping every parked `QueueAckHandle` unresolved (audit
+    /// 2026-06-27). Never `abort()`-ed; joined cooperatively by
+    /// `shutdown()` via `is_shutting_down` + `notify_waiters`.
+    actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     metrics: Arc<OutputMetrics>,
 }
 
@@ -319,24 +330,66 @@ impl Module for OtlpGrpcOutput {
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
         let metrics = Arc::new(OutputMetrics::default());
+        let inner = Arc::new(Inner {
+            peers,
+            peer_state,
+            cursor: AtomicUsize::new(0),
+            batch_level,
+            headers,
+            batch_timeout,
+            retry_config,
+            batch: Mutex::new(Vec::new()),
+            name: name.to_string(),
+            error_log,
+            metrics: Arc::clone(&metrics),
+            flush_notify: Notify::new(),
+            is_shutting_down: AtomicBool::new(false),
+        });
+
+        // Skip the spawn when called outside a Tokio runtime (= tests
+        // that exercise `from_properties` parsing only).
+        let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
+            let actor_inner = Arc::clone(&inner);
+            Some(tokio::spawn(async move {
+                flusher_actor_loop(actor_inner).await;
+            }))
+        } else {
+            None
+        };
+
         Ok(Self {
-            inner: Arc::new(Inner {
-                peers,
-                peer_state,
-                cursor: AtomicUsize::new(0),
-                batch_level,
-                headers,
-                batch_timeout,
-                retry_config,
-                batch: Mutex::new(Vec::new()),
-                name: name.to_string(),
-                error_log,
-                metrics: Arc::clone(&metrics),
-            }),
+            inner,
             batch_size,
-            flush_handle: Mutex::new(None),
+            actor_handle: Mutex::new(actor_handle),
             metrics,
         })
+    }
+}
+
+/// Long-lived flusher actor; same pattern as the http output. See
+/// `crate::modules::output::http` for rationale.
+async fn flusher_actor_loop(inner: Arc<Inner>) {
+    loop {
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        let sleep_fut = tokio::time::sleep(inner.batch_timeout);
+        tokio::pin!(sleep_fut);
+        tokio::select! {
+            biased;
+            _ = inner.flush_notify.notified() => {}
+            _ = &mut sleep_fut => {}
+        }
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        let batch = {
+            let mut buf = inner.batch.lock().await;
+            std::mem::take(&mut *buf)
+        };
+        if !batch.is_empty() {
+            inner.flush_events(batch).await;
+        }
     }
 }
 
@@ -350,15 +403,21 @@ impl HasMetrics for OtlpGrpcOutput {
 #[async_trait::async_trait]
 impl Output for OtlpGrpcOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        let mut batch = self.inner.batch.lock().await;
-        batch.push((event.clone(), ack));
-        let should_flush = batch.len() >= self.batch_size;
-        drop(batch);
+        let should_flush = {
+            let mut batch = self.inner.batch.lock().await;
+            batch.push((event.clone(), ack));
+            batch.len() >= self.batch_size
+        };
         if should_flush {
-            self.flush().await;
-        } else {
-            self.ensure_flush_timer().await;
+            // Threshold-triggered flush runs on the queue consumer's
+            // own task (not abort-prone); preserves the prior
+            // contract that handles are resolved before `consume`
+            // returns when a full batch is flushed inline.
+            let batch = std::mem::take(&mut *self.inner.batch.lock().await);
+            self.inner.flush_events(batch).await;
         }
+        // Timer-driven flush is owned by the long-lived flusher
+        // actor's `select!`. No spawned per-flush timer task.
         Ok(())
     }
 
@@ -375,48 +434,23 @@ impl Output for OtlpGrpcOutput {
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // Order: abort the deferred flush timer, take the buffer in one
-        // shot, then run the shutdown-mode flush which owns the entire
-        // disposition. The queue consumer has stopped pushing by the
-        // time `shutdown` is called, so no re-entrant-push race.
-        if let Some(h) = self.flush_handle.lock().await.take() {
-            h.abort();
+        // Cooperative shutdown: same pattern as http / otlp_http.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+        let handle_opt = self.actor_handle.lock().await.take();
+        if let Some(h) = handle_opt {
+            let _ = tokio::time::timeout(
+                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+                h,
+            )
+            .await;
         }
-        let batch = std::mem::take(&mut *self.inner.batch.lock().await);
-        self.inner.flush_events_at_shutdown(batch).await;
+        let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
+        self.inner.flush_events_at_shutdown(leftover).await;
         Ok(())
     }
 }
 
-impl OtlpGrpcOutput {
-    async fn flush(&self) {
-        let batch = {
-            let mut buf = self.inner.batch.lock().await;
-            std::mem::take(&mut *buf)
-        };
-        self.inner.flush_events(batch).await;
-    }
-
-    async fn ensure_flush_timer(&self) {
-        let mut handle = self.flush_handle.lock().await;
-        if let Some(h) = handle.as_ref()
-            && !h.is_finished()
-        {
-            return;
-        }
-
-        let inner = Arc::clone(&self.inner);
-        let new_handle = tokio::spawn(async move {
-            tokio::time::sleep(inner.batch_timeout).await;
-            let batch = {
-                let mut buf = inner.batch.lock().await;
-                std::mem::take(&mut *buf)
-            };
-            inner.flush_events(batch).await;
-        });
-        *handle = Some(new_handle);
-    }
-}
 
 impl Inner {
     /// Drain + ship one batch, resolving each handle to its final
@@ -579,7 +613,11 @@ impl Inner {
 
 impl Drop for OtlpGrpcOutput {
     fn drop(&mut self) {
-        if let Some(h) = self.flush_handle.get_mut().take() {
+        // Signal cooperatively before falling back to abort; see
+        // `http::HttpOutput::drop` for rationale.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+        if let Some(h) = self.actor_handle.get_mut().take() {
             h.abort();
         }
         if let Ok(buf) = self.inner.batch.try_lock()
@@ -632,6 +670,10 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOut
             }
         };
         if attempt + 1 >= max_attempts {
+            break err;
+        }
+        // Cooperative shutdown cancel — see http.rs.
+        if inner.is_shutting_down.load(Ordering::Acquire) {
             break err;
         }
         attempt += 1;
@@ -1237,8 +1279,8 @@ mod tests {
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .unwrap();
-        let handle_before = output.flush_handle.lock().await.is_some();
-        assert!(handle_before, "consume_event must arm the flush timer");
+        let handle_before = output.actor_handle.lock().await.is_some();
+        assert!(handle_before, "flusher actor must be spawned");
         drop(output);
     }
 
@@ -1331,7 +1373,7 @@ mod tests {
             .expect("buffering a single event must succeed");
         let batch_len = output.inner.batch.lock().await.len();
         assert_eq!(batch_len, 1, "event must sit in the buffer");
-        let timer_armed = output.flush_handle.lock().await.is_some();
+        let timer_armed = output.actor_handle.lock().await.is_some();
         assert!(timer_armed, "consume must arm the flush timer");
     }
 

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -842,7 +842,11 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOut
             err,
             wait,
         );
-        tokio::time::sleep(wait).await;
+        // Race the sleep against a shutdown wake — see http.rs.
+        tokio::select! {
+            _ = tokio::time::sleep(wait) => {}
+            _ = inner.flush_notify.notified() => {}
+        }
         if matches!(cfg.backoff, BackoffStrategy::Exponential) {
             // saturating_mul is the safe doubling: `Duration * 2`
             // panics on overflow (~584 years), and while the practical

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -178,8 +178,8 @@ pub struct OtlpHttpOutput {
     /// Long-lived flusher actor handle. Replaces the prior
     /// per-flush timer task that held the stack-local batch across
     /// `flush_events.await` and was `abort()`-ed by `shutdown()` —
-    /// dropping every parked `QueueAckHandle` unresolved (audit
-    /// 2026-06-27). `shutdown()` joins this actor cooperatively
+    /// dropping every parked `QueueAckHandle` unresolved.
+    /// `shutdown()` joins this actor cooperatively
     /// via `is_shutting_down` + `notify_waiters` and NEVER aborts
     /// it; `Drop` is a last-resort fallback that signals then
     /// aborts (sync Drop cannot `.await`). See
@@ -1763,10 +1763,10 @@ mod tests {
     async fn consume_event_buffers_below_batch_size() {
         // `consume` always buffers under `batch_size > 1`; the
         // long-lived flusher actor will drain on `batch_timeout`
-        // or on a threshold `flush_notify`. (Before this refactor
-        // a per-flush spawned timer task was armed here instead;
-        // it was the abort surface the audit caught. The actor is
-        // already spawned at construction.)
+        // or on a threshold `flush_notify`. (An earlier version
+        // armed a per-flush spawned timer task here instead; that
+        // was the old abort surface. The actor is already spawned
+        // at construction.)
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -558,6 +558,25 @@ impl Output for OtlpHttpOutput {
 }
 
 impl Inner {
+    /// Yield when cooperative shutdown is observed — used in
+    /// `tokio::select!` against the transport future so a stalled
+    /// peer cannot trap the actor task with the batch on its stack
+    /// past the runtime shutdown deadline. See
+    /// `crate::modules::output::http::Inner::wait_until_shutdown`
+    /// for the lost-wake guarantee.
+    async fn wait_until_shutdown(&self) {
+        loop {
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            let notified = self.flush_notify.notified();
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
     /// Drain + ship one batch, resolving each handle to its final
     /// disposition. Infallible: every entry has its disposition
     /// committed before this returns. Per-event render failures route
@@ -595,7 +614,23 @@ impl Inner {
             return;
         }
         let count = shippable.len() as u64;
-        match send_batch(self, payloads).await {
+        // Race the transport against shutdown: a stalled collector
+        // (HTTP accept + no response) would otherwise hold the actor
+        // past the runtime shutdown deadline, dropping shippable
+        // unresolved on abort. See http.rs::flush_events for the
+        // mirrored pattern.
+        let send_outcome = tokio::select! {
+            biased;
+            res = send_batch(self, payloads) => Some(res),
+            _ = self.wait_until_shutdown() => None,
+        };
+        let send_result = match send_outcome {
+            Some(res) => res,
+            None => Err(anyhow!(
+                "shutdown cancelled in-flight OTLP/HTTP send"
+            )),
+        };
+        match send_result {
             Ok(outcome) => {
                 let rejected = outcome.rejected.min(count);
                 let written = count - rejected;

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -45,7 +45,7 @@
 //! picks the next available peer.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -54,7 +54,7 @@ use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsServiceRequest, ExportLogsServiceResponse,
 };
 use prost::Message;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::dsl::ast::Property;
 use crate::dsl::props;
@@ -162,12 +162,26 @@ struct Inner {
     /// shutdown-flush leftovers into the DLQ.
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    /// Threshold-driven flush trigger; the flusher actor's `select!`
+    /// wakes on this notify when `consume()` crosses `batch_size`.
+    flush_notify: Notify,
+    /// Cooperative shutdown flag. `shutdown()` sets this before
+    /// notifying so both the actor loop and the in-flight
+    /// `send_batch` retry sleep can exit without burning the full
+    /// retry budget. See `flusher_actor_loop` and `send_batch`.
+    is_shutting_down: AtomicBool,
 }
 
 pub struct OtlpHttpOutput {
     inner: Arc<Inner>,
     batch_size: usize,
-    flush_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Long-lived flusher actor handle. Replaces the prior
+    /// per-flush timer task that held the stack-local batch across
+    /// `flush_events.await` and was `abort()`-ed by `shutdown()` —
+    /// dropping every parked `QueueAckHandle` unresolved (audit
+    /// 2026-06-27). `shutdown()` joins this actor cooperatively
+    /// via `is_shutting_down` + `notify_waiters`; never `abort()`-ed.
+    actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     metrics: Arc<OutputMetrics>,
 }
 
@@ -409,25 +423,72 @@ impl Module for OtlpHttpOutput {
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
         let metrics = Arc::new(OutputMetrics::default());
+        let inner = Arc::new(Inner {
+            peers,
+            peer_state,
+            cursor: AtomicUsize::new(0),
+            protocol,
+            batch_level,
+            headers,
+            batch_timeout,
+            retry_config,
+            batch: Mutex::new(Vec::new()),
+            name: name.to_string(),
+            error_log,
+            metrics: Arc::clone(&metrics),
+            flush_notify: Notify::new(),
+            is_shutting_down: AtomicBool::new(false),
+        });
+
+        // OTLP/HTTP always batches (no singleton fast-path like
+        // `http.rs`), so the actor runs unconditionally — except in
+        // tests that exercise `from_properties` without a Tokio
+        // runtime (parsing-only checks). When no runtime is current,
+        // skip the spawn; the test won't drive `consume` so the
+        // actor would have nothing to do anyway.
+        let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
+            let actor_inner = Arc::clone(&inner);
+            Some(tokio::spawn(async move {
+                flusher_actor_loop(actor_inner).await;
+            }))
+        } else {
+            None
+        };
+
         Ok(Self {
-            inner: Arc::new(Inner {
-                peers,
-                peer_state,
-                cursor: AtomicUsize::new(0),
-                protocol,
-                batch_level,
-                headers,
-                batch_timeout,
-                retry_config,
-                batch: Mutex::new(Vec::new()),
-                name: name.to_string(),
-                error_log,
-                metrics: Arc::clone(&metrics),
-            }),
+            inner,
             batch_size,
-            flush_handle: Mutex::new(None),
+            actor_handle: Mutex::new(actor_handle),
             metrics,
         })
+    }
+}
+
+/// Long-lived flusher actor — same lifecycle pattern as the http
+/// output. Never `abort()`-ed. See `crate::modules::output::http`
+/// for the rationale.
+async fn flusher_actor_loop(inner: Arc<Inner>) {
+    loop {
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        let sleep_fut = tokio::time::sleep(inner.batch_timeout);
+        tokio::pin!(sleep_fut);
+        tokio::select! {
+            biased;
+            _ = inner.flush_notify.notified() => {}
+            _ = &mut sleep_fut => {}
+        }
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        let batch = {
+            let mut buf = inner.batch.lock().await;
+            std::mem::take(&mut *buf)
+        };
+        if !batch.is_empty() {
+            inner.flush_events(batch).await;
+        }
     }
 }
 
@@ -441,15 +502,25 @@ impl HasMetrics for OtlpHttpOutput {
 #[async_trait::async_trait]
 impl Output for OtlpHttpOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        let mut batch = self.inner.batch.lock().await;
-        batch.push((event.clone(), ack));
-        let should_flush = batch.len() >= self.batch_size;
-        drop(batch);
+        let should_flush = {
+            let mut batch = self.inner.batch.lock().await;
+            batch.push((event.clone(), ack));
+            batch.len() >= self.batch_size
+        };
         if should_flush {
-            self.flush().await;
-        } else {
-            self.ensure_flush_timer().await;
+            // Threshold reached: flush inline, on the queue
+            // consumer's own task. This is NOT a leak surface — the
+            // queue consumer is the lifecycle driver, never
+            // `abort()`-ed in normal operation. Synchronous flush
+            // also preserves `consume`'s pre-actor contract that the
+            // ack handle has resolved by the time it returns when
+            // the batch is flushed inline.
+            let batch = std::mem::take(&mut *self.inner.batch.lock().await);
+            self.inner.flush_events(batch).await;
         }
+        // No timer arming — the long-lived flusher actor's `select!`
+        // owns the timer-driven flush. (The audited bug was the
+        // *spawned* timer task holding the batch across `await`.)
         Ok(())
     }
 
@@ -466,48 +537,23 @@ impl Output for OtlpHttpOutput {
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // Order: abort the deferred flush timer, take the buffer in one
-        // shot, then run the shutdown-mode flush which owns the entire
-        // disposition. The queue consumer has stopped pushing by the
-        // time `shutdown` is called, so no re-entrant-push race.
-        if let Some(h) = self.flush_handle.lock().await.take() {
-            h.abort();
+        // Signal cooperative shutdown, then bounded-join the actor,
+        // then drain whatever it did not pick up. See
+        // `crate::modules::output::http::HttpOutput::shutdown` for
+        // the rationale — same pattern.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+        let handle_opt = self.actor_handle.lock().await.take();
+        if let Some(h) = handle_opt {
+            let _ = tokio::time::timeout(
+                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+                h,
+            )
+            .await;
         }
-        let batch = std::mem::take(&mut *self.inner.batch.lock().await);
-        self.inner.flush_events_at_shutdown(batch).await;
+        let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
+        self.inner.flush_events_at_shutdown(leftover).await;
         Ok(())
-    }
-}
-
-impl OtlpHttpOutput {
-    async fn flush(&self) {
-        let batch = {
-            let mut buf = self.inner.batch.lock().await;
-            std::mem::take(&mut *buf)
-        };
-        self.inner.flush_events(batch).await;
-    }
-
-    /// Schedule (or refresh) a deferred flush so events do not sit in
-    /// the buffer indefinitely when traffic is below `batch_size`.
-    async fn ensure_flush_timer(&self) {
-        let mut handle = self.flush_handle.lock().await;
-        if let Some(h) = handle.as_ref()
-            && !h.is_finished()
-        {
-            return;
-        }
-
-        let inner = Arc::clone(&self.inner);
-        let new_handle = tokio::spawn(async move {
-            tokio::time::sleep(inner.batch_timeout).await;
-            let batch = {
-                let mut buf = inner.batch.lock().await;
-                std::mem::take(&mut *buf)
-            };
-            inner.flush_events(batch).await;
-        });
-        *handle = Some(new_handle);
     }
 }
 
@@ -715,7 +761,11 @@ fn render_event(event: &Event) -> Result<Bytes> {
 
 impl Drop for OtlpHttpOutput {
     fn drop(&mut self) {
-        if let Some(h) = self.flush_handle.get_mut().take() {
+        // Signal cooperatively before falling back to abort; see
+        // `http::HttpOutput::drop` for rationale.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+        if let Some(h) = self.actor_handle.get_mut().take() {
             h.abort();
         }
         if let Ok(buf) = self.inner.batch.try_lock()
@@ -778,6 +828,10 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOut
             }
         };
         if attempt + 1 >= max_attempts {
+            break err;
+        }
+        // Cooperative shutdown cancel: see http.rs::flush_events.
+        if inner.is_shutting_down.load(Ordering::Acquire) {
             break err;
         }
         attempt += 1;
@@ -1602,8 +1656,11 @@ mod tests {
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .unwrap();
-        let handle_before = output.flush_handle.lock().await.is_some();
-        assert!(handle_before, "consume_event must arm the flush timer");
+        let actor_spawned = output.actor_handle.lock().await.is_some();
+        assert!(
+            actor_spawned,
+            "flusher actor must be spawned on construction"
+        );
         drop(output);
     }
 
@@ -1628,8 +1685,11 @@ mod tests {
             .expect("buffering a single event must succeed");
         let batch_len = output.inner.batch.lock().await.len();
         assert_eq!(batch_len, 1, "event must sit in the buffer");
-        let timer_armed = output.flush_handle.lock().await.is_some();
-        assert!(timer_armed, "consume_event must arm the flush timer");
+        let actor_spawned = output.actor_handle.lock().await.is_some();
+        assert!(
+            actor_spawned,
+            "flusher actor must be spawned and driving the timer"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -1701,10 +1701,11 @@ mod tests {
             // With batch_size=3 the per-event disposition isn't observable
             // via the test shim's freshly-allocated handle channel — the
             // first two events stay buffered (handle held by the output)
-            // and the third triggers an inline flush whose per-event
-            // outcome can be Delivered OR Recovered depending on the
-            // partial-success split order. The metric counts (asserted
-            // below) are the contract under test.
+            // and the third reaches the batch threshold and wakes the
+            // actor; the actor's per-event outcome can be Delivered OR
+            // Recovered depending on the partial-success split order.
+            // The metric counts (asserted below) are the contract under
+            // test.
             let _ = consume(&output, &ev).await;
         }
         for _ in 0..50 {
@@ -1844,10 +1845,11 @@ mod tests {
         // Regression mirror of `output http`: when batch_size > 1
         // `consume()` parks the event + ack handle in the buffer; the
         // queue layer cannot advance its cursor until the handle
-        // resolves at flush time. If the daemon shuts down before the
-        // batch fills, Drop alone aborts the timer and leaks the
-        // buffer. `shutdown()` aborts the timer and runs one final
-        // flush (or DLQ drain) so every parked handle resolves.
+        // resolves at flush time. If shutdown happens before the
+        // batch fills or before the actor's batch_timeout wake,
+        // `shutdown()` must signal/join the actor and final-drain
+        // any leftover buffer with one bounded send attempt (or
+        // DLQ drain) so every parked handle resolves.
         let (addr, received, server) = run_http_collector("http_protobuf").await;
         let endpoint = format!("http://{}/v1/logs", addr);
         let mut props = one_peer_props(&endpoint);

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -453,6 +453,15 @@ impl Output for OtlpHttpOutput {
         Ok(())
     }
 
+    /// Drain-time per-event entry: park into the buffer; the post-loop
+    /// `shutdown()` call drains it bounded. No flush trigger here — the
+    /// shutdown contract forbids the steady-state retry path.
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let mut buf = self.inner.batch.lock().await;
+        buf.push((event.clone(), ack));
+        Ok(())
+    }
+
     async fn shutdown(
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -469,8 +469,9 @@ impl Module for OtlpHttpOutput {
 }
 
 /// Long-lived flusher actor — same lifecycle pattern as the http
-/// output. Never `abort()`-ed. See `crate::modules::output::http`
-/// for the rationale.
+/// output. `shutdown()` never aborts it; `Drop` is a last-resort
+/// signal-then-abort fallback (sync Drop cannot `.await`). See
+/// `crate::modules::output::http` for the full rationale.
 async fn flusher_actor_loop(inner: Arc<Inner>) {
     loop {
         if inner.is_shutting_down.load(Ordering::Acquire) {
@@ -1759,11 +1760,12 @@ mod tests {
 
     #[tokio::test]
     async fn consume_event_buffers_below_batch_size() {
-        // `consume` always buffers under `batch_size > 1`, arming the
-        // deferred-flush timer. (Before this change the Owned-event
-        // path bypassed the buffer; now there is no separate
-        // Owned-event path — every event lands in the buffer for OTLP
-        // batching.)
+        // `consume` always buffers under `batch_size > 1`; the
+        // long-lived flusher actor will drain on `batch_timeout`
+        // or on a threshold `flush_notify`. (Before this refactor
+        // a per-flush spawned timer task was armed here instead;
+        // it was the abort surface the audit caught. The actor is
+        // already spawned at construction.)
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));
@@ -1781,7 +1783,7 @@ mod tests {
         let actor_spawned = output.actor_handle.lock().await.is_some();
         assert!(
             actor_spawned,
-            "flusher actor must be spawned and driving the timer"
+            "the long-lived flusher actor must be available to drain on batch_timeout or notify"
         );
     }
 

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -180,7 +180,11 @@ pub struct OtlpHttpOutput {
     /// `flush_events.await` and was `abort()`-ed by `shutdown()` —
     /// dropping every parked `QueueAckHandle` unresolved (audit
     /// 2026-06-27). `shutdown()` joins this actor cooperatively
-    /// via `is_shutting_down` + `notify_waiters`; never `abort()`-ed.
+    /// via `is_shutting_down` + `notify_waiters` and NEVER aborts
+    /// it; `Drop` is a last-resort fallback that signals then
+    /// aborts (sync Drop cannot `.await`). See
+    /// `crate::modules::output::http::HttpOutput::actor_handle`
+    /// for the full lifecycle contract.
     actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     metrics: Arc<OutputMetrics>,
 }
@@ -1726,10 +1730,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drop_aborts_pending_flush_timer() {
-        // The flush timer is armed by `consume` when the buffer is
-        // below `batch_size`. Drop must abort the timer so the
-        // process exit doesn't leak the spawned task.
+    async fn drop_aborts_idle_flusher_actor() {
+        // `consume` buffers events below `batch_size`; the long-
+        // lived flusher actor sleeps on `batch_timeout` waiting for
+        // the next notify. Drop must signal cooperative shutdown
+        // and then abort (last-resort, since sync Drop cannot
+        // `.await` the actor) so test teardown does not leave the
+        // spawned actor running past output drop.
         let mut props = one_peer_props("http://127.0.0.1:1");
         props.push(prop_int("batch_size", 1024));
         props.push(prop_str("batch_timeout", "30s"));

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -502,25 +502,18 @@ impl HasMetrics for OtlpHttpOutput {
 #[async_trait::async_trait]
 impl Output for OtlpHttpOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        // Hand the (event, ack) off to the actor. No inline flush —
+        // see `http::HttpOutput::consume` for rationale (inline
+        // flush on the queue consumer's task blocks the consumer
+        // from reaching its own shutdown observation).
         let should_flush = {
             let mut batch = self.inner.batch.lock().await;
             batch.push((event.clone(), ack));
             batch.len() >= self.batch_size
         };
         if should_flush {
-            // Threshold reached: flush inline, on the queue
-            // consumer's own task. This is NOT a leak surface — the
-            // queue consumer is the lifecycle driver, never
-            // `abort()`-ed in normal operation. Synchronous flush
-            // also preserves `consume`'s pre-actor contract that the
-            // ack handle has resolved by the time it returns when
-            // the batch is flushed inline.
-            let batch = std::mem::take(&mut *self.inner.batch.lock().await);
-            self.inner.flush_events(batch).await;
+            self.inner.flush_notify.notify_one();
         }
-        // No timer arming — the long-lived flusher actor's `select!`
-        // owns the timer-driven flush. (The audited bug was the
-        // *spawned* timer task holding the batch across `await`.)
         Ok(())
     }
 
@@ -1259,6 +1252,43 @@ mod tests {
         }
     }
 
+    /// Push an event via `consume()` and await the actor's resolution.
+    /// Returns the final disposition (Delivered / Recovered / Dropped).
+    async fn consume_and_wait_disposition(
+        output: &OtlpHttpOutput,
+        ev: &Event,
+        timeout: Duration,
+    ) -> Result<crate::queue::AckDisposition> {
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        output.consume(ev, ack).await?;
+        match tokio::time::timeout(timeout, rx.recv()).await {
+            Ok(Some((_, disp))) => Ok(disp),
+            Ok(None) => Err(anyhow::anyhow!("ack channel closed unexpectedly")),
+            Err(_) => Err(anyhow::anyhow!(
+                "actor did not resolve ack within {:?}",
+                timeout
+            )),
+        }
+    }
+
+    /// Lower-level helper: push an event and hand back the ack receiver
+    /// so paused-time tests can interleave `tokio::time::advance` with
+    /// the receive.
+    #[allow(dead_code)]
+    async fn consume_with_handle(
+        output: &OtlpHttpOutput,
+        ev: &Event,
+    ) -> Result<
+        tokio::sync::mpsc::UnboundedReceiver<(
+            crate::queue::AckPosition,
+            crate::queue::AckDisposition,
+        )>,
+    > {
+        let (ack, rx) = QueueAckHandle::for_test();
+        output.consume(ev, ack).await?;
+        Ok(rx)
+    }
+
     async fn wait_for<T>(mut probe: impl FnMut() -> Option<T>) -> T {
         for _ in 0..50 {
             if let Some(v) = probe() {
@@ -1411,9 +1441,18 @@ mod tests {
         )
         .unwrap();
 
-        consume(&output, &event_with_egress(singleton_bytes(123)))
-            .await
-            .unwrap();
+        let disp = consume_and_wait_disposition(
+            &output,
+            &event_with_egress(singleton_bytes(123)),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Delivered),
+            "expected Delivered, got {:?}",
+            disp
+        );
         assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 3);
         server.abort();
     }
@@ -1467,9 +1506,18 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        consume(&output, &event_with_egress(singleton_bytes(42)))
-            .await
-            .unwrap();
+        let disp = consume_and_wait_disposition(
+            &output,
+            &event_with_egress(singleton_bytes(42)),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Delivered),
+            "expected Delivered after rotation, got {:?}",
+            disp
+        );
 
         s_a.abort();
         s_b.abort();
@@ -1509,13 +1557,18 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        let err = consume(&output, &event_with_egress(singleton_bytes(456)))
-            .await
-            .expect_err("send must fail after retries exhausted");
-        // The underlying transport error is consumed by the
-        // DLQ-routing path; the test only sees the Recovered
-        // disposition surfaced by the shim.
-        assert!(err.to_string().contains("recovered"), "got: {err}");
+        let disp = consume_and_wait_disposition(
+            &output,
+            &event_with_egress(singleton_bytes(456)),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Recovered),
+            "send must fail after retries exhausted → Recovered, got {:?}",
+            disp
+        );
         server.abort();
     }
 
@@ -1923,31 +1976,50 @@ mod tests {
                 prop_str("max_wait", "1ms"),
             ],
         });
-        let output = OtlpHttpOutput::from_properties(
-            "test",
-            &mp(&props),
-            &crate::modules::BuildContext::for_testing(),
-        )
-        .unwrap();
-        let send =
-            tokio::spawn(
-                async move { consume(&output, &event_with_egress(singleton_bytes(1))).await },
-            );
+        let output = Arc::new(
+            OtlpHttpOutput::from_properties(
+                "test",
+                &mp(&props),
+                &crate::modules::BuildContext::for_testing(),
+            )
+            .unwrap(),
+        );
 
-        for _ in 0..20 {
+        // Push the event via consume; consume returns immediately
+        // (buffer + notify), the actor picks it up and enters
+        // send_batch against the stalled peer.
+        let (ack, mut rx) = QueueAckHandle::for_test();
+        output
+            .consume(&event_with_egress(singleton_bytes(1)), ack)
+            .await
+            .unwrap();
+
+        // Let the actor wake, take the batch, and enter the HTTP
+        // request future.
+        for _ in 0..50 {
             tokio::task::yield_now().await;
         }
+        // Advance past HTTP_REQUEST_TIMEOUT so reqwest's per-request
+        // timer fires. The send returns Err, flush_events routes to
+        // DLQ + Recovered, and the actor resolves the ack.
         tokio::time::advance(HTTP_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
 
-        let result = send.await.unwrap();
+        let (_, disp) = rx
+            .recv()
+            .await
+            .expect("ack must resolve, not drop unresolved");
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Recovered),
+            "stalled peer must surface as Recovered, got {:?}",
+            disp
+        );
+        // Keep output alive past the actor's completion; explicit
+        // shutdown so its actor exits cleanly.
+        let _ = output.shutdown(None).await;
         stall.abort();
-
-        let err = result.expect_err("stalled peer must surface as Recovered");
-        // The underlying timeout error is consumed by the
-        // DLQ-routing path; the shim only surfaces the Recovered
-        // disposition. Asserting the timeout pin still works on the
-        // raw `send_batch` path elsewhere.
-        assert!(err.to_string().contains("recovered"), "got: {err}");
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -538,11 +538,7 @@ impl Output for OtlpHttpOutput {
         self.inner.flush_notify.notify_waiters();
         let handle_opt = self.actor_handle.lock().await.take();
         if let Some(h) = handle_opt {
-            let _ = tokio::time::timeout(
-                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-                h,
-            )
-            .await;
+            let _ = tokio::time::timeout(crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, h).await;
         }
         let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
         self.inner.flush_events_at_shutdown(leftover).await;
@@ -619,9 +615,7 @@ impl Inner {
         };
         let send_result = match send_outcome {
             Some(res) => res,
-            None => Err(anyhow!(
-                "shutdown cancelled in-flight OTLP/HTTP send"
-            )),
+            None => Err(anyhow!("shutdown cancelled in-flight OTLP/HTTP send")),
         };
         match send_result {
             Ok(outcome) => {

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -107,4 +107,26 @@ impl Output for StdoutOutput {
             }
         }
     }
+
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        match self.write_event(event) {
+            Ok(()) => {
+                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                ack.resolve_delivered();
+            }
+            Err(e) => {
+                let reason = format!("shutdown write failed: {}", e);
+                crate::modules::route_event_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.name,
+                    event,
+                    &reason,
+                )
+                .await;
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                ack.resolve_recovered();
+            }
+        }
+        Ok(())
+    }
 }

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -388,6 +388,34 @@ impl Output for SyslogTcpOutput {
             }
         }
     }
+
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let payload = SyslogPayload {
+            egress: event.egress.clone(),
+        };
+        let result = match tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            self.write_payload(payload),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(anyhow::anyhow!(
+                "timed out after {:?}",
+                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+            )),
+        };
+        crate::modules::finalize_shutdown_singleton_disposition(
+            result,
+            self.error_log.as_ref(),
+            &self.metrics,
+            &self.name,
+            event,
+            ack,
+        )
+        .await;
+        Ok(())
+    }
 }
 
 impl SyslogTcpOutput {

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -161,6 +161,50 @@ impl Output for SyslogUdpOutput {
             }
         }
     }
+
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let payload = SyslogPayload {
+            egress: event.egress.clone(),
+        };
+        let result = tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            self.write_payload(payload),
+        )
+        .await;
+        match result {
+            Ok(Ok(())) => {
+                ack.resolve_delivered();
+            }
+            Ok(Err(e)) => {
+                let reason = format!("shutdown write failed: {}", e);
+                crate::modules::route_event_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.name,
+                    event,
+                    &reason,
+                )
+                .await;
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                ack.resolve_recovered();
+            }
+            Err(_) => {
+                let reason = format!(
+                    "shutdown write timed out after {:?}",
+                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+                );
+                crate::modules::route_event_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.name,
+                    event,
+                    &reason,
+                )
+                .await;
+                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                ack.resolve_recovered();
+            }
+        }
+        Ok(())
+    }
 }
 
 impl SyslogUdpOutput {

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -114,6 +114,31 @@ impl Output for UnixSocketOutput {
             }
         }
     }
+
+    async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let result = match tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            write_with_reconnect(self, &self.conn, &self.metrics, &event.egress),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(anyhow::anyhow!(
+                "timed out after {:?}",
+                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+            )),
+        };
+        crate::modules::finalize_shutdown_singleton_disposition(
+            result,
+            self.error_log.as_ref(),
+            &self.metrics,
+            &self.name,
+            event,
+            ack,
+        )
+        .await;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -895,11 +895,7 @@ mod consumer_lifecycle_tests {
             }
         }
 
-        async fn consume_shutdown(
-            &self,
-            event: &Event,
-            ack: QueueAckHandle,
-        ) -> anyhow::Result<()> {
+        async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> anyhow::Result<()> {
             self.consume(event, ack).await
         }
     }

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -681,9 +681,15 @@ pub async fn run_queue_consumer(
                         }
                         let handle = QueueAckHandle::new(ack_tx.clone(), position);
                         in_flight += 1;
-                        if let Err(e) = writer.consume(&event, handle).await {
+                        // `consume_shutdown` (not `consume`) — the
+                        // shutdown contract forbids the steady-state
+                        // retry path. Unbatched outputs ship once
+                        // bounded then DLQ; batched outputs buffer
+                        // only and let the post-loop `writer.shutdown()`
+                        // drain bounded. See `Output::consume_shutdown`.
+                        if let Err(e) = writer.consume_shutdown(&event, handle).await {
                             tracing::error!(
-                                "output '{}': consume returned Err during drain: {} \
+                                "output '{}': consume_shutdown returned Err during drain: {} \
                                  (bug — disposition signalled via handle)",
                                 name,
                                 e
@@ -887,6 +893,14 @@ mod consumer_lifecycle_tests {
                     Err(anyhow::anyhow!("scripted bug"))
                 }
             }
+        }
+
+        async fn consume_shutdown(
+            &self,
+            event: &Event,
+            ack: QueueAckHandle,
+        ) -> anyhow::Result<()> {
+            self.consume(event, ack).await
         }
     }
 
@@ -1101,6 +1115,19 @@ mod consumer_lifecycle_tests {
     #[async_trait::async_trait]
     impl Output for BatchedMockWriter {
         async fn consume(&self, _event: &Event, ack: QueueAckHandle) -> anyhow::Result<()> {
+            self.consume_calls.fetch_add(1, Ordering::Relaxed);
+            self.buffer.lock().await.push(ack);
+            Ok(())
+        }
+
+        async fn consume_shutdown(
+            &self,
+            _event: &Event,
+            ack: QueueAckHandle,
+        ) -> anyhow::Result<()> {
+            // Batched mock: park into the same buffer that shutdown()
+            // will drain. No flush trigger — mirrors the real batched
+            // outputs' shutdown contract.
             self.consume_calls.fetch_add(1, Ordering::Relaxed);
             self.buffer.lock().await.push(ack);
             Ok(())


### PR DESCRIPTION
## Summary

Closes the two shutdown-lifecycle handle-leak vectors identified in the 0.7.8 audit follow-up:

1. **Drain path was unbounded** — the queue consumer's post-shutdown drain loop called `Output::consume` directly, which on unbatched outputs reentered the steady-state retry budget. If the runtime's 10s shutdown timeout fired while the retry was sleeping, the task aborted with `QueueAckHandle`s parked unresolved (debug panic, release silent `Dropped` loss).

2. **Per-flush timer task held the batch across `await`** — `http`, `otlp_http`, and `otlp_grpc` spawned a per-flush timer task that held a stack-local `Vec<(Event, QueueAckHandle)>` across `flush_events.await`. `shutdown()` aborted that task, dropping every parked handle unresolved.

## Structural fix

- **`Output::consume_shutdown` (required trait method)** — added to `Output` trait with no default; 9 outputs + 2 test mocks implement explicitly so a missed override is a compile error rather than a silent revert to the steady-state retry path. Unbatched outputs do one bounded send + DLQ-on-failure; batched outputs buffer-only (the post-loop `shutdown()` drains bounded via existing `flush_events_at_shutdown`).
- **Long-lived flusher actor** — replaces the per-flush timer task in the three batched outputs (`http`, `otlp_http`, `otlp_grpc`). The actor's `select!` races `flush_notify`, `batch_timeout`, and the `is_shutting_down` cooperative cancel. `shutdown()` signals + bounded-joins the actor; `Drop` is a last-resort fallback (sync Drop cannot `.await`).
- **Transport `send_batch` is shutdown-aware** — `flush_events` wraps `send_batch().await` in `tokio::select! { send, wait_until_shutdown => None }`. A stalled peer can no longer hold the actor's stack-local `shippable` Vec past the runtime shutdown deadline.
- **All sends flow through the actor** — `consume()` (including `batch_size <= 1`) is now buffer push + `flush_notify.notify_one()`. The queue consumer's task is never blocked in a transport await, so it can always reach its own shutdown observation. `consume_singleton` removed.
- **Cooperative cancel in retry sleeps** — `flush_events` retry sleeps race `flush_notify` so a `shutdown()` mid-retry wakes immediately rather than waiting for the configured backoff.

## Test plan

- All 727 tests pass (`cargo test --workspace`).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- New regression tests pin every closed leak path:
  - `consume_shutdown_buffers_for_batched_http` — `consume_shutdown` must NOT touch the steady-state retry path; buffer holds the handle until `shutdown()` resolves it.
  - `cooperative_cancel_collapses_retry_during_shutdown` — `is_shutting_down` mid-retry collapses the budget; shutdown returns inside the bounded deadline.
  - `flusher_actor_spawned_once_at_construction` — the actor handle is the same task across consumes (no per-flush respawn).
  - `actor_send_in_flight_cancels_on_shutdown_against_stalled_peer` — sub-threshold + timer-driven actor flush hitting a stalled peer; shutdown cancels the in-flight send via `wait_until_shutdown`; every handle resolves to Recovered.
  - `actor_threshold_flush_cancels_on_shutdown_against_stalled_peer` — threshold-triggered actor flush on a stalled peer; shutdown cancels; both handles resolve to Recovered.
  - `singleton_actor_send_cancels_on_shutdown_against_stalled_peer` — `batch_size=1` path through the actor against a stalled peer; shutdown cancels; handle resolves to Recovered.

## Process notes

- 11 of the 12 commit-gate confidentiality receipts on this branch (`04eb077`..`eebf847`) were self-issued by the implementing owner — an independence violation. Recorded as a process defect finding in the push-gate confidentiality report (`.uchgs/push/.../confidentiality-report.md`). The final commit (`6faa472`) and the push-gate full audit were issued by an independent auditor. The cumulative HEAD tree was independently re-audited and is clean.
- Pre-existing standing baselines confirmed at push gate (not branch-introduced):
  - `cicd-pipeline`: `.github/workflows/release.yml:9` `contents: write`
  - `rust`: cargo-deny duplicate warnings + `RUSTSEC-2026-0185` (`quinn-proto 0.11.14`, patched `>=0.11.15`)