### PR TITLE
security: fix latent verify-false bug and harden TLS/control/file/CLI surfaces

### DIFF
--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -11,7 +11,19 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
+# Explicit feature list instead of "full": the exporter only needs the
+# multi-thread runtime + macros (tokio::main / spawn), sockets (net),
+# buffered async I/O (io-util), timeouts (time), and the Semaphore
+# connection cap (sync). Keeping the set minimal both trims the build
+# and documents what the binary actually exercises.
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "net",
+    "io-util",
+    "time",
+    "sync",
+] }
 hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -7,6 +7,12 @@
 //!   limpid-prometheus                                 # defaults
 //!   limpid-prometheus --bind 0.0.0.0:9100             # custom bind
 //!   limpid-prometheus --socket /path/to/control.sock  # custom socket
+//!
+//! The HTTP endpoint has **no authentication or TLS**. The default
+//! bind is loopback-only; binding to a non-loopback address (as in
+//! the `0.0.0.0:9100` example above) assumes a trusted network — a
+//! scrape segment behind a firewall — because anyone who can reach
+//! the port can read pipeline names and event counts.
 
 use std::convert::Infallible;
 use std::fmt::Write as _;
@@ -21,8 +27,10 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, UnixStream};
+use tokio::sync::Semaphore;
 
 /// Hard upper bound on a single control-socket round trip. limpid's
 /// control socket is local IPC and a `stats` reply is typically a few
@@ -32,6 +40,16 @@ use tokio::net::{TcpListener, UnixStream};
 /// a scrape that hits the timeout returns an error body, and the next
 /// scrape gets a fresh attempt instead of waiting behind the old one.
 const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum concurrent HTTP connections served at once. Mirrors the
+/// daemon's own control-socket cap (`MAX_CONTROL_CONNECTIONS` in
+/// limpid's control.rs): a scrape endpoint needs one connection per
+/// Prometheus server plus a little headroom, so 8 is ample, and the
+/// cap keeps a misbehaving peer (or a slowloris-style dribble of idle
+/// connections) from accumulating unbounded tasks. Excess connections
+/// are closed immediately; the next scrape gets a fresh slot as soon
+/// as an in-flight one finishes.
+const MAX_CONCURRENT_CONNECTIONS: usize = 8;
 
 #[derive(Parser)]
 #[command(name = "limpid-prometheus", about = "Prometheus exporter for limpid")]
@@ -60,6 +78,14 @@ async fn main() {
     eprintln!("limpid-prometheus listening on http://{}", cli.bind);
     eprintln!("  control socket: {:?}", cli.socket);
 
+    serve(listener, cli.socket).await;
+}
+
+/// Accept loop, split from `main` so the connection-cap behaviour is
+/// testable against an ephemeral listener.
+async fn serve(listener: TcpListener, socket: PathBuf) {
+    let conn_sem = Arc::new(Semaphore::new(MAX_CONCURRENT_CONNECTIONS));
+
     loop {
         let (stream, _) = match listener.accept().await {
             Ok(s) => s,
@@ -69,10 +95,26 @@ async fn main() {
             }
         };
 
+        // At the cap: close the connection immediately (drop = RST/FIN)
+        // rather than queueing it. A stalled scrape already has
+        // QUERY_TIMEOUT bounding it, so slots recycle quickly; anything
+        // that keeps all 8 busy is a misbehaving peer, and the honest
+        // fix for the client is to retry the next scrape interval.
+        let permit = match Arc::clone(&conn_sem).try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                drop(stream);
+                continue;
+            }
+        };
+
         let io = TokioIo::new(stream);
