### PR TITLE
docs(readme): add release and deps.rs status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/naoto256/limpid/actions/workflows/ci.yml/badge.svg)](https://github.com/naoto256/limpid/actions/workflows/ci.yml)
 [![Release](https://github.com/naoto256/limpid/actions/workflows/release.yml/badge.svg)](https://github.com/naoto256/limpid/actions/workflows/release.yml)
+[![GitHub release](https://img.shields.io/github/v/release/naoto256/limpid?sort=semver&display_name=tag)](https://github.com/naoto256/limpid/releases/latest)
+[![Dependencies](https://deps.rs/repo/github/naoto256/limpid/status.svg)](https://deps.rs/repo/github/naoto256/limpid)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
 **Log pipelines, limpid as intent.**


### PR DESCRIPTION
## Summary
- Add a GitHub release badge and a deps.rs dependency-status badge next to the existing CI badge in README.md.

## Test plan
- [x] uchgs push-gate audit (8 scopes) — 6 pass, 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this README-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added additional status badges to the top of the README, including release version and dependency information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->