### PR TITLE
fix: CodeRabbit cluster findings for 0.7.8 release

### DIFF
--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -336,10 +336,7 @@ async fn query_control(socket_path: &Path, command: &str) -> Result<String, Stri
                     // with whatever bytes had been collected so far,
                     // so `/health` would 200 with a truncated body —
                     // masking a broken control socket as healthy.
-                    return Err(format!(
-                        "control socket read failed: {}",
-                        e
-                    ));
+                    return Err(format!("control socket read failed: {}", e));
                 }
             }
         }

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -91,17 +91,18 @@ async fn handle_request(
     socket_path: &Path,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
     match req.uri().path() {
-        "/health" => {
-            let body = match query_control(socket_path, "health").await {
-                Ok(s) => s,
-                Err(e) => e,
-            };
-            Ok(Response::builder()
+        "/health" => match query_control(socket_path, "health").await {
+            Ok(body) => Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", "text/plain")
                 .body(Full::new(Bytes::from(body)))
-                .unwrap())
-        }
+                .unwrap()),
+            Err(e) => Ok(Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .header("content-type", "text/plain")
+                .body(Full::new(Bytes::from(e)))
+                .unwrap()),
+        },
         "/metrics" => {
             let body = match query_control(socket_path, "stats").await {
                 Ok(json) => match json_to_prometheus(&json) {
@@ -328,7 +329,18 @@ async fn query_control(socket_path: &Path, command: &str) -> Result<String, Stri
             match reader.read_line(&mut line).await {
                 Ok(0) => break,
                 Ok(_) => result.push_str(&line),
-                Err(_) => break,
+                Err(e) => {
+                    // Surface the read error rather than treating
+                    // mid-response failure as clean EOF. The previous
+                    // `Err(_) => break` flow returned `Ok(result)`
+                    // with whatever bytes had been collected so far,
+                    // so `/health` would 200 with a truncated body —
+                    // masking a broken control socket as healthy.
+                    return Err(format!(
+                        "control socket read failed: {}",
+                        e
+                    ));
+                }
             }
         }
         Ok::<_, String>(result)

--- a/crates/limpid/src/check/outputs.rs
+++ b/crates/limpid/src/check/outputs.rs
@@ -146,7 +146,19 @@ fn analyze_property(
             // FuncCall, etc.) still gets walked by `check_types` so
             // unknown-function / type-mismatch diagnostics inside
             // template bodies continue to surface.
-            let skip_expr_types = schema_owned && matches!(expr.kind, ExprKind::Ident(_));
+            // The parser folds both bare idents (`framing
+            // non_transparent`) and dotted paths (`key_field
+            // workspace.user_id`) into the same `ExprKind::Ident`
+            // variant — `parts` length distinguishes them. The skip
+            // applies only to the single-segment case: that is the
+            // only shape that can legitimately be a schema enum
+            // variant or string-payload literal whose textual
+            // spelling happens to collide with `workspace`,
+            // `egress`, or `error`. Anything dotted IS a runtime
+            // reference and must still be rejected by the
+            // pipeline-only-state check.
+            let skip_expr_types = schema_owned
+                && matches!(&expr.kind, ExprKind::Ident(parts) if parts.len() == 1);
             if !skip_expr_types {
                 expr_types::check_types(
                     expr,
@@ -156,16 +168,31 @@ fn analyze_property(
                     *value_span,
                     diagnostics,
                 );
+                // `collect_workspace_refs` is gated on the same
+                // `skip_expr_types` condition: a schema-owned
+                // single-segment bare ident is a literal value
+                // (enum variant or string payload), not a runtime
+                // expression reading workspace / egress / error.
+                // Walking it would have the same false-positive
+                // shape `check_types` does — e.g. a property
+                // declared as `Enum` with a variant literally named
+                // `error` would be rejected by
+                // `check_pipeline_only_reference` even though it
+                // never resolves at runtime as a reference to the
+                // pipeline-only `error` ident. Dotted idents
+                // (`workspace.x`), templates, function calls, and
+                // property accesses still get walked because their
+                // value shapes fall outside the bare-ident skip.
+                collect_workspace_refs(expr, &mut |path| {
+                    check_pipeline_only_reference(
+                        path,
+                        output_name,
+                        pipeline_name,
+                        *value_span,
+                        diagnostics,
+                    );
+                });
             }
-            collect_workspace_refs(expr, &mut |path| {
-                check_pipeline_only_reference(
-                    path,
-                    output_name,
-                    pipeline_name,
-                    *value_span,
-                    diagnostics,
-                );
-            });
         }
         Property::Block { properties, .. } => {
             // Descend into the inner schema for this block's key if

--- a/crates/limpid/src/check/outputs.rs
+++ b/crates/limpid/src/check/outputs.rs
@@ -157,8 +157,8 @@ fn analyze_property(
             // `egress`, or `error`. Anything dotted IS a runtime
             // reference and must still be rejected by the
             // pipeline-only-state check.
-            let skip_expr_types = schema_owned
-                && matches!(&expr.kind, ExprKind::Ident(parts) if parts.len() == 1);
+            let skip_expr_types =
+                schema_owned && matches!(&expr.kind, ExprKind::Ident(parts) if parts.len() == 1);
             if !skip_expr_types {
                 expr_types::check_types(
                     expr,

--- a/crates/limpid/src/check/parser_effects.rs
+++ b/crates/limpid/src/check/parser_effects.rs
@@ -36,21 +36,26 @@ pub(super) fn apply_parser_effects(
     // Defaults arg (HashLit): every declared key becomes a workspace
     // binding too, with type inferred from the literal value. This is
     // the "user-declared schema" knob that lets parse_json / parse_kv
-    // narrow the wildcard to a precise key set. The registry declares
-    // which positional slots may hold the HashLit — parse_kv accepts
-    // it at both args[1] (2-arg form) and args[2] (3-arg form), so the
-    // scan walks the slots in order and takes the first match.
-    let defaults_entries = info.defaults_arg_indices.iter().find_map(|&i| {
-        if let Some(Expr {
-            kind: ExprKind::HashLit(entries),
-            ..
-        }) = args.get(i)
-        {
-            Some(entries)
-        } else {
-            None
-        }
-    });
+    // narrow the wildcard to a precise key set. Parsers whose defaults
+    // position depends on the type of earlier args (parse_kv) supply a
+    // shape-aware extractor; everyone else falls back to the
+    // index-list scan, which takes the first HashLit at any declared
+    // slot.
+    let defaults_entries = if let Some(extractor) = info.defaults_arg_extractor {
+        extractor(args)
+    } else {
+        info.defaults_arg_indices.iter().find_map(|&i| {
+            if let Some(Expr {
+                kind: ExprKind::HashLit(entries),
+                ..
+            }) = args.get(i)
+            {
+                Some(entries)
+            } else {
+                None
+            }
+        })
+    };
     if let Some(entries) = defaults_entries {
         for (k, v) in entries {
             let path = vec!["workspace".to_string(), k.clone()];
@@ -153,6 +158,34 @@ mod tests {
             Some(&FieldType::String)
         );
         assert!(!bindings.is_workspace_wildcard());
+    }
+
+    // parse_kv with a non-string second arg + HashLit third arg is
+    // not a valid runtime call shape — `parse_kv_impl` bails because
+    // `args[1]` must be a String separator when `args[2]` is present
+    // (`(Some(Object), Some(_))` falls into the catch-all bail arm).
+    // The shape-aware extractor refuses to narrow from either
+    // HashLit; the wildcard fallback then keeps downstream
+    // `workspace.*` reads admissible at `--check` time, but no
+    // *specific* key set is pinned. Pre-fix, the index-list scan
+    // picked up the HashLit at `args[1]` and narrowed the workspace
+    // to {ignored}, so downstream reads of `workspace.user` would
+    // fail `--check` for a call that would have bailed at runtime
+    // anyway.
+    #[test]
+    fn parse_kv_invalid_three_arg_shape_falls_back_to_wildcard() {
+        let reg = registry();
+        let mut bindings = Bindings::new();
+        let args = vec![
+            ident("ingress"),
+            hash(&[("ignored", string(""))]),
+            hash(&[("user", string(""))]),
+        ];
+        apply_parser_effects(None, "parse_kv", &args, &reg, &mut bindings);
+        assert!(
+            bindings.is_workspace_wildcard(),
+            "invalid call shape must not pin a key set; fall back to wildcard"
+        );
     }
 
     // parse_kv with no defaults HashLit anywhere → wildcard, matching

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -78,6 +78,21 @@ pub enum PropertyValueKind {
 }
 
 impl PropertyValueKind {
+    /// Whether this variant's outer property shape is `Property::Block`
+    /// (block-shaped) versus `Property::KeyValue` (scalar-shaped).
+    /// Used by `check_one_of` to decide which `OneOf` variants are
+    /// *structural* matches for the actual property — independent of
+    /// whatever inner content errors the variant's full validator
+    /// produced.
+    fn expects_block_outer_shape(self) -> bool {
+        matches!(
+            self,
+            PropertyValueKind::Block(_)
+                | PropertyValueKind::BlockMap(_)
+                | PropertyValueKind::StringMap
+        )
+    }
+
     fn label(self) -> &'static str {
         match self {
             PropertyValueKind::String => "String",
@@ -422,11 +437,15 @@ fn check_one_of(
     // Ident, got Block" which is actively misleading when the user
     // wrote a Block and the real problem is one missing inner key.
     //
-    // A structural failure shows up as `ExpectedBlock` (variant wanted
-    // a block, got a scalar) or `ExpectedValue` (variant wanted a
-    // scalar, got a block). Any other error kind means the variant
-    // recognised the outer shape and is reporting a content-level
-    // problem.
+    // Structural match is decided by comparing the variant's expected
+    // outer shape (`Block` / `BlockMap` / `StringMap` → block-shaped;
+    // everything else → scalar-shaped) against the actual `Property`
+    // variant. Earlier this filter walked the per-variant error list
+    // looking for `ExpectedBlock` / `ExpectedValue` kinds, which
+    // misclassified variants that fit the outer shape but produced an
+    // inner `ExpectedValue` (e.g. a nested scalar key whose value
+    // shape was wrong) — those nested errors disqualified the variant
+    // even though its outer shape matched.
     //
     // When 0 or 2+ variants structurally match we deliberately
     // collapse to `OneOfMismatch`:
@@ -441,16 +460,12 @@ fn check_one_of(
     //     `OneOfMismatch { expected: ["String", "Int"], actual:
     //     "Bool" }` reads as "expected String | Int, got Bool" which
     //     names all valid forms in one line.
-    let structural_matches: Vec<&Vec<SchemaError>> = per_variant
+    let actual_is_block = matches!(prop, Property::Block { .. });
+    let structural_matches: Vec<&Vec<SchemaError>> = variants
         .iter()
-        .filter(|errs| {
-            !errs.iter().any(|e| {
-                matches!(
-                    e.kind,
-                    SchemaErrorKind::ExpectedBlock | SchemaErrorKind::ExpectedValue
-                )
-            })
-        })
+        .zip(per_variant.iter())
+        .filter(|(kind, _)| kind.expects_block_outer_shape() == actual_is_block)
+        .map(|(_, errs)| errs)
         .collect();
 
     if let [only] = structural_matches.as_slice() {
@@ -1177,6 +1192,59 @@ mod tests {
         );
         assert_eq!(errs.len(), 1, "{errs:?}");
         assert!(matches!(errs[0].kind, SchemaErrorKind::MissingRequired));
+        assert_eq!(errs[0].key, "cert");
+    }
+
+    #[test]
+    fn one_of_surfaces_inner_nested_value_error_when_block_variant_matches() {
+        // Regression: the structural-match filter used to look at the
+        // per-variant error list for `ExpectedBlock` / `ExpectedValue`
+        // kinds. That misclassified variants whose outer shape DID
+        // match but whose inner content produced an `ExpectedValue` —
+        // e.g. an inline block where a scalar inner key was instead
+        // written as a sub-block. The fix decides structural match
+        // from the variant's expected outer shape vs. the actual
+        // `Property` variant, so nested errors inside an otherwise-
+        // matching block variant no longer disqualify it.
+        const INNER: &[PropertySpec] = &[PropertySpec {
+            name: "cert",
+            required: true,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::String,
+        }];
+        const S: &[PropertySpec] = &[PropertySpec {
+            name: "tls",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::OneOf(&[
+                PropertyValueKind::Block(INNER),
+                PropertyValueKind::Enum(&["profile_a"]),
+            ]),
+        }];
+        // Inline block where `cert` is written as a sub-block instead
+        // of a String value. The Block variant should structurally
+        // match and surface its inner `ExpectedValue` error rather
+        // than collapse to a generic `OneOfMismatch`.
+        let errs = validate(
+            &[Property::Block {
+                key: "tls".into(),
+                key_span: None,
+                properties: vec![Property::Block {
+                    key: "cert".into(),
+                    key_span: None,
+                    properties: vec![],
+                }],
+            }],
+            S,
+        );
+        assert_eq!(errs.len(), 1, "{errs:?}");
+        assert!(
+            matches!(errs[0].kind, SchemaErrorKind::ExpectedValue),
+            "expected ExpectedValue, got {:?}",
+            errs[0].kind
+        );
         assert_eq!(errs[0].key, "cert");
     }
 

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -1157,13 +1157,12 @@ mod tests {
 
     #[test]
     fn one_of_surfaces_inner_block_error_when_block_variant_matches() {
-        // The motivating CodeRabbit case: OneOf[Block(inner_schema),
-        // Ident]. The user wrote a Block but forgot a required inner
-        // key. The Block variant matches structurally and reports
-        // MissingRequired; the Ident variant fails with ExpectedValue
-        // (structural). Exactly one structural match → return the
-        // Block variant's inner error rather than a vague
-        // "expected Block | Ident, got Block".
+        // OneOf[Block(inner_schema), Ident] where the user wrote a
+        // Block but forgot a required inner key. The Block variant
+        // matches structurally and reports MissingRequired; the Ident
+        // variant fails with ExpectedValue (structural). Exactly one
+        // structural match → return the Block variant's inner error
+        // rather than a vague "expected Block | Ident, got Block".
         const INNER: &[PropertySpec] = &[PropertySpec {
             name: "cert",
             required: true,

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -48,7 +48,7 @@
 //!
 //! # Output flavor: re-deliver the pre-rendered event directly to the
 //! # named output's queue; the sink re-routes via its own `consume()`.
-//! jq -c 'select(.kind == "output") | .event' /var/log/limpid/errored.jsonl \
+//! jq -c 'select(.kind == "output" and .output.name == "<output-name>") | .event' /var/log/limpid/errored.jsonl \
 //!     | limpidctl inject output <output-name> --json
 //! ```
 //!

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -49,6 +49,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         ],
         wildcards: true,
         defaults_arg_indices: &[1],
+        defaults_arg_extractor: None,
     });
 }
 

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -506,14 +506,15 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_extension_keys_last_one_wins() {
+    fn duplicate_extension_keys_first_one_wins() {
         // Some vendors emit the same key twice (intentionally for
         // multi-value sources, accidentally for buggy templates).
-        // The parser collapses to a single emission; pin the
-        // last-one-wins semantics so an operator can rely on the
-        // observable shape. A regression that flipped to
-        // first-one-wins or panicked would change downstream
-        // pipelines silently.
+        // `ObjectBuilder` does not deduplicate, so both `src` entries
+        // are emitted in source order; `lookup` returns the first
+        // match, making the observable semantics first-one-wins. Pin
+        // it here so a future change to dedup or reverse insertion
+        // order is a visible, intentional break instead of a silent
+        // downstream-pipeline behaviour flip.
         let bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let owned = dummy_event();
@@ -525,11 +526,7 @@ mod tests {
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        // Whichever wins, only one `src` entry should be observable
-        // via lookup (which returns the first match). Confirm at
-        // least that the parse succeeded with both src and dst
-        // distinguishable.
-        assert!(lookup(entries, "src").is_some());
+        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
         assert_eq!(lookup(entries, "dst"), Some(Value::String("8.8.8.8")));
     }
 }

--- a/crates/limpid/src/functions/mod.rs
+++ b/crates/limpid/src/functions/mod.rs
@@ -133,6 +133,11 @@ impl FunctionSig {
 // Parser trait
 // ---------------------------------------------------------------------------
 
+/// Shape-aware defaults extractor for parsers whose defaults slot
+/// depends on the types of preceding args. See [`ParserInfo`].
+pub type DefaultsArgExtractor =
+    for<'a> fn(&'a [crate::dsl::ast::Expr]) -> Option<&'a Vec<(String, crate::dsl::ast::Expr)>>;
+
 /// Static metadata about a parser-style function (one that returns a
 /// `Value::Object` whose keys merge into `event.workspace`).
 ///
@@ -152,11 +157,25 @@ impl FunctionSig {
 /// `defaults_arg_indices` declares the positional slots where a
 /// `defaults` HashLit may appear in the call shape. The analyzer scans
 /// exactly those slots (in order) and uses the first HashLit it finds.
-/// Mirror the runtime impl's call shape: if the impl accepts the
-/// HashLit at more than one position (parse_kv accepts both
-/// `parse_kv(text, defaults)` and `parse_kv(text, sep, defaults)`),
-/// list every slot. Parsers without a defaults arg leave the slice
-/// empty.
+/// This default scan fits parsers with a single fixed defaults
+/// position (`parse_json`, `parse_syslog`, `parse_cef`, ...) where any
+/// HashLit at the declared slot is unambiguously the defaults arg.
+///
+/// Parsers whose call shape allows defaults at more than one position
+/// only when an earlier arg has a specific type (e.g.
+/// `parse_kv(text, sep_string, defaults)` only allows defaults at
+/// `args[2]` when `args[1]` is a string separator) MUST provide a
+/// `defaults_arg_extractor`. The extractor encodes the parser's real
+/// call-shape rules so the analyzer doesn't extract defaults from a
+/// runtime-invalid call shape — for example, `parse_kv(text, int_lit,
+/// hashlit)` would silently narrow workspace via the HashLit at
+/// `args[2]` even though the runtime rejects the call because
+/// `args[1]` is not a separator string. The extractor returns `None`
+/// for both valid-no-defaults and invalid-shape calls; the wildcard
+/// fallback below handles both the same way.
+///
+/// Parsers without a defaults arg (`regex_parse`) leave the slice
+/// empty and set the extractor to `None`.
 #[derive(Debug, Clone)]
 pub struct ParserInfo {
     pub namespace: Option<&'static str>,
@@ -172,8 +191,17 @@ pub struct ParserInfo {
     /// analyzer scans these slots and uses the first HashLit found to
     /// pin precise workspace keys; if none match, wildcard parsers fall
     /// back to a wildcard workspace. Empty for parsers that don't take
-    /// a defaults arg (e.g. `regex_parse`).
+    /// a defaults arg (e.g. `regex_parse`). Ignored when
+    /// `defaults_arg_extractor` is `Some` — that field takes precedence
+    /// for parsers with shape-dependent defaults positions.
     pub defaults_arg_indices: &'static [usize],
+    /// Optional shape-aware defaults extractor for parsers whose
+    /// defaults slot depends on the types of preceding args (e.g.
+    /// `parse_kv` accepts `args[2]` as defaults only when `args[1]` is
+    /// a string separator). When `Some`, the extractor fully replaces
+    /// the `defaults_arg_indices` scan; when `None`, the analyzer uses
+    /// the default index-list behavior described above.
+    pub defaults_arg_extractor: Option<DefaultsArgExtractor>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/limpid/src/functions/otlp/encode.rs
+++ b/crates/limpid/src/functions/otlp/encode.rs
@@ -285,12 +285,7 @@ fn coerce_u64(v: Value<'_>) -> Option<u64> {
         // u64 range and would saturate to `u64::MAX` for the same
         // reason. Out-of-range floats flow to `None` here and pick
         // up the `timestamp_u64_field` warn-once + encode-0 path.
-        Value::Float(f)
-            if f.is_finite()
-                && f >= 0.0
-                && f.fract() == 0.0
-                && f < u64::MAX as f64 =>
-        {
+        Value::Float(f) if f.is_finite() && f >= 0.0 && f.fract() == 0.0 && f < u64::MAX as f64 => {
             Some(f as u64)
         }
         Value::Timestamp(dt) => dt.timestamp_nanos_opt().and_then(|n| u64::try_from(n).ok()),

--- a/crates/limpid/src/functions/otlp/encode.rs
+++ b/crates/limpid/src/functions/otlp/encode.rs
@@ -275,7 +275,24 @@ fn i32_field(entries: Entries<'_>, key: &str) -> Option<i32> {
 fn coerce_u64(v: Value<'_>) -> Option<u64> {
     match v {
         Value::Int(n) if n >= 0 => Some(n as u64),
-        Value::Float(f) if f.is_finite() && f >= 0.0 && f.fract() == 0.0 => Some(f as u64),
+        // `f < u64::MAX as f64` (strict less-than): `as u64` is a
+        // saturating cast since Rust 1.45, so a value that satisfies
+        // the existing finite / non-negative / integral guards but
+        // sits above the u64 range would silently saturate to
+        // `u64::MAX` and be encoded as a year-2554+ timestamp on the
+        // wire. The strict bound also rejects `u64::MAX as f64`
+        // itself: that f64 rounds up to 2^64, which is outside the
+        // u64 range and would saturate to `u64::MAX` for the same
+        // reason. Out-of-range floats flow to `None` here and pick
+        // up the `timestamp_u64_field` warn-once + encode-0 path.
+        Value::Float(f)
+            if f.is_finite()
+                && f >= 0.0
+                && f.fract() == 0.0
+                && f < u64::MAX as f64 =>
+        {
+            Some(f as u64)
+        }
         Value::Timestamp(dt) => dt.timestamp_nanos_opt().and_then(|n| u64::try_from(n).ok()),
         _ => None,
     }
@@ -542,6 +559,33 @@ mod tests {
         let lr = hashlit_to_log_record(&Value::Object(entries)).unwrap();
         assert_eq!(lr.time_unix_nano, expected);
         assert_eq!(lr.observed_time_unix_nano, expected);
+    }
+
+    #[test]
+    fn coerce_u64_rejects_oversized_float_instead_of_saturating() {
+        // `as u64` is a saturating cast since Rust 1.45: a value
+        // that satisfies the finite / non-negative / integral guards
+        // but sits above the u64 range would silently encode as
+        // `u64::MAX` on the wire (= year 2554+ in OTLP nanos). The
+        // upper-bound guard must take it through `None` instead so
+        // the warn-once + encode-0 path catches it.
+        assert_eq!(coerce_u64(Value::Float(1e30)), None);
+
+        // `u64::MAX as f64` is the saturating target itself. The
+        // f64 rounds *up* to 2^64 (= one ulp past the u64 range)
+        // because u64::MAX is not exactly representable; the strict
+        // `<` comparison must catch that boundary so the cast does
+        // not silently land at `u64::MAX`.
+        assert_eq!(coerce_u64(Value::Float(u64::MAX as f64)), None);
+
+        // Round-trip safety: a u64-fitting integral float still
+        // passes through. This literal is inside the u64 range and
+        // is representable as an integral f64 at this magnitude's
+        // spacing, so `fract() == 0.0` and the cast is safe.
+        assert_eq!(
+            coerce_u64(Value::Float(1_700_000_000_000_000_000.0)),
+            Some(1_700_000_000_000_000_000)
+        );
     }
 
     #[test]

--- a/crates/limpid/src/functions/primitives/parse_json.rs
+++ b/crates/limpid/src/functions/primitives/parse_json.rs
@@ -23,6 +23,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         produces: Vec::new(),
         wildcards: true,
         defaults_arg_indices: &[1],
+        defaults_arg_extractor: None,
     });
 }
 

--- a/crates/limpid/src/functions/primitives/parse_kv.rs
+++ b/crates/limpid/src/functions/primitives/parse_kv.rs
@@ -14,6 +14,7 @@ use anyhow::{Result, bail};
 
 use super::parse_json::{apply_defaults, type_name};
 use super::val_to_str;
+use crate::dsl::ast::{Expr, ExprKind};
 use crate::functions::{FunctionRegistry, FunctionSig, ParserInfo};
 
 const DEFAULT_SEP: u8 = b' ';
@@ -33,8 +34,53 @@ pub fn register(reg: &mut FunctionRegistry) {
         name: "parse_kv",
         produces: Vec::new(),
         wildcards: true,
+        // Retained for documentation; the extractor below takes over
+        // the actual scan because parse_kv's defaults position depends
+        // on the type of `args[1]`.
         defaults_arg_indices: &[1, 2],
+        defaults_arg_extractor: Some(extract_defaults),
     });
+}
+
+/// Mirrors `parse_kv_impl`'s call-shape rules so the analyzer only
+/// narrows workspace for calls the runtime will actually accept:
+///
+/// * `parse_kv(text)` — no defaults
+/// * `parse_kv(text, defaults_hashlit)` — args[1] is the HashLit
+/// * `parse_kv(text, separator_string)` — separator only, no defaults
+/// * `parse_kv(text, separator_string, defaults_hashlit)` — args[2] is the HashLit
+///
+/// Any other shape (e.g. `parse_kv(text, int_lit, hashlit)` or
+/// `parse_kv(text, hashlit, hashlit)`) is rejected by `parse_kv_impl`
+/// at runtime; the analyzer therefore returns `None` here so the
+/// wildcard fallback kicks in instead of narrowing workspace based on
+/// a HashLit that the runtime will never honour.
+fn extract_defaults(args: &[Expr]) -> Option<&Vec<(String, Expr)>> {
+    fn hash_at(args: &[Expr], i: usize) -> Option<&Vec<(String, Expr)>> {
+        match args.get(i).map(|e| &e.kind) {
+            Some(ExprKind::HashLit(entries)) => Some(entries),
+            _ => None,
+        }
+    }
+    fn is_separator_string(args: &[Expr], i: usize) -> bool {
+        matches!(
+            args.get(i).map(|e| &e.kind),
+            Some(ExprKind::StringLit(_) | ExprKind::Template(_))
+        )
+    }
+
+    match args.len() {
+        // `parse_kv(text)` — no defaults available
+        0..=1 => None,
+        // `parse_kv(text, x)` — defaults only if x is a HashLit
+        2 => hash_at(args, 1),
+        // `parse_kv(text, sep, defaults)` — args[1] must be a
+        // string-shaped separator; otherwise the runtime rejects the
+        // call regardless of what `args[2]` holds.
+        3 if is_separator_string(args, 1) => hash_at(args, 2),
+        // Any other 3-arg shape is invalid at runtime; do not narrow.
+        _ => None,
+    }
 }
 
 fn parse_kv_impl<'bump>(

--- a/crates/limpid/src/functions/primitives/regex_parse.rs
+++ b/crates/limpid/src/functions/primitives/regex_parse.rs
@@ -65,6 +65,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         produces: Vec::new(),
         wildcards: true,
         defaults_arg_indices: &[],
+        defaults_arg_extractor: None,
     });
 }
 

--- a/crates/limpid/src/functions/syslog/parse.rs
+++ b/crates/limpid/src/functions/syslog/parse.rs
@@ -53,6 +53,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         ],
         wildcards: false,
         defaults_arg_indices: &[1],
+        defaults_arg_extractor: None,
     });
 }
 

--- a/crates/limpid/src/modules/input/tail.rs
+++ b/crates/limpid/src/modules/input/tail.rs
@@ -219,6 +219,12 @@ impl Input for TailInput {
                 // its eventual drop — caught by the recv branch above.
                 generation = generation.wrapping_add(1);
                 let _ = drain_acks_into_watermark(&mut ack_rx, generation);
+                // Persist the reset before the next read can advance
+                // the in-memory cursor. A crash here without the
+                // write would let the state file's stale offset
+                // (from the previous file) silently skip the head
+                // of the new file on restart.
+                self.save_position(acked_offset);
                 last_inode = current_inode;
             } else if meta.len() < read_offset {
                 info!(
@@ -229,6 +235,11 @@ impl Input for TailInput {
                 acked_offset = 0;
                 generation = generation.wrapping_add(1);
                 let _ = drain_acks_into_watermark(&mut ack_rx, generation);
+                // Same persistence reason as the rotation branch
+                // above — without this write a crash before the
+                // next ack would leave the state file pointing past
+                // the truncated file's new contents.
+                self.save_position(acked_offset);
             }
 
             // No new data

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -61,7 +61,7 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
-use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
+use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet, read_body_capped};
 use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{BackoffStrategy, QueueAckHandle, RetryConfig};
@@ -75,6 +75,17 @@ use super::{BatchLevel, decode_drained_to_request};
 /// flush future open indefinitely and starve the rotation/retry path.
 /// Matches the gRPC side.
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Upper bound on the success-response body that the partial_success
+/// decoder will buffer. `ExportLogsServiceResponse` is normally a few
+/// dozen bytes (just `rejected_log_records` + an optional short
+/// `error_message`); 64 KiB leaves room for a verbose collector
+/// without giving a malicious or misconfigured peer a way to drive
+/// the daemon into out-of-memory by streaming gigabytes back on a
+/// 2xx reply. Bytes beyond the cap are dropped and the response is
+/// treated as fully accepted — the same fallback shape we use when
+/// the body cannot be decoded.
+const SUCCESS_BODY_BYTE_CAP: usize = 64 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HttpProtocol {
@@ -936,7 +947,14 @@ async fn send_once(
     // collectors into ship errors. Same semantics as
     // `otlp_grpc::send_once` so the two transports report identical
     // metrics for identical receiver behaviour.
-    let body_bytes = resp.bytes().await.unwrap_or_default();
+    //
+    // `read_body_capped` instead of `Response::bytes()` so a peer
+    // returning an oversized 2xx body cannot drive the daemon into
+    // out-of-memory. Bytes beyond the cap are dropped; the truncated
+    // buffer either decodes cleanly (typical case — the partial-
+    // success record is tiny) or fails to decode and we fall through
+    // to the "fully accepted" branch below.
+    let body_bytes = read_body_capped(resp, SUCCESS_BODY_BYTE_CAP).await;
     let rejected = if body_bytes.is_empty() {
         0
     } else {

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::dsl::schema::PropertySpec;
 use crate::event::Event;
@@ -54,12 +54,18 @@ impl HasMetrics for StdoutOutput {
 
 impl StdoutOutput {
     /// Pure write step — extracted so `consume` can drive the retry
-    /// loop without duplicating the print. Returns `Err` only for
-    /// genuine I/O failures; stdout is unbuffered for our purposes so
-    /// this almost always succeeds.
+    /// loop without duplicating the print. Goes through
+    /// `io::stdout().lock()` + `writeln!` rather than the `println!`
+    /// macro: `println!` panics on a broken pipe (the canonical case
+    /// is `limpid | head` where `head` exits before draining stdout),
+    /// which would tear down the daemon mid-run. The locked-write
+    /// path surfaces the I/O error here instead so the retry / DLQ
+    /// path in `consume` decides the disposition.
     fn write_event(&self, event: &Event) -> Result<()> {
+        use std::io::Write;
         let msg = String::from_utf8_lossy(&event.egress);
-        println!("{}", msg);
+        let mut out = std::io::stdout().lock();
+        writeln!(out, "{}", msg).context("stdout write failed")?;
         Ok(())
     }
 }

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -354,6 +354,7 @@ impl Output for SyslogTcpOutput {
             };
             match self.write_payload(payload).await {
                 Ok(()) => {
+                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_delivered();
                     return Ok(());
                 }
@@ -419,11 +420,16 @@ impl Output for SyslogTcpOutput {
 }
 
 impl SyslogTcpOutput {
-    /// Send one syslog frame via the peer-rotation helper. Private —
-    /// reached only from [`Output::consume`].
+    /// Send one syslog frame via the peer-rotation helper. Returns
+    /// `Ok(())` on a successful write to the wire and `Err(_)`
+    /// otherwise. Disposition metrics are the caller's responsibility:
+    /// the steady-state `consume()` path bumps `events_written` on its
+    /// own `Ok` branch, and `consume_shutdown()` lets
+    /// `finalize_shutdown_singleton_disposition` bump it. Bumping here
+    /// double-counted the shutdown path because both the helper and
+    /// this method would tick the counter.
     async fn write_payload(&self, payload: SyslogPayload) -> Result<()> {
         let framing = self.framing;
-        let metrics = Arc::clone(&self.metrics);
         let connectors = self.connectors.clone();
         let result = self
             .peers
@@ -484,10 +490,7 @@ impl SyslogTcpOutput {
             .await;
 
         match result {
-            Ok(()) => {
-                metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
+            Ok(()) => Ok(()),
             Err(err) => Err(anyhow::anyhow!("{}", err)),
         }
     }

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -284,10 +284,9 @@ pub enum ErroredEventContext {
     Output {
         /// Wall-clock at which the error was raised.
         timestamp: chrono::DateTime<chrono::Utc>,
-        /// Pipeline name — empty for runtime-side enqueue failures
-        /// (the runtime accumulates one record per failed output, with
-        /// no single pipeline ownership beyond the dispatch context;
-        /// kept blank rather than misattributed).
+        /// Pipeline name when known. Runtime-side enqueue failures carry
+        /// the dispatching pipeline; sink-side retry / shutdown records
+        /// leave this blank because they no longer have pipeline context.
         pipeline: String,
         /// Failure site: `<output_name>` for retry exhaustion,
         /// `<output_name> shutdown` for batched shutdown drain, or

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -8,11 +8,11 @@
 //!   position. Restart replays from this cursor for at-least-once.
 //! - Segments below the acked position are deleted once `ack_to`
 //!   advances through them; unread segments are never deleted.
-//! - Max total size is enforced by dropping the oldest consumed
-//!   segments (= those before the current read cursor); the read
-//!   cursor's own segment and any unread segments are protected even
-//!   when the cap is exceeded, so an undersized `max_size` cannot
-//!   silently drop pending events.
+//! - Max total size is enforced by dropping the oldest acked
+//!   segments (= those below the acked cursor); segments at or above
+//!   the acked cursor are protected (they may still hold in-flight
+//!   events whose ack handles have not resolved), so an undersized
+//!   `max_size` cannot silently drop pending events.
 //!
 //! This survives process restarts: on startup, the consumer resumes
 //! from the acked cursor position.
@@ -770,20 +770,21 @@ mod tests {
 
     #[test]
     fn enforce_max_size_deletes_oldest_consumed_segments_until_under_cap() {
-        // 5 segments seq=0..4, each 1024 bytes; cap = 2048, reader is
-        // sitting on seq=4 (everything before consumed). Caller must
-        // delete seq=0, 1, 2 to fit; seq=3 might or might not be
-        // removed depending on order, but seq=4 (== current_read_seq)
-        // must stay because it's the live read target.
+        // 5 segments seq=0..4, each 1024 bytes; cap = 2048, acked
+        // cursor at seq=4 (everything below has been acked). Caller
+        // must delete seq=0, 1, 2 to fit; seq=3 might or might not be
+        // removed depending on order, but seq=4 (== current_acked_seq)
+        // must stay because it may still contain data at or after
+        // the persisted acked cursor.
         let dir = tempfile::tempdir().unwrap();
         for s in 0..5u64 {
             make_segment(dir.path(), s, 1024);
         }
-        enforce_max_size(dir.path(), 2048, /* current_read_seq */ 4, 4);
-        // seq < 4 may be deleted; seq=4 MUST stay (live read segment).
+        enforce_max_size(dir.path(), 2048, /* current_acked_seq */ 4, 4);
+        // seq < 4 may be deleted; seq=4 MUST stay (boundary segment).
         assert!(
             segment_exists(dir.path(), 4),
-            "live read segment must not be deleted"
+            "acked-cursor boundary segment must not be deleted"
         );
     }
 

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -56,8 +56,19 @@ struct DiskQueueState {
     write_file: Option<fs::File>,
     /// Current write segment size.
     write_size: u64,
-    /// Current read segment sequence (updated by receiver to protect unread segments).
+    /// Current read segment sequence (updated by receiver). Tracked
+    /// for observability; the GC boundary is `acked_seq` below — the
+    /// reader can advance `read_seq` past events that have not yet
+    /// been acked, so `read_seq` alone would let `enforce_max_size`
+    /// delete a segment whose events are still in-flight.
     read_seq: u64,
+    /// Last acked segment sequence (updated by the receiver after
+    /// `ack_to` advances its acked cursor). This is the protective
+    /// boundary for `enforce_max_size`: segments below `acked_seq`
+    /// have no in-flight handles and are safe to delete; segments at
+    /// or above `acked_seq` may still hold unacked events that the
+    /// at-least-once contract guarantees to replay on restart.
+    acked_seq: u64,
 }
 
 pub struct DiskQueueSender {
@@ -151,6 +162,11 @@ pub fn create_disk_queue(
         write_file: None,
         write_size: 0,
         read_seq,
+        // Boot with acked_seq == read_seq: anything at recover time is
+        // either already acked (cursor file points past it) or never
+        // existed. Receiver's `ack_to` will advance this as the new
+        // session progresses.
+        acked_seq: read_seq,
     }));
 
     Ok((
@@ -329,6 +345,9 @@ impl DiskQueueReceiver {
         self.acked_seq = new_seq;
         self.acked_offset = new_offset;
         save_cursor(&self.dir, self.acked_seq, self.acked_offset);
+        // Propagate to shared state so `enforce_max_size` honours the
+        // at-least-once boundary on the next write-side GC pass.
+        self.sync_acked_seq();
     }
 
     fn try_read_next(&mut self) -> Option<(Event, AckPosition)> {
@@ -451,10 +470,25 @@ impl DiskQueueReceiver {
         } // end loop
     }
 
-    /// Update the shared state's read_seq so enforce_max_size can protect unread segments.
+    /// Sync the receiver's read cursor to shared state for
+    /// observability. The GC boundary in `enforce_max_size` is
+    /// `acked_seq`, not `read_seq` — see `sync_acked_seq` and the
+    /// `DiskQueueState::acked_seq` doc.
     fn sync_read_seq(&self) {
         if let Ok(mut state) = self.state.lock() {
             state.read_seq = self.read_seq;
+        }
+    }
+
+    /// Sync the receiver's acked cursor to shared state. Called
+    /// after `ack_to` advances `self.acked_seq` so the next
+    /// `enforce_max_size` invocation (from `write_to_segment`)
+    /// honours the at-least-once boundary: segments at or above
+    /// `acked_seq` may still hold in-flight events that must replay
+    /// on restart.
+    fn sync_acked_seq(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.acked_seq = self.acked_seq;
         }
     }
 }
@@ -509,13 +543,17 @@ fn write_to_segment(state: &mut DiskQueueState, data: &[u8]) -> bool {
     }
     state.write_size += buf.len() as u64;
 
-    // Enforce max size
-    enforce_max_size(&state.dir, state.max_size, state.read_seq, state.write_seq);
+    // Enforce max size. The protective boundary is `acked_seq` —
+    // segments below it have no in-flight unacked events and are
+    // safe to delete. Using `read_seq` would let a slow consumer's
+    // unacked segment vanish: `read_seq` advances as `recv()` moves
+    // past events that have not yet been acked.
+    enforce_max_size(&state.dir, state.max_size, state.acked_seq, state.write_seq);
 
     true
 }
 
-fn enforce_max_size(dir: &Path, max_size: u64, current_read_seq: u64, _current_write_seq: u64) {
+fn enforce_max_size(dir: &Path, max_size: u64, current_acked_seq: u64, _current_write_seq: u64) {
     if max_size == 0 {
         return;
     }
@@ -551,8 +589,8 @@ fn enforce_max_size(dir: &Path, max_size: u64, current_read_seq: u64, _current_w
         if total <= max_size {
             break;
         }
-        if seq >= current_read_seq {
-            break; // don't delete unread or current segments
+        if seq >= current_acked_seq {
+            break; // don't delete segments that may still hold unacked events
         }
         let path = segment_path(dir, seq);
         if fs::remove_file(&path).is_ok() {
@@ -750,25 +788,57 @@ mod tests {
     }
 
     #[test]
-    fn enforce_max_size_never_deletes_unread_segments_even_when_over_cap() {
-        // 4 segments seq=0..3, each 1 MiB. Cap = 100 KiB, reader is
-        // ONLY at seq=0 (everything ahead is unread). enforce_max_size
-        // is forbidden from deleting unread data (= `seq >= current_read_seq`),
-        // so the function must STOP at seq=0 even though total is
-        // still over the cap. This is the data-loss invariant: an
-        // operator setting a too-small max_size must not silently lose
-        // events that haven't been processed yet.
+    fn enforce_max_size_never_deletes_unacked_segments_even_when_over_cap() {
+        // 4 segments seq=0..3, each 1 MiB. Cap = 100 KiB, acked
+        // cursor is at seq=0 (nothing has been acked yet). The
+        // boundary `seq >= current_acked_seq` forbids the function
+        // from deleting any segment that may still hold in-flight
+        // or unread events. This is the at-least-once invariant: an
+        // operator setting a too-small max_size must not silently
+        // lose events whose ack handles have not resolved.
         let dir = tempfile::tempdir().unwrap();
         for s in 0..4u64 {
             make_segment(dir.path(), s, 1024 * 1024);
         }
-        enforce_max_size(dir.path(), 100 * 1024, /* current_read_seq */ 0, 3);
-        // All 4 segments must still exist: seq=0 is current_read_seq
-        // (live), seq=1..3 are unread, NONE are deletable.
+        enforce_max_size(dir.path(), 100 * 1024, /* current_acked_seq */ 0, 3);
+        // All 4 segments must still exist: nothing is below
+        // acked_seq, so NONE are deletable.
         for s in 0..4u64 {
             assert!(
                 segment_exists(dir.path(), s),
-                "seq={s} was deleted but is at or past the read cursor"
+                "seq={s} was deleted but is at or past the acked cursor"
+            );
+        }
+    }
+
+    #[test]
+    fn enforce_max_size_protects_read_but_unacked_segments() {
+        // Regression for the at-least-once boundary: an event may be
+        // `recv()`-ed (advances `read_seq`) but not yet acked. The
+        // GC boundary must use `acked_seq`, not `read_seq` — using
+        // `read_seq` would let `enforce_max_size` delete a segment
+        // whose events are still in-flight under the contract, and
+        // the daemon would silently lose them on the next restart.
+        //
+        // 4 segments seq=0..3, each 1 MiB. Cap = 100 KiB. Reader has
+        // advanced to seq=3 (read everything), but acked_seq is
+        // still 1 (only segment 0 fully resolved). seq=1..2 must be
+        // protected even though the read cursor is past them.
+        let dir = tempfile::tempdir().unwrap();
+        for s in 0..4u64 {
+            make_segment(dir.path(), s, 1024 * 1024);
+        }
+        enforce_max_size(dir.path(), 100 * 1024, /* current_acked_seq */ 1, 3);
+        // seq=0 < acked_seq=1 → may be deleted to free space.
+        assert!(
+            !segment_exists(dir.path(), 0),
+            "seq=0 is below acked_seq, must be deletable to enforce the cap"
+        );
+        // seq=1..3 >= acked_seq=1 → MUST be preserved.
+        for s in 1..4u64 {
+            assert!(
+                segment_exists(dir.path(), s),
+                "seq={s} is at or above acked_seq=1; in-flight events must replay on restart"
             );
         }
     }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -509,9 +509,19 @@ async fn run_pipeline_with_outputs(
     // `events_finished` / `events_discarded` decision still observes
     // the original semantics (Finished AND emitted ≥1 output → finished).
     let outputs = std::mem::take(&mut result.outputs);
-    let mut failed_outputs: Vec<String> = Vec::new();
+    // Each failed enqueue carries the per-output `OwnedEvent`
+    // snapshot so the DLQ record reflects the value the pipeline
+    // produced for that sink. The input event the function received
+    // is not equivalent: the pipeline may have produced a different
+    // egress for the output, and `inject output` replay must
+    // preserve the bytes the sink would have shipped.
+    let mut failed_outputs: Vec<(String, crate::event::OwnedEvent)> = Vec::new();
     for (output_name, event) in outputs {
         if let Some(sender) = ctx.output_senders.get(&output_name) {
+            // Clone before send: the sender consumes `event`. `OwnedEvent`
+            // clone is cheap (Bytes are refcounted; workspace cost
+            // scales with the per-event populated keys).
+            let snapshot = event.clone();
             if let Err(e) = sender.send(event).await {
                 // QueueSender::send already bumped per-output
                 // `events_failed` on the Err branch — that gives the
@@ -523,7 +533,7 @@ async fn run_pipeline_with_outputs(
                     "pipeline '{}': enqueue to output '{}' failed: {}",
                     pipeline.name, output_name, e
                 );
-                failed_outputs.push(output_name);
+                failed_outputs.push((output_name, snapshot));
             }
         } else {
             // Unknown output name slipped past startup validation —
@@ -533,7 +543,7 @@ async fn run_pipeline_with_outputs(
                 "pipeline '{}': output '{}' not found",
                 pipeline.name, output_name
             );
-            failed_outputs.push(output_name);
+            failed_outputs.push((output_name, event));
         }
     }
 
@@ -555,8 +565,7 @@ async fn run_pipeline_with_outputs(
              error, or unknown output)"
             .to_string();
         result.termination = crate::pipeline::PipelineTermination::Errored;
-        let owned = event.to_owned();
-        for output_name in failed_outputs {
+        for (output_name, snapshot) in failed_outputs {
             result
                 .errored
                 .push(crate::pipeline::ErroredEventContext::Output {
@@ -565,7 +574,7 @@ async fn run_pipeline_with_outputs(
                     site: format!("{} enqueue", output_name),
                     reason: reason.clone(),
                     output_name: output_name.clone(),
-                    event: crate::pipeline::OutputEvent::from_owned(&owned),
+                    event: crate::pipeline::OutputEvent::from_owned(&snapshot),
                 });
         }
     }

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -38,7 +38,7 @@ Anywhere an expression is evaluated — there's no callsite restriction on the f
 - **Process bodies**: `workspace.limpid.severity_id = normalize_severity(workspace.cef.severity)`.
 - **Pipeline-level conditions**: `if is_critical(workspace.limpid.severity_id) { output urgent }`.
 - **`output` templates over event-intrinsic args**: `path "/var/log/limpid/${normalize_proto(source.port)}/events.log"` — the function call itself is fine; what *its arguments* may reference is restricted by the surrounding surface (output config rejects `workspace`, `egress`, `error`; see [DSL Syntax → String interpolation](../dsl-syntax.md#string-interpolation)). To route on a pipeline-mutable value, branch in the pipeline body and select between outputs whose own templates only reference event-intrinsic fields:
-  ```
+  ```limpid
   def output proto_tcp { type file path "/var/log/limpid/tcp/events.log" }
   def output proto_udp { type file path "/var/log/limpid/udp/events.log" }
   def pipeline split {


### PR DESCRIPTION
## Summary

Resolves 15 actionable CodeRabbit findings from PR #89 (release/0.7.8 → main). Each fix was independently verified, audit-gated through uchgs commit-gate, and committed per functional unit.

## Findings addressed

- **#1 prometheus**: propagate control-socket errors instead of silent break; map `/health` to 503 on failure
- **#2 dsl/schema**: decide `OneOf` structural match by outer shape, not nested error kinds — preserves inner-block diagnostics
- **#3 check/parser_effects**: shape-aware defaults extraction for `parse_kv`; invalid 3-arg shapes now fall back to wildcard instead of false-narrowing the workspace
- **#4 otlp/encode**: reject oversized floats in `coerce_u64` instead of saturating
- **#5 output/otlp/http**: cap success response body at 64 KiB to bound memory
- **#6 queue/disk**: protect unacked segments from `enforce_max_size` GC by gating on `acked_seq` instead of `read_seq`
- **#7 runtime**: snapshot per-output event before sender consumes it (DLQ build no longer loses the event)
- **#8 check/outputs**: skip pipeline-only ident check only for schema-owned single-segment bare idents (dotted refs like `workspace.x` still rejected)
- **#9 error_log**: scope output replay jq filter by output name to prevent cross-sink misrouting
- **#10 cef**: pin first-one-wins for duplicate extension keys (test was claiming last-one-wins; observable semantics are first-one-wins)
- **#11 input/tail**: persist watermark reset on rotation/truncation
- **#12 output/stdout**: replace `println!` with locked `writeln!` to avoid EPIPE panic
- **#13 output/syslog_tcp**: drop double `events_written` bump on shutdown drain
- **#14 pipeline**: align Output DLQ `pipeline`-field rustdoc with runtime (enqueue failures carry pipeline, sink-side blanks)
- **#15 docs/functions**: add `limpid` language specifier to pipeline-routing fence

## Process

- Every finding verified by an independent reviewer before fix
- Per-finding workflow: plan → reviewer agreement → implement → reviewer check → commit-gate confidentiality audit → commit
- Commits separated by functional unit (style/rustfmt isolated from logic changes)
- Final push gate: 8 scopes audited (abstraction, boundary-contract, ci-precheck, cicd-pipeline, confidentiality, readme-current, rust, security); abstraction follow-up landed in `304b02f`; cicd-pipeline / rust standing baselines confirmed unchanged

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (693 + 27 + 1 + 10 passing)
- [x] `cargo audit --json` (0 vulnerabilities)
- [x] `cargo-deny check` (exit 0)

Targets `release/0.7.8` so PR #89 picks up these fixes before merging to `main`.
