### PR TITLE
refactor(output): extract BatchedSink skeleton for http/otlp outputs

### DIFF
--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -1,0 +1,631 @@
+//! Shared actor skeleton for the batched network outputs (`http`,
+//! `otlp_http`, `otlp_grpc`). The three sinks differ only in how an
+//! event becomes a payload, how a drained batch becomes one wire
+//! request, and how a single send attempt is performed — everything
+//! else (buffering, the flusher actor, the retry loop, the shutdown
+//! lifecycle, ack-handle resolution, DLQ routing, metrics) is the
+//! same protocol and lives here so a lifecycle fix lands once instead
+//! of as three parallel patches.
+//!
+//! ### Actor lifecycle contract
+//!
+//! The long-lived flusher actor owns every send — both batched
+//! flushes and singleton (`batch_size <= 1`). The queue consumer's
+//! task is never blocked in a transport `await`; that separation is
+//! what makes the actor's `wait_until_shutdown` race effective:
+//! shutdown can be observed independently of whatever the consumer is
+//! doing. (An earlier implementation performed an inline flush on the
+//! consumer's task and blocked the consumer from reaching its own
+//! shutdown observation.)
+//!
+//! - **Normal operation (`shutdown()`)**: NEVER aborts the actor. It
+//!   signals cooperative shutdown via `is_shutting_down` +
+//!   `flush_notify.notify_waiters()` and joins it bounded by
+//!   `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The actor resolves every
+//!   stack-local handle (Delivered / Recovered via DLQ) before
+//!   exiting.
+//! - **`Drop` fallback (last-resort)**: sync `Drop` cannot `.await`
+//!   the actor, so it signals first then calls `abort()` as a last
+//!   resort. This path is for teardown scenarios where `shutdown()`
+//!   was not invoked (e.g. config reload in tests). The signal gives
+//!   the actor a chance to exit cleanly before the abort lands; in
+//!   practice the runtime calls `shutdown()` before drop in
+//!   production.
+//!
+//! Earlier versions of these outputs spawned a per-flush *timer* task
+//! that held the stack-local batch across `flush_events.await`; when
+//! `shutdown()` abort()-ed that task every parked `QueueAckHandle`
+//! dropped unresolved (debug `debug_assert!(resolved)` panic, release
+//! silent `Dropped` loss). The structural fix moves the abort surface
+//! to this single actor handle and keeps `abort()` off the
+//! `shutdown()` path entirely.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::sync::{Mutex, Notify};
+
+use crate::event::Event;
+use crate::metrics::OutputMetrics;
+use crate::queue::{QueueAckHandle, RetryConfig};
+
+/// Transport-success outcome from a single export call.
+///
+/// `rejected` is the number of records the receiver acknowledged as
+/// not-stored (OTLP's `partial_success.rejected_log_records`). The
+/// HTTP 2xx / gRPC OK is still a transport success — the receiver
+/// processed the request, it just refused some records (typically
+/// quota / schema / size violations). limpid does not retry rejected
+/// records (selective re-send is queued for a later release); the
+/// counter split lets `events_failed` reflect the data loss so
+/// operator dashboards stay accurate. Transports without a
+/// partial-success concept (plain HTTP) report `rejected: 0`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct SendOutcome {
+    pub rejected: u64,
+}
+
+/// The per-transport surface of a batched output. Everything the
+/// skeleton cannot know: payload rendering, batch preparation, and
+/// one send attempt (including peer selection + cooldown, typically
+/// via `syslog_peers::RotatingPeers`).
+#[async_trait::async_trait]
+pub(crate) trait BatchSinkPolicy: Send + Sync + 'static {
+    /// Per-event payload buffered until flush.
+    type Payload: Send + 'static;
+    /// Wire-ready form of one drained batch. Built once per flush
+    /// (before the retry loop) and shared by every attempt.
+    type Prepared: Send + Sync;
+
+    /// Output kind label used in log / error wording
+    /// (e.g. `"http output"`, `"otlp_http output"`).
+    fn kind(&self) -> &'static str;
+
+    /// Event → payload. Failures route the offending event to the
+    /// DLQ on its own without dropping the rest of the batch.
+    fn render(&self, event: &Event) -> Result<Self::Payload>;
+
+    /// Batch payloads → sendable form (e.g. join + optional gzip, or
+    /// proto decode + batch-level merge). Runs once per flush, before
+    /// the retry loop; a failure routes the whole shippable batch to
+    /// the DLQ without consuming the retry budget (the transformation
+    /// is deterministic, so re-attempting it cannot succeed).
+    fn prepare(&self, payloads: Vec<Self::Payload>) -> Result<Self::Prepared>;
+
+    /// One send attempt. Retry pacing, shutdown races, and disposition
+    /// handling belong to the skeleton — implementations just pick a
+    /// peer, ship, and record peer cooldown state.
+    async fn send(&self, prepared: &Self::Prepared) -> Result<SendOutcome>;
+}
+
+/// Batched-output skeleton: buffer + flusher actor + shutdown
+/// lifecycle. Output modules embed one of these and delegate their
+/// `Output` trait methods to it.
+pub(crate) struct BatchedSink<P: BatchSinkPolicy> {
+    pub(crate) inner: Arc<SinkShared<P>>,
+    pub(crate) batch_size: usize,
+    /// Long-lived flusher actor handle; see the module docs for the
+    /// full lifecycle contract (`shutdown()` joins, only `Drop`
+    /// aborts). `None` only when constructed outside a Tokio runtime
+    /// (parsing-only unit tests).
+    pub(crate) actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+/// State shared between the consume side (queue consumer hand-off
+/// into the buffer) and the flusher actor task.
+pub(crate) struct SinkShared<P: BatchSinkPolicy> {
+    pub(crate) policy: P,
+    /// Operator-facing instance name; surfaced on shutdown-flush
+    /// recovery and render-failure records.
+    pub(crate) name: String,
+    batch_timeout: Duration,
+    /// Per-flush retry policy. Without an internal retry, one
+    /// transient ship failure would lose the whole drained batch
+    /// (the queue layer cannot re-push a buffered batch — its cursor
+    /// only advances when each event's ack handle resolves). The
+    /// retry budget for batched outputs lives entirely here.
+    pub(crate) retry: RetryConfig,
+    /// Buffered events awaiting flush, paired with their queue ack
+    /// handles. Render happens at flush time so per-event render
+    /// failures can be routed to DLQ on their own without dropping
+    /// the rest of the batch; the ack handle resolves when the
+    /// event's disposition is decided (delivered on flush success,
+    /// recovered on DLQ landing).
+    pub(crate) batch: Mutex<Vec<(Event, QueueAckHandle)>>,
+    /// `error_log` writer injected at construction time by the
+    /// runtime via `BuildContext`. Used by the flush path to route
+    /// per-event render failures and shutdown-flush leftovers into
+    /// the DLQ. `None` when the operator did not configure
+    /// `control { error_log "..." }` — the flush path then falls
+    /// back to a `tracing` log line.
+    pub(crate) error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    metrics: Arc<OutputMetrics>,
+    /// Threshold-driven flush trigger. `consume()` calls
+    /// `notify_one()` when the buffer crosses `batch_size`; the
+    /// flusher actor's `select!` wakes and drains.
+    flush_notify: Notify,
+    /// Co-operative cancel flag. `shutdown()` sets this to true
+    /// before notifying the actor; both the actor loop and the
+    /// in-flight `flush_events` retry loop check it so they exit
+    /// without burning the full retry budget.
+    is_shutting_down: AtomicBool,
+}
+
+impl<P: BatchSinkPolicy> BatchedSink<P> {
+    /// Build the sink and spawn the flusher actor. Spawn is skipped
+    /// when there is no Tokio runtime (= parsing-only unit tests
+    /// outside `#[tokio::test]`).
+    pub(crate) fn new(
+        policy: P,
+        name: &str,
+        batch_size: usize,
+        batch_timeout: Duration,
+        retry: RetryConfig,
+        error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+        metrics: Arc<OutputMetrics>,
+    ) -> Self {
+        let inner = Arc::new(SinkShared {
+            policy,
+            name: name.to_string(),
+            batch_timeout,
+            retry,
+            batch: Mutex::new(Vec::with_capacity(batch_size.max(1))),
+            error_log,
+            metrics,
+            flush_notify: Notify::new(),
+            is_shutting_down: AtomicBool::new(false),
+        });
+        let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
+            let actor_inner = Arc::clone(&inner);
+            Some(tokio::spawn(async move {
+                flusher_actor_loop(actor_inner).await;
+            }))
+        } else {
+            None
+        };
+        Self {
+            inner,
+            batch_size,
+            actor_handle: Mutex::new(actor_handle),
+        }
+    }
+
+    /// Batched-buffer consume: park the `(Event, ack)` pair in the
+    /// in-memory buffer and arm/run the flush. The ack handle stays
+    /// with the event and resolves at flush time (delivered or
+    /// recovered) — not now. The actor drains the buffer on
+    /// `flush_notify`, on `batch_timeout`, or on `is_shutting_down`;
+    /// this works for both batched (`batch_size > 1`) and singleton
+    /// (`batch_size <= 1`) modes — for the latter the actor flushes a
+    /// one-element batch on each notify.
+    pub(crate) async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let should_flush = {
+            let mut buf = self.inner.batch.lock().await;
+            buf.push((event.clone(), ack));
+            buf.len() >= self.batch_size
+        };
+        if should_flush {
+            self.inner.flush_notify.notify_one();
+        }
+        // The actor's `select!` already races the `batch_timeout`
+        // sleep — no separate timer to arm.
+        Ok(())
+    }
+
+    /// Drain-time per-event entry: park the `(event, ack)` pair in the
+    /// buffer that the post-loop `shutdown()` call will drain bounded.
+    /// Deliberately does NOT trigger a flush from here — that would
+    /// re-enter the steady-state retry path (`flush_events`'
+    /// exponential backoff loop) which the shutdown contract forbids.
+    /// The buffer holds the handle until `shutdown()` resolves it via
+    /// `flush_events_at_shutdown`'s bounded single attempt + DLQ route.
+    pub(crate) async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let mut buf = self.inner.batch.lock().await;
+        buf.push((event.clone(), ack));
+        Ok(())
+    }
+
+    pub(crate) async fn shutdown(&self) -> Result<()> {
+        // 1. Signal cooperative shutdown. `is_shutting_down`
+        //    propagates to the actor's outer `select!`, to the
+        //    retry sleep race, and (via the transport-cancel race
+        //    in `flush_events`) to the in-flight send call itself.
+        //    `notify_waiters` wakes every current `.notified()`
+        //    awaiter so a stalled peer's transport future is dropped
+        //    immediately rather than blocking until its read timeout.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+
+        // 2. Bounded join of the flusher actor. The actor's invariant
+        //    is that EVERY stack-local `(Event, QueueAckHandle)` it
+        //    has taken is resolved (Delivered on success, Recovered on
+        //    transport cancel / retry exhaustion / DLQ recovery)
+        //    before `flush_events` returns and before the actor exits.
+        //    The cooperative cancels above guarantee the actor reaches
+        //    that exit promptly even when a peer stalls — so a healthy
+        //    actor finishes well inside `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`.
+        //    The timeout here is a defensive guard against a future
+        //    bug (e.g. a new transport path that forgets the cancel
+        //    race); it is NOT a contract that allows unresolved
+        //    handles. We deliberately do NOT `abort()` — abort would
+        //    re-open the unresolved-handle leak.
+        let handle_opt = self.actor_handle.lock().await.take();
+        if let Some(h) = handle_opt {
+            let _ = tokio::time::timeout(crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, h).await;
+        }
+
+        // 3. Final drain. The buffer holds only events pushed via
+        //    `consume_shutdown` (the queue consumer's drain path
+        //    after shutdown signal) plus anything that arrived too
+        //    late for the actor's last iteration. The actor's own
+        //    in-flight batch was already resolved by `flush_events`
+        //    before the actor exited. `flush_events_at_shutdown`
+        //    does one bounded send attempt then routes the rest to
+        //    DLQ + Recovered.
+        let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
+        self.inner.flush_events_at_shutdown(leftover).await;
+        Ok(())
+    }
+}
+
+impl<P: BatchSinkPolicy> Drop for BatchedSink<P> {
+    fn drop(&mut self) {
+        // Signal the actor cooperatively before falling back to
+        // abort — `shutdown()` should have already done this and
+        // joined, but Drop is the last-resort path (Output dropped
+        // without an explicit `shutdown()` call, e.g. config
+        // teardown in tests). The actor's stack-local batch on a
+        // bare abort would drop handles unresolved; setting
+        // `is_shutting_down` and `notify_waiters` here gives it a
+        // chance to exit cleanly first, even though we cannot await
+        // its completion from a sync Drop.
+        self.inner.is_shutting_down.store(true, Ordering::Release);
+        self.inner.flush_notify.notify_waiters();
+        if let Some(h) = self.actor_handle.get_mut().take() {
+            h.abort();
+        }
+        // Best-effort warn on leaked buffered events. Awaiting the
+        // lock here would block the warn under contention; try_lock
+        // is the right behaviour for a Drop path. Each leftover
+        // handle's own Drop impl fires `Dropped` back at the queue
+        // consumer — the cursor will not advance for them.
+        if let Ok(buf) = self.inner.batch.try_lock()
+            && !buf.is_empty()
+        {
+            tracing::warn!(
+                "{}: {} events in buffer at shutdown (will be re-delivered from queue)",
+                self.inner.policy.kind(),
+                buf.len()
+            );
+        }
+    }
+}
+
+/// Long-lived flusher actor. Drains the buffer on either of three
+/// triggers: threshold-driven `flush_notify`, timer-driven
+/// `batch_timeout` sleep, or shutdown via `is_shutting_down`. See the
+/// module docs for the lifecycle contract (`shutdown()` never aborts
+/// this actor).
+async fn flusher_actor_loop<P: BatchSinkPolicy>(inner: Arc<SinkShared<P>>) {
+    loop {
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        // Race the triggers. `biased` makes the notify arm the
+        // priority one so a `notify_waiters()` race with a
+        // threshold notify still exits cleanly on the follow-up
+        // `is_shutting_down` check.
+        let sleep_fut = tokio::time::sleep(inner.batch_timeout);
+        tokio::pin!(sleep_fut);
+        tokio::select! {
+            biased;
+            _ = inner.flush_notify.notified() => {}
+            _ = &mut sleep_fut => {}
+        }
+        if inner.is_shutting_down.load(Ordering::Acquire) {
+            break;
+        }
+        let batch = {
+            let mut buf = inner.batch.lock().await;
+            std::mem::take(&mut *buf)
+        };
+        if !batch.is_empty() {
+            // `flush_events` resolves every handle (Delivered on
+            // success, Recovered on retry-exhausted DLQ). It checks
+            // `is_shutting_down` between retry attempts so a
+            // shutdown signal collapses the retry budget to one
+            // attempt instead of burning the full backoff window.
+            inner.flush_events(batch).await;
+        }
+    }
+}
+
+impl<P: BatchSinkPolicy> SinkShared<P> {
+    /// Yield when the cooperative shutdown signal is observed. Used
+    /// in `tokio::select!` to race the transport send future so a
+    /// stalled peer cannot trap the actor task with the batch on its
+    /// stack past the runtime shutdown deadline.
+    ///
+    /// The double-check around `notified()` closes the lost-wake race:
+    /// if `is_shutting_down` flips between our load and the call to
+    /// `notified()`, the re-check catches it; otherwise the next
+    /// `notify_waiters()` (from `shutdown()`) wakes us.
+    async fn wait_until_shutdown(&self) {
+        loop {
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            let notified = self.flush_notify.notified();
+            if self.is_shutting_down.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+            // After the notify wake, the next iteration's `load`
+            // decides whether to return (shutdown observed) or loop
+            // (spurious wake from a threshold-driven flush nudge).
+        }
+    }
+
+    /// Render every buffered event, routing per-event render failures
+    /// to the DLQ (Recovered) on their own so they don't drop the
+    /// rest of the batch. `site` distinguishes the steady-state and
+    /// shutdown flush wordings in DLQ records.
+    async fn render_batch(
+        &self,
+        batch: Vec<(Event, QueueAckHandle)>,
+        site: &str,
+    ) -> (Vec<P::Payload>, Vec<(Event, QueueAckHandle)>) {
+        let mut payloads: Vec<P::Payload> = Vec::with_capacity(batch.len());
+        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
+        let mut render_failures: Vec<(Event, QueueAckHandle, anyhow::Error)> = Vec::new();
+        for (ev, ack) in batch {
+            match self.policy.render(&ev) {
+                Ok(p) => {
+                    payloads.push(p);
+                    shippable.push((ev, ack));
+                }
+                Err(e) => render_failures.push((ev, ack, e)),
+            }
+        }
+        for (ev, ack, err) in render_failures {
+            let reason = format!("render failed during {}: {}", site, err);
+            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
+                .await;
+            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_recovered();
+        }
+        (payloads, shippable)
+    }
+
+    /// Commit a transport-success outcome: split the batch between
+    /// `events_written` (accepted) and `events_failed` (rejected via
+    /// partial success) and resolve every handle. The receiver does
+    /// not identify *which* records were rejected, so we approximate
+    /// by routing the trailing `rejected` entries to the DLQ and
+    /// resolving the rest as Delivered — metric totals are accurate
+    /// either way. `rejected: 0` (the plain-HTTP case) resolves the
+    /// whole batch as Delivered.
+    async fn resolve_send_success(
+        &self,
+        shippable: Vec<(Event, QueueAckHandle)>,
+        outcome: SendOutcome,
+    ) {
+        let count = shippable.len() as u64;
+        let rejected = outcome.rejected.min(count);
+        let written = count - rejected;
+        if written > 0 {
+            self.metrics
+                .events_written
+                .fetch_add(written, Ordering::Relaxed);
+        }
+        if rejected > 0 {
+            self.metrics
+                .events_failed
+                .fetch_add(rejected, Ordering::Relaxed);
+        }
+        let split = (count - rejected) as usize;
+        let mut iter = shippable.into_iter();
+        for (_, ack) in iter.by_ref().take(split) {
+            ack.resolve_delivered();
+        }
+        for (ev, ack) in iter {
+            let reason = "collector reported partial_success rejection".to_string();
+            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
+                .await;
+            ack.resolve_recovered();
+        }
+    }
+
+    /// Drain + ship one batch, resolving each handle to its final
+    /// disposition. Infallible from the caller's POV: every entry
+    /// has its disposition committed before this returns. Render
+    /// failures route the offending event to DLQ on its own
+    /// (resolve_recovered); the rest proceed to the send loop.
+    /// Transport failures consume the per-flush retry budget; on
+    /// exhaust the whole shippable subset is routed to DLQ.
+    async fn flush_events(&self, batch: Vec<(Event, QueueAckHandle)>) {
+        if batch.is_empty() {
+            return;
+        }
+        let (payloads, shippable) = self.render_batch(batch, "batch flush").await;
+        if payloads.is_empty() {
+            return;
+        }
+        let prepared = match self.policy.prepare(payloads) {
+            Ok(p) => p,
+            Err(e) => {
+                // Deterministic transformation failure (encode /
+                // decode / compress): re-attempting cannot succeed,
+                // so skip the retry budget and route straight to DLQ.
+                let reason = format!("flush failed: {}", e);
+                for (ev, ack) in shippable {
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        &ev,
+                        &reason,
+                    )
+                    .await;
+                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                    ack.resolve_recovered();
+                }
+                return;
+            }
+        };
+        let mut attempt = 0u32;
+        let mut wait = self.retry.initial_wait;
+        let final_err = loop {
+            // Race the transport against the shutdown signal. A
+            // stalled peer (= TCP accepted but never responds) holds
+            // the send future past the runtime shutdown deadline —
+            // without the race the actor task gets aborted with the
+            // stack-local shippable Vec, dropping every parked
+            // QueueAckHandle unresolved (the unresolved-handle
+            // regression). With the race, a `shutdown()` mid-flight
+            // cancels the send future (the transport client cancels
+            // the connection on drop) and falls through to the DLQ +
+            // Recovered path below.
+            let send_outcome = tokio::select! {
+                biased;
+                res = self.policy.send(&prepared) => Some(res),
+                _ = self.wait_until_shutdown() => None,
+            };
+            match send_outcome {
+                Some(Ok(outcome)) => {
+                    self.resolve_send_success(shippable, outcome).await;
+                    return;
+                }
+                None => {
+                    break anyhow::anyhow!(
+                        "shutdown cancelled in-flight send (collapsed retry budget)"
+                    );
+                }
+                Some(Err(e)) => {
+                    attempt += 1;
+                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    if attempt >= self.retry.max_attempts {
+                        break e;
+                    }
+                    // Cooperative shutdown cancel: if `shutdown()`
+                    // signalled mid-retry, abandon the budget and
+                    // route the shippable batch straight to DLQ.
+                    // Burning the full backoff window would outlast
+                    // the runtime's 10s shutdown timeout and leak
+                    // the stack-local handles when the task is
+                    // aborted by the runtime.
+                    if self.is_shutting_down.load(Ordering::Acquire) {
+                        break e;
+                    }
+                    tracing::warn!(
+                        "{} '{}': flush attempt {}/{} failed: {} — retrying in {:?}",
+                        self.policy.kind(),
+                        self.name,
+                        attempt,
+                        self.retry.max_attempts,
+                        e,
+                        wait
+                    );
+                    // Race the sleep against a shutdown wake. The
+                    // bare check before the sleep only catches a
+                    // shutdown that arrived between attempts; a
+                    // shutdown that fires *during* the sleep would
+                    // otherwise be stuck until the sleep elapses
+                    // (5s+ in practice, longer than the runtime
+                    // shutdown budget). `flush_notify.notify_waiters`
+                    // is called by `shutdown()`, so the sleep arm
+                    // here wakes immediately and the next iteration
+                    // sees `is_shutting_down=true` and breaks.
+                    tokio::select! {
+                        _ = tokio::time::sleep(wait) => {}
+                        _ = self.flush_notify.notified() => {}
+                    }
+                    wait = self.retry.next_wait(wait);
+                }
+            }
+        };
+        // Retry exhausted: route every shippable event to DLQ and
+        // resolve Recovered. The batch is gone from the buffer at
+        // this point — the disk-queue cursor will not advance until
+        // every handle resolves, so a daemon crash here replays the
+        // batch on restart (the ack-handle invariant).
+        let reason = format!("flush failed after {} attempts: {}", attempt, final_err);
+        for (ev, ack) in shippable {
+            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
+                .await;
+            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            ack.resolve_recovered();
+        }
+    }
+
+    /// Shutdown single-attempt flush; never uses the steady-state retry
+    /// budget. Render failures route per-event to DLQ as before,
+    /// partial successes are honoured (the rejected tail goes to DLQ
+    /// with the `partial_success` reason — distinct from transport
+    /// failure), and the shippable subset gets one send attempt
+    /// wrapped in `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The `shippable`
+    /// vector is held in this frame across the `timeout()` boundary so
+    /// an `Elapsed` outcome does NOT drop it — otherwise the inner
+    /// handles would fire `QueueAckHandle::Drop` and be counted as
+    /// silent loss.
+    async fn flush_events_at_shutdown(&self, batch: Vec<(Event, QueueAckHandle)>) {
+        if batch.is_empty() {
+            return;
+        }
+        let (payloads, shippable) = self.render_batch(batch, "shutdown flush").await;
+        if payloads.is_empty() {
+            return;
+        }
+        let prepared = match self.policy.prepare(payloads) {
+            Ok(p) => p,
+            Err(e) => {
+                let err = anyhow::anyhow!("transport error: {}", e);
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
+                return;
+            }
+        };
+        let send_outcome = tokio::time::timeout(
+            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+            self.policy.send(&prepared),
+        )
+        .await;
+        match send_outcome {
+            Ok(Ok(outcome)) => {
+                self.resolve_send_success(shippable, outcome).await;
+            }
+            Ok(Err(send_err)) => {
+                let err = anyhow::anyhow!("transport error: {}", send_err);
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
+            }
+            Err(_elapsed) => {
+                let err = anyhow::anyhow!(
+                    "deadline exceeded after {:?} during shutdown flush",
+                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+                );
+                crate::modules::route_shutdown_batch_to_dlq(
+                    self.error_log.as_ref(),
+                    &self.metrics,
+                    &self.name,
+                    shippable,
+                    &err,
+                )
+                .await;
+            }
+        }
+    }
+}

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -53,8 +53,8 @@
 //! ack handle resolves, not when `consume` returns.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tokio::sync::{Mutex, Notify};
