### PR TITLE
ci(deps): audit journal feature deps, pin cargo-deb, fix RUSTSEC-2026-0190

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libsystemd-dev
 
       - name: Install cargo-deb
-        run: cargo install cargo-deb
+        # Pinned + --locked so packaging tooling is reproducible; bump the
+        # pin deliberately (review the cargo-deb changelog) rather than
+        # floating to whatever crates.io serves at release time.
+        run: cargo install cargo-deb --version 3.7.0 --locked
 
       - name: Build release
         run: cargo build --release -p limpid -p limpidctl -p limpid-prometheus --features journal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,17 @@ jobs:
           fi
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
 
+      - name: Generate checksums
+        # SHA256SUMS lets consumers verify asset integrity offline
+        # (`sha256sum -c SHA256SUMS`). Basenames (not paths) so the
+        # check works from the download directory. Cryptographic
+        # provenance (attest-build-provenance) is a separate decision:
+        # it needs the `id-token: write` permission, so it is left to
+        # an explicit owner call rather than bundled here.
+        run: |
+          cd target/debian
+          sha256sum *.deb > SHA256SUMS
+
       - name: Upload to GitHub Release
         env:
           # Pre-installed gh CLI on the runner authenticates with the
@@ -83,6 +94,7 @@ jobs:
           # `steps.notes.outputs.name`.
           RELEASE_TITLE: ${{ steps.notes.outputs.name }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" target/debian/*.deb \
+          gh release create "${GITHUB_REF_NAME}" \
+            target/debian/*.deb target/debian/SHA256SUMS \
             --title "$RELEASE_TITLE" \
             --notes-file RELEASE_NOTES.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/deny.toml
+++ b/deny.toml
@@ -27,8 +27,14 @@ targets = [
     { triple = "x86_64-apple-darwin" },
     { triple = "aarch64-apple-darwin" },
 ]
-# Include every workspace member's full dep closure (default, made explicit).
-all-features = false
+# Include every workspace member's full dep closure, including
+# optional/off-by-default features (`journal`, `kafka`). Release builds
+# enable `--features journal` (.github/workflows/release.yml), which
+# pulls in the `systemd` crate; with `all-features = false` that whole
+# dep closure was silently exempt from license/advisories/bans/sources
+# checks. `true` ensures every feature-gated dep that can ship in a
+# release binary is actually audited.
+all-features = true
 
 [licenses]
 # Confidence floor for SPDX expression matching. cargo-deny's default is
@@ -42,8 +48,8 @@ confidence-threshold = 0.93
 # - MIT / Apache-2.0 / BSD-{2,3}-Clause / ISC / 0BSD / Zlib: permissive,
 #   attribution-only or weaker. Compatible with limpid's MIT OR Apache-2.0
 #   distribution.
-# - Unicode-3.0 / Unicode-DFS-2016: governs the Unicode tables in icu_*,
-#   unicode-ident, unicode-* crates. Permissive with attribution.
+# - Unicode-3.0: governs the Unicode tables in icu_*, unicode-ident,
+#   unicode-* crates. Permissive with attribution.
 # - CC0-1.0: public-domain dedication; treated as permissive.
 #
 # Deliberately NOT listed (would need explicit re-evaluation if a dep
@@ -71,12 +77,29 @@ allow = [
     # attribution license for datasets — compatible with limpid's
     # redistribution posture.
     "CDLA-Permissive-2.0",
+    # Unlicense: public-domain dedication with a permissive fallback —
+    # same obligations-free family as 0BSD / CC0. Reached via
+    # cstr-argument <- systemd (journal feature). Compatible with
+    # limpid's redistribution posture.
+    "Unlicense",
 ]
 
-# Per-crate exceptions go here as needed (e.g. a single utility crate
-# with an SPDX expression cargo-deny can't fully parse). Empty for now —
-# add with rationale if a finding requires it.
-exceptions = []
+# Per-crate exceptions: licenses accepted for a specific crate only,
+# without admitting them workspace-wide. Each entry MUST carry a
+# rationale comment and the condition under which it can be removed.
+#
+# systemd / libsystemd-sys (LGPL-2.1-or-later WITH GCC-exception-2.0):
+# the `journal` feature is opt-in; these crates are thin binding
+# wrappers around libsystemd, which stays dynamically linked — only the
+# wrapper code itself is statically linked into limpid. The
+# workspace-wide LGPL-avoidance policy above is unchanged; this is a
+# deliberate two-crate exception, not a policy shift. Remove both
+# entries if/when the journald reader migrates to an MIT/Apache-family
+# implementation.
+exceptions = [
+    { crate = "systemd", allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"] },
+    { crate = "libsystemd-sys", allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"] },
+]
 
 [advisories]
 # RustSec database — checked at every audit. `version = 2` is the

--- a/docs/src/design-principles.md
+++ b/docs/src/design-principles.md
@@ -87,7 +87,7 @@ These are not principles — they are concrete consequences of the five principl
 
 ### Domain knowledge ships as DSL snippets, not Rust
 
-Typical parsing patterns — OTLP normalization, OCSF mapping, Windows Snare parsing, Apache / nginx / Cisco ASA / FortiGate log formats — are not built-in Rust modules. They are DSL snippets that users `include` from their configuration. Snippets shipped with limpid live read-only under `/usr/share/limpid/snippets/` (organized as `parsers/`, `composers/`, `_common/`); user-authored snippets live wherever the operator keeps them.
+Typical parsing patterns — OTLP normalization, OCSF mapping, Windows Snare parsing, Apache / nginx / Cisco ASA / FortiGate log formats — are not built-in Rust modules. They are DSL snippets that users `include` from their configuration. Snippets shipped with limpid live read-only under `/usr/share/limpid/snippets/` (organized as `parsers/`, `composers/`, `filters/`, `functions/`); user-authored snippets live wherever the operator keeps them.
 
 - Users can include them as-is, modify them, ignore them, or replace them
 - A specification change (e.g. OTLP version update) is a DSL edit, not a Rust release

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -26,7 +26,7 @@ prefix.
 
 ## What's included (v0.7.0)
 
-### Parsers (18)
+### Parsers (26)
 
 | File | Source | OCSF class(es) emitted |
 |---|---|---|

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -17,8 +17,11 @@ prefix.
 │                workspace.limpid.* (currently OCSF 1.3.0;
 │                also the replay-shape composer for parser
 │                regression capture)
-└─ filters/      pre-parser noise filters (drop / pass-through
-                 by content predicate)
+├─ filters/      pre-parser noise filters (drop / pass-through
+│                by content predicate)
+└─ functions/    shared pure functions (RFC 3164 timestamp
+                 parsing, protocol-name → IANA number, HTTP
+                 method → OCSF activity_id)
 ```
 
 ## What's included (v0.7.0)


### PR DESCRIPTION
## Summary
- deny.toml: switch to all-features=true so the release build's `journal` feature deps (systemd, libsystemd-sys) are actually audited; add a scoped LGPL exception for those two crates only (rationale: opt-in feature, thin dynamic-link wrapper, removal path is a permissive-license journald reader) plus an Unlicense allowlist entry for cstr-argument.
- release.yml: pin `cargo install cargo-deb` to 3.7.0 --locked; add a SHA256SUMS generation step for release .deb assets.
- Bump anyhow to 1.0.103, resolving RUSTSEC-2026-0190.
- Sync docs/src/design-principles.md and packaging/snippets/README.md with the actual snippet directory layout and parser count.

## Test plan
- [x] cargo build/test/clippy/fmt all pass
- [x] `cargo deny check`: advisories/bans/licenses/sources all pass
- [x] `cargo audit`: clean
- [x] uchgs push-gate audit (8 scopes, iterated after a docs fix) — all 8 pass