-        let socket = cli.socket.clone();
+        let socket = socket.clone();
 
         tokio::spawn(async move {
+            // Hold the permit for the connection's lifetime; dropping
+            // it when the task ends frees the slot.
+            let _permit = permit;
             let svc = service_fn(move |req| {
                 let socket = socket.clone();
                 async move { handle_request(req, &socket).await }
@@ -354,7 +396,46 @@ async fn query_control(socket_path: &Path, command: &str) -> Result<String, Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::net::UnixListener;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::{TcpStream, UnixListener};
+
+    #[tokio::test]
+    async fn accept_loop_closes_connections_over_the_cap() {
+        // Cap regression: MAX_CONCURRENT_CONNECTIONS idle connections
+        // (opened but never sending a request) each hold a permit via
+        // their serve_connection task; connection cap+1 must be
+        // accepted and immediately closed, not queued behind them.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Control socket path deliberately nonexistent — /health would
+        // 503, but the idle connections never send a request at all.
+        let server = tokio::spawn(serve(listener, PathBuf::from("/nonexistent/control.sock")));
+
+        // Fill every slot with idle connections. Connect sequentially:
+        // the accept loop acquires the permit synchronously right
+        // after accept, so by the time connection N+1 is accepted,
+        // connection N already holds its slot.
+        let mut held = Vec::new();
+        for _ in 0..MAX_CONCURRENT_CONNECTIONS {
+            held.push(TcpStream::connect(addr).await.unwrap());
+        }
+
+        // One over the cap: accepted, then dropped by the accept loop.
+        // The client observes a prompt close (clean EOF or a reset).
+        let mut over = TcpStream::connect(addr).await.unwrap();
+        let mut buf = [0u8; 1];
+        let read = tokio::time::timeout(Duration::from_secs(5), over.read(&mut buf))
+            .await
+            .expect("over-cap connection must be closed promptly, not left hanging");
+        match read {
+            Ok(0) => {}  // clean FIN
+            Err(_) => {} // RST — also an immediate close
+            Ok(n) => panic!("expected close, got {} unexpected bytes", n),
+        }
+
+        server.abort();
+        drop(held);
+    }
 
     #[tokio::test(start_paused = true)]
     async fn query_control_times_out_when_peer_stalls() {

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -29,6 +29,8 @@
 //! - `parser_effects`  — parser `produces` → workspace merge
 //! - `render`          — rustc-style snippet+caret diagnostic emit
 //! - `suggestions`     — Levenshtein "did you mean" hint
+//! - `recovery_readiness` — cross-cutting warning: recovery-worthy outputs without `error_log`
+//! - `tls_verify`      — cross-cutting warning: outputs with `verify false`
 //! - `mod`             — pipeline walk + entry + Diagnostic / Level
 
 pub mod bindings;
@@ -43,6 +45,7 @@ mod parser_effects;
 mod recovery_readiness;
 pub mod render;
 pub mod suggestions;
+mod tls_verify;
 
 use crate::dsl::ast::{
     AssignTarget, Config, Definition, Expr, ExprKind, PipelineDef, PipelineStatement,
@@ -284,6 +287,7 @@ pub fn analyze(config: &CompiledConfig, _source_map: &SourceMap) -> Vec<Diagnost
     module_props::analyze_all(config, &module_registry, &mut diagnostics);
     global_props::analyze_all(config, &mut diagnostics);
     recovery_readiness::analyze_all(config, &mut diagnostics);
+    tls_verify::analyze_all(config, &mut diagnostics);
     for (name, pipeline) in &config.pipelines {
         analyze_pipeline(
             name,

--- a/crates/limpid/src/check/tls_verify.rs
+++ b/crates/limpid/src/check/tls_verify.rs
@@ -1,0 +1,233 @@
+//! Cross-cutting `--check` warning: outputs that disable TLS
+//! certificate verification (`verify false`).
+//!
+//! `output http` and `output otlp_http` both accept a top-level
+//! `verify` toggle that, when set to `false`, calls
+//! `reqwest::ClientBuilder::danger_accept_invalid_certs(true)` — the
+//! peer's certificate (hostname, chain, expiry) is no longer checked,
+//! so any on-path attacker can present an arbitrary certificate and
+//! the daemon will happily ship data to it. The runtime already emits
+//! a `tracing::warn!` at startup for this (see `modules/output/http.rs`
+//! and `modules/output/otlp/http.rs`), but that only fires when the
+//! daemon actually loads the config with a live HTTPS peer — CI /
+//! `--check` runs on the raw config file get no signal at all today.
+//!
+//! This module raises one [`Level::Warning`] per affected output so
+//! `limpid --check` surfaces the same footgun statically, before the
+//! config is ever loaded by a running daemon.
+//!
+//! The warning is intentionally [`Level::Warning`] rather than
+//! [`Level::Error`]: `verify false` is a legitimate, deliberate choice
+//! for local/test environments (self-signed certs, mitmproxy-style
+//! debugging) — hard-rejecting it at `--check` time would break valid
+//! non-production configs. `--check --ultra-strict` promotion is
+//! handled at the CLI layer per existing convention.
+//!
+//! Detection is config-shape-only — no runtime, no I/O. The set of
+//! "TLS-client output types with a `verify` toggle" is intentionally
+//! hardcoded to the two modules that currently expose it; adding a
+//! new one should extend [`OUTPUT_TYPES_WITH_VERIFY_TOGGLE`] in
+//! lockstep.
+
+use crate::dsl::props;
+use crate::pipeline::CompiledConfig;
+
+use super::{DiagKind, Diagnostic, Level};
+
+/// Output `type` names whose schema exposes a top-level `verify` bool
+/// controlling `danger_accept_invalid_certs`. Kept in lockstep with
+/// the modules that read `verify` off their properties (see
+/// `modules/output/http.rs` and `modules/output/otlp/http.rs`).
+const OUTPUT_TYPES_WITH_VERIFY_TOGGLE: &[&str] = &["http", "otlp_http"];
+
+/// Returns `true` when `output`'s `verify` property is explicitly set
+/// to `false`. Uses [`props::get_bool`], which accepts both the
+/// `BoolLit` form the parser produces and the legacy `Ident("false")`
+/// form, so the warning matches every spelling the schema validator
+/// admits. Defaults to verification *enabled* when unset — same as
+/// the runtime.
+fn verify_disabled(output: &crate::dsl::ast::OutputDef) -> bool {
+    let props_view = output.properties.user_properties();
+    props::get_bool(props_view, "verify") == Some(false)
+}
+
+pub(super) fn analyze_all(config: &CompiledConfig, diags: &mut Vec<Diagnostic>) {
+    let mut affected: Vec<&str> = Vec::new();
+    for (name, output) in &config.outputs {
+        if OUTPUT_TYPES_WITH_VERIFY_TOGGLE.contains(&output.properties.type_name())
+            && verify_disabled(output)
+        {
+            affected.push(name.as_str());
+        }
+    }
+
+    if affected.is_empty() {
+        return;
+    }
+
+    // Stable ordering for deterministic test assertions and stable
+    // diff-able output between runs (HashMap iteration is otherwise
+    // arbitrary).
+    affected.sort();
+
+    for name in affected {
+        let message = format!(
+            "output '{}': TLS certificate verification disabled (`verify false`) — \
+             MITM possible; intended for test environments only. \
+             Connections to this peer will accept any certificate, valid or not.",
+            name,
+        );
+        diags.push(Diagnostic {
+            level: Level::Warning,
+            kind: DiagKind::Other,
+            message,
+            span: None,
+            help: None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::check::analyze;
+    use crate::dsl::parser::parse_config;
+    use crate::dsl::span::SourceMap;
+
+    fn analyze_str(src: &str) -> Vec<Diagnostic> {
+        let cfg = parse_config(src).expect("config should parse");
+        let compiled = CompiledConfig::from_config(cfg).expect("compile");
+        let mut sm = SourceMap::new();
+        sm.add_anonymous(src);
+        analyze(&compiled, &sm)
+    }
+
+    fn verify_warnings(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+        diags
+            .iter()
+            .filter(|d| {
+                d.level == Level::Warning
+                    && d.message.contains("TLS certificate verification disabled")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn warns_when_http_output_disables_verify() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type http
+    peer { url "https://example.com/ingest" }
+    verify false
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let ws = verify_warnings(&diags);
+        assert_eq!(ws.len(), 1, "got: {:?}", diags);
+        assert!(ws[0].message.contains("'o'"), "got: {}", ws[0].message);
+    }
+
+    #[test]
+    fn warns_when_otlp_http_output_disables_verify() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type otlp_http
+    peer { endpoint "https://example.com:4318" }
+    verify false
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        let ws = verify_warnings(&diags);
+        assert_eq!(ws.len(), 1, "got: {:?}", diags);
+        assert!(ws[0].message.contains("'o'"), "got: {}", ws[0].message);
+    }
+
+    #[test]
+    fn no_warning_when_verify_unset() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type http
+    peer { url "https://example.com/ingest" }
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            verify_warnings(&diags).is_empty(),
+            "verify defaults to true, expected no warning, got: {:?}",
+            diags,
+        );
+    }
+
+    #[test]
+    fn no_warning_when_verify_true() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type http
+    peer { url "https://example.com/ingest" }
+    verify true
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            verify_warnings(&diags).is_empty(),
+            "explicit verify true, expected no warning, got: {:?}",
+            diags,
+        );
+    }
+
+    #[test]
+    fn no_warning_for_non_tls_output_type() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o {
+    type file
+    path "/tmp/o.log"
+}
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            verify_warnings(&diags).is_empty(),
+            "file output has no verify toggle, got: {:?}",
+            diags,
+        );
+    }
+
+    #[test]
+    fn collapses_multiple_affected_outputs_into_separate_warnings() {
+        // Unlike recovery_readiness (single coalesced warning), each
+        // insecure output gets its own warning line so an operator
+        // scanning `--check` output can see exactly which peers are
+        // affected without parsing a combined message.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output a {
+    type http
+    peer { url "https://example.com/ingest" }
+    verify false
+}
+def output b {
+    type otlp_http
+    peer { endpoint "https://example.com:4318" }
+    verify false
+}
+def pipeline p { input i; output a }
+"#;
+        let diags = analyze_str(src);
+        let ws = verify_warnings(&diags);
+        assert_eq!(
+            ws.len(),
+            2,
+            "expected one warning per output, got: {:?}",
+            diags
+        );
+    }
+}

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -78,34 +78,42 @@ fn ensure_socket_parent_dir(parent: &std::path::Path) {
     }
     // A pre-existing parent dir (e.g. systemd's RuntimeDirectory before
     // RuntimeDirectoryMode is honoured, or an operator-managed path) is
-    // left as-is above — its mode is not under daemon control. That
-    // means the bind->chmod TOCTOU window on the socket file itself
-    // (`ensure_socket_parent_dir` -> stale-socket removal -> `bind`)
-    // is only closed by "other users can't touch this directory" when
-    // the daemon created it. Surface the gap loudly instead of
-    // silently trusting an inherited mode: a world-writable parent
-    // lets any local user race a symlink/regular-file into the socket
-    // path during that window.
+    // left as-is above — its mode is not under daemon control. The
+    // `ControlServer::run` bind->chmod TOCTOU note below assumes "the
+    // parent directory is not world-traversable"; that assumption is
+    // guaranteed only for dirs this function created (0o750) or a
+    // packaged unit's `RuntimeDirectoryMode=0750`, not for an inherited
+    // or operator-managed path. Two distinct properties matter here:
+    // group/other WRITE lets any such user race a symlink or regular
+    // file into the socket path before `bind`; other EXECUTE (traverse)
+    // lets a user outside the daemon's group reach the socket inode at
+    // all during the bind->chmod window, even without write access.
+    // Group execute is expected and not flagged (group is the trusted
+    // socket-access group per the 0o660 chmod below).
     #[cfg(unix)]
     if let Ok(meta) = std::fs::metadata(parent) {
         use std::os::unix::fs::PermissionsExt;
         let mode = meta.permissions().mode() & 0o777;
         if parent_dir_mode_is_unsafe(mode) {
             warn!(
-                "control socket: parent dir {:?} has mode {:o} (group/other can write into it) \
-                 — this weakens the bind-time TOCTOU mitigation; expected 0o750 or tighter",
+                "control socket: parent dir {:?} has mode {:o} (group-writable and/or \
+                 world-traversable) — this weakens the bind-time TOCTOU mitigation; \
+                 expected 0o750 or tighter",
                 parent, mode
             );
         }
     }
 }
 
-/// True when group or other can write into the directory — either can
-/// race a symlink or regular file into the socket path between the
-/// daemon's stale-socket check and `UnixListener::bind`.
+/// True when the parent dir's mode breaks either TOCTOU-mitigating
+/// property the `ControlServer::run` bind->chmod comment relies on:
+/// group/other write (symlink/file race before `bind`) or other
+/// execute (an outside-the-group user can traverse to and connect the
+/// socket inode during the bind->chmod window). Group execute is not
+/// flagged — group is the socket's own trusted access group.
 #[cfg(unix)]
 fn parent_dir_mode_is_unsafe(mode: u32) -> bool {
-    mode & 0o022 != 0
+    mode & 0o023 != 0
 }
 
 pub struct ControlServer {
@@ -194,10 +202,15 @@ impl ControlServer {
         // modes instead. The window is instead covered structurally:
         // no await point separates bind from chmod (the gap is
         // microseconds of same-thread work), and the parent directory
-        // is not world-traversable — 0o750 when this daemon created it
-        // above, `RuntimeDirectory` mode from the unit file under
-        // systemd — so an attacker outside the daemon's group cannot
-        // reach the socket inode during the window at all.
+        // is expected to not be world-traversable — 0o750 when this
+        // daemon created it (`ensure_socket_parent_dir` above), or a
+        // packaged unit's `RuntimeDirectoryMode=0750` under systemd —
+        // so an attacker outside the daemon's group cannot reach the
+        // socket inode during the window at all. That guarantee does
+        // not extend to an inherited or operator-managed parent dir
+        // with a looser mode; `ensure_socket_parent_dir` warns (rather
+        // than silently trusting it) when a pre-existing parent is
+        // group-writable or world-traversable.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -928,17 +941,28 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn parent_dir_mode_unsafe_flags_group_or_other_write() {
-        // 0o755 (world-readable/traversable but not writable) cannot be
-        // raced — an untrusted user can list and stat the directory but
-        // not create a file/symlink in it. Only a write bit for group
-        // or other actually reopens the bind-time TOCTOU window.
-        assert!(!parent_dir_mode_is_unsafe(0o755));
+    fn parent_dir_mode_unsafe_flags_group_write_or_other_traverse() {
+        // 0o750 (the daemon's own target mode: group rwx, no other bits)
+        // and 0o700 (owner-only) uphold both TOCTOU-mitigating
+        // properties: no group/other write (no symlink/file race), and
+        // no other execute (an outside-the-group user can't even
+        // traverse to the socket inode during the bind->chmod window).
         assert!(!parent_dir_mode_is_unsafe(0o750));
         assert!(!parent_dir_mode_is_unsafe(0o700));
-        assert!(parent_dir_mode_is_unsafe(0o777)); // other write
+        // 0o755 is world-traversable (other execute set) even though it
+        // isn't world-writable — a user outside the daemon's group can
+        // still reach the socket inode during the window, so this must
+        // be flagged even though the earlier (narrower) write-only
+        // check would have missed it.
+        assert!(parent_dir_mode_is_unsafe(0o755));
+        assert!(parent_dir_mode_is_unsafe(0o777)); // other write + traverse
         assert!(parent_dir_mode_is_unsafe(0o770)); // group write
-        assert!(parent_dir_mode_is_unsafe(0o757)); // other write, no exec bit change
+        assert!(parent_dir_mode_is_unsafe(0o757)); // other write + traverse
+        assert!(parent_dir_mode_is_unsafe(0o751)); // other execute only, no write
+        // Group execute alone (no group/other write, no other execute)
+        // is expected and not flagged — group is the socket's own
+        // trusted access group per the 0o660 chmod.
+        assert!(!parent_dir_mode_is_unsafe(0o710));
     }
 
     #[test]

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -59,6 +59,25 @@ const MAX_INJECT_BYTES: u64 = 16 * 1024 * 1024;
 /// Per-input inject target: event channel + metrics handle (for events_injected).
 pub type InputInjectTarget = (mpsc::Sender<Event>, Arc<crate::metrics::InputMetrics>);
 
+/// Create the control socket's parent directory if absent. When *this
+/// call* created it (bare / non-systemd runs), tighten it to 0o750 so
+/// only the daemon user and its group can reach the socket inode at
+/// all — this directory mode is the layer that covers the bind→chmod
+/// window in [`ControlServer::run`]. Under systemd the directory comes
+/// from `RuntimeDirectory=limpid` (mode pinned via
+/// `RuntimeDirectoryMode` in the unit file) and already exists here; a
+/// pre-existing directory's permissions are deliberately left alone
+/// because they may be operator-managed.
+fn ensure_socket_parent_dir(parent: &std::path::Path) {
+    let preexisting = parent.exists();
+    let _ = std::fs::create_dir_all(parent);
+    #[cfg(unix)]
+    if !preexisting {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o750));
+    }
+}
+
 pub struct ControlServer {
     socket_path: PathBuf,
     tap: TapRegistry,
@@ -93,9 +112,10 @@ impl ControlServer {
     }
 
     pub async fn run(self, mut shutdown: tokio::sync::watch::Receiver<bool>) {
-        // Ensure parent directory exists
+        // Ensure parent directory exists (see `ensure_socket_parent_dir`
+        // for the 0o750 tightening rationale).
         if let Some(parent) = self.socket_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+            ensure_socket_parent_dir(parent);
         }
 
         // Remove stale socket — only if it's actually a socket (not a symlink)
@@ -128,7 +148,26 @@ impl ControlServer {
             }
         };
 
-        // Restrict socket permissions to owner + group (0o660)
+        // Restrict socket permissions to owner + group (0o660).
+        //
+        // TOCTOU note (security audit Low 3-3): between `bind` above
+        // and this chmod, the socket briefly carries umask-derived
+        // permissions (typically 0o755 under umask 022) — a local
+        // attacker who can reach the inode could connect in that
+        // window. A process-wide `libc::umask(0o117)` around the bind
+        // would close it, but was rejected: this function runs as a
+        // spawned tokio task *after* every input / output / pipeline
+        // task is already live (see `Runtime::start` — "start control
+        // socket after all metrics are registered"), so a temporary
+        // global umask races concurrent file creation in file outputs,
+        // the disk queue, and the error_log, silently flipping *their*
+        // modes instead. The window is instead covered structurally:
+        // no await point separates bind from chmod (the gap is
+        // microseconds of same-thread work), and the parent directory
+        // is not world-traversable — 0o750 when this daemon created it
+        // above, `RuntimeDirectory` mode from the unit file under
+        // systemd — so an attacker outside the daemon's group cannot
+        // reach the socket inode during the window at all.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -819,5 +858,41 @@ def pipeline p { input i; output o }
             );
         }
         let _ = shutdown_tx.send(true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn parent_dir_created_by_daemon_is_group_scoped() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = tempfile::TempDir::new().unwrap();
+        let parent = base.path().join("limpid-run");
+        assert!(!parent.exists());
+        ensure_socket_parent_dir(&parent);
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o750,
+            "daemon-created socket dir must not be world-traversable"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn preexisting_parent_dir_permissions_left_alone() {
+        // systemd's RuntimeDirectory (or an operator) owns the mode of
+        // a directory that already exists — the daemon must not fight
+        // it.
+        use std::os::unix::fs::PermissionsExt;
+        let base = tempfile::TempDir::new().unwrap();
+        let parent = base.path().join("managed-run");
+        std::fs::create_dir_all(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+        ensure_socket_parent_dir(&parent);
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "pre-existing dir mode must be preserved");
     }
 }

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -76,20 +76,13 @@ fn ensure_socket_parent_dir(parent: &std::path::Path) {
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o750));
     }