@@ -65,7 +65,7 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
-use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
+use crate::modules::output::syslog_peers::{RotatingPeers, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 use crate::tls::ClientTlsConfig;
@@ -174,24 +174,14 @@ struct HttpPeer {
     client: reqwest::Client,
 }
 
-struct PeerState {
-    cooldown_until: Mutex<Option<Instant>>,
-}
-
-impl Default for PeerState {
-    fn default() -> Self {
-        Self {
-            cooldown_until: Mutex::new(None),
-        }
-    }
-}
-
 /// Shared state between `consume()` (= the queue consumer's hand-off
 /// into the buffer) and the flusher actor task.
 struct Inner {
     peers: Vec<HttpPeer>,
-    peer_state: Vec<PeerState>,
-    cursor: AtomicUsize,
+    /// Round-robin cursor + per-peer failure cooldown; one candidate
+    /// per send attempt. See `RotatingPeers` for the selection and
+    /// cooldown contract.
+    rotation: RotatingPeers,
     method: reqwest::Method,
     content_type: String,
     headers: Vec<(String, String)>,
@@ -452,14 +442,13 @@ impl Module for HttpOutput {
             );
         };
 
-        let peer_state = peers.iter().map(|_| PeerState::default()).collect();
+        let rotation = RotatingPeers::new(peers.len());
 
         let retry = RetryConfig::from_output_properties(properties)?;
         let metrics = Arc::new(OutputMetrics::default());
         let inner = Arc::new(Inner {
             peers,
-            peer_state,
-            cursor: AtomicUsize::new(0),
+            rotation,
             method,
             content_type,
             headers,
@@ -907,36 +896,15 @@ impl Inner {
             body_str.into_bytes()
         };
 
-        let n = self.peers.len();
-        let start = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
-        let now = Instant::now();
-
-        // Pick the next non-cooled peer in rotation; if every peer is
-        // cooled, fall back to the rotation start (the queue layer's
-        // retry then handles the persistent-failure case).
-        let mut idx = start;
-        for offset in 0..n {
-            let candidate = (start + offset) % n;
-            let guard = self.peer_state[candidate].cooldown_until.lock().await;
-            if guard.is_none_or(|until| until <= now) {
-                idx = candidate;
-                break;
-            }
-        }
-
+        let idx = self.rotation.select().await;
         let peer = &self.peers[idx];
         match send_once(peer, self, &body).await {
             Ok(()) => {
-                *self.peer_state[idx].cooldown_until.lock().await = None;
+                self.rotation.mark_success(idx).await;
                 Ok(())
             }
             Err(e) => {
-                // Cool down relative to the *failure time*, not request
-                // start. With a 30s request timeout and a 5s cooldown,
-                // measuring from `now` could record an already-expired
-                // cooldown and immediately reselect the same bad peer.
-                *self.peer_state[idx].cooldown_until.lock().await =
-                    Some(Instant::now() + PEER_COOLDOWN);
+                self.rotation.mark_failure(idx).await;
                 Err(e)
             }
         }
@@ -1020,7 +988,9 @@ mod tests {
     use super::*;
     use crate::dsl::ast::{Expr, ExprKind, Property};
     use crate::event::Event;
+    use crate::modules::output::syslog_peers::PEER_COOLDOWN;
     use std::net::SocketAddr;
+    use std::time::Instant;
 
     fn mp(props: &[Property]) -> crate::dsl::module_props::ModuleProperties {
         crate::dsl::module_props::ModuleProperties::from_parts("http", props.to_vec())
@@ -1802,9 +1772,10 @@ def output o {{
         let pre_call = Instant::now();
         let _ = consume_and_wait_disposition(&output, &event_with("hello"), Duration::from_secs(5))
             .await;
-        let cooldown_until = output.inner.peer_state[0]
-            .cooldown_until
-            .lock()
+        let cooldown_until = output
+            .inner
+            .rotation
+            .cooldown_until(0)
             .await
             .expect("cooldown must be set after failure");
         server.abort();

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -1104,15 +1104,29 @@ def output o {{
 }}
 "#
         );
+        // The verify toggle lives on the HttpSinkPolicy, so exercise
+        // the trait's `send` directly through it. Same code path that
+        // the skeleton's flush loop takes at runtime — just without
+        // the buffer/notify/actor scaffolding a per-event driver would
+        // need for a single fixture request.
+        use crate::modules::output::batched::BatchSinkPolicy;
         let insecure = HttpOutput::from_properties(
             "o",
             &parsed_output_props(&src_insecure, "o"),
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        insecure
+        let body = insecure
+            .sink
             .inner
-            .send_batch(&["hello".to_string()])
+            .policy
+            .prepare(vec!["hello".to_string()])
+            .unwrap();
+        insecure
+            .sink
+            .inner
+            .policy
+            .send(&body)
             .await
             .expect("verify false must accept the self-signed cert");
 
@@ -1131,9 +1145,17 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        let err = strict
+        let body = strict
+            .sink
             .inner
-            .send_batch(&["hello".to_string()])
+            .policy
+            .prepare(vec!["hello".to_string()])
+            .unwrap();
+        let err = strict
+            .sink
+            .inner
+            .policy
+            .send(&body)
             .await
             .expect_err("default client must reject the self-signed cert");
         server.abort();

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -873,7 +873,7 @@ mod tests {
         )
         .unwrap();
         // Drive each event end-to-end before pushing the next, so
-        // batch_size=1 → one event per send_batch → cursor advances
+        // batch_size=1 → one event per send → cursor advances
         // once per event (= the round-robin invariant). With the
         // actor refactor, a fast sequence of `consume()` calls can
         // otherwise batch multiple events into one flush; awaiting
@@ -2260,7 +2260,7 @@ def output o {{
     }
 
     /// Audit-identified leak (2026-06-27 follow-up): the flusher actor
-    /// was mid-`send_batch().await` against a stalled peer when
+    /// was mid-`send().await` against a stalled peer when
     /// `shutdown()` signalled. The previous fix collapsed retry sleeps
     /// but not the transport call itself, so the actor sat on its
     /// stack-local `shippable` Vec until the runtime aborted it,
@@ -2268,7 +2268,7 @@ def output o {{
     /// panic; release: silent loss).
     ///
     /// This test sets up that exact race — actor wakes via
-    /// `batch_timeout`, enters `send_batch` against a TCP listener
+    /// `batch_timeout`, enters `send` against a TCP listener
     /// that accepts but never responds, `shutdown()` fires — and
     /// asserts every handle resolves to `Recovered` (via DLQ) inside
     /// the bounded shutdown budget.
@@ -2284,7 +2284,7 @@ def output o {{
             error_log: Some(Arc::clone(&writer)),
         };
         // Short timer wake + large batch_size so the actor (not
-        // consume itself) is the path that calls `send_batch`.
+        // consume itself) is the path that calls `send`.
         let output = Arc::new(
             HttpOutput::from_properties(
                 "test",
@@ -2309,14 +2309,14 @@ def output o {{
             .unwrap();
 
         // Give the actor time to wake, take the batch, and enter
-        // `send_batch` against the stalled peer. 200ms > batch_timeout
+        // `send` against the stalled peer. 200ms > batch_timeout
         // (100ms) plus a small margin for actor wake + transport
         // handshake. The reqwest client's 30s read timeout would be
         // the dominant wait without our cooperative cancel.
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         // Now call shutdown. With the cooperative transport cancel,
-        // the actor's `send_batch` future is dropped, the loop falls
+        // the actor's `send` future is dropped, the loop falls
         // through to the DLQ + Recovered path, the actor exits
         // cleanly, and shutdown joins it well within
         // SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT.
@@ -2391,7 +2391,7 @@ def output o {{
         );
 
         // Push two events: the second hits the threshold, fires
-        // flush_notify, the actor wakes and enters send_batch
+        // flush_notify, the actor wakes and enters send
         // against the stalled peer.
         let (ack1, mut rx1) = QueueAckHandle::for_test();
         let (ack2, mut rx2) = QueueAckHandle::for_test();
@@ -2447,7 +2447,7 @@ def output o {{
     /// every event flows through the actor, so the same bounded-
     /// shutdown contract applies. consume() pushes one event
     /// (threshold reached at 1), the actor wakes, enters
-    /// send_batch, shutdown signals, the handle resolves to
+    /// send, shutdown signals, the handle resolves to
     /// Recovered via DLQ.
     #[tokio::test]
     async fn singleton_actor_send_cancels_on_shutdown_against_stalled_peer() {

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -53,17 +53,16 @@
 //! ack handle resolves, not when `consume` returns.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use tokio::sync::{Mutex, Notify};
 
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
+use crate::modules::output::batched::{BatchSinkPolicy, BatchedSink, SendOutcome};
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet};
 use crate::modules::output::syslog_peers::{RotatingPeers, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output};
@@ -174,9 +173,12 @@ struct HttpPeer {
     client: reqwest::Client,
 }
 
-/// Shared state between `consume()` (= the queue consumer's hand-off
-/// into the buffer) and the flusher actor task.
-struct Inner {
+/// Transport policy plugged into the shared [`BatchedSink`] skeleton:
+/// render = lossy UTF-8 of `event.egress`, prepare = newline join +
+/// optional gzip, send = one attempt against the next rotation
+/// candidate. Buffering, retry, and the shutdown lifecycle live in
+/// `crate::modules::output::batched`.
+struct HttpSinkPolicy {
     peers: Vec<HttpPeer>,
     /// Round-robin cursor + per-peer failure cooldown; one candidate
     /// per send attempt. See `RotatingPeers` for the selection and
@@ -185,71 +187,11 @@ struct Inner {
     method: reqwest::Method,
     content_type: String,
     headers: Vec<(String, String)>,
-    batch_timeout: Duration,
     compress: bool,
-    /// Buffered events awaiting flush, paired with their queue ack
-    /// handles. Render happens at flush time so per-event render
-    /// failures can be routed to DLQ on their own without dropping
-    /// the rest of the batch; the ack handle resolves when the
-    /// event's disposition is decided (delivered on flush success,
-    /// recovered on DLQ landing).
-    batch: Mutex<Vec<(Event, QueueAckHandle)>>,
-    /// Operator-facing instance name; surfaced on shutdown-flush
-    /// recovery and render-failure records.
-    name: String,
-    /// Per-flush retry policy. Without an internal retry, one
-    /// transient ship failure would lose the whole drained batch
-    /// (the queue layer cannot re-push a buffered batch — its cursor
-    /// only advances when each event's ack handle resolves). The
-    /// retry budget for batched outputs lives entirely here.
-    retry: RetryConfig,
-    /// `error_log` writer injected at construction time by the
-    /// runtime via `BuildContext` in `from_properties`.
-    /// Used by the flush path to route per-event render failures and
-    /// shutdown-flush leftovers into the DLQ. `None` when the
-    /// operator did not configure `control { error_log "..." }` —
-    /// the flush path then falls back to a `tracing::error!` line.
-    error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
-    metrics: Arc<OutputMetrics>,
-    /// Threshold-driven flush trigger. `consume()` calls
-    /// `notify_one()` when the buffer crosses `batch_size`; the
-    /// flusher actor's `select!` wakes and drains.
-    flush_notify: Notify,
-    /// Co-operative cancel flag. `shutdown()` sets this to true
-    /// before notifying the actor; both the actor loop and the
-    /// in-flight `flush_events` retry loop check it so they exit
-    /// without burning the full retry budget.
-    is_shutting_down: AtomicBool,
 }
 
 pub struct HttpOutput {
-    inner: Arc<Inner>,
-    batch_size: usize,
-    /// Long-lived flusher actor handle. The actor task owns the
-    /// timer + flush-driven flush lifecycle.
-    ///
-    /// **Lifecycle contract**:
-    /// - **Normal operation (`shutdown()`)**: NEVER aborts the
-    ///   actor. It signals cooperative shutdown via
-    ///   `is_shutting_down` + `flush_notify.notify_waiters()` and
-    ///   joins it bounded by `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The
-    ///   actor resolves every stack-local handle (Delivered /
-    ///   Recovered via DLQ) before exiting.
-    /// - **`Drop` fallback (last-resort)**: sync `Drop` cannot
-    ///   `.await` the actor, so it signals first then calls
-    ///   `abort()` as a last resort. This path is for teardown
-    ///   scenarios where `shutdown()` was not invoked (e.g. config
-    ///   reload in tests). The signal gives the actor a chance to
-    ///   exit cleanly before the abort lands; in practice the
-    ///   runtime calls `shutdown()` before drop in production.
-    ///
-    /// Earlier versions of this output spawned a per-flush *timer*
-    /// task that held the stack-local batch across
-    /// `flush_events.await`; when `shutdown()` abort()-ed that task
-    /// every parked `QueueAckHandle` dropped unresolved. The
-    /// structural fix moves the abort surface to this single actor
-    /// handle and keeps `abort()` off the `shutdown()` path entirely.
-    actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    sink: BatchedSink<HttpSinkPolicy>,
     metrics: Arc<OutputMetrics>,
 }
 
@@ -446,97 +388,29 @@ impl Module for HttpOutput {
 
         let retry = RetryConfig::from_output_properties(properties)?;
         let metrics = Arc::new(OutputMetrics::default());
-        let inner = Arc::new(Inner {
+        let policy = HttpSinkPolicy {
             peers,
             rotation,
             method,
             content_type,
             headers,
-            batch_timeout,
             compress,
-            batch: Mutex::new(Vec::with_capacity(batch_size.max(1))),
-            name: name.to_string(),
+        };
+        // The shared skeleton spawns the flusher actor that owns
+        // every send — both batched flushes and singleton
+        // (`batch_size <= 1`). See `crate::modules::output::batched`
+        // for the actor / shutdown lifecycle contract.
+        let sink = BatchedSink::new(
+            policy,
+            name,
+            batch_size,
+            batch_timeout,
             retry,
             error_log,
-            metrics: Arc::clone(&metrics),
-            flush_notify: Notify::new(),
-            is_shutting_down: AtomicBool::new(false),
-        });
+            Arc::clone(&metrics),
+        );
 
-        // The flusher actor owns every send — both batched flushes
-        // and singleton (`batch_size <= 1`) — so the queue
-        // consumer's task is never blocked in a `send_batch.await`.
-        // That separation is what makes the actor's
-        // `wait_until_shutdown` race effective: shutdown can be
-        // observed independently of whatever the consumer is doing.
-        // Spawn unconditionally except when there is no runtime (=
-        // parsing-only unit tests outside `#[tokio::test]`).
-        let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
-            let actor_inner = Arc::clone(&inner);
-            Some(tokio::spawn(async move {
-                flusher_actor_loop(actor_inner).await;
-            }))
-        } else {
-            None
-        };
-
-        Ok(Self {
-            inner,
-            batch_size,
-            actor_handle: Mutex::new(actor_handle),
-            metrics,
-        })
-    }
-}
-
-/// Long-lived flusher actor. Drains the buffer on either of three
-/// triggers: threshold-driven `flush_notify`, timer-driven
-/// `batch_timeout` sleep, or shutdown via `is_shutting_down`.
-///
-/// **`shutdown()` never aborts this actor** — it signals
-/// cooperative shutdown and joins bounded. `Drop` is a last-resort
-/// fallback that signals then aborts, since sync `Drop` cannot
-/// `.await`. See `HttpOutput::actor_handle` for the full lifecycle
-/// contract.
-///
-/// Earlier versions spawned a per-flush *timer* task that held a
-/// stack-local `Vec<(Event, QueueAckHandle)>` across
-/// `flush_events.await`, and `shutdown()` would abort()-ing it
-/// dropped every parked handle unresolved
-/// (debug `debug_assert!(resolved)` panic, release silent `Dropped`
-/// loss). Consolidating the timer + flush lifecycle into this single
-/// actor and keeping `abort()` off the `shutdown()` path is the
-/// structural fix.
-async fn flusher_actor_loop(inner: Arc<Inner>) {
-    loop {
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break;
-        }
-        // Race the three triggers. `biased` makes shutdown the
-        // priority arm so a `notify_waiters()` race with a
-        // threshold notify still exits cleanly.
-        let sleep_fut = tokio::time::sleep(inner.batch_timeout);
-        tokio::pin!(sleep_fut);
-        tokio::select! {
-            biased;
-            _ = inner.flush_notify.notified() => {}
-            _ = &mut sleep_fut => {}
-        }
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break;
-        }
-        let batch = {
-            let mut buf = inner.batch.lock().await;
-            std::mem::take(&mut *buf)
-        };
-        if !batch.is_empty() {
-            // `flush_events` resolves every handle (Delivered on
-            // success, Recovered on retry-exhausted DLQ). It checks
-            // `is_shutting_down` between retry attempts so a
-            // shutdown signal collapses the retry budget to one
-            // attempt instead of burning the full backoff window.
-            inner.flush_events(batch).await;
-        }
+        Ok(Self { sink, metrics })
     }
 }
 
@@ -550,338 +424,54 @@ impl HasMetrics for HttpOutput {
 #[async_trait::async_trait]
 impl Output for HttpOutput {
     /// Batched-buffer consume: park the `(Event, ack)` pair in the
-    /// in-memory buffer and arm/run the flush. The ack handle stays
-    /// with the event and resolves at flush time (delivered or
-    /// recovered) — not now. Returning `Ok(())` only signals that
-    /// the output took ownership of the lifecycle.
+    /// sink buffer; the ack handle resolves at flush time (delivered
+    /// or recovered) — not now. Returning `Ok(())` only signals that
+    /// the output took ownership of the lifecycle. See
+    /// `BatchedSink::consume` for the actor hand-off rationale.
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        // Hand the (event, ack) off to the actor and return. The
-        // actor drains the buffer on `flush_notify`, on
-        // `batch_timeout`, or on `is_shutting_down`. The queue
-        // consumer's task is NEVER held in a `send_batch.await`
-        // here — that separation is what makes shutdown observable
-        // independently of the consumer. (An earlier implementation
-        // performed an inline flush on the consumer's task and
-        // blocked the consumer from reaching its own shutdown
-        // observation.) Works for
-        // both batched (`batch_size > 1`) and singleton
-        // (`batch_size <= 1`) modes — for the latter the actor
-        // flushes a one-element batch on each notify.
-        let should_flush = {
-            let mut buf = self.inner.batch.lock().await;
-            buf.push((event.clone(), ack));
-            buf.len() >= self.batch_size
-        };
-        if should_flush {
-            self.inner.flush_notify.notify_one();
-        }
-        // The actor's `select!` already races the `batch_timeout`
-        // sleep — no separate timer to arm.
-        Ok(())
+        self.sink.consume(event, ack).await
     }
 
-    /// Drain-time per-event entry: park the `(event, ack)` pair in the
-    /// buffer that the post-loop `shutdown()` call will drain bounded.
-    /// Deliberately does NOT trigger a flush from here — that would
-    /// re-enter the steady-state retry path (the old inline-singleton /
-    /// `flush_events` exponential backoff loops) which the shutdown
-    /// contract forbids. The buffer holds the handle until `shutdown()`
-    /// resolves it via `flush_events_at_shutdown`'s bounded single
-    /// attempt + DLQ route.
+    /// Drain-time per-event entry: buffer only; the post-loop
+    /// `shutdown()` call drains it bounded. See
+    /// `BatchedSink::consume_shutdown` for the shutdown contract.
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        let mut buf = self.inner.batch.lock().await;
-        buf.push((event.clone(), ack));
-        Ok(())
+        self.sink.consume_shutdown(event, ack).await
     }
 
     async fn shutdown(
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // 1. Signal cooperative shutdown. `is_shutting_down`
-        //    propagates to the actor's outer `select!`, to the
-        //    retry sleep race, and (via the transport-cancel race
-        //    in `flush_events`) to the in-flight `send_batch` call
-        //    itself. `notify_waiters` wakes every current `.notified()`
-        //    awaiter so a stalled peer's transport future is dropped
-        //    immediately rather than blocking until its read timeout.
-        self.inner.is_shutting_down.store(true, Ordering::Release);
-        self.inner.flush_notify.notify_waiters();
-
-        // 2. Bounded join of the flusher actor. The actor's invariant
-        //    is that EVERY stack-local `(Event, QueueAckHandle)` it
-        //    has taken is resolved (Delivered on success, Recovered on
-        //    transport cancel / retry exhaustion / DLQ recovery)
-        //    before `flush_events` returns and before the actor exits.
-        //    The cooperative cancels above guarantee the actor reaches
-        //    that exit promptly even when a peer stalls — so a healthy
-        //    actor finishes well inside `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`.
-        //    The timeout here is a defensive guard against a future
-        //    bug (e.g. a new transport path that forgets the cancel
-        //    race); it is NOT a contract that allows unresolved
-        //    handles. We deliberately do NOT `abort()` — abort would
-        //    re-open the leak this commit set closes.
-        let handle_opt = self.actor_handle.lock().await.take();
-        if let Some(h) = handle_opt {
-            let _ = tokio::time::timeout(crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, h).await;
-        }
-
-        // 3. Final drain. The buffer holds only events pushed via
-        //    `consume_shutdown` (the queue consumer's drain path
-        //    after shutdown signal) plus anything that arrived too
-        //    late for the actor's last iteration. The actor's own
-        //    in-flight batch was already resolved by `flush_events`
-        //    before the actor exited. `flush_events_at_shutdown`
-        //    does one bounded send attempt then routes the rest to
-        //    DLQ + Recovered.
-        let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
-        self.inner.flush_events_at_shutdown(leftover).await;
-        Ok(())
+        self.sink.shutdown().await
     }
 }
 
-/// Render a single event into its HTTP body string. Called from the
-/// consumer-side flush path on an owned `Event`, so no borrowed-view
-/// arena setup is required.
-fn render_event(event: &Event) -> Result<String> {
-    Ok(String::from_utf8_lossy(&event.egress).into_owned())
-}
+#[async_trait::async_trait]
+impl BatchSinkPolicy for HttpSinkPolicy {
+    type Payload = String;
+    type Prepared = Vec<u8>;
 
-impl Inner {
-    /// Drain + ship one batch, resolving each handle to its final
-    /// disposition. Infallible from the caller's POV: every entry
-    /// has its disposition committed before this returns. Render
-    /// failures route the offending event to DLQ on its own
-    /// (resolve_recovered); the rest proceed to the HTTP send loop.
-    /// Transport failures consume the per-flush retry budget; on
-    /// exhaust the whole shippable subset is routed to DLQ.
-    /// Yield when the cooperative shutdown signal is observed. Used
-    /// in `tokio::select!` to race the transport `send_batch` future
-    /// so a stalled peer cannot trap the actor task with the batch on
-    /// its stack past the runtime shutdown deadline.
-    ///
-    /// The double-check around `notified()` closes the lost-wake race:
-    /// if `is_shutting_down` flips between our load and the call to
-    /// `notified()`, the re-check catches it; otherwise the next
-    /// `notify_waiters()` (from `shutdown()`) wakes us.
-    async fn wait_until_shutdown(&self) {
-        loop {
-            if self.is_shutting_down.load(Ordering::Acquire) {
-                return;
-            }
-            let notified = self.flush_notify.notified();
-            if self.is_shutting_down.load(Ordering::Acquire) {
-                return;
-            }
-            notified.await;
-            // After the notify wake, the next iteration's `load`
-            // decides whether to return (shutdown observed) or loop
-            // (spurious wake from a threshold-driven flush nudge).
-        }
+    fn kind(&self) -> &'static str {
+        "http output"
     }
 
-    async fn flush_events(&self, batch: Vec<(Event, QueueAckHandle)>) {
-        if batch.is_empty() {
-            return;
-        }
-        let mut messages: Vec<String> = Vec::with_capacity(batch.len());
-        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
-        let mut render_failures: Vec<(Event, QueueAckHandle, anyhow::Error)> = Vec::new();
-        for (ev, ack) in batch {
-            match render_event(&ev) {
-                Ok(m) => {
-                    messages.push(m);
-                    shippable.push((ev, ack));
-                }
-                Err(e) => render_failures.push((ev, ack, e)),
-            }
-        }
-        for (ev, ack, err) in render_failures {
-            let reason = format!("render failed during batch flush: {}", err);
-            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
-                .await;
-            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-            ack.resolve_recovered();
-        }
-        if messages.is_empty() {
-            return;
-        }
-        let count = shippable.len() as u64;
-        let mut attempt = 0u32;
-        let mut wait = self.retry.initial_wait;
-        let final_err = loop {
-            // Race the transport against the shutdown signal. A
-            // stalled peer (= TCP accepted but never responds) holds
-            // `send_batch().await` past the runtime shutdown deadline
-            // — without the race the actor task gets aborted with
-            // the stack-local shippable Vec, dropping every parked
-            // QueueAckHandle unresolved (the unresolved-handle
-            // regression). With the race, a `shutdown()` mid-flight
-            // cancels the send future (reqwest cancels the connection
-            // on drop) and falls through to the DLQ + Recovered path
-            // below.
-            let send_outcome = tokio::select! {
-                biased;
-                res = self.send_batch(&messages) => Some(res),
-                _ = self.wait_until_shutdown() => None,
-            };
-            match send_outcome {
-                Some(Ok(())) => {
-                    self.metrics
-                        .events_written
-                        .fetch_add(count, Ordering::Relaxed);
-                    for (_, ack) in shippable {
-                        ack.resolve_delivered();
-                    }
-                    return;
-                }
-                None => {
-                    break anyhow::anyhow!(
-                        "shutdown cancelled in-flight send (collapsed retry budget)"
-                    );
-                }
-                Some(Err(e)) => {
-                    attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
-                    if attempt >= self.retry.max_attempts {
-                        break e;
-                    }
-                    // Cooperative shutdown cancel: if `shutdown()`
-                    // signalled mid-retry, abandon the budget and
-                    // route the shippable batch straight to DLQ.
-                    // Burning the full backoff window would outlast
-                    // the runtime's 10s shutdown timeout and leak
-                    // the stack-local handles when the task is
-                    // aborted by the runtime.
-                    if self.is_shutting_down.load(Ordering::Acquire) {
-                        break e;
-                    }
-                    tracing::warn!(
-                        "output '{}': flush attempt {}/{} failed: {} — retrying in {:?}",
-                        self.name,
-                        attempt,
-                        self.retry.max_attempts,
-                        e,
-                        wait
-                    );
-                    // Race the sleep against a shutdown wake. The
-                    // bare check before the sleep only catches a
-                    // shutdown that arrived between attempts; a
-                    // shutdown that fires *during* the sleep would
-                    // otherwise be stuck until the sleep elapses
-                    // (5s+ in practice, longer than the runtime
-                    // shutdown budget). `flush_notify.notify_waiters`
-                    // is called by `shutdown()`, so the sleep arm
-                    // here wakes immediately and the next iteration
-                    // sees `is_shutting_down=true` and breaks.
-                    tokio::select! {
-                        _ = tokio::time::sleep(wait) => {}
-                        _ = self.flush_notify.notified() => {}
-                    }
-                    wait = self.retry.next_wait(wait);
-                }
-            }
-        };
-        // Retry exhausted: route every shippable event to DLQ and
-        // resolve Recovered. The batch is gone from the buffer at
-        // this point — the disk-queue cursor will not advance until
-        // every handle resolves, so a daemon crash here replays the
-        // batch on restart (the ack-handle invariant).
-        let reason = format!("flush failed after {} attempts: {}", attempt, final_err);
-        for (ev, ack) in shippable {
-            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
-                .await;
-            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-            ack.resolve_recovered();
-        }
+    /// Render a single event into its HTTP body string. Called from
+    /// the flush path on an owned `Event`, so no borrowed-view arena
+    /// setup is required. Kept fallible (the lossy conversion itself
+    /// cannot fail) so per-event DLQ routing stays available if a
+    /// stricter render is ever introduced.
+    fn render(&self, event: &Event) -> Result<String> {
+        Ok(String::from_utf8_lossy(&event.egress).into_owned())
     }
 
-    /// Shutdown single-attempt flush; never uses the steady-state retry
-    /// budget. Render failures route per-event to DLQ as before; the
-    /// shippable subset gets one `send_batch` call wrapped in
-    /// `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The `shippable` vector is held
-    /// in this frame across the `timeout()` boundary so an `Elapsed`
-    /// outcome does NOT drop it — otherwise the inner handles would
-    /// fire `QueueAckHandle::Drop` and be counted as silent loss.
-    async fn flush_events_at_shutdown(&self, batch: Vec<(Event, QueueAckHandle)>) {
-        if batch.is_empty() {
-            return;
-        }
-        let mut messages: Vec<String> = Vec::with_capacity(batch.len());
-        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
-        let mut render_failures: Vec<(Event, QueueAckHandle, anyhow::Error)> = Vec::new();
-        for (ev, ack) in batch {
-            match render_event(&ev) {
-                Ok(m) => {
-                    messages.push(m);
-                    shippable.push((ev, ack));
-                }
-                Err(e) => render_failures.push((ev, ack, e)),
-            }
-        }
-        for (ev, ack, err) in render_failures {
-            let reason = format!("render failed during shutdown flush: {}", err);
-            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
-                .await;
-            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-            ack.resolve_recovered();
-        }
-        if messages.is_empty() {
-            return;
-        }
-        let count = shippable.len() as u64;
-        let send_outcome = tokio::time::timeout(
-            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-            self.send_batch(&messages),
-        )
-        .await;
-        match send_outcome {
-            Ok(Ok(())) => {
-                self.metrics
-                    .events_written
-                    .fetch_add(count, Ordering::Relaxed);
-                for (_, ack) in shippable {
-                    ack.resolve_delivered();
-                }
-            }
-            Ok(Err(send_err)) => {
-                let err = anyhow::anyhow!("transport error: {}", send_err);
-                crate::modules::route_shutdown_batch_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    shippable,
-                    &err,
-                )
-                .await;
-            }
-            Err(_elapsed) => {
-                let err = anyhow::anyhow!(
-                    "deadline exceeded after {:?} during shutdown flush",
-                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
-                );
-                crate::modules::route_shutdown_batch_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    shippable,
-                    &err,
-                )
-                .await;
-            }
-        }
-    }
-
-    /// Ship `messages` to one of the configured peers, rotating to the
-    /// next peer in round-robin order. A peer that fails the request
-    /// is cooled down for `PEER_COOLDOWN` and skipped on subsequent
-    /// flushes. When every peer is currently cooled the rotation falls
-    /// back to the cursor start — the per-flush retry loop on `Inner`
-    /// then handles longer-term re-delivery without dropping the batch.
-    async fn send_batch(&self, messages: &[String]) -> Result<()> {
+    /// Join the batch bodies and optionally gzip. Runs once per flush
+    /// (the skeleton prepares before its retry loop), so compression
+    /// is not re-done per attempt — the transformation is
+    /// deterministic, so the wire bytes are identical either way.
+    fn prepare(&self, messages: Vec<String>) -> Result<Vec<u8>> {
         let body_str = messages.join("\n");
-
-        let body: Vec<u8> = if self.compress {
+        if self.compress {
             use flate2::Compression;
             use flate2::write::GzEncoder;
             use std::io::Write;
@@ -891,17 +481,26 @@ impl Inner {
                 .context("http output: gzip compression failed")?;
             encoder
                 .finish()
-                .context("http output: gzip finalization failed")?
+                .context("http output: gzip finalization failed")
         } else {
-            body_str.into_bytes()
-        };
+            Ok(body_str.into_bytes())
+        }
+    }
 
+    /// One send attempt against the next rotation candidate. A peer
+    /// that fails is cooled down for `PEER_COOLDOWN` and skipped on
+    /// subsequent sends; when every peer is cooled the rotation falls
+    /// back to the cursor start — the skeleton's per-flush retry loop
+    /// then handles longer-term re-delivery without dropping the
+    /// batch. Plain HTTP has no partial-success concept, so success
+    /// reports `rejected: 0` (= the whole batch is Delivered).
+    async fn send(&self, body: &Vec<u8>) -> Result<SendOutcome> {
         let idx = self.rotation.select().await;
         let peer = &self.peers[idx];
-        match send_once(peer, self, &body).await {
+        match send_once(peer, self, body).await {
             Ok(()) => {
                 self.rotation.mark_success(idx).await;
-                Ok(())
+                Ok(SendOutcome { rejected: 0 })
             }
             Err(e) => {
                 self.rotation.mark_failure(idx).await;
@@ -911,16 +510,16 @@ impl Inner {
     }
 }
 
-async fn send_once(peer: &HttpPeer, inner: &Inner, body: &[u8]) -> Result<()> {
-    let mut request = peer.client.request(inner.method.clone(), &peer.url);
+async fn send_once(peer: &HttpPeer, policy: &HttpSinkPolicy, body: &[u8]) -> Result<()> {
+    let mut request = peer.client.request(policy.method.clone(), &peer.url);
 
-    request = request.header("Content-Type", &inner.content_type);
+    request = request.header("Content-Type", &policy.content_type);
 
-    if inner.compress {
+    if policy.compress {
         request = request.header("Content-Encoding", "gzip");
     }
 
-    for (key, value) in &inner.headers {
+    for (key, value) in &policy.headers {
         request = request.header(key.as_str(), value.as_str());
     }
 
@@ -951,37 +550,8 @@ async fn send_once(peer: &HttpPeer, inner: &Inner, body: &[u8]) -> Result<()> {
     Ok(())
 }
 
-impl Drop for HttpOutput {
-    fn drop(&mut self) {
-        // Signal the actor cooperatively before falling back to
-        // abort — `shutdown()` should have already done this and
-        // joined, but Drop is the last-resort path (Output dropped
-        // without an explicit `shutdown()` call, e.g. config
-        // teardown in tests). The actor's stack-local batch on a
-        // bare abort would drop handles unresolved; calling
-        // `is_shutting_down` and `notify_waiters` here gives it a
-        // chance to exit cleanly first, even though we cannot await
-        // its completion from a sync Drop.
-        self.inner.is_shutting_down.store(true, Ordering::Release);
-        self.inner.flush_notify.notify_waiters();
-        if let Some(h) = self.actor_handle.get_mut().take() {
-            h.abort();
-        }
-        // Best-effort warn on leaked buffered events. Holding an Arc
-        // here would block the warn under contention; try_lock is the
-        // right behaviour for a Drop path. Each leftover handle's
-        // own Drop impl fires `Dropped` back at the queue consumer
-        // — the cursor will not advance for them.
-        if let Ok(buf) = self.inner.batch.try_lock()
-            && !buf.is_empty()
-        {
-            tracing::warn!(
-                "http output: {} events in buffer lost on shutdown (will be re-delivered from queue)",
-                buf.len()
-            );
-        }
-    }
-}
+// Drop lifecycle (cooperative signal → last-resort abort) lives on
+// `BatchedSink`; `HttpOutput` needs no Drop of its own.
 
 #[cfg(test)]
 mod tests {
@@ -991,6 +561,7 @@ mod tests {
     use crate::modules::output::syslog_peers::PEER_COOLDOWN;
     use std::net::SocketAddr;
     use std::time::Instant;
+    use tokio::sync::Mutex;
 
     fn mp(props: &[Property]) -> crate::dsl::module_props::ModuleProperties {
         crate::dsl::module_props::ModuleProperties::from_parts("http", props.to_vec())
@@ -1104,8 +675,8 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
-        assert_eq!(output.inner.peers[0].url, "http://x:8080/");
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
+        assert_eq!(output.sink.inner.policy.peers[0].url, "http://x:8080/");
     }
 
     #[test]
@@ -1121,8 +692,8 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 3);
-        assert_eq!(output.inner.peers[2].url, "http://c:8080/");
+        assert_eq!(output.sink.inner.policy.peers.len(), 3);
+        assert_eq!(output.sink.inner.policy.peers[2].url, "http://c:8080/");
     }
 
     #[test]
@@ -1478,7 +1049,7 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
     }
 
     #[tokio::test]
@@ -1662,11 +1233,12 @@ def output o {{
         .unwrap();
         // `consume` resolves the ack and swallows the underlying
         // transport error inside its DLQ-routing path.
-        // Hit `Inner::send_batch` directly so we can still assert on
-        // the snippet-cap behaviour at the transport layer.
-        let err = output
-            .inner
-            .send_batch(&["hello".to_string()])
+        // Hit the policy's prepare + send directly so we can still
+        // assert on the snippet-cap behaviour at the transport layer.
+        let policy = &output.sink.inner.policy;
+        let body = policy.prepare(vec!["hello".to_string()]).unwrap();
+        let err = policy
+            .send(&body)
             .await
             .expect_err("500 must surface as Err at the transport layer");
         server.abort();
@@ -1721,9 +1293,10 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        let err = output
-            .inner
-            .send_batch(&["hello".to_string()])
+        let policy = &output.sink.inner.policy;
+        let body = policy.prepare(vec!["hello".to_string()]).unwrap();
+        let err = policy
+            .send(&body)
             .await
             .expect_err("502 must surface as Err at the transport layer");
         server.abort();
@@ -1773,7 +1346,9 @@ def output o {{
         let _ = consume_and_wait_disposition(&output, &event_with("hello"), Duration::from_secs(5))
             .await;
         let cooldown_until = output
+            .sink
             .inner
+            .policy
             .rotation
             .cooldown_until(0)
             .await
@@ -1823,9 +1398,9 @@ def output o {{
         );
         // After the actor drains the 1-element batch, the buffer
         // must be empty again.
-        let batch_len = output.inner.batch.lock().await.len();
+        let batch_len = output.sink.inner.batch.lock().await.len();
         assert_eq!(batch_len, 0, "actor must drain the singleton batch");
-        let actor_spawned = output.actor_handle.lock().await.is_some();
+        let actor_spawned = output.sink.actor_handle.lock().await.is_some();
         assert!(
             actor_spawned,
             "the flusher actor is spawned for every batch_size (singleton included)"
@@ -1892,7 +1467,7 @@ def output o {{
             Some((_, crate::queue::AckDisposition::Recovered))
         ));
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             0,
             "buffer must be empty after flush — handles already resolved"
         );
@@ -1976,7 +1551,7 @@ def output o {{
         consume(&output, &event_with("ev1")).await.unwrap();
         consume(&output, &event_with("ev2")).await.unwrap();
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             2,
             "events must sit in the buffer (batch_size and timer both far away)"
         );
@@ -1987,7 +1562,7 @@ def output o {{
 
         // Buffer drained.
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             0,
             "shutdown() must drain the buffer"
         );
@@ -2056,7 +1631,7 @@ def output o {{
         // Drop two events into the buffer (no flush triggered).
         consume(&output, &event_with("ev1")).await.unwrap();
         consume(&output, &event_with("ev2")).await.unwrap();
-        assert_eq!(output.inner.batch.lock().await.len(), 2);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 2);
 
         // shutdown -> flush() → server returns 500 → retry exhausts →
         // each entry routes to DLQ with `Recovered`. Buffer empty,
@@ -2065,7 +1640,7 @@ def output o {{
         server.abort();
 
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             0,
             "shutdown recovery must drain the buffer"
         );
@@ -2114,7 +1689,7 @@ def output o {{
         server.abort();
         // Buffer drained: flush_events routes to log-without-DLQ
         // (because error_log is None) and resolves Recovered.
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
     }
 
     /// shutdown flush succeeds + error_log set → success path is
@@ -2193,7 +1768,7 @@ def output o {{
         server.abort();
         // Buffer is drained either way (we took() before attempting
         // the DLQ write); the contract is that we don't crash.
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
     }
 
     /// Counts every POST the failing collector receives so the test
@@ -2226,6 +1801,65 @@ def output o {{
             let _ = axum::serve(listener, app).await;
         });
         (addr, count, server)
+    }
+
+    /// Pins the steady-state retry budget: `max_attempts = N` means
+    /// exactly N send attempts (the first try + N-1 retries) before
+    /// the batch routes to DLQ as Recovered. Guards the shared
+    /// `BatchedSink` retry loop against off-by-one drift — the http
+    /// and otlp outputs historically counted attempts with different
+    /// (but equivalent) arithmetic, and this test keeps the unified
+    /// loop honest.
+    #[tokio::test]
+    async fn retry_budget_makes_exactly_max_attempts_sends() {
+        let (addr, post_count, server) = run_counting_failing_collector().await;
+        let url = format!("http://{}/", addr);
+        let retry = Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 3),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+                Property::KeyValue {
+                    key: "backoff".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
+                    value_span: None,
+                },
+            ],
+        };
+        let output = HttpOutput::from_properties(
+            "test",
+            &mp(&[peer_block(&url), prop_int("batch_size", 1), retry]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+
+        let disp =
+            consume_and_wait_disposition(&output, &event_with("retry-pin"), Duration::from_secs(5))
+                .await
+                .unwrap();
+        server.abort();
+        assert!(
+            matches!(disp, crate::queue::AckDisposition::Recovered),
+            "budget exhaust must resolve Recovered, got {:?}",
+            disp
+        );
+        let posts = post_count.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            posts, 3,
+            "max_attempts=3 must make exactly 3 send attempts, got {}",
+            posts
+        );
+        assert_eq!(
+            output
+                .metrics
+                .retries
+                .load(std::sync::atomic::Ordering::Relaxed),
+            3,
+            "the retries metric counts every failed attempt"
+        );
     }
 
     /// Regression for the 0.7.8 shutdown panic / silent loss: at shutdown
@@ -2294,7 +1928,7 @@ def output o {{
             "shutdown took {:?} — must be bounded by SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT",
             elapsed
         );
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
         let body = tokio::fs::read_to_string(&path).await.unwrap();
         assert_eq!(
             body.lines().count(),
@@ -2373,7 +2007,7 @@ def output o {{
             "shutdown took {:?} — must be bounded by SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT",
             elapsed
         );
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
 
         let body = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = body.lines().collect();
@@ -2412,6 +2046,7 @@ def output o {{
         // the runtime would have handed to us — no Mutex, no None
         // window between construction and consumer spawn.
         let stored = output
+            .sink
             .inner
             .error_log
             .as_ref()
@@ -2472,7 +2107,7 @@ def output o {{
             elapsed
         );
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             1,
             "event must land in the buffer"
         );
@@ -2597,7 +2232,7 @@ def output o {{
         )
         .unwrap();
         let handle_id_before = {
-            let guard = output.actor_handle.lock().await;
+            let guard = output.sink.actor_handle.lock().await;
             guard
                 .as_ref()
                 .map(|h| h.id())
@@ -2608,7 +2243,7 @@ def output o {{
         consume(&output, &event_with("b")).await.unwrap();
         consume(&output, &event_with("c")).await.unwrap();
         let handle_id_after = {
-            let guard = output.actor_handle.lock().await;
+            let guard = output.sink.actor_handle.lock().await;
             guard
                 .as_ref()
                 .map(|h| h.id())

--- a/crates/limpid/src/modules/output/mod.rs
+++ b/crates/limpid/src/modules/output/mod.rs
@@ -1,5 +1,6 @@
 //! Output modules: write processed events to external destinations.
 
+pub(crate) mod batched;
 pub mod file;
 pub mod http;
 pub(crate) mod http_util;

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -436,9 +436,10 @@ async fn send_once(
     // events between `events_written` (accepted) and `events_failed`
     // (rejected by the server). Selective re-send of *only* the
     // rejected records is queued for a later release; the retry loop
-    // in `send_batch` handles hard failures (connection refused, 5xx,
-    // …) but not partial-success deltas, since the rejected set is a
-    // strict subset of what already shipped.
+    // now lives in the batched-sink flush path (`flush_events`), not
+    // in this policy's `send`; it handles hard failures (connection
+    // refused, 5xx, …) but not partial-success deltas, since the
+    // rejected set is a strict subset of what already shipped.
     let inner_resp = response.into_inner();
     let rejected = inner_resp
         .partial_success
@@ -1079,7 +1080,7 @@ mod tests {
             .unwrap();
 
         // Let the actor wake, take the batch, and reach the
-        // GRPC_REQUEST_TIMEOUT-wrapped send_batch await.
+        // GRPC_REQUEST_TIMEOUT-wrapped send await.
         for _ in 0..50 {
             tokio::task::yield_now().await;
         }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -46,7 +46,6 @@
 //! not the cooldown, protects the single-peer-just-failed case.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -54,7 +53,6 @@ use bytes::Bytes;
 use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsServiceRequest, logs_service_client::LogsServiceClient,
 };
-use tokio::sync::{Mutex, Notify};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 use crate::dsl::ast::Property;
@@ -62,9 +60,10 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
+use crate::modules::output::batched::{BatchSinkPolicy, BatchedSink, SendOutcome};
 use crate::modules::output::syslog_peers::{RotatingPeers, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output};
-use crate::queue::{BackoffStrategy, QueueAckHandle, RetryConfig};
+use crate::queue::{QueueAckHandle, RetryConfig};
 
 use super::{BatchLevel, decode_drained_to_request};
 
@@ -81,7 +80,14 @@ struct GrpcPeer {
     channel: Channel,
 }
 
-struct Inner {
+/// Transport policy plugged into the shared [`BatchedSink`] skeleton:
+/// render = refcount bump on the per-event ResourceLogs proto bytes,
+/// prepare = decode + `batch_level` merge into one
+/// `ExportLogsServiceRequest`, send = one attempt against the next
+/// rotation candidate. Buffering, retry (the shared `RetryConfig`
+/// vocabulary spliced in by the queue layer), and the shutdown
+/// lifecycle live in `crate::modules::output::batched`.
+struct OtlpGrpcSinkPolicy {
     peers: Vec<GrpcPeer>,
     /// Round-robin cursor + per-peer failure cooldown; one candidate
     /// per send attempt. See `RotatingPeers` for the selection and
@@ -89,51 +95,10 @@ struct Inner {
     rotation: RotatingPeers,
     batch_level: BatchLevel,
     headers: Vec<(String, String)>,
-    batch_timeout: Duration,
-    /// Per-batch retry policy. The shared `RetryConfig` parser
-    /// (`crate::queue::RETRY_PROPERTY_SPEC`) is spliced into every
-    /// output's schema by the queue layer, so `otlp_grpc` speaks the
-    /// same `retry { max_attempts initial_wait max_wait backoff }`
-    /// vocabulary as the rest of the outputs — see [`super::http`]
-    /// for the batched-output rationale (without an internal retry,
-    /// one transient ship failure loses the whole drained batch —
-    /// the queue layer cannot re-push a buffered batch; its cursor
-    /// only advances when each event's ack handle resolves).
-    retry_config: RetryConfig,
-    /// Buffered events awaiting flush, paired with their queue ack
-    /// handles. Render happens at flush time; handles resolve on
-    /// flush (delivered / recovered), not at `consume` return.
-    batch: Mutex<Vec<(Event, QueueAckHandle)>>,
-    /// Operator-facing instance name; surfaced on shutdown-flush
-    /// recovery and render-failure records.
-    name: String,
-    /// `error_log` writer injected at construction time by the
-    /// runtime via `BuildContext` in `from_properties`.
-    /// Used by the flush path to route per-event render failures and
-    /// shutdown-flush leftovers into the DLQ.
-    error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
-    metrics: Arc<OutputMetrics>,
-    /// Threshold-driven flush trigger; the flusher actor's `select!`
-    /// wakes on this notify when `consume()` crosses `batch_size`.
-    flush_notify: Notify,
-    /// Cooperative shutdown flag. See `super::http` for details.
-    is_shutting_down: AtomicBool,
 }
 
 pub struct OtlpGrpcOutput {
-    inner: Arc<Inner>,
-    batch_size: usize,
-    /// Long-lived flusher actor handle. Replaces the prior per-flush
-    /// spawned timer task that held the stack-local batch across
-    /// `flush_events.await` and was `abort()`-ed by `shutdown()`,
-    /// dropping every parked `QueueAckHandle` unresolved.
-    /// `shutdown()` NEVER aborts the actor; it signals
-    /// cooperatively via `is_shutting_down` + `notify_waiters` and
-    /// joins bounded. `Drop` is a last-resort fallback that signals
-    /// then aborts (sync Drop cannot `.await`). See
-    /// `crate::modules::output::http::HttpOutput::actor_handle`
-    /// for the full lifecycle contract.
-    actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    sink: BatchedSink<OtlpGrpcSinkPolicy>,
     metrics: Arc<OutputMetrics>,
 }
 
@@ -324,65 +289,26 @@ impl Module for OtlpGrpcOutput {
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
         let metrics = Arc::new(OutputMetrics::default());
-        let inner = Arc::new(Inner {
+        let policy = OtlpGrpcSinkPolicy {
             peers,
             rotation,
             batch_level,
             headers,
+        };
+        // The shared skeleton spawns the flusher actor; see
+        // `crate::modules::output::batched` for the actor / shutdown
+        // lifecycle contract.
+        let sink = BatchedSink::new(
+            policy,
+            name,
+            batch_size,
             batch_timeout,
             retry_config,
-            batch: Mutex::new(Vec::new()),
-            name: name.to_string(),
             error_log,
-            metrics: Arc::clone(&metrics),
-            flush_notify: Notify::new(),
-            is_shutting_down: AtomicBool::new(false),
-        });
+            Arc::clone(&metrics),
+        );
 
-        // Skip the spawn when called outside a Tokio runtime (= tests
-        // that exercise `from_properties` parsing only).
-        let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
-            let actor_inner = Arc::clone(&inner);
-            Some(tokio::spawn(async move {
-                flusher_actor_loop(actor_inner).await;
-            }))
-        } else {
-            None
-        };
-
-        Ok(Self {
-            inner,
-            batch_size,
-            actor_handle: Mutex::new(actor_handle),
-            metrics,
-        })
-    }
-}
-
-/// Long-lived flusher actor; same pattern as the http output. See
-/// `crate::modules::output::http` for rationale.
-async fn flusher_actor_loop(inner: Arc<Inner>) {
-    loop {
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break;
-        }
-        let sleep_fut = tokio::time::sleep(inner.batch_timeout);
-        tokio::pin!(sleep_fut);
-        tokio::select! {
-            biased;
-            _ = inner.flush_notify.notified() => {}
-            _ = &mut sleep_fut => {}
-        }
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break;
-        }
-        let batch = {
-            let mut buf = inner.batch.lock().await;
-            std::mem::take(&mut *buf)
-        };
-        if !batch.is_empty() {
-            inner.flush_events(batch).await;
-        }
+        Ok(Self { sink, metrics })
     }
 }
 
@@ -395,309 +321,82 @@ impl HasMetrics for OtlpGrpcOutput {
 
 #[async_trait::async_trait]
 impl Output for OtlpGrpcOutput {
+    /// Buffer-only consume; the sink's actor owns every send. See
+    /// `BatchedSink::consume` for the hand-off rationale.
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        // Hand the (event, ack) off to the actor — see
-        // `http::HttpOutput::consume` for rationale.
-        let should_flush = {
-            let mut batch = self.inner.batch.lock().await;
-            batch.push((event.clone(), ack));
-            batch.len() >= self.batch_size
-        };
-        if should_flush {
-            self.inner.flush_notify.notify_one();
-        }
-        Ok(())
+        self.sink.consume(event, ack).await
     }
 
-    /// Drain-time per-event entry: park into the buffer; the post-loop
-    /// `shutdown()` call drains it bounded. No flush trigger here — the
-    /// shutdown contract forbids the steady-state retry path.
+    /// Drain-time per-event entry: buffer only; the post-loop
+    /// `shutdown()` call drains it bounded. See
+    /// `BatchedSink::consume_shutdown` for the shutdown contract.
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        let mut buf = self.inner.batch.lock().await;
-        buf.push((event.clone(), ack));
-        Ok(())
+        self.sink.consume_shutdown(event, ack).await
     }
 
     async fn shutdown(
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // Cooperative shutdown: same pattern as http / otlp_http.
-        self.inner.is_shutting_down.store(true, Ordering::Release);
-        self.inner.flush_notify.notify_waiters();
-        let handle_opt = self.actor_handle.lock().await.take();
-        if let Some(h) = handle_opt {
-            let _ = tokio::time::timeout(crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, h).await;
-        }
-        let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
-        self.inner.flush_events_at_shutdown(leftover).await;
-        Ok(())
+        self.sink.shutdown().await
     }
 }
 
-impl Inner {
-    /// Yield on cooperative shutdown — see `http::Inner::wait_until_shutdown`.
-    async fn wait_until_shutdown(&self) {
-        loop {
-            if self.is_shutting_down.load(Ordering::Acquire) {
-                return;
-            }
-            let notified = self.flush_notify.notified();
-            if self.is_shutting_down.load(Ordering::Acquire) {
-                return;
-            }
-            notified.await;
-        }
+#[async_trait::async_trait]
+impl BatchSinkPolicy for OtlpGrpcSinkPolicy {
+    type Payload = Bytes;
+    type Prepared = ExportLogsServiceRequest;
+
+    fn kind(&self) -> &'static str {
+        "otlp_grpc output"
     }
 
-    /// Drain + ship one batch, resolving each handle to its final
-    /// disposition. Mirrors the http counterpart's ack-handle
-    /// semantics: infallible to the caller, per-event DLQ routing on
-    /// render failure, per-flush retry budget on transport, and
-    /// Recovered-on-exhaust.
-    async fn flush_events(&self, batch: Vec<(Event, QueueAckHandle)>) {
-        if batch.is_empty() {
-            return;
-        }
-        // OTLP render is a refcount bump on `event.egress` — no
-        // failure path here, but we keep the same code shape as the
-        // http counterpart for future-proofing.
-        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
-        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
-        for (ev, ack) in batch {
-            payloads.push(ev.egress.clone());
-            shippable.push((ev, ack));
-        }
-        if payloads.is_empty() {
-            return;
-        }
-        let count = shippable.len() as u64;
-        // Race the transport against shutdown — see http.rs.
-        let send_outcome = tokio::select! {
-            biased;
-            res = send_batch(self, payloads) => Some(res),
-            _ = self.wait_until_shutdown() => None,
-        };
-        let send_result = match send_outcome {
-            Some(res) => res,
-            None => Err(anyhow!("shutdown cancelled in-flight OTLP/gRPC send")),
-        };
-        match send_result {
+    /// Render a single Event into its OTLP `ResourceLogs` proto bytes
+    /// — just a refcount bump on `event.egress`. Infallible in
+    /// practice; the `Result` keeps per-event DLQ routing available
+    /// (the pipeline egress contract is validated in `prepare`).
+    fn render(&self, event: &Event) -> Result<Bytes> {
+        Ok(event.egress.clone())
+    }
+
+    /// Decode the drained per-event protos and merge per
+    /// `batch_level` into one request. A decode failure (= pipeline
+    /// egress is not valid ResourceLogs) is deterministic, so the
+    /// skeleton routes the batch to DLQ without burning the retry
+    /// budget.
+    fn prepare(&self, drained: Vec<Bytes>) -> Result<ExportLogsServiceRequest> {
+        decode_drained_to_request(drained, self.batch_level)
+    }
+
+    /// One send attempt against the next rotation candidate; see
+    /// `RotatingPeers` for the selection + cooldown contract
+    /// (cooldown is measured from failure time so a slow 30s
+    /// GRPC_REQUEST_TIMEOUT failure cannot record an already-expired
+    /// cooldown).
+    async fn send(&self, req: &ExportLogsServiceRequest) -> Result<SendOutcome> {
+        let idx = self.rotation.select().await;
+        match send_once(&self.peers[idx], self, req).await {
             Ok(outcome) => {
-                let rejected = outcome.rejected.min(count);
-                let written = count - rejected;
-                if written > 0 {
-                    self.metrics
-                        .events_written
-                        .fetch_add(written, Ordering::Relaxed);
-                }
-                if rejected > 0 {
-                    self.metrics
-                        .events_failed
-                        .fetch_add(rejected, Ordering::Relaxed);
-                }
-                let split = (count - rejected) as usize;
-                let mut iter = shippable.into_iter();
-                for (_, ack) in iter.by_ref().take(split) {
-                    ack.resolve_delivered();
-                }
-                for (ev, ack) in iter {
-                    let reason = "collector reported partial_success rejection".to_string();
-                    crate::modules::route_event_to_dlq(
-                        self.error_log.as_ref(),
-                        &self.name,
-                        &ev,
-                        &reason,
-                    )
-                    .await;
-                    ack.resolve_recovered();
-                }
+                self.rotation.mark_success(idx).await;
+                Ok(outcome)
             }
             Err(e) => {
-                let reason = format!("flush failed: {}", e);
-                for (ev, ack) in shippable {
-                    crate::modules::route_event_to_dlq(
-                        self.error_log.as_ref(),
-                        &self.name,
-                        &ev,
-                        &reason,
-                    )
-                    .await;
-                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                    ack.resolve_recovered();
-                }
+                self.rotation.mark_failure(idx).await;
+                Err(e)
             }
         }
     }
-
-    /// Shutdown single-attempt flush; never uses the steady-state retry
-    /// budget. Partial successes are honoured (the rejected tail goes to
-    /// DLQ with the `partial_success` reason — distinct from transport
-    /// failure), and the shippable subset gets one `send_batch` call
-    /// wrapped in `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The `shippable`
-    /// vector is held in this frame across the `timeout()` boundary so
-    /// an `Elapsed` outcome does NOT drop it — otherwise the inner
-    /// handles would fire `QueueAckHandle::Drop` and be counted as
-    /// silent loss.
-    async fn flush_events_at_shutdown(&self, batch: Vec<(Event, QueueAckHandle)>) {
-        if batch.is_empty() {
-            return;
-        }
-        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
-        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
-        for (ev, ack) in batch {
-            payloads.push(ev.egress.clone());
-            shippable.push((ev, ack));
-        }
-        if payloads.is_empty() {
-            return;
-        }
-        let count = shippable.len() as u64;
-        let send_outcome = tokio::time::timeout(
-            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-            send_batch(self, payloads),
-        )
-        .await;
-        match send_outcome {
-            Ok(Ok(outcome)) => {
-                let rejected = outcome.rejected.min(count);
-                let written = count - rejected;
-                if written > 0 {
-                    self.metrics
-                        .events_written
-                        .fetch_add(written, Ordering::Relaxed);
-                }
-                if rejected > 0 {
-                    self.metrics
-                        .events_failed
-                        .fetch_add(rejected, Ordering::Relaxed);
-                }
-                let split = (count - rejected) as usize;
-                let mut iter = shippable.into_iter();
-                for (_, ack) in iter.by_ref().take(split) {
-                    ack.resolve_delivered();
-                }
-                for (ev, ack) in iter {
-                    let reason = "collector reported partial_success rejection".to_string();
-                    crate::modules::route_event_to_dlq(
-                        self.error_log.as_ref(),
-                        &self.name,
-                        &ev,
-                        &reason,
-                    )
-                    .await;
-                    ack.resolve_recovered();
-                }
-            }
-            Ok(Err(send_err)) => {
-                let err = anyhow::anyhow!("transport error: {}", send_err);
-                crate::modules::route_shutdown_batch_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    shippable,
-                    &err,
-                )
-                .await;
-            }
-            Err(_elapsed) => {
-                let err = anyhow::anyhow!(
-                    "deadline exceeded after {:?} during shutdown flush",
-                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
-                );
-                crate::modules::route_shutdown_batch_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    shippable,
-                    &err,
-                )
-                .await;
-            }
-        }
-    }
-}
-
-impl Drop for OtlpGrpcOutput {
-    fn drop(&mut self) {
-        // Signal cooperatively before falling back to abort; see
-        // `http::HttpOutput::drop` for rationale.
-        self.inner.is_shutting_down.store(true, Ordering::Release);
-        self.inner.flush_notify.notify_waiters();
-        if let Some(h) = self.actor_handle.get_mut().take() {
-            h.abort();
-        }
-        if let Ok(buf) = self.inner.batch.try_lock()
-            && !buf.is_empty()
-        {
-            tracing::warn!(
-                "otlp_grpc output: {} events in buffer at shutdown (will be re-delivered from queue)",
-                buf.len()
-            );
-        }
-    }
-}
-
-async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOutcome> {
-    let req = decode_drained_to_request(drained, inner.batch_level)?;
-
-    let cfg = &inner.retry_config;
-    let max_attempts = cfg.max_attempts.max(1);
-    let mut attempt = 0u32;
-    let mut wait = cfg.initial_wait;
-
-    let final_err = loop {
-        // One candidate per attempt; see `RotatingPeers` for the
-        // selection + cooldown contract (cooldown is measured from
-        // failure time so a slow 30s GRPC_REQUEST_TIMEOUT failure
-        // cannot record an already-expired cooldown).
-        let idx = inner.rotation.select().await;
-        let err = match send_once(&inner.peers[idx], inner, &req).await {
-            Ok(outcome) => {
-                inner.rotation.mark_success(idx).await;
-                return Ok(outcome);
-            }
-            Err(e) => {
-                inner.rotation.mark_failure(idx).await;
-                e
-            }
-        };
-        if attempt + 1 >= max_attempts {
-            break err;
-        }
-        // Cooperative shutdown cancel — see http.rs.
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break err;
-        }
-        attempt += 1;
-        tracing::warn!(
-            "otlp_grpc output: ship attempt {}/{} failed: {} — retrying in {:?}",
-            attempt,
-            max_attempts,
-            err,
-            wait,
-        );
-        // Race the sleep against a shutdown wake — see http.rs.
-        tokio::select! {
-            _ = tokio::time::sleep(wait) => {}
-            _ = inner.flush_notify.notified() => {}
-        }
-        if matches!(cfg.backoff, BackoffStrategy::Exponential) {
-            wait = wait.saturating_mul(2).min(cfg.max_wait);
-        }
-    };
-    Err(final_err)
 }
 
 async fn send_once(
     peer: &GrpcPeer,
-    inner: &Inner,
+    policy: &OtlpGrpcSinkPolicy,
     req: &ExportLogsServiceRequest,
-) -> Result<super::SendOutcome> {
+) -> Result<SendOutcome> {
     let mut client = LogsServiceClient::new(peer.channel.clone());
     let mut request = tonic::Request::new(req.clone());
     let metadata = request.metadata_mut();
-    for (k, v) in &inner.headers {
+    for (k, v) in &policy.headers {
         // Lower-case the metadata key per HTTP/2 / gRPC convention;
         // tonic enforces this and will refuse `Authorization` etc.
         let key_lc = k.to_ascii_lowercase();
@@ -760,7 +459,7 @@ async fn send_once(
             }
         );
     }
-    Ok(super::SendOutcome { rejected })
+    Ok(SendOutcome { rejected })
 }
 
 // Note: `verify false` is intentionally not a property on `otlp_grpc`.
@@ -782,6 +481,8 @@ mod tests {
     use opentelemetry_proto::tonic::resource::v1::Resource;
     use prost::Message;
     use std::net::SocketAddr;
+    use std::sync::atomic::Ordering;
+    use tokio::sync::Mutex;
 
     fn mp(props: &[Property]) -> crate::dsl::module_props::ModuleProperties {
         crate::dsl::module_props::ModuleProperties::from_parts("otlp_grpc", props.to_vec())
@@ -853,8 +554,8 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
-        assert_eq!(output.inner.peers[0].endpoint, "http://x:4317");
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
+        assert_eq!(output.sink.inner.policy.peers[0].endpoint, "http://x:4317");
     }
 
     #[test]
@@ -878,7 +579,7 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
     }
 
     #[test]
@@ -938,7 +639,7 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
     }
 
     #[tokio::test]
@@ -949,7 +650,7 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
     }
 
     #[tokio::test]
@@ -964,8 +665,8 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 2);
-        assert_eq!(output.inner.peers[0].endpoint, "http://a:4317");
+        assert_eq!(output.sink.inner.policy.peers.len(), 2);
+        assert_eq!(output.sink.inner.policy.peers[0].endpoint, "http://a:4317");
     }
 
     #[test]
@@ -1000,7 +701,10 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert!(matches!(output.inner.batch_level, BatchLevel::None));
+        assert!(matches!(
+            output.sink.inner.policy.batch_level,
+            BatchLevel::None
+        ));
     }
 
     #[tokio::test]
@@ -1011,7 +715,7 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.batch_size, 1);
+        assert_eq!(output.sink.batch_size, 1);
     }
 
     #[tokio::test]
@@ -1031,7 +735,7 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.retry_config.max_attempts, 2);
+        assert_eq!(output.sink.inner.retry.max_attempts, 2);
     }
 
     // ---- wire-level round-trip ----
@@ -1312,7 +1016,7 @@ mod tests {
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .unwrap();
-        let handle_before = output.actor_handle.lock().await.is_some();
+        let handle_before = output.sink.actor_handle.lock().await.is_some();
         assert!(handle_before, "flusher actor must be spawned");
         drop(output);
     }
@@ -1416,9 +1120,9 @@ mod tests {
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .expect("buffering a single event must succeed");
-        let batch_len = output.inner.batch.lock().await.len();
+        let batch_len = output.sink.inner.batch.lock().await.len();
         assert_eq!(batch_len, 1, "event must sit in the buffer");
-        let actor_spawned = output.actor_handle.lock().await.is_some();
+        let actor_spawned = output.sink.actor_handle.lock().await.is_some();
         assert!(
             actor_spawned,
             "the long-lived flusher actor must be available to drain on batch_timeout or notify"
@@ -1470,7 +1174,7 @@ mod tests {
                 .unwrap();
         }
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             2,
             "writes must land in the buffer"
         );
@@ -1478,7 +1182,7 @@ mod tests {
         output.shutdown(None).await.unwrap();
 
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             0,
             "shutdown() must drain the buffer"
         );
@@ -1546,7 +1250,7 @@ mod tests {
             rx2.recv().await,
             Some((_, crate::queue::AckDisposition::Recovered))
         ));
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
     }
 
     // -----------------------------------------------------------------------
@@ -1577,7 +1281,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        assert_eq!(output.inner.batch.lock().await.len(), 2);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 2);
     }
 
     #[tokio::test]
@@ -1597,7 +1301,7 @@ mod tests {
         buffer_two(&output).await;
 
         output.shutdown(Some(&writer)).await.unwrap();
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
 
         let body = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = body.lines().collect();
@@ -1628,7 +1332,7 @@ mod tests {
         buffer_two(&output).await;
 
         output.shutdown(None).await.expect("shutdown is infallible");
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
     }
 
     #[tokio::test]
@@ -1689,7 +1393,7 @@ mod tests {
             std::path::PathBuf::from("/nonexistent/limpid-grpc-test/errored.jsonl"),
         ));
         output.shutdown(Some(&writer)).await.unwrap();
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
     }
 
     /// Constructor-time error_log injection — see the matching test
@@ -1711,6 +1415,7 @@ mod tests {
         )
         .unwrap();
         let stored = output
+            .sink
             .inner
             .error_log
             .as_ref()

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -46,8 +46,8 @@
 //! not the cooldown, protects the single-peer-just-failed case.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use bytes::Bytes;
@@ -62,7 +62,7 @@ use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
-use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
+use crate::modules::output::syslog_peers::{RotatingPeers, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{BackoffStrategy, QueueAckHandle, RetryConfig};
 
@@ -81,22 +81,12 @@ struct GrpcPeer {
     channel: Channel,
 }
 
-struct PeerState {
-    cooldown_until: Mutex<Option<Instant>>,
-}
-
-impl Default for PeerState {
-    fn default() -> Self {
-        Self {
-            cooldown_until: Mutex::new(None),
-        }
-    }
-}
-
 struct Inner {
     peers: Vec<GrpcPeer>,
-    peer_state: Vec<PeerState>,
-    cursor: AtomicUsize,
+    /// Round-robin cursor + per-peer failure cooldown; one candidate
+    /// per send attempt. See `RotatingPeers` for the selection and
+    /// cooldown contract.
+    rotation: RotatingPeers,
     batch_level: BatchLevel,
     headers: Vec<(String, String)>,
     batch_timeout: Duration,
@@ -329,15 +319,14 @@ impl Module for OtlpGrpcOutput {
             );
         };
 
-        let peer_state = peers.iter().map(|_| PeerState::default()).collect();
+        let rotation = RotatingPeers::new(peers.len());
 
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
         let metrics = Arc::new(OutputMetrics::default());
         let inner = Arc::new(Inner {
             peers,
-            peer_state,
-            cursor: AtomicUsize::new(0),
+            rotation,
             batch_level,
             headers,
             batch_timeout,
@@ -651,7 +640,6 @@ impl Drop for OtlpGrpcOutput {
 
 async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOutcome> {
     let req = decode_drained_to_request(drained, inner.batch_level)?;
-    let n = inner.peers.len();
 
     let cfg = &inner.retry_config;
     let max_attempts = cfg.max_attempts.max(1);
@@ -659,31 +647,18 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOut
     let mut wait = cfg.initial_wait;
 
     let final_err = loop {
-        let start = inner.cursor.fetch_add(1, Ordering::Relaxed) % n;
-        let now = Instant::now();
-        let mut idx = start;
-        for offset in 0..n {
-            let candidate = (start + offset) % n;
-            let guard = inner.peer_state[candidate].cooldown_until.lock().await;
-            if guard.is_none_or(|until| until <= now) {
-                idx = candidate;
-                break;
-            }
-        }
-
+        // One candidate per attempt; see `RotatingPeers` for the
+        // selection + cooldown contract (cooldown is measured from
+        // failure time so a slow 30s GRPC_REQUEST_TIMEOUT failure
+        // cannot record an already-expired cooldown).
+        let idx = inner.rotation.select().await;
         let err = match send_once(&inner.peers[idx], inner, &req).await {
             Ok(outcome) => {
-                *inner.peer_state[idx].cooldown_until.lock().await = None;
+                inner.rotation.mark_success(idx).await;
                 return Ok(outcome);
             }
             Err(e) => {
-                // Measure cooldown from failure time, not request start:
-                // `now` was captured before `send_once`, so for any non-
-                // trivial request latency (and especially after a 30s
-                // GRPC_REQUEST_TIMEOUT firing) `now + PEER_COOLDOWN`
-                // can already be in the past, defeating the rotation.
-                *inner.peer_state[idx].cooldown_until.lock().await =
-                    Some(Instant::now() + PEER_COOLDOWN);
+                inner.rotation.mark_failure(idx).await;
                 e
             }
         };

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -45,8 +45,8 @@
 //! picks the next available peer.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use bytes::Bytes;
@@ -62,7 +62,7 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet, read_body_capped};
-use crate::modules::output::syslog_peers::{PEER_COOLDOWN, iter_peers_block};
+use crate::modules::output::syslog_peers::{RotatingPeers, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{BackoffStrategy, QueueAckHandle, RetryConfig};
 use crate::tls::ClientTlsConfig;
@@ -119,29 +119,12 @@ struct HttpPeer {
     client: reqwest::Client,
 }
 
-struct PeerState {
-    cooldown_until: Mutex<Option<Instant>>,
-}
-
-impl Default for PeerState {
-    fn default() -> Self {
-        Self {
-            cooldown_until: Mutex::new(None),
-        }
-    }
-}
-
 struct Inner {
     peers: Vec<HttpPeer>,
-    /// Per-peer cooldown state. Same length as `peers`. Wrapped in
-    /// `Mutex` because `Instant` is not `Copy`-loadable from an atomic
-    /// — but contention is low (one short critical section per flush
-    /// per peer).
-    peer_state: Vec<PeerState>,
-    /// Round-robin cursor. Incremented per flush so successive flushes
-    /// start at successive peers; the rotation inside one flush handles
-    /// retries.
-    cursor: AtomicUsize,
+    /// Round-robin cursor + per-peer failure cooldown; one candidate
+    /// per send attempt. See `RotatingPeers` for the selection and
+    /// cooldown contract.
+    rotation: RotatingPeers,
     protocol: HttpProtocol,
     batch_level: BatchLevel,
     headers: Vec<(String, String)>,
@@ -440,15 +423,14 @@ impl Module for OtlpHttpOutput {
             );
         };
 
-        let peer_state = peers.iter().map(|_| PeerState::default()).collect();
+        let rotation = RotatingPeers::new(peers.len());
 
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
         let metrics = Arc::new(OutputMetrics::default());
         let inner = Arc::new(Inner {
             peers,
-            peer_state,
-            cursor: AtomicUsize::new(0),
+            rotation,
             protocol,
             batch_level,
             headers,
@@ -826,7 +808,6 @@ impl Drop for OtlpHttpOutput {
 
 async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOutcome> {
     let req = decode_drained_to_request(drained, inner.batch_level)?;
-    let n = inner.peers.len();
 
     let cfg = &inner.retry_config;
     let max_attempts = cfg.max_attempts.max(1);
@@ -834,41 +815,18 @@ async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOut
     let mut wait = cfg.initial_wait;
 
     let final_err = loop {
-        // Pick the next peer to try. Rotation starts at `cursor` and
-        // walks forward looking for one whose cooldown has expired. If
-        // every peer is currently cooled (typical single-peer retry
-        // path: the peer just failed on the previous attempt) fall
-        // back to the rotation start — the retry budget is what
-        // protects us, not the cooldown. The cooldown's actual job is
-        // to bias *future flushes* away from a known-bad peer when an
-        // alternative exists.
-        let start = inner.cursor.fetch_add(1, Ordering::Relaxed) % n;
-        let now = Instant::now();
-        let mut idx = start;
-        for offset in 0..n {
-            let candidate = (start + offset) % n;
-            let guard = inner.peer_state[candidate].cooldown_until.lock().await;
-            if guard.is_none_or(|until| until <= now) {
-                idx = candidate;
-                break;
-            }
-        }
-
+        // One candidate per attempt; see `RotatingPeers` for the
+        // selection + cooldown contract (cooldown is measured from
+        // failure time so a slow 30s HTTP_REQUEST_TIMEOUT failure
+        // cannot record an already-expired cooldown).
+        let idx = inner.rotation.select().await;
         let err = match send_once(&inner.peers[idx], inner, &req).await {
             Ok(outcome) => {
-                // Reset cooldown on success so future flushes pick
-                // this peer freely.
-                *inner.peer_state[idx].cooldown_until.lock().await = None;
+                inner.rotation.mark_success(idx).await;
                 return Ok(outcome);
             }
             Err(e) => {
-                // Measure cooldown from failure time, not request start:
-                // `now` was captured before `send_once`, so for any non-
-                // trivial request latency (and especially after a 30s
-                // HTTP_REQUEST_TIMEOUT firing) `now + PEER_COOLDOWN`
-                // can already be in the past, defeating the rotation.
-                *inner.peer_state[idx].cooldown_until.lock().await =
-                    Some(Instant::now() + PEER_COOLDOWN);
+                inner.rotation.mark_failure(idx).await;
                 e
             }
         };
@@ -1004,6 +962,7 @@ mod tests {
     use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
     use opentelemetry_proto::tonic::resource::v1::Resource;
     use std::net::SocketAddr;
+    use std::sync::atomic::AtomicUsize;
 
     fn mp(props: &[Property]) -> crate::dsl::module_props::ModuleProperties {
         crate::dsl::module_props::ModuleProperties::from_parts("otlp_http", props.to_vec())

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -263,6 +263,24 @@ fn parse_peer(name: &str, peer_props: &[Property], verify: bool) -> Result<HttpP
         })
         .transpose()?;
 
+    if !verify
+        && let Some(tls) = &tls_config
+        && tls.ca_path.is_some()
+    {
+        // CA bundling is meaningless when verification is off; warn the
+        // operator so the misconfiguration is visible, then proceed
+        // with the remaining (identity) bits of the tls block. Mirrors
+        // the matching guard in `output http` — the two paths otherwise
+        // drifted on how `verify false` + `tls.ca` interacts (this
+        // path used to hard-fail on an unreadable CA even with
+        // verification disabled).
+        tracing::warn!(
+            "output '{}': peer '{}' ignores tls.ca because 'verify false' disables certificate validation",
+            name,
+            endpoint
+        );
+    }
+
     // Explicit ≥ TLS 1.2 floor, mirroring the rustls-side pin in
     // `crate::tls::TLS_PROTOCOL_VERSIONS` (see the rationale there
     // and the matching builder in `output http`).
@@ -286,7 +304,10 @@ fn parse_peer(name: &str, peer_props: &[Property], verify: bool) -> Result<HttpP
         }
     }
     if let Some(tls) = &tls_config {
-        if let Some(ca_path) = &tls.ca_path {
+        // Skip CA loading when verify is off — `danger_accept_invalid_certs`
+        // already short-circuits server-cert validation, and adding a root
+        // would be wasted work (and could mask the warning above).
+        if verify && let Some(ca_path) = &tls.ca_path {
             let pem = std::fs::read(ca_path)
                 .with_context(|| format!("output '{}': cannot read CA cert {}", name, ca_path))?;
             let cert = reqwest::Certificate::from_pem(&pem).with_context(|| {
@@ -644,6 +665,33 @@ mod tests {
             err.to_string().contains("'peer {") && err.to_string().contains("'peers {"),
             "unexpected: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn verify_false_ignores_unreadable_tls_ca() {
+        // Regression: this path used to load `tls.ca` unconditionally,
+        // so `verify false` + an unreadable CA hard-failed at
+        // `from_properties` instead of matching `output http`, where
+        // the same combination warns-and-continues. Point at a CA path
+        // that cannot exist and confirm construction still succeeds.
+        let src = r#"
+def output o {
+    type otlp_http
+    peer {
+        endpoint "https://example.com/v1/logs"
+        tls { ca "/nonexistent/does-not-exist.pem" }
+    }
+    verify false
+}
+"#;
+        let cfg = crate::dsl::parser::parse_config(src).expect("parse");
+        let compiled = crate::pipeline::CompiledConfig::from_config(cfg).expect("compile");
+        OtlpHttpOutput::from_properties(
+            "o",
+            &compiled.outputs["o"].properties,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("verify false must ignore an unreadable tls.ca");
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -707,7 +707,7 @@ def output o {{
         // encoding is irrelevant to what this test pins (whether
         // danger_accept_invalid_certs reached the client builder).
         let insecure = build("verify false");
-        insecure.inner.peers[0]
+        insecure.sink.inner.policy.peers[0]
             .client
             .get(format!("https://{addr}/"))
             .send()
@@ -715,7 +715,7 @@ def output o {{
             .expect("verify false must accept the self-signed cert");
 
         let strict = build("");
-        let err = strict.inner.peers[0]
+        let err = strict.sink.inner.policy.peers[0]
             .client
             .get(format!("https://{addr}/"))
             .send()

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -1693,7 +1693,7 @@ def output o {{
 
         // Push the event via consume; consume returns immediately
         // (buffer + notify), the actor picks it up and enters
-        // send_batch against the stalled peer.
+        // send against the stalled peer.
         let (ack, mut rx) = QueueAckHandle::for_test();
         output
             .consume(&event_with_egress(singleton_bytes(1)), ack)

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -45,7 +45,6 @@
 //! picks the next available peer.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -54,17 +53,17 @@ use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsServiceRequest, ExportLogsServiceResponse,
 };
 use prost::Message;
-use tokio::sync::{Mutex, Notify};
 
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
+use crate::modules::output::batched::{BatchSinkPolicy, BatchedSink, SendOutcome};
 use crate::modules::output::http_util::{ERROR_BODY_BYTE_CAP, error_snippet, read_body_capped};
 use crate::modules::output::syslog_peers::{RotatingPeers, iter_peers_block};
 use crate::modules::{HasMetrics, Module, Output};
-use crate::queue::{BackoffStrategy, QueueAckHandle, RetryConfig};
+use crate::queue::{QueueAckHandle, RetryConfig};
 use crate::tls::ClientTlsConfig;
 
 use super::{BatchLevel, decode_drained_to_request};
@@ -119,7 +118,14 @@ struct HttpPeer {
     client: reqwest::Client,
 }
 
-struct Inner {
+/// Transport policy plugged into the shared [`BatchedSink`] skeleton:
+/// render = refcount bump on the per-event ResourceLogs proto bytes,
+/// prepare = decode + `batch_level` merge into one
+/// `ExportLogsServiceRequest`, send = one attempt against the next
+/// rotation candidate. Buffering, retry (the shared `RetryConfig`
+/// vocabulary spliced in by the queue layer), and the shutdown
+/// lifecycle live in `crate::modules::output::batched`.
+struct OtlpHttpSinkPolicy {
     peers: Vec<HttpPeer>,
     /// Round-robin cursor + per-peer failure cooldown; one candidate
     /// per send attempt. See `RotatingPeers` for the selection and
@@ -128,58 +134,10 @@ struct Inner {
     protocol: HttpProtocol,
     batch_level: BatchLevel,
     headers: Vec<(String, String)>,
-    batch_timeout: Duration,
-    /// Per-batch retry policy. The shared `RetryConfig` parser
-    /// (`crate::queue::RETRY_PROPERTY_SPEC`) is spliced into every
-    /// output's schema by the queue layer, so OTLP speaks the same
-    /// `retry { max_attempts initial_wait max_wait backoff }`
-    /// vocabulary as the rest of the outputs — no module-local
-    /// duplicate of the property spec.
-    ///
-    /// Internal retry matters for OTLP specifically because it batches
-    /// Events from multiple `consume()` calls — without an internal
-    /// retry, a single transient ship failure would lose the whole
-    /// drained batch (the queue layer cannot re-push a buffered batch;
-    /// its cursor only advances when each event's ack handle resolves).
-    retry_config: RetryConfig,
-    /// Buffered events awaiting flush, paired with their queue ack
-    /// handles. Render happens at flush time so per-event render
-    /// failures route to DLQ on their own; the ack resolves at flush
-    /// time (delivered / recovered) — never at `consume` return.
-    batch: Mutex<Vec<(Event, QueueAckHandle)>>,
-    /// Operator-facing instance name; surfaced on shutdown-flush
-    /// recovery and render-failure records.
-    name: String,
-    /// `error_log` writer injected at construction time by the
-    /// runtime via `BuildContext` in `from_properties`.
-    /// Used by the flush path to route per-event render failures and
-    /// shutdown-flush leftovers into the DLQ.
-    error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
-    metrics: Arc<OutputMetrics>,
-    /// Threshold-driven flush trigger; the flusher actor's `select!`
-    /// wakes on this notify when `consume()` crosses `batch_size`.
-    flush_notify: Notify,
-    /// Cooperative shutdown flag. `shutdown()` sets this before
-    /// notifying so both the actor loop and the in-flight
-    /// `send_batch` retry sleep can exit without burning the full
-    /// retry budget. See `flusher_actor_loop` and `send_batch`.
-    is_shutting_down: AtomicBool,
 }
 
 pub struct OtlpHttpOutput {
-    inner: Arc<Inner>,
-    batch_size: usize,
-    /// Long-lived flusher actor handle. Replaces the prior
-    /// per-flush timer task that held the stack-local batch across
-    /// `flush_events.await` and was `abort()`-ed by `shutdown()` —
-    /// dropping every parked `QueueAckHandle` unresolved.
-    /// `shutdown()` joins this actor cooperatively
-    /// via `is_shutting_down` + `notify_waiters` and NEVER aborts
-    /// it; `Drop` is a last-resort fallback that signals then
-    /// aborts (sync Drop cannot `.await`). See
-    /// `crate::modules::output::http::HttpOutput::actor_handle`
-    /// for the full lifecycle contract.
-    actor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    sink: BatchedSink<OtlpHttpSinkPolicy>,
     metrics: Arc<OutputMetrics>,
 }
 
@@ -428,72 +386,27 @@ impl Module for OtlpHttpOutput {
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
         let metrics = Arc::new(OutputMetrics::default());
-        let inner = Arc::new(Inner {
+        let policy = OtlpHttpSinkPolicy {
             peers,
             rotation,
             protocol,
             batch_level,
             headers,
+        };
+        // The shared skeleton spawns the flusher actor; see
+        // `crate::modules::output::batched` for the actor / shutdown
+        // lifecycle contract.
+        let sink = BatchedSink::new(
+            policy,
+            name,
+            batch_size,
             batch_timeout,
             retry_config,
-            batch: Mutex::new(Vec::new()),
-            name: name.to_string(),
             error_log,
-            metrics: Arc::clone(&metrics),
-            flush_notify: Notify::new(),
-            is_shutting_down: AtomicBool::new(false),
-        });
+            Arc::clone(&metrics),
+        );
 
-        // OTLP/HTTP always batches (no singleton fast-path like
-        // `http.rs`), so the actor runs unconditionally — except in
-        // tests that exercise `from_properties` without a Tokio
-        // runtime (parsing-only checks). When no runtime is current,
-        // skip the spawn; the test won't drive `consume` so the
-        // actor would have nothing to do anyway.
-        let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
-            let actor_inner = Arc::clone(&inner);
-            Some(tokio::spawn(async move {
-                flusher_actor_loop(actor_inner).await;
-            }))
-        } else {
-            None
-        };
-
-        Ok(Self {
-            inner,
-            batch_size,
-            actor_handle: Mutex::new(actor_handle),
-            metrics,
-        })
-    }
-}
-
-/// Long-lived flusher actor — same lifecycle pattern as the http
-/// output. `shutdown()` never aborts it; `Drop` is a last-resort
-/// signal-then-abort fallback (sync Drop cannot `.await`). See
-/// `crate::modules::output::http` for the full rationale.
-async fn flusher_actor_loop(inner: Arc<Inner>) {
-    loop {
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break;
-        }
-        let sleep_fut = tokio::time::sleep(inner.batch_timeout);
-        tokio::pin!(sleep_fut);
-        tokio::select! {
-            biased;
-            _ = inner.flush_notify.notified() => {}
-            _ = &mut sleep_fut => {}
-        }
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break;
-        }
-        let batch = {
-            let mut buf = inner.batch.lock().await;
-            std::mem::take(&mut *buf)
-        };
-        if !batch.is_empty() {
-            inner.flush_events(batch).await;
-        }
+        Ok(Self { sink, metrics })
     }
 }
 
@@ -506,368 +419,79 @@ impl HasMetrics for OtlpHttpOutput {
 
 #[async_trait::async_trait]
 impl Output for OtlpHttpOutput {
+    /// Buffer-only consume; the sink's actor owns every send. See
+    /// `BatchedSink::consume` for the hand-off rationale.
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        // Hand the (event, ack) off to the actor. No inline flush —
-        // see `http::HttpOutput::consume` for rationale (inline
-        // flush on the queue consumer's task blocks the consumer
-        // from reaching its own shutdown observation).
-        let should_flush = {
-            let mut batch = self.inner.batch.lock().await;
-            batch.push((event.clone(), ack));
-            batch.len() >= self.batch_size
-        };
-        if should_flush {
-            self.inner.flush_notify.notify_one();
-        }
-        Ok(())
+        self.sink.consume(event, ack).await
     }
 
-    /// Drain-time per-event entry: park into the buffer; the post-loop
-    /// `shutdown()` call drains it bounded. No flush trigger here — the
-    /// shutdown contract forbids the steady-state retry path.
+    /// Drain-time per-event entry: buffer only; the post-loop
+    /// `shutdown()` call drains it bounded. See
+    /// `BatchedSink::consume_shutdown` for the shutdown contract.
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        let mut buf = self.inner.batch.lock().await;
-        buf.push((event.clone(), ack));
-        Ok(())
+        self.sink.consume_shutdown(event, ack).await
     }
 
     async fn shutdown(
         &self,
         _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     ) -> Result<()> {
-        // Signal cooperative shutdown, then bounded-join the actor,
-        // then drain whatever it did not pick up. See
-        // `crate::modules::output::http::HttpOutput::shutdown` for
-        // the rationale — same pattern.
-        self.inner.is_shutting_down.store(true, Ordering::Release);
-        self.inner.flush_notify.notify_waiters();
-        let handle_opt = self.actor_handle.lock().await.take();
-        if let Some(h) = handle_opt {
-            let _ = tokio::time::timeout(crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, h).await;
-        }
-        let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
-        self.inner.flush_events_at_shutdown(leftover).await;
-        Ok(())
+        self.sink.shutdown().await
     }
 }
 
-impl Inner {
-    /// Yield when cooperative shutdown is observed — used in
-    /// `tokio::select!` against the transport future so a stalled
-    /// peer cannot trap the actor task with the batch on its stack
-    /// past the runtime shutdown deadline. See
-    /// `crate::modules::output::http::Inner::wait_until_shutdown`
-    /// for the lost-wake guarantee.
-    async fn wait_until_shutdown(&self) {
-        loop {
-            if self.is_shutting_down.load(Ordering::Acquire) {
-                return;
-            }
-            let notified = self.flush_notify.notified();
-            if self.is_shutting_down.load(Ordering::Acquire) {
-                return;
-            }
-            notified.await;
-        }
+#[async_trait::async_trait]
+impl BatchSinkPolicy for OtlpHttpSinkPolicy {
+    type Payload = Bytes;
+    type Prepared = ExportLogsServiceRequest;
+
+    fn kind(&self) -> &'static str {
+        "otlp_http output"
     }
 
-    /// Drain + ship one batch, resolving each handle to its final
-    /// disposition. Infallible: every entry has its disposition
-    /// committed before this returns. Per-event render failures route
-    /// to DLQ (Recovered); the rest go through `send_batch` (which
-    /// owns its own retry budget). On transport exhaust the shippable
-    /// subset routes to DLQ as Recovered. Partial-success rejects from
-    /// the collector are counted as Recovered too (the spec doesn't
-    /// tell us which records were rejected, so we attribute the
-    /// rejection to the first N entries; metrics totals are accurate
-    /// even if per-event attribution is approximate).
-    async fn flush_events(&self, batch: Vec<(Event, QueueAckHandle)>) {
-        if batch.is_empty() {
-            return;
-        }
-        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
-        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
-        let mut render_failures: Vec<(Event, QueueAckHandle, anyhow::Error)> = Vec::new();
-        for (ev, ack) in batch {
-            match render_event(&ev) {
-                Ok(p) => {
-                    payloads.push(p);
-                    shippable.push((ev, ack));
-                }
-                Err(e) => render_failures.push((ev, ack, e)),
-            }
-        }
-        for (ev, ack, err) in render_failures {
-            let reason = format!("render failed during batch flush: {}", err);
-            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
-                .await;
-            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-            ack.resolve_recovered();
-        }
-        if payloads.is_empty() {
-            return;
-        }
-        let count = shippable.len() as u64;
-        // Race the transport against shutdown: a stalled collector
-        // (HTTP accept + no response) would otherwise hold the actor
-        // past the runtime shutdown deadline, dropping shippable
-        // unresolved on abort. See http.rs::flush_events for the
-        // mirrored pattern.
-        let send_outcome = tokio::select! {
-            biased;
-            res = send_batch(self, payloads) => Some(res),
-            _ = self.wait_until_shutdown() => None,
-        };
-        let send_result = match send_outcome {
-            Some(res) => res,
-            None => Err(anyhow!("shutdown cancelled in-flight OTLP/HTTP send")),
-        };
-        match send_result {
+    /// Render a single Event into its OTLP `ResourceLogs` proto bytes
+    /// — just a refcount bump on `event.egress`. Infallible in
+    /// practice; the `Result` keeps per-event DLQ routing available
+    /// (the pipeline egress contract is validated in `prepare`).
+    fn render(&self, event: &Event) -> Result<Bytes> {
+        Ok(event.egress.clone())
+    }
+
+    /// Decode the drained per-event protos and merge per
+    /// `batch_level` into one request. A decode failure (= pipeline
+    /// egress is not valid ResourceLogs) is deterministic, so the
+    /// skeleton routes the batch to DLQ without burning the retry
+    /// budget.
+    fn prepare(&self, drained: Vec<Bytes>) -> Result<ExportLogsServiceRequest> {
+        decode_drained_to_request(drained, self.batch_level)
+    }
+
+    /// One send attempt against the next rotation candidate; see
+    /// `RotatingPeers` for the selection + cooldown contract
+    /// (cooldown is measured from failure time so a slow 30s
+    /// HTTP_REQUEST_TIMEOUT failure cannot record an already-expired
+    /// cooldown).
+    async fn send(&self, req: &ExportLogsServiceRequest) -> Result<SendOutcome> {
+        let idx = self.rotation.select().await;
+        match send_once(&self.peers[idx], self, req).await {
             Ok(outcome) => {
-                let rejected = outcome.rejected.min(count);
-                let written = count - rejected;
-                if written > 0 {
-                    self.metrics
-                        .events_written
-                        .fetch_add(written, Ordering::Relaxed);
-                }
-                if rejected > 0 {
-                    self.metrics
-                        .events_failed
-                        .fetch_add(rejected, Ordering::Relaxed);
-                }
-                // Partial-success attribution: the OTLP spec does not
-                // identify which records were rejected, so we approximate
-                // by routing the trailing `rejected` entries to the DLQ
-                // and resolving the rest as Delivered. Metric totals
-                // are accurate either way.
-                let split = (count - rejected) as usize;
-                let mut iter = shippable.into_iter();
-                for (_, ack) in iter.by_ref().take(split) {
-                    ack.resolve_delivered();
-                }
-                for (ev, ack) in iter {
-                    let reason = "collector reported partial_success rejection".to_string();
-                    crate::modules::route_event_to_dlq(
-                        self.error_log.as_ref(),
-                        &self.name,
-                        &ev,
-                        &reason,
-                    )
-                    .await;
-                    ack.resolve_recovered();
-                }
+                self.rotation.mark_success(idx).await;
+                Ok(outcome)
             }
             Err(e) => {
-                // send_batch's retry budget already exhausted. DLQ
-                // every event and resolve Recovered.
-                let reason = format!("flush failed: {}", e);
-                for (ev, ack) in shippable {
-                    crate::modules::route_event_to_dlq(
-                        self.error_log.as_ref(),
-                        &self.name,
-                        &ev,
-                        &reason,
-                    )
-                    .await;
-                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                    ack.resolve_recovered();
-                }
+                self.rotation.mark_failure(idx).await;
+                Err(e)
             }
         }
     }
-
-    /// Shutdown single-attempt flush; never uses the steady-state retry
-    /// budget. Render failures route per-event to DLQ as before, partial
-    /// successes are honoured (the rejected tail goes to DLQ with the
-    /// `partial_success` reason — distinct from transport failure),
-    /// and the shippable subset gets one `send_batch` call wrapped in
-    /// `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The `shippable` vector is held
-    /// in this frame across the `timeout()` boundary so an `Elapsed`
-    /// outcome does NOT drop it — otherwise the inner handles would
-    /// fire `QueueAckHandle::Drop` and be counted as silent loss.
-    async fn flush_events_at_shutdown(&self, batch: Vec<(Event, QueueAckHandle)>) {
-        if batch.is_empty() {
-            return;
-        }
-        let mut payloads: Vec<Bytes> = Vec::with_capacity(batch.len());
-        let mut shippable: Vec<(Event, QueueAckHandle)> = Vec::with_capacity(batch.len());
-        let mut render_failures: Vec<(Event, QueueAckHandle, anyhow::Error)> = Vec::new();
-        for (ev, ack) in batch {
-            match render_event(&ev) {
-                Ok(p) => {
-                    payloads.push(p);
-                    shippable.push((ev, ack));
-                }
-                Err(e) => render_failures.push((ev, ack, e)),
-            }
-        }
-        for (ev, ack, err) in render_failures {
-            let reason = format!("render failed during shutdown flush: {}", err);
-            crate::modules::route_event_to_dlq(self.error_log.as_ref(), &self.name, &ev, &reason)
-                .await;
-            self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-            ack.resolve_recovered();
-        }
-        if payloads.is_empty() {
-            return;
-        }
-        let count = shippable.len() as u64;
-        let send_outcome = tokio::time::timeout(
-            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-            send_batch(self, payloads),
-        )
-        .await;
-        match send_outcome {
-            Ok(Ok(outcome)) => {
-                let rejected = outcome.rejected.min(count);
-                let written = count - rejected;
-                if written > 0 {
-                    self.metrics
-                        .events_written
-                        .fetch_add(written, Ordering::Relaxed);
-                }
-                if rejected > 0 {
-                    self.metrics
-                        .events_failed
-                        .fetch_add(rejected, Ordering::Relaxed);
-                }
-                let split = (count - rejected) as usize;
-                let mut iter = shippable.into_iter();
-                for (_, ack) in iter.by_ref().take(split) {
-                    ack.resolve_delivered();
-                }
-                for (ev, ack) in iter {
-                    let reason = "collector reported partial_success rejection".to_string();
-                    crate::modules::route_event_to_dlq(
-                        self.error_log.as_ref(),
-                        &self.name,
-                        &ev,
-                        &reason,
-                    )
-                    .await;
-                    ack.resolve_recovered();
-                }
-            }
-            Ok(Err(send_err)) => {
-                let err = anyhow::anyhow!("transport error: {}", send_err);
-                crate::modules::route_shutdown_batch_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    shippable,
-                    &err,
-                )
-                .await;
-            }
-            Err(_elapsed) => {
-                let err = anyhow::anyhow!(
-                    "deadline exceeded after {:?} during shutdown flush",
-                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
-                );
-                crate::modules::route_shutdown_batch_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    shippable,
-                    &err,
-                )
-                .await;
-            }
-        }
-    }
-}
-
-/// Render a single Event into its OTLP `ResourceLogs` proto bytes —
-/// just a refcount bump on `event.egress`. Called from the
-/// consumer-side flush path on an owned `Event`, so no borrowed-view
-/// arena setup is required.
-fn render_event(event: &Event) -> Result<Bytes> {
-    Ok(event.egress.clone())
-}
-
-impl Drop for OtlpHttpOutput {
-    fn drop(&mut self) {
-        // Signal cooperatively before falling back to abort; see
-        // `http::HttpOutput::drop` for rationale.
-        self.inner.is_shutting_down.store(true, Ordering::Release);
-        self.inner.flush_notify.notify_waiters();
-        if let Some(h) = self.actor_handle.get_mut().take() {
-            h.abort();
-        }
-        if let Ok(buf) = self.inner.batch.try_lock()
-            && !buf.is_empty()
-        {
-            tracing::warn!(
-                "otlp_http output: {} events in buffer at shutdown (will be re-delivered from queue)",
-                buf.len()
-            );
-        }
-    }
-}
-
-async fn send_batch(inner: &Inner, drained: Vec<Bytes>) -> Result<super::SendOutcome> {
-    let req = decode_drained_to_request(drained, inner.batch_level)?;
-
-    let cfg = &inner.retry_config;
-    let max_attempts = cfg.max_attempts.max(1);
-    let mut attempt = 0u32;
-    let mut wait = cfg.initial_wait;
-
-    let final_err = loop {
-        // One candidate per attempt; see `RotatingPeers` for the
-        // selection + cooldown contract (cooldown is measured from
-        // failure time so a slow 30s HTTP_REQUEST_TIMEOUT failure
-        // cannot record an already-expired cooldown).
-        let idx = inner.rotation.select().await;
-        let err = match send_once(&inner.peers[idx], inner, &req).await {
-            Ok(outcome) => {
-                inner.rotation.mark_success(idx).await;
-                return Ok(outcome);
-            }
-            Err(e) => {
-                inner.rotation.mark_failure(idx).await;
-                e
-            }
-        };
-        if attempt + 1 >= max_attempts {
-            break err;
-        }
-        // Cooperative shutdown cancel: see http.rs::flush_events.
-        if inner.is_shutting_down.load(Ordering::Acquire) {
-            break err;
-        }
-        attempt += 1;
-        tracing::warn!(
-            "otlp_http output: ship attempt {}/{} failed: {} — retrying in {:?}",
-            attempt,
-            max_attempts,
-            err,
-            wait,
-        );
-        // Race the sleep against a shutdown wake — see http.rs.
-        tokio::select! {
-            _ = tokio::time::sleep(wait) => {}
-            _ = inner.flush_notify.notified() => {}
-        }
-        if matches!(cfg.backoff, BackoffStrategy::Exponential) {
-            // saturating_mul is the safe doubling: `Duration * 2`
-            // panics on overflow (~584 years), and while the practical
-            // reach of that limit is "never", making the bound
-            // explicit is the defensive choice — `.min(max_wait)` then
-            // clamps back to the configured ceiling.
-            wait = wait.saturating_mul(2).min(cfg.max_wait);
-        }
-    };
-    Err(final_err)
 }
 
 async fn send_once(
     peer: &HttpPeer,
-    inner: &Inner,
+    policy: &OtlpHttpSinkPolicy,
     req: &ExportLogsServiceRequest,
-) -> Result<super::SendOutcome> {
-    let body = match inner.protocol {
+) -> Result<SendOutcome> {
+    let body = match policy.protocol {
         HttpProtocol::Protobuf => {
             let mut buf = Vec::with_capacity(req.encoded_len());
             req.encode(&mut buf)
@@ -880,9 +504,9 @@ async fn send_once(
     let mut http_req = peer
         .client
         .post(&peer.endpoint)
-        .header("Content-Type", inner.protocol.content_type())
+        .header("Content-Type", policy.protocol.content_type())
         .body(body);
-    for (k, v) in &inner.headers {
+    for (k, v) in &policy.headers {
         http_req = http_req.header(k, v);
     }
     let resp = http_req
@@ -923,7 +547,7 @@ async fn send_once(
     let rejected = if body_bytes.is_empty() {
         0
     } else {
-        let parsed = match inner.protocol {
+        let parsed = match policy.protocol {
             HttpProtocol::Protobuf => ExportLogsServiceResponse::decode(&*body_bytes).ok(),
             HttpProtocol::Json => {
                 serde_json::from_slice::<ExportLogsServiceResponse>(&body_bytes).ok()
@@ -950,7 +574,7 @@ async fn send_once(
         }
         r
     };
-    Ok(super::SendOutcome { rejected })
+    Ok(SendOutcome { rejected })
 }
 
 #[cfg(test)]
@@ -962,7 +586,8 @@ mod tests {
     use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
     use opentelemetry_proto::tonic::resource::v1::Resource;
     use std::net::SocketAddr;
-    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
 
     fn mp(props: &[Property]) -> crate::dsl::module_props::ModuleProperties {
         crate::dsl::module_props::ModuleProperties::from_parts("otlp_http", props.to_vec())
@@ -1117,8 +742,11 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
-        assert_eq!(output.inner.peers[0].endpoint, "http://x:4318/v1/logs");
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
+        assert_eq!(
+            output.sink.inner.policy.peers[0].endpoint,
+            "http://x:4318/v1/logs"
+        );
     }
 
     #[test]
@@ -1159,7 +787,10 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert!(matches!(output.inner.protocol, HttpProtocol::Protobuf));
+        assert!(matches!(
+            output.sink.inner.policy.protocol,
+            HttpProtocol::Protobuf
+        ));
     }
 
     #[test]
@@ -1184,7 +815,10 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert!(matches!(output.inner.batch_level, BatchLevel::None));
+        assert!(matches!(
+            output.sink.inner.policy.batch_level,
+            BatchLevel::None
+        ));
     }
 
     #[test]
@@ -1195,7 +829,7 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.batch_size, 1);
+        assert_eq!(output.sink.batch_size, 1);
     }
 
     #[test]
@@ -1211,9 +845,9 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 3);
-        assert_eq!(output.inner.peers[0].endpoint, "http://a");
-        assert_eq!(output.inner.peers[2].endpoint, "http://c");
+        assert_eq!(output.sink.inner.policy.peers.len(), 3);
+        assert_eq!(output.sink.inner.policy.peers[0].endpoint, "http://a");
+        assert_eq!(output.sink.inner.policy.peers[2].endpoint, "http://c");
     }
 
     #[test]
@@ -1258,9 +892,9 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.retry_config.max_attempts, 2);
+        assert_eq!(output.sink.inner.retry.max_attempts, 2);
         assert_eq!(
-            output.inner.retry_config.initial_wait,
+            output.sink.inner.retry.initial_wait,
             Duration::from_millis(100)
         );
     }
@@ -1818,7 +1452,7 @@ def output o {{
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .unwrap();
-        let actor_spawned = output.actor_handle.lock().await.is_some();
+        let actor_spawned = output.sink.actor_handle.lock().await.is_some();
         assert!(
             actor_spawned,
             "flusher actor must be spawned on construction"
@@ -1846,9 +1480,9 @@ def output o {{
         consume(&output, &event_with_egress(singleton_bytes(1)))
             .await
             .expect("buffering a single event must succeed");
-        let batch_len = output.inner.batch.lock().await.len();
+        let batch_len = output.sink.inner.batch.lock().await.len();
         assert_eq!(batch_len, 1, "event must sit in the buffer");
-        let actor_spawned = output.actor_handle.lock().await.is_some();
+        let actor_spawned = output.sink.actor_handle.lock().await.is_some();
         assert!(
             actor_spawned,
             "the long-lived flusher actor must be available to drain on batch_timeout or notify"
@@ -1901,7 +1535,7 @@ def output o {{
             Some((_, crate::queue::AckDisposition::Recovered))
         ));
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             0,
             "buffer must be empty — handles already resolved",
         );
@@ -1939,7 +1573,7 @@ def output o {{
                 .unwrap();
         }
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             2,
             "writes must land in the buffer (batch_size and timer both far away)"
         );
@@ -1948,7 +1582,7 @@ def output o {{
         output.shutdown(None).await.unwrap();
 
         assert_eq!(
-            output.inner.batch.lock().await.len(),
+            output.sink.inner.batch.lock().await.len(),
             0,
             "shutdown() must drain the buffer"
         );
@@ -2119,7 +1753,7 @@ def output o {{
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        assert_eq!(output.inner.peers.len(), 1);
+        assert_eq!(output.sink.inner.policy.peers.len(), 1);
     }
 
     // -----------------------------------------------------------------------
@@ -2151,7 +1785,7 @@ def output o {{
                 .await
                 .unwrap();
         }
-        assert_eq!(output.inner.batch.lock().await.len(), 2);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 2);
     }
 
     #[tokio::test]
@@ -2168,7 +1802,7 @@ def output o {{
         buffer_two(&output).await;
 
         output.shutdown(Some(&writer)).await.unwrap();
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
 
         let body = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = body.lines().collect();
@@ -2202,7 +1836,7 @@ def output o {{
         buffer_two(&output).await;
 
         output.shutdown(None).await.expect("shutdown is infallible");
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
     }
 
     #[tokio::test]
@@ -2252,7 +1886,7 @@ def output o {{
             std::path::PathBuf::from("/nonexistent/limpid-otlp-http-test/errored.jsonl"),
         ));
         output.shutdown(Some(&writer)).await.unwrap();
-        assert_eq!(output.inner.batch.lock().await.len(), 0);
+        assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
     }
 
     /// Constructor-time error_log injection — see the matching test
@@ -2274,6 +1908,7 @@ def output o {{
         )
         .unwrap();
         let stored = output
+            .sink
             .inner
             .error_log
             .as_ref()

--- a/crates/limpid/src/modules/output/otlp/mod.rs
+++ b/crates/limpid/src/modules/output/otlp/mod.rs
@@ -47,20 +47,10 @@ use opentelemetry_proto::tonic::{
 };
 use prost::Message;
 
-/// Transport-success outcome from a single OTLP export call.
-///
-/// `rejected` is the number of LogRecords the receiver acknowledged
-/// as not-stored via OTLP's `partial_success.rejected_log_records`.
-/// The HTTP 2xx / gRPC OK is still a transport success — the receiver
-/// processed the request, it just refused some records (typically
-/// quota / schema / size violations). limpid does not retry rejected
-/// records (selective re-send is queued for a later release); the
-/// counter split lets `events_failed` reflect the data loss so
-/// operator dashboards stay accurate.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct SendOutcome {
-    pub rejected: u64,
-}
+// The per-export `SendOutcome` (partial-success rejected count) lives
+// in `crate::modules::output::batched` — it is the shared batched-sink
+// vocabulary, not an OTLP-only concept (plain HTTP reports
+// `rejected: 0`).
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BatchLevel {

--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -330,6 +330,82 @@ impl<C> PeerList<C> {
     }
 }
 
+/// Cursor-driven single-candidate peer rotation with per-peer failure
+/// cooldown. Shared by the batched HTTP / OTLP outputs, whose retry
+/// loop wants exactly one candidate per send attempt (`select` →
+/// attempt → `mark_success` / `mark_failure`).
+///
+/// This is deliberately NOT merged with [`PeerList::write_with_rotation_at`]:
+/// that helper tries *every* available peer within one call and owns
+/// the per-peer connection state, while this type hands out one index
+/// at a time and leaves the transport attempt to the caller — the
+/// batched outputs' retry budget (not the rotation) is what drives
+/// re-attempts there.
+pub struct RotatingPeers {
+    /// Round-robin cursor. Incremented per selection so successive
+    /// sends start at successive peers.
+    cursor: AtomicUsize,
+    /// Per-peer cooldown expiry. Same length as the caller's peer
+    /// list. Wrapped in `Mutex` because `Instant` is not
+    /// `Copy`-loadable from an atomic — but contention is low (one
+    /// short critical section per send per peer).
+    cooldown_until: Vec<Mutex<Option<Instant>>>,
+}
+
+impl RotatingPeers {
+    /// `len` is the number of peers; must be at least 1 (every
+    /// caller's config layer already rejects empty peer lists).
+    pub fn new(len: usize) -> Self {
+        Self {
+            cursor: AtomicUsize::new(0),
+            cooldown_until: (0..len).map(|_| Mutex::new(None)).collect(),
+        }
+    }
+
+    /// Pick the next candidate: rotation starts at the cursor and
+    /// walks forward looking for a peer whose cooldown has expired.
+    /// If every peer is currently cooled (typical single-peer retry
+    /// path: the peer just failed on the previous attempt) fall back
+    /// to the rotation start — the caller's retry budget is what
+    /// protects us, not the cooldown. The cooldown's actual job is to
+    /// bias *future sends* away from a known-bad peer when an
+    /// alternative exists.
+    pub async fn select(&self) -> usize {
+        let n = self.cooldown_until.len();
+        let start = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
+        let now = Instant::now();
+        for offset in 0..n {
+            let candidate = (start + offset) % n;
+            let guard = self.cooldown_until[candidate].lock().await;
+            if guard.is_none_or(|until| until <= now) {
+                return candidate;
+            }
+        }
+        start
+    }
+
+    /// Reset the peer's cooldown so future selections pick it freely.
+    pub async fn mark_success(&self, idx: usize) {
+        *self.cooldown_until[idx].lock().await = None;
+    }
+
+    /// Cool the peer down for `PEER_COOLDOWN`, measured from *failure
+    /// time*, not selection time: the transport attempt may take up
+    /// to its request timeout (30s for the HTTP/OTLP outputs), which
+    /// is longer than `PEER_COOLDOWN` (5s) — anchoring on the
+    /// selection-time `Instant` could record an already-expired
+    /// cooldown and immediately reselect the same bad peer.
+    pub async fn mark_failure(&self, idx: usize) {
+        *self.cooldown_until[idx].lock().await = Some(Instant::now() + PEER_COOLDOWN);
+    }
+
+    /// Test-only view of a peer's cooldown expiry.
+    #[cfg(test)]
+    pub async fn cooldown_until(&self, idx: usize) -> Option<Instant> {
+        *self.cooldown_until[idx].lock().await
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum PeerSendError {
     #[error("no peers configured")]
@@ -595,6 +671,37 @@ mod tests {
                 .load(Ordering::Relaxed),
             2
         );
+    }
+
+    #[tokio::test]
+    async fn rotating_peers_round_robin_and_cooldown_skip() {
+        let rot = RotatingPeers::new(3);
+        // Cursor-driven rotation: successive selects walk the ring.
+        assert_eq!(rot.select().await, 0);
+        assert_eq!(rot.select().await, 1);
+        assert_eq!(rot.select().await, 2);
+        // Cool peer 0 down: the next rotation start (cursor = 0)
+        // skips it and lands on peer 1.
+        rot.mark_failure(0).await;
+        assert_eq!(rot.select().await, 1);
+        // Success resets the cooldown; peer 0 is selectable again.
+        rot.mark_success(0).await;
+        assert_eq!(rot.select().await, 1); // cursor = 1
+        assert_eq!(rot.select().await, 2); // cursor = 2
+        assert_eq!(rot.select().await, 0); // cursor = 0, no cooldown
+    }
+
+    #[tokio::test]
+    async fn rotating_peers_falls_back_to_rotation_start_when_all_cooled() {
+        // Single-peer retry path: the peer just failed, so every peer
+        // is cooled — select must still hand out a candidate (the
+        // rotation start), leaving re-attempt pacing to the caller's
+        // retry budget.
+        let rot = RotatingPeers::new(2);
+        rot.mark_failure(0).await;
+        rot.mark_failure(1).await;
+        assert_eq!(rot.select().await, 0);
+        assert_eq!(rot.select().await, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Extract `RotatingPeers` in `syslog_peers.rs` — a small "one candidate per attempt" cursor + cooldown type, distinct from the existing `PeerList` (which tries every peer in one call). Both are honest coupling seams, not one over-DRY'd behind the other.
- Extract the actor skeleton shared by `output http`, `output otlp_http`, and `output otlp_grpc` into `modules/output/batched.rs` behind a `BatchSinkPolicy` trait. Buffer, `flush_notify`, `is_shutting_down`, actor spawn, threshold/timer/shutdown race, retry loop, cooperative shutdown 3-step, `Drop`, `flush_events_at_shutdown`, per-event DLQ routing, and metrics counting all live in the skeleton. The three policies contribute only `render` / `prepare` / `send`.
- Honest-coupling seams kept on the policy side: http's gzip in `prepare`, OTLP's partial-success accounting via `SendOutcome.rejected`, gRPC's `GRPC_REQUEST_TIMEOUT`. Attempt-level shutdown race is unified across all three — a strict improvement for gRPC (previously only checked between attempts). Preserved gzip is now per-flush instead of per-attempt (idempotent, so wire-observable behaviour unchanged).
- Follow-up fixes surfaced during audit:
  - Dead references to the removed `send_batch` method (11 comments / test docs) pointed at methods that no longer exist. Repointed at the actual `send` / `flush_events` names.
  - `otlp_http` used to load `tls.ca` unconditionally, so `verify false` + an unreadable CA hard-failed at `from_properties`. It now warns and skips CA loading when verification is off, matching `output http`'s existing surface. Pinned with a new regression test (`verify_false_ignores_unreadable_tls_ca`).

## Test plan
- [x] cargo build/test/clippy/fmt all pass (722+27+2+14 tests)
- [x] Verify-false e2e regression tests (rebased onto the new `sink.inner.policy.{send, peers}` path) still catch the reqwest client toggle
- [x] uchgs push-gate audit (8 scopes, iterated once for the otlp_http CA parity finding) — 6 pass, 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this refactor