### PR TITLE
chore(release): cut 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Pre-1.0 releases may introduce breaking changes freely as the DSL and
 runtime shape converge. After 1.0, changes will follow semver strictly.
 
-## [Unreleased] - 0.7.8
+## [0.7.8] - 2026-06-27
 
 ### Changed (BREAKING) — `secondary <name>` removed from every output
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "clap",
@@ -1484,7 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.7"
+version = "0.7.8"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.7"
+version = "0.7.8"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.7"
+version = "0.7.8"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true


### PR DESCRIPTION
## Summary

Final release-prep for 0.7.8.

- **Workspace crate versions** bumped 0.7.7 → 0.7.8 across `limpid`, `limpidctl`, `limpid-prometheus`.
- **Cargo.lock** regenerated; `cargo update -p quinn-proto` advances 0.11.14 → 0.11.15, **clearing `RUSTSEC-2026-0185`** from the cargo-audit standing baseline that this release cycle has been carrying.
- **CHANGELOG.md** Unreleased section header converted to `[0.7.8] - 2026-06-27`.

## Test plan

- `cargo test --workspace`: 727 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo audit`: **0 advisories** (RUSTSEC-2026-0185 resolved by the quinn-proto bump).
- `cargo deny check`: exit 0. Residual cargo-deny duplicate-crate WARN-level findings (`hashbrown`, `indexmap`, `socket2`, `thiserror`, `thiserror-impl`, `tower`, `webpki-roots`) remain as standing baseline under the existing `multiple-versions = "warn"` policy.

## Process notes

Pre-existing standing baselines confirmed at push gate:
- `cicd-pipeline`: `release.yml contents: write` (workflow unchanged on this branch).
- `rust`: residual cargo-deny duplicate-crate WARN-level findings only; the RUSTSEC entry that was the standing baseline through the 0.7.8 cycle is closed by this PR.

Commit-gate confidentiality and push-gate full audit (8 scopes) issued by an independent auditor.