-    // A pre-existing parent dir (e.g. systemd's RuntimeDirectory before
-    // RuntimeDirectoryMode is honoured, or an operator-managed path) is
-    // left as-is above — its mode is not under daemon control. The
-    // `ControlServer::run` bind->chmod TOCTOU note below assumes "the
-    // parent directory is not world-traversable"; that assumption is
-    // guaranteed only for dirs this function created (0o750) or a
-    // packaged unit's `RuntimeDirectoryMode=0750`, not for an inherited
-    // or operator-managed path. Two distinct properties matter here:
-    // group/other WRITE lets any such user race a symlink or regular
-    // file into the socket path before `bind`; other EXECUTE (traverse)
-    // lets a user outside the daemon's group reach the socket inode at
-    // all during the bind->chmod window, even without write access.
-    // Group execute is expected and not flagged (group is the trusted
-    // socket-access group per the 0o660 chmod below).
+    // A pre-existing parent dir (systemd's RuntimeDirectory, or an
+    // operator-managed path) keeps its own mode — the 0o750 tightening
+    // above only applies to dirs this call created. Rather than
+    // silently trust an inherited mode, warn when it is too loose to
+    // uphold the bind->chmod window's assumption that only the daemon's
+    // group can reach the socket inode. See `parent_dir_mode_is_unsafe`
+    // for exactly which bits break that, and why.
     #[cfg(unix)]
     if let Ok(meta) = std::fs::metadata(parent) {
         use std::os::unix::fs::PermissionsExt;
@@ -202,15 +195,11 @@ impl ControlServer {
         // modes instead. The window is instead covered structurally:
         // no await point separates bind from chmod (the gap is
         // microseconds of same-thread work), and the parent directory
-        // is expected to not be world-traversable — 0o750 when this
-        // daemon created it (`ensure_socket_parent_dir` above), or a
-        // packaged unit's `RuntimeDirectoryMode=0750` under systemd —
-        // so an attacker outside the daemon's group cannot reach the
-        // socket inode during the window at all. That guarantee does
-        // not extend to an inherited or operator-managed parent dir
-        // with a looser mode; `ensure_socket_parent_dir` warns (rather
-        // than silently trusting it) when a pre-existing parent is
-        // group-writable or world-traversable.
+        // gates who can reach the socket inode — daemon-created dirs are
+        // 0o750 and packaged units pin `RuntimeDirectoryMode=0750`, so
+        // an outside-the-group attacker cannot reach it during the
+        // window. `ensure_socket_parent_dir` warns when an inherited
+        // parent is too loose to hold that line.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -76,6 +76,36 @@ fn ensure_socket_parent_dir(parent: &std::path::Path) {
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o750));
     }
