### PR TITLE
packaging: tighten systemd sandboxing and fix generated postinst

### DIFF
--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -102,4 +102,11 @@ assets = [
     # so the .deb just needs the directory once snippets exist.
 ]
 maintainer-scripts = "../../packaging"
-systemd-units = { unit-name = "limpid", unit-scripts = "../../packaging" }
+# start = false preserves the existing "enable but don't start on first
+# install" behaviour: cargo-deb's dh_installsystemd port defaults both
+# `enable` and `start` to true when unset (see cargo-deb's
+# SystemdUnitsConfig -> dh_installsystemd::Options mapping), which would
+# silently start limpid.service as part of `#DEBHELPER#` and conflict
+# with rsyslog/syslog-ng still bound to the syslog ports on upgrade.
+# enable = true is the default and is listed explicitly for clarity.
+systemd-units = { unit-name = "limpid", unit-scripts = "../../packaging", enable = true, start = false }

--- a/docs/src/operations/packaging.md
+++ b/docs/src/operations/packaging.md
@@ -84,7 +84,7 @@ ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid
 - `ProtectSystem=strict` makes the filesystem read-only except for explicitly allowed paths
 - `RuntimeDirectory=limpid` ensures `/var/run/limpid/` exists for the control socket
 - `ExecReload=/bin/kill -HUP $MAINPID` triggers hot reload via SIGHUP
-- `ReadWritePaths` covers only this daemon's own state/log directories; `PrivateDevices=yes` means a `/dev/log` `unix_socket` input needs an explicit `BindPaths=/dev/log` drop-in (see [systemd](./systemd.md#adding-write-paths))
+- `ReadWritePaths` covers only this daemon's own state/log directories; `PrivateDevices=yes` means a `/dev/log` `unix_socket` input needs a `PrivateDevices=no` drop-in (see [systemd](./systemd.md#adding-write-paths))
 
 See [systemd](./systemd.md) for operational details.
 

--- a/docs/src/operations/packaging.md
+++ b/docs/src/operations/packaging.md
@@ -69,16 +69,22 @@ The included unit file (`packaging/limpid.service`) runs limpid as the `syslog` 
 User=syslog
 Group=syslog
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallFilter=@system-service
+ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid
 ```
 
 - `CAP_NET_BIND_SERVICE` allows binding to privileged ports (514) without root
 - `ProtectSystem=strict` makes the filesystem read-only except for explicitly allowed paths
 - `RuntimeDirectory=limpid` ensures `/var/run/limpid/` exists for the control socket
 - `ExecReload=/bin/kill -HUP $MAINPID` triggers hot reload via SIGHUP
+- `ReadWritePaths` covers only this daemon's own state/log directories; `PrivateDevices=yes` means a `/dev/log` `unix_socket` input needs an explicit `BindPaths=/dev/log` drop-in (see [systemd](./systemd.md#adding-write-paths))
 
 See [systemd](./systemd.md) for operational details.
 

--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -152,13 +152,15 @@ If your file outputs write to directories outside the defaults, add them to `Rea
 ReadWritePaths=/var/log/limpid /path/to/other/output/dir
 ```
 
-If you configure a `unix_socket` input at `/dev/log` as a syslog(3) replacement, `PrivateDevices=yes` keeps it out of reach unless you also bind it in:
+If you configure a `unix_socket` input at `/dev/log` as a syslog(3) replacement, `PrivateDevices=yes` isolates limpid's socket in a private `/dev` that host processes writing to `/dev/log` can't reach — `BindPaths` doesn't fix this, since limpid *creates* the socket rather than connecting to an existing one. Disable device isolation for this unit instead:
 
 ```ini
 # /etc/systemd/system/limpid.service.d/override.conf
 [Service]
-BindPaths=/dev/log
+PrivateDevices=no
 ```
+
+(`/dev/log` is also commonly a symlink on the host; the `unix_socket` input refuses to bind over one, so remove it first if present.)
 
 Then reload systemd:
 

--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -22,6 +22,7 @@ RestartSec=5
 User=syslog
 Group=syslog
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 RuntimeDirectory=limpid
 StateDirectory=limpid
@@ -30,11 +31,33 @@ ConfigurationDirectory=limpid
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+SystemCallFilter=@system-service
+UMask=0027
+ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid
 
 [Install]
 WantedBy=multi-user.target
 ```