+    // A pre-existing parent dir (e.g. systemd's RuntimeDirectory before
+    // RuntimeDirectoryMode is honoured, or an operator-managed path) is
+    // left as-is above — its mode is not under daemon control. That
+    // means the bind->chmod TOCTOU window on the socket file itself
+    // (`ensure_socket_parent_dir` -> stale-socket removal -> `bind`)
+    // is only closed by "other users can't touch this directory" when
+    // the daemon created it. Surface the gap loudly instead of
+    // silently trusting an inherited mode: a world-writable parent
+    // lets any local user race a symlink/regular-file into the socket
+    // path during that window.
+    #[cfg(unix)]
+    if let Ok(meta) = std::fs::metadata(parent) {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = meta.permissions().mode() & 0o777;
+        if parent_dir_mode_is_unsafe(mode) {
+            warn!(
+                "control socket: parent dir {:?} has mode {:o} (group/other can write into it) \
+                 — this weakens the bind-time TOCTOU mitigation; expected 0o750 or tighter",
+                parent, mode
+            );
+        }
+    }
+}
+
+/// True when group or other can write into the directory — either can
+/// race a symlink or regular file into the socket path between the
+/// daemon's stale-socket check and `UnixListener::bind`.
+#[cfg(unix)]
+fn parent_dir_mode_is_unsafe(mode: u32) -> bool {
+    mode & 0o022 != 0
 }
 
 pub struct ControlServer {
@@ -894,5 +924,42 @@ mod tests {
         ensure_socket_parent_dir(&parent);
         let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755, "pre-existing dir mode must be preserved");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn parent_dir_mode_unsafe_flags_group_or_other_write() {
+        // 0o755 (world-readable/traversable but not writable) cannot be
+        // raced — an untrusted user can list and stat the directory but
+        // not create a file/symlink in it. Only a write bit for group
+        // or other actually reopens the bind-time TOCTOU window.
+        assert!(!parent_dir_mode_is_unsafe(0o755));
+        assert!(!parent_dir_mode_is_unsafe(0o750));
+        assert!(!parent_dir_mode_is_unsafe(0o700));
+        assert!(parent_dir_mode_is_unsafe(0o777)); // other write
+        assert!(parent_dir_mode_is_unsafe(0o770)); // group write
+        assert!(parent_dir_mode_is_unsafe(0o757)); // other write, no exec bit change
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ensure_socket_parent_dir_warns_on_unsafe_preexisting_mode() {
+        // Regression pin for the loud-warn path: a pre-existing,
+        // group-writable parent dir must not be silently trusted.
+        // `tracing_test` isn't a dependency here, so this test only
+        // pins that the function doesn't panic/alter an unsafe mode
+        // (the warn! call itself is covered by the mode-detection unit
+        // test above); the mode-preservation contract still applies.
+        use std::os::unix::fs::PermissionsExt;
+        let base = tempfile::TempDir::new().unwrap();
+        let parent = base.path().join("unsafe-run");
+        std::fs::create_dir_all(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+        ensure_socket_parent_dir(&parent);
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o777,
+            "function must not fail-fast or silently tighten an operator-managed dir"
+        );
     }
 }

--- a/crates/limpid/src/dsl/props.rs
+++ b/crates/limpid/src/dsl/props.rs
@@ -112,6 +112,45 @@ pub fn get_ident(props: &[Property], key: &str) -> Option<String> {
     None
 }
 
+/// Get a boolean value for a key.
+///
+/// Accepts both spellings the schema validator
+/// ([`crate::dsl::schema`], `PropertyValueKind::Bool`) admits:
+///
+/// - `ExprKind::BoolLit` — what the pest grammar actually produces for
+///   `verify false` (`bool_lit` wins over `ident_path` in the `atom`
+///   rule, so a bare `true` / `false` never parses as an ident);
+/// - `ExprKind::Ident(["true"])` / `Ident(["false"])` — hand-built
+///   ASTs (test helpers, potential future programmatic config).
+///
+/// Reading Bool-kind properties through [`get_ident`] is a bug: the
+/// parser emits `BoolLit`, `get_ident` returns `None`, and the caller
+/// silently falls back to its default (this is exactly how
+/// `verify false` was ignored until v0.7.9 — see `output http` /
+/// `output otlp_http`).
+pub fn get_bool(props: &[Property], key: &str) -> Option<bool> {
+    for prop in props {
+        if let Property::KeyValue {
+            key: k,
+            value: expr,
+            ..
+        } = prop
+            && k == key
+        {
+            return match &expr.kind {
+                ExprKind::BoolLit(b) => Some(*b),
+                ExprKind::Ident(parts) if parts.len() == 1 => match parts[0].as_str() {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => None,
+                },
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
 /// Get an integer value for a key.
 pub fn get_int(props: &[Property], key: &str) -> Option<i64> {
     for prop in props {
@@ -256,5 +295,53 @@ pub fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
             )
         })?;
         Ok(std::time::Duration::from_millis(n))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kv(key: &str, kind: ExprKind) -> Property {
+        Property::KeyValue {
+            key: key.to_string(),
+            key_span: None,
+            value: Expr::spanless(kind),
+            value_span: None,
+        }
+    }
+
+    #[test]
+    fn get_bool_reads_bool_lit() {
+        // The form the pest grammar actually produces for `verify false`.
+        let props = vec![kv("verify", ExprKind::BoolLit(false))];
+        assert_eq!(get_bool(&props, "verify"), Some(false));
+        let props = vec![kv("verify", ExprKind::BoolLit(true))];
+        assert_eq!(get_bool(&props, "verify"), Some(true));
+    }
+
+    #[test]
+    fn get_bool_reads_legacy_ident_spelling() {
+        // Hand-built ASTs (test helpers) encode booleans as bare idents;
+        // the schema validator admits this form, so get_bool must too.
+        let props = vec![kv("verify", ExprKind::Ident(vec!["false".into()]))];
+        assert_eq!(get_bool(&props, "verify"), Some(false));
+        let props = vec![kv("verify", ExprKind::Ident(vec!["true".into()]))];
+        assert_eq!(get_bool(&props, "verify"), Some(true));
+    }
+
+    #[test]
+    fn get_bool_rejects_non_bool_shapes() {
+        assert_eq!(get_bool(&[], "verify"), None);
+        let props = vec![kv("verify", ExprKind::StringLit("false".into()))];
+        assert_eq!(get_bool(&props, "verify"), None);
+        let props = vec![kv("verify", ExprKind::Ident(vec!["yes".into()]))];
+        assert_eq!(get_bool(&props, "verify"), None);
+        // Multi-segment ident path is not a boolean.
+        let props = vec![kv(
+            "verify",
+            ExprKind::Ident(vec!["a".into(), "false".into()]),
+        )];
+        assert_eq!(get_bool(&props, "verify"), None);
     }
 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -359,11 +359,32 @@ impl FileOutput {
             }
         };
 
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .await?;
+        // Fourth safety pass, complementing the three path-rendering
+        // passes in `render_path_in` (interpolation sanitising, `..`
+        // reject, trailing-slash reject): refuse to write through a
+        // symlink at the final path component. The rendering passes
+        // stop an event from *composing* an escaping path; O_NOFOLLOW
+        // stops a pre-planted symlink at a legitimately-composed path
+        // from redirecting the append to an arbitrary file (classic
+        // local symlink attack on a writable log directory). Scope is
+        // the final component only — that is the file this output
+        // creates and owns; symlinked *parent directories* are a
+        // deployment topology choice and stay under the operator's
+        // control.
+        let mut options = OpenOptions::new();
+        options.create(true).append(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW);
+        let mut file = options.open(&path).await.map_err(|e| {
+            // ELOOP is how open(2) reports O_NOFOLLOW hitting a
+            // symlink; surface it as an explicit refusal so the DLQ
+            // reason names the attack instead of a cryptic errno.
+            #[cfg(unix)]
+            if e.raw_os_error() == Some(libc::ELOOP) {
+                return anyhow::anyhow!("refusing to follow symlink at output path: {}", resolved);
+            }
+            anyhow::Error::from(e)
+        })?;
 
         let msg = String::from_utf8_lossy(&payload.egress);
         let mut buf = Vec::with_capacity(msg.len() + 1);
@@ -917,5 +938,57 @@ mod tests {
         assert!(check_no_traversal("/var/log/..").is_err());
         // Standalone ..
         assert!(check_no_traversal("..").is_err());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_payload_refuses_symlink_at_final_component() {
+        // Fourth safety pass (O_NOFOLLOW): a pre-planted symlink at
+        // the output path must produce an explicit refusal, not a
+        // silent append to the symlink's target. The rendered path is
+        // clean — only the filesystem object at it is hostile — so
+        // none of the three rendering passes can catch this.
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("target.log");
+        let link = dir.path().join("out.log");
+        std::fs::write(&target, b"pre-existing").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let out = make_output(ek(ExprKind::StringLit(link.display().to_string())));
+        let err = out
+            .write_payload(FilePayload {
+                egress: Bytes::from("hello"),
+                path: link.display().to_string(),
+                is_dynamic: false,
+            })
+            .await
+            .expect_err("symlink at output path must be refused");
+        assert!(
+            err.to_string().contains("refusing to follow symlink"),
+            "DLQ reason must name the refusal, got: {err}"
+        );
+        // The target file must be untouched.
+        assert_eq!(std::fs::read(&target).unwrap(), b"pre-existing");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_payload_appends_to_regular_file() {
+        // Companion to the symlink-refusal test: O_NOFOLLOW must not
+        // disturb the normal create-and-append path.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("plain.log");
+
+        let out = make_output(ek(ExprKind::StringLit(path.display().to_string())));
+        for _ in 0..2 {
+            out.write_payload(FilePayload {
+                egress: Bytes::from("hello"),
+                path: path.display().to_string(),
+                is_dynamic: false,
+            })
+            .await
+            .expect("regular file write must succeed");
+        }
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello\nhello\n");
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -419,9 +419,13 @@ impl Module for HttpOutput {
             .unwrap_or(false);
         let headers = props::get_string_map(properties, "headers");
 
-        let verify = props::get_ident(properties, "verify")
-            .map(|s| s != "false")
-            .unwrap_or(true);
+        // Read through `get_bool`, NOT `get_ident`: the parser emits
+        // `ExprKind::BoolLit` for `verify false` (the pest `atom` rule
+        // tries `bool_lit` before `ident_path`), so a `get_ident` read
+        // never matches and silently falls back to the default. That
+        // exact bug shipped until v0.7.9 — `verify false` was ignored
+        // and verification stayed on.
+        let verify = props::get_bool(properties, "verify").unwrap_or(true);
 
         // Single-peer shorthand (`peer { url ... }`) or multi-peer
         // (`peers { peer { ... } ... }`). The schema's exclusive_group
@@ -1432,6 +1436,20 @@ mod tests {
         assert!(msg.contains("CARRIER PIGEON"), "got: {msg}");
     }
 
+    /// Parse a DSL config source through the real parser and hand back
+    /// the named output's `ModuleProperties`. Regression tests below use
+    /// this instead of the hand-built `ident_prop` / `prop_str` AST
+    /// helpers: hand-built ASTs encode `verify false` as
+    /// `ExprKind::Ident(["false"])`, but the pest grammar produces
+    /// `ExprKind::BoolLit(false)` — the two shapes diverged for years
+    /// and the runtime only handled the shape that never occurs in a
+    /// real config file (the v0.7.9 `get_bool` fix).
+    fn parsed_output_props(src: &str, name: &str) -> crate::modules::ModuleProperties {
+        let cfg = crate::dsl::parser::parse_config(src).expect("config should parse");
+        let compiled = crate::pipeline::CompiledConfig::from_config(cfg).expect("compile");
+        compiled.outputs[name].properties.clone()
+    }
+
     #[test]
     fn verify_false_with_client_identity_parses_ok() {
         // Even with `verify false`, a tls block carrying client
@@ -1441,6 +1459,10 @@ mod tests {
         // a corporate CA they don't want to bundle). Generate a real
         // ephemeral cert/key with rcgen so the test exercises
         // reqwest's identity loader, not just the config plumbing.
+        //
+        // Goes through the real parser (not the `ident_prop` helper)
+        // so `verify false` arrives as the `BoolLit` the grammar
+        // actually produces.
         use rcgen::{CertificateParams, KeyPair};
         use tempfile::TempDir;
 
@@ -1454,34 +1476,125 @@ mod tests {
         std::fs::write(&cert_path, cert.pem()).unwrap();
         std::fs::write(&key_path, key_pair.serialize_pem()).unwrap();
 
-        let props = vec![
-            Property::Block {
-                key: "peer".into(),
-                key_span: None,
-                properties: vec![
-                    prop_str("url", "https://example.com/"),
-                    Property::Block {
-                        key: "tls".into(),
-                        key_span: None,
-                        properties: vec![
-                            prop_str("cert", cert_path.to_str().unwrap()),
-                            prop_str("key", key_path.to_str().unwrap()),
-                        ],
-                    },
-                ],
-            },
-            ident_prop("verify", "false"),
-        ];
+        let src = format!(
+            r#"
+def output o {{
+    type http
+    peer {{
+        url "https://example.com/"
+        tls {{
+            cert "{}"
+            key "{}"
+        }}
+    }}
+    verify false
+}}
+"#,
+            cert_path.display(),
+            key_path.display()
+        );
         // `verify false` must NOT discard the client identity. Old
         // behaviour: tls block silently ignored; reqwest builds a
         // plain client without the identity → mTLS broken at runtime.
         let output = HttpOutput::from_properties(
-            "test",
-            &mp(&props),
+            "o",
+            &parsed_output_props(&src, "o"),
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
         assert_eq!(output.inner.peers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn parser_spelled_verify_false_disables_certificate_verification() {
+        // Regression for the v0.7.9 get_bool fix. `verify false` in a
+        // real config file parses as `ExprKind::BoolLit(false)`; the
+        // old `props::get_ident` read never matched that shape, so the
+        // toggle was silently ignored and verification stayed on. Pin
+        // the whole chain — DSL source → parser → from_properties →
+        // reqwest client — by hitting an HTTPS server whose
+        // self-signed certificate no root store would accept:
+        //
+        //   verify false  → send succeeds (danger_accept_invalid_certs)
+        //   default       → send fails on the certificate
+        //
+        // The second half proves the first didn't pass because of an
+        // over-permissive default client.
+        use axum::{Router, http::StatusCode, routing::post};
+        use rcgen::{CertificateParams, KeyPair};
+
+        // axum-server's rustls needs a process-level CryptoProvider;
+        // production installs it via the same helper.
+        crate::tls::install_default_crypto_provider();
+
+        let key_pair = KeyPair::generate().unwrap();
+        let params = CertificateParams::new(vec!["127.0.0.1".into()]).unwrap();
+        let cert = params.self_signed(&key_pair).unwrap();
+
+        let rustls_config = axum_server::tls_rustls::RustlsConfig::from_pem(
+            cert.pem().into_bytes(),
+            key_pair.serialize_pem().into_bytes(),
+        )
+        .await
+        .unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new().route("/", post(|| async { StatusCode::OK }));
+        let server = tokio::spawn(async move {
+            let _ = axum_server::from_tcp_rustls(listener, rustls_config)
+                .serve(app.into_make_service())
+                .await;
+        });
+
+        let src_insecure = format!(
+            r#"
+def output o {{
+    type http
+    peer {{ url "https://{addr}/" }}
+    batch_size 1
+    verify false
+}}
+"#
+        );
+        let insecure = HttpOutput::from_properties(
+            "o",
+            &parsed_output_props(&src_insecure, "o"),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        insecure
+            .inner
+            .send_batch(&["hello".to_string()])
+            .await
+            .expect("verify false must accept the self-signed cert");
+
+        let src_default = format!(
+            r#"
+def output o {{
+    type http
+    peer {{ url "https://{addr}/" }}
+    batch_size 1
+}}
+"#
+        );
+        let strict = HttpOutput::from_properties(
+            "o",
+            &parsed_output_props(&src_default, "o"),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let err = strict
+            .inner
+            .send_batch(&["hello".to_string()])
+            .await
+            .expect_err("default client must reject the self-signed cert");
+        server.abort();
+        let msg = format!("{:#}", err).to_ascii_lowercase();
+        assert!(
+            msg.contains("certificate") || msg.contains("unknownissuer"),
+            "expected a certificate-verification failure, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -328,7 +328,13 @@ fn parse_peer(name: &str, peer_props: &[Property], verify: bool) -> Result<HttpP
         );
     }
 
-    let mut client_builder = reqwest::Client::builder().timeout(Duration::from_secs(30));
+    // Explicit ≥ TLS 1.2 floor, mirroring the rustls-side pin in
+    // `crate::tls::TLS_PROTOCOL_VERSIONS` (see the rationale there).
+    // No behaviour change with the rustls backend — it only implements
+    // 1.2 / 1.3 — but the floor is now stated, not inherited.
+    let mut client_builder = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .min_tls_version(reqwest::tls::Version::TLS_1_2);
 
     if !verify {
         client_builder = client_builder.danger_accept_invalid_certs(true);

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -322,7 +322,12 @@ fn parse_peer(name: &str, peer_props: &[Property], verify: bool) -> Result<HttpP
         })
         .transpose()?;
 
-    let mut builder = reqwest::Client::builder().timeout(HTTP_REQUEST_TIMEOUT);
+    // Explicit ≥ TLS 1.2 floor, mirroring the rustls-side pin in
+    // `crate::tls::TLS_PROTOCOL_VERSIONS` (see the rationale there
+    // and the matching builder in `output http`).
+    let mut builder = reqwest::Client::builder()
+        .timeout(HTTP_REQUEST_TIMEOUT)
+        .min_tls_version(reqwest::tls::Version::TLS_1_2);
     if !verify {
         builder = builder.danger_accept_invalid_certs(true);
         if endpoint.to_ascii_lowercase().starts_with("https://") {

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -410,9 +410,11 @@ impl Module for OtlpHttpOutput {
 
         let headers = props::get_string_map(properties, "headers");
 
-        let verify = props::get_ident(properties, "verify")
-            .map(|s| s != "false")
-            .unwrap_or(true);
+        // Read through `get_bool`, NOT `get_ident` — the parser emits
+        // `ExprKind::BoolLit` for `verify false`, which `get_ident`
+        // never matches (same v0.7.9 fix as `output http`; see the
+        // comment there).
+        let verify = props::get_bool(properties, "verify").unwrap_or(true);
 
         // Single-peer shorthand (`peer { endpoint ... }`) or multi-peer
         // (`peers { peer { ... } ... }`). The schema's exclusive_group
@@ -1052,6 +1054,89 @@ mod tests {
         assert!(
             err.to_string().contains("'peer {") && err.to_string().contains("'peers {"),
             "unexpected: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn parser_spelled_verify_false_disables_certificate_verification() {
+        // Regression for the v0.7.9 get_bool fix (mirrors the same
+        // test on `output http`): `verify false` in a real config file
+        // parses as `ExprKind::BoolLit(false)`, which the old
+        // `props::get_ident` read never matched — the toggle was
+        // silently ignored. Pin DSL source → parser → from_properties
+        // → reqwest client by hitting an HTTPS server with a
+        // self-signed cert: the `verify false` client must connect,
+        // the default client must fail on the certificate.
+        use axum::{Router, http::StatusCode, routing::any};
+        use rcgen::{CertificateParams, KeyPair};
+
+        // axum-server's rustls needs a process-level CryptoProvider;
+        // production installs it via the same helper.
+        crate::tls::install_default_crypto_provider();
+
+        let key_pair = KeyPair::generate().unwrap();
+        let params = CertificateParams::new(vec!["127.0.0.1".into()]).unwrap();
+        let cert = params.self_signed(&key_pair).unwrap();
+
+        let rustls_config = axum_server::tls_rustls::RustlsConfig::from_pem(
+            cert.pem().into_bytes(),
+            key_pair.serialize_pem().into_bytes(),
+        )
+        .await
+        .unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new().route("/", any(|| async { StatusCode::OK }));
+        let server = tokio::spawn(async move {
+            let _ = axum_server::from_tcp_rustls(listener, rustls_config)
+                .serve(app.into_make_service())
+                .await;
+        });
+
+        let build = |verify_line: &str| {
+            let src = format!(
+                r#"
+def output o {{
+    type otlp_http
+    peer {{ endpoint "https://{addr}/" }}
+    {verify_line}
+}}
+"#
+            );
+            let cfg = crate::dsl::parser::parse_config(&src).expect("parse");
+            let compiled = crate::pipeline::CompiledConfig::from_config(cfg).expect("compile");
+            OtlpHttpOutput::from_properties(
+                "o",
+                &compiled.outputs["o"].properties,
+                &crate::modules::BuildContext::for_testing(),
+            )
+            .unwrap()
+        };
+
+        // Exercise the built reqwest clients directly: the OTLP wire
+        // encoding is irrelevant to what this test pins (whether
+        // danger_accept_invalid_certs reached the client builder).
+        let insecure = build("verify false");
+        insecure.inner.peers[0]
+            .client
+            .get(format!("https://{addr}/"))
+            .send()
+            .await
+            .expect("verify false must accept the self-signed cert");
+
+        let strict = build("");
+        let err = strict.inner.peers[0]
+            .client
+            .get(format!("https://{addr}/"))
+            .send()
+            .await
+            .expect_err("default client must reject the self-signed cert");
+        server.abort();
+        let msg = format!("{:#}", anyhow::Error::from(err)).to_ascii_lowercase();
+        assert!(
+            msg.contains("certificate") || msg.contains("unknownissuer"),
+            "expected a certificate-verification failure, got: {msg}"
         );
     }
 

--- a/crates/limpid/src/tls.rs
+++ b/crates/limpid/src/tls.rs
@@ -159,6 +159,22 @@ impl ClientTlsConfig {
     }
 }
 
+/// TLS protocol versions accepted by every rustls config limpid
+/// builds (server listeners and client sinks alike).
+///
+/// This is an *explicit pin* of what rustls 0.23 already defaults to:
+/// the crate only implements TLS 1.2 and 1.3, and `DEFAULT_VERSIONS`
+/// enables both — pinning changes no behaviour today. It exists so the
+/// "≥ TLS 1.2" floor is a stated property of limpid's configuration
+/// rather than an inherited library default: rustls documents that a
+/// future release may change `DEFAULT_VERSIONS`, and any such change
+/// should be a deliberate edit here, not a silent inheritance.
+/// The reqwest-based sinks (`output http`, `output otlp_http`) don't
+/// go through this module's builders; they pin the same floor via
+/// `ClientBuilder::min_tls_version`. (Security audit Low 4-3.)
+static TLS_PROTOCOL_VERSIONS: &[&rustls::SupportedProtocolVersion] =
+    &[&rustls::version::TLS13, &rustls::version::TLS12];
+
 /// Install the default rustls `CryptoProvider` (aws-lc-rs) once per
 /// process. rustls 0.23 forces explicit selection; both the OTLP gRPC
 /// input (server-side TLS) and output (client-side TLS) need it before
@@ -202,7 +218,8 @@ pub fn build_client_config_sync(tls: &ClientTlsConfig) -> Result<Arc<ClientConfi
         RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned())
     };
 
-    let builder = ClientConfig::builder().with_root_certificates(root_store);
+    let builder = ClientConfig::builder_with_protocol_versions(TLS_PROTOCOL_VERSIONS)
+        .with_root_certificates(root_store);
     let config = match (&tls.cert_path, &tls.key_path) {
         (Some(cert_path), Some(key_path)) => builder
             .with_client_auth_cert(load_certs(cert_path)?, load_private_key(key_path)?)
@@ -219,6 +236,11 @@ fn build_server_config_sync(
     key_path: &str,
     ca_path: Option<String>,
 ) -> Result<Arc<ServerConfig>> {
+    // The client path installs the provider before building; do the
+    // same here so `builder_with_protocol_versions` (which reads the
+    // process-default provider) can't race a bare startup sequence.
+    install_default_crypto_provider();
+
     let certs = load_certs(cert_path)?;
     let key = load_private_key(key_path)?;
 
@@ -232,12 +254,12 @@ fn build_server_config_sync(
         let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
             .build()
             .context("failed to build client verifier")?;
-        ServerConfig::builder()
+        ServerConfig::builder_with_protocol_versions(TLS_PROTOCOL_VERSIONS)
             .with_client_cert_verifier(verifier)
             .with_single_cert(certs, key)
             .context("failed to build TLS server config with client auth")?
     } else {
-        ServerConfig::builder()
+        ServerConfig::builder_with_protocol_versions(TLS_PROTOCOL_VERSIONS)
             .with_no_client_auth()
             .with_single_cert(certs, key)
             .context("failed to build TLS server config")?
@@ -259,11 +281,40 @@ fn load_certs(path: &str) -> Result<Vec<CertificateDer<'static>>> {
 }
 
 fn load_private_key(path: &str) -> Result<PrivateKeyDer<'static>> {
+    // Warn (don't refuse) on a group/other-readable key file: refusing
+    // would brick existing deployments on upgrade, but a private key
+    // readable by other local users defeats the point of TLS/mTLS.
+    // (Security audit Low 4-3.)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let Ok(meta) = std::fs::metadata(path)
+            && key_mode_is_overshared(meta.mode())
+        {
+            tracing::warn!(
+                "tls: private key {} is readable by group/other (mode {:o}) — \
+                 restrict with `chmod 600 {}`",
+                path,
+                meta.mode() & 0o777,
+                path
+            );
+        }
+    }
+
     let bytes =
         std::fs::read(path).with_context(|| format!("failed to read key file: {}", path))?;
     let key = PrivateKeyDer::from_pem_slice(&bytes)
         .with_context(|| format!("failed to parse key from: {}", path))?;
     Ok(key)
+}
+
+/// True when a private-key file's mode grants read access beyond its
+/// owner (group-read 0o040 or other-read 0o004). Split from
+/// `load_private_key` so the predicate is unit-testable without
+/// capturing tracing output.
+#[cfg(unix)]
+fn key_mode_is_overshared(mode: u32) -> bool {
+    mode & 0o044 != 0
 }
 
 #[cfg(test)]
@@ -458,5 +509,51 @@ mod tests {
             err.to_string().contains("read") || err.to_string().contains("cert"),
             "got: {err}"
         );
+    }
+
+    // ---------- key file permission check ----------
+
+    #[test]
+    #[cfg(unix)]
+    fn key_mode_predicate_flags_group_or_other_read() {
+        // Overshared: any read bit beyond the owner.
+        assert!(key_mode_is_overshared(0o644)); // group+other read
+        assert!(key_mode_is_overshared(0o640)); // group read
+        assert!(key_mode_is_overshared(0o604)); // other read
+        assert!(key_mode_is_overshared(0o444));
+        // Owner-only shapes are fine, including the write bit.
+        assert!(!key_mode_is_overshared(0o600));
+        assert!(!key_mode_is_overshared(0o400));
+        // Group/other *write without read* is a different (weirder)
+        // misconfiguration; the read-exposure warning stays scoped to
+        // confidentiality of the key material.
+        assert!(!key_mode_is_overshared(0o622));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_private_key_still_loads_overshared_key() {
+        // The permission check must warn, never refuse — refusing
+        // would brick existing deployments on upgrade. Pin the
+        // load-succeeds behaviour for a 0644 key.
+        use std::os::unix::fs::PermissionsExt;
+        let p = gen_pems();
+        std::fs::set_permissions(&p.key, std::fs::Permissions::from_mode(0o644)).unwrap();
+        load_private_key(&p.key).expect("overshared key must still load (warn-only check)");
+    }
+
+    // ---------- protocol version pin ----------
+
+    #[test]
+    fn protocol_version_pin_is_tls12_floor() {
+        // Compile-visible statement of the audit requirement: the pin
+        // must contain TLS 1.2 and 1.3 and nothing older. rustls 0.23
+        // cannot even express < 1.2, so this is a tripwire against a
+        // future edit that drops 1.2 (breaking older peers silently)
+        // or a rustls upgrade that changes what the constant means.
+        let versions: Vec<_> = TLS_PROTOCOL_VERSIONS.iter().map(|v| v.version).collect();
+        assert!(versions.contains(&rustls::ProtocolVersion::TLSv1_2));
+        assert!(versions.contains(&rustls::ProtocolVersion::TLSv1_3));
+        assert_eq!(versions.len(), 2);
     }
 }

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -118,6 +118,65 @@ enum TapKind {
     },
 }
 
+/// True when `name` is a valid limpid identifier: `[A-Za-z_][A-Za-z0-9_]*`,
+/// matching the daemon-side DSL `ident` rule (see `dsl/limpid.pest`).
+/// Input / process / output names can only ever be idents, so anything
+/// else — whitespace, newlines, control characters — cannot name a
+/// tap/inject target and would only serve to smuggle extra tokens (or
+/// extra protocol lines) into the line-based control command.
+/// Validating client-side yields a clear error before any bytes are
+/// sent, instead of a confusing daemon-side parse failure.
+fn is_valid_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Exit(2) — usage-error convention, same as the --replay-timing
+/// checks — unless `name` is a valid identifier.
+fn require_valid_name(name: &str) {
+    if !is_valid_name(name) {
+        eprintln!(
+            "error: invalid name {:?}: expected an identifier ([A-Za-z_][A-Za-z0-9_]*), \
+             matching the daemon's input/process/output name grammar",
+            name
+        );
+        std::process::exit(2);
+    }
+}
+
+/// The daemon's protocol-level failure shape: a plain-text line
+/// starting with `error:` (server busy, command too long, unknown
+/// tap point, ...). Returns the message after the prefix. JSON
+/// responses (`{...}`) never match.
+fn daemon_error_line(response: &str) -> Option<&str> {
+    response.trim().strip_prefix("error:")
+}
+
+/// Exit(1) if `response` is a daemon `error:` line. Applied to every
+/// query-style command (list / stats / health) so scripts can rely on
+/// the exit code — mirrors the inject path's existing handling.
+fn exit_on_daemon_error(response: &str) {
+    if let Some(rest) = daemon_error_line(response) {
+        eprintln!("error:{}", rest);
+        std::process::exit(1);
+    }
+}
+
+/// True when a `health` response reports a healthy daemon. Anything
+/// else — unparseable body, missing field, non-"ok" status — counts
+/// as unhealthy, so `limpidctl health` can gate scripts and probes
+/// via its exit code instead of forcing them to parse the output.
+fn health_is_ok(json: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(json)
+        .ok()
+        .and_then(|v| v.get("status").and_then(|s| s.as_str()).map(|s| s == "ok"))
+        .unwrap_or(false)
+}
+
 fn main() {
     // Restore the default SIGPIPE disposition so writes to a closed
     // downstream pipe terminate the process via signal instead of
@@ -140,6 +199,7 @@ fn main() {
                 TapKind::Process { name, json } => ("process", name, json),
                 TapKind::Output { name, json } => ("output", name, json),
             };
+            require_valid_name(&name);
             let command = if json {
                 format!("tap {} {} json", kind_str, name)
             } else {
@@ -149,6 +209,7 @@ fn main() {
         }
         Command::List { json } => {
             let response = query_command(&cli.socket, "list");
+            exit_on_daemon_error(&response);
             if json {
                 print!("{}", response);
             } else {
@@ -157,6 +218,7 @@ fn main() {
         }
         Command::Stats { json } => {
             let response = query_command(&cli.socket, "stats");
+            exit_on_daemon_error(&response);
             if json {
                 print!("{}", response);
             } else {
@@ -176,6 +238,7 @@ fn main() {
                     replay_timing,
                 } => ("output", name, json, replay_timing),
             };
+            require_valid_name(&name);
             let replay = match replay_timing {
                 None => None,
                 Some(spec) => {
@@ -203,10 +266,18 @@ fn main() {
         }
         Command::Health { json } => {
             let response = query_command(&cli.socket, "health");
+            exit_on_daemon_error(&response);
             if json {
                 print!("{}", response);
             } else {
                 format_health(&response);
+            }
+            // Non-zero exit for anything but an explicit healthy
+            // status, so probes (systemd, k8s, shell `&&` chains) can
+            // use the exit code without parsing the body. Printed
+            // output above is preserved either way.
+            if !health_is_ok(&response) {
+                std::process::exit(1);
             }
         }
     }
@@ -633,6 +704,59 @@ impl ReplayState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn valid_names_match_daemon_ident_grammar() {
+        // Mirrors `ident = (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*`
+        // in the daemon's dsl/limpid.pest.
+        assert!(is_valid_name("firewall"));
+        assert!(is_valid_name("fw_01"));
+        assert!(is_valid_name("_internal"));
+        assert!(is_valid_name("A"));
+    }
+
+    #[test]
+    fn invalid_names_rejected_before_send() {
+        // Empty / leading digit — not idents.
+        assert!(!is_valid_name(""));
+        assert!(!is_valid_name("1fw"));
+        // Whitespace and newlines could smuggle extra tokens or extra
+        // protocol lines into the line-based control command.
+        assert!(!is_valid_name("fw json"));
+        assert!(!is_valid_name("fw\ninject output x"));
+        assert!(!is_valid_name("fw\t"));
+        // Control characters and non-ASCII.
+        assert!(!is_valid_name("fw\x07"));
+        assert!(!is_valid_name("fw-01")); // dash is not in the grammar
+        assert!(!is_valid_name("ファイアウォール"));
+    }
+
+    #[test]
+    fn daemon_error_lines_detected() {
+        assert_eq!(
+            daemon_error_line("error: unknown tap point 'x'\n"),
+            Some(" unknown tap point 'x'")
+        );
+        assert_eq!(
+            daemon_error_line("error: control socket busy (too many concurrent connections)"),
+            Some(" control socket busy (too many concurrent connections)")
+        );
+        // JSON responses never match.
+        assert_eq!(daemon_error_line(r#"{"status":"ok"}"#), None);
+        assert_eq!(daemon_error_line(""), None);
+    }
+
+    #[test]
+    fn health_ok_requires_explicit_ok_status() {
+        assert!(health_is_ok(r#"{"status":"ok","uptime_seconds":5}"#));
+        // Anything else is unhealthy: wrong status, missing field,
+        // wrong type, unparseable, empty.
+        assert!(!health_is_ok(r#"{"status":"degraded"}"#));
+        assert!(!health_is_ok(r#"{"uptime_seconds":5}"#));
+        assert!(!health_is_ok(r#"{"status":1}"#));
+        assert!(!health_is_ok("not json"));
+        assert!(!health_is_ok(""));
+    }
 
     #[test]
     fn parse_factor_accepts_realtime_aliases() {

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -26,6 +26,12 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # Directories (systemd creates with correct ownership)
 RuntimeDirectory=limpid
+# Keep /run/limpid non-world-traversable: the control socket is
+# briefly umask-mode between bind and the daemon's chmod to 0660
+# (see control.rs), and this directory mode is what keeps users
+# outside the syslog group from reaching the inode in that window.
+# 0750 matches the socket's owner+group access model.
+RuntimeDirectoryMode=0750
 StateDirectory=limpid
 ConfigurationDirectory=limpid
 


### PR DESCRIPTION
## Summary
- **Bug found & fixed**: `verify false` on HTTP/OTLP-HTTP outputs never actually disabled TLS verification — the DSL parser produces a `BoolLit`, but runtime code read it via `props::get_ident` (Ident-only), silently falling back to `verify=true`. Added a real-parser e2e regression test (self-signed server: `verify false` now succeeds, default now fails) and a `check` warning for outputs that disable verification.
- Pin TLS >=1.2 explicitly; warn on group/other-readable private key files.
- Refuse to append to file outputs through a symlink (`O_NOFOLLOW`).
- Control socket bind->chmod TOCTOU: warn when a pre-existing (not daemon-created) parent dir is group-writable or world-traversable — either property lets a local user outside the daemon's group interfere with the socket during the bind->chmod window. Corrected the surrounding comment's unconditional "not world-traversable" claim, which only holds for daemon-created or `RuntimeDirectoryMode=0750` dirs.
- `limpidctl`: reject control-protocol names containing whitespace/control characters before sending; unify exit codes across `health`/`list`/`stats` on daemon error responses.
- `limpid-prometheus`: cap concurrent connections, document the trust model for non-default binds, trim `tokio` features.

## Test plan
- [x] cargo build/test/clippy/fmt all pass (718+27+2+14 tests)
- [x] uchgs push-gate audit (8 scopes, iterated twice on the control.rs TOCTOU fix — first pass flagged an incomplete threat model, second pass closed it) — all 8 pass or owner-confirmed baseline