+
+The full unit (`packaging/limpid.service`) carries a comment above each
+directive explaining why it's safe for limpid's inputs/outputs; this
+page shows the trimmed shape. Notably `PrivateDevices=yes` gives the
+unit a private `/dev` without the host's `/dev/log` — see [Adding write
+paths](#adding-write-paths) below for the `/dev/log` and extra
+`ReadWritePaths` drop-ins.
 
 ## Key features
 
@@ -121,10 +144,20 @@ sudo systemctl restart limpid-prometheus
 
 ## Adding write paths
 
-If your file outputs write to directories outside the defaults, add them to `ReadWritePaths`:
+If your file outputs write to directories outside the defaults, add them to `ReadWritePaths` via a drop-in rather than editing the shipped unit:
 
 ```ini
-ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log /var/log/custom
+# /etc/systemd/system/limpid.service.d/override.conf
+[Service]
+ReadWritePaths=/var/log/limpid /path/to/other/output/dir
+```
+
+If you configure a `unix_socket` input at `/dev/log` as a syslog(3) replacement, `PrivateDevices=yes` keeps it out of reach unless you also bind it in:
+
+```ini
+# /etc/systemd/system/limpid.service.d/override.conf
+[Service]
+BindPaths=/dev/log
 ```
 
 Then reload systemd:

--- a/packaging/limpid-prometheus.service
+++ b/packaging/limpid-prometheus.service
@@ -11,14 +11,46 @@ ExecStart=/usr/bin/limpid-prometheus --bind ${LIMPID_PROMETHEUS_BIND} --socket $
 Restart=on-failure
 RestartSec=5
 
-# Run as same user as limpid (needs access to control socket)
-User=syslog
-Group=syslog
+# limpid-prometheus only reads limpid's control socket (stats/health
+# over AF_UNIX, see crates/limpid-prometheus/src/main.rs) and serves
+# HTTP on --bind; it never writes to disk, so it does not need a
+# dedicated uid/StateDirectory the way limpid.service does.
+# DynamicUser=yes allocates a throwaway system user per-start instead
+# of running as the shared `syslog` account; SupplementaryGroups=syslog
+# is the one thing still needed from that account, since the control
+# socket at /var/run/limpid is group-owned syslog with mode 0o660
+# (crates/limpid/src/control.rs:135) and this process must read it.
+DynamicUser=yes
+SupplementaryGroups=syslog
 
 # Security hardening
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
+# No capabilities are needed: --bind here defaults to a high port
+# (9100) and CAP_NET_BIND_SERVICE is only required for the <1024
+# syslog listener ports that limpid.service (not this exporter) binds.
+CapabilityBoundingSet=
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# AF_UNIX for the control-socket client connection, AF_INET/AF_INET6
+# for the Prometheus HTTP listener (--bind). No AF_NETLINK: this
+# process opens no netlink sockets anywhere in main.rs.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+# @system-service covers tokio + hyper, both pure-Rust with no native
+# codec dependencies (unlike limpid.service's optional kafka feature),
+# so this filter is lower-risk here than on the main daemon.
+SystemCallFilter=@system-service
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -40,6 +40,21 @@ ProtectHome=yes
 # unix socket, journald via the `journal` feature) or outputs (file,
 # kafka, HTTP, OTLP). Isolating all of these narrows the blast radius of
 # a compromised pipeline/parser without touching any codepath in use.
+#
+# PrivateDevices=yes gives the unit a private, minimal /dev, which does
+# NOT include the host's /dev/log. This is fine by default: no input
+# config ships in this package (limpid.conf.example only sets up
+# `include` directives; operators add their own `inputs/*.limpid`), so
+# the unix_socket input's `/dev/log` path
+# (crates/limpid/src/modules/input/unix_socket.rs) is opt-in, not a
+# default codepath. Operators who configure `input { type unix_socket
+# path "/dev/log" }` as a syslog(3) replacement must bind-mount the
+# host socket into the private /dev via a drop-in, e.g.:
+#   /etc/systemd/system/limpid.service.d/override.conf:
+#     [Service]
+#     BindPaths=/dev/log
+# BindPaths punches a specific, explicit hole through PrivateDevices
+# without disabling device isolation for everything else.
 PrivateTmp=yes
 PrivateDevices=yes
 ProtectKernelTunables=yes

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -47,14 +47,19 @@ ProtectHome=yes
 # `include` directives; operators add their own `inputs/*.limpid`), so
 # the unix_socket input's `/dev/log` path
 # (crates/limpid/src/modules/input/unix_socket.rs) is opt-in, not a
-# default codepath. Operators who configure `input { type unix_socket
-# path "/dev/log" }` as a syslog(3) replacement must bind-mount the
-# host socket into the private /dev via a drop-in, e.g.:
+# default codepath. That input creates its own socket via
+# `UnixDatagram::bind()` rather than connecting to an existing one, so
+# `BindPaths=` (which surfaces an existing host path into the private
+# namespace) cannot make a socket limpid creates inside the sandbox
+# visible to host processes writing to /dev/log — the two would sit in
+# disjoint mount namespaces. Operators who configure `input { type
+# unix_socket path "/dev/log" }` as a syslog(3) replacement must
+# disable device isolation for this unit via a drop-in, e.g.:
 #   /etc/systemd/system/limpid.service.d/override.conf:
 #     [Service]
-#     BindPaths=/dev/log
-# BindPaths punches a specific, explicit hole through PrivateDevices
-# without disabling device isolation for everything else.
+#     PrivateDevices=no
+# (/dev/log is also commonly a symlink on the host, which the
+# unix_socket input refuses to bind over — remove it first if present.)
 PrivateTmp=yes
 PrivateDevices=yes
 ProtectKernelTunables=yes

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -15,7 +15,14 @@ RestartSec=5
 # Run as dedicated user
 User=syslog
 Group=syslog
+# AmbientCapabilities grants the capability at process start;
+# CapabilityBoundingSet caps what the process can ever hold (e.g. across
+# a re-exec or a dropped-then-regained ambient set). Without an explicit
+# bounding set, the default is "all capabilities the service's uid could
+# reach", which is far wider than the one capability limpid actually
+# needs to bind syslog's privileged ports (514/tcp, 514/udp, etc).
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # Directories (systemd creates with correct ownership)
 RuntimeDirectory=limpid
@@ -26,7 +33,61 @@ ConfigurationDirectory=limpid
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log
+# limpid does not use /tmp, real devices (other than the standard null/
+# zero/random handed to every service by PrivateDevices), kernel tunables,
+# kernel modules, kernel log access (kmsg), cgroup management, wall-clock
+# adjustment, or hostname changes for any of its inputs (syslog UDP/TCP/
+# unix socket, journald via the `journal` feature) or outputs (file,
+# kafka, HTTP, OTLP). Isolating all of these narrows the blast radius of
+# a compromised pipeline/parser without touching any codepath in use.
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# Address families actually opened by limpid:
+#   AF_UNIX    - syslog unix-socket input, control socket (/var/run/limpid),
+#                and the journald `journal` feature's libsystemd calls
+#                (sd_journal_open reads journal files directly, but
+#                libsystemd internally may touch AF_UNIX for its own
+#                bookkeeping; no AF_NETLINK usage was found in the journal
+#                input (crates/limpid/src/modules/input/journal.rs) or
+#                anywhere else in the tree, so AF_NETLINK is intentionally
+#                left out below)
+#   AF_INET/6  - syslog UDP/TCP input+output, kafka, HTTP, OTLP (HTTP/gRPC)
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+# @system-service is systemd's curated allowlist for long-running daemons;
+# it already includes madvise/mmap/futex/epoll/etc used by tokio and by
+# aws-lc-rs (rustls's crypto backend, used for the HTTP/OTLP outputs and
+# journal/kafka TLS). Not verified against the optional `kafka` feature's
+# librdkafka (a C library with its own compression codecs); if a build
+# with `--features kafka` fails under this filter, drop it there first.
+SystemCallFilter=@system-service
+# MemoryDenyWriteExecute is deliberately omitted: limpid optionally links
+# librdkafka (C, `kafka` feature, cmake-build) whose bundled compression
+# codecs (zstd/lz4/snappy) are not audited here for W^X-violating runtime
+# codegen. Flagging as uncertain per the hardening brief rather than
+# guessing; revisit once the kafka build path can be tested on real
+# hardware.
+UMask=0027
+# The control socket is created with explicit 0o660 permissions in
+# control.rs (see crates/limpid/src/control.rs:135,
+# std::fs::set_permissions after bind), so UMask does not affect it.
+ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid
+# Only /var/log/limpid (this daemon's own log directory) is writable by
+# default; ProtectSystem=strict makes the rest of the filesystem
+# read-only. Operators using the `file` output to write elsewhere must
+# add a drop-in, e.g.:
+#   /etc/systemd/system/limpid.service.d/override.conf:
+#     [Service]
+#     ReadWritePaths=/var/log/limpid /path/to/other/output/dir
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -9,6 +9,15 @@ if ! getent passwd syslog >/dev/null 2>&1; then
     useradd --system --no-create-home --shell /usr/sbin/nologin -g syslog syslog
 fi
 
+# Refuse to proceed if any target is a symlink (would let a pre-staged
+# symlink redirect config/state writes outside the intended tree).
+for d in /etc/limpid /var/lib/limpid /var/log/limpid; do
+    if [ -L "$d" ]; then
+        echo "ERROR: $d is a symlink; refusing to install over it." >&2
+        exit 1
+    fi
+done
+
 # Create directories with correct ownership
 mkdir -p /etc/limpid/inputs /etc/limpid/outputs /etc/limpid/processes /etc/limpid/pipelines
 mkdir -p /var/lib/limpid /var/log/limpid
@@ -30,10 +39,14 @@ for svc in rsyslog syslog-ng td-agent fluentd; do
     fi
 done
 
-# Enable and start limpid (don't start automatically on first install)
-systemctl daemon-reload
-systemctl enable limpid
-
+# Unit enable/start is handled by the debhelper systemd-units snippet
+# below (#DEBHELPER#), generated from `systemd-units` in
+# crates/limpid/Cargo.toml (enable = true, start = false — enables the
+# unit but does not start it, so an operator running rsyslog/syslog-ng
+# on the same ports isn't disrupted by an upgrade). The debhelper
+# snippet also guards its systemctl calls with
+# `[ -d /run/systemd/system ]`, so this script no longer aborts under
+# `set -e` in containers without a running systemd.
 #DEBHELPER#
 
 echo ""

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -40,9 +40,9 @@ for svc in rsyslog syslog-ng td-agent fluentd; do
 done
 
 # Unit enable/start is handled by the debhelper systemd-units snippet
-# below (#DEBHELPER#), generated from `systemd-units` in
-# crates/limpid/Cargo.toml (enable = true, start = false — enables the
-# unit but does not start it, so an operator running rsyslog/syslog-ng
+# inserted below at the DEBHELPER marker, generated from `systemd-units`
+# in crates/limpid/Cargo.toml (enable = true, start = false — enables
+# the unit but does not start it, so an operator running rsyslog/syslog-ng
 # on the same ports isn't disrupted by an upgrade). The debhelper
 # snippet also guards its systemctl calls with
 # `[ -d /run/systemd/system ]`, so this script no longer aborts under


### PR DESCRIPTION
## Summary
- Add systemd sandboxing directives to limpid.service and limpid-prometheus.service (CapabilityBoundingSet, PrivateTmp/Devices, Protect*, Restrict*, SystemCallFilter, UMask) and narrow ReadWritePaths to /var/log/limpid.
- Switch limpid-prometheus.service to DynamicUser with SupplementaryGroups=syslog.
- Consolidate postinst's systemd enable/start into the debhelper-generated snippet (fixes a duplicate-marker bug that produced an invalid generated postinst — verified with `cargo deb` + `sh -n`).
- Document the `/dev/log` syslog(3)-replacement path: PrivateDevices=no via drop-in is required (BindPaths does not work here since the unix_socket input creates its own socket rather than connecting to an existing one).
- Sync docs/src/operations/systemd.md and packaging.md with the new directive set.

## Test plan
- [x] cargo build/test/clippy/fmt all pass
- [x] `cargo deb` package generation + generated postinst `sh -n` syntax check
- [x] uchgs push-gate audit (8 scopes, 3 rounds after blocker fixes) — 6 pass, 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this change