### PR TITLE
packaging: drop redundant ReadWritePaths entries

### DIFF
--- a/docs/src/operations/packaging.md
+++ b/docs/src/operations/packaging.md
@@ -84,7 +84,8 @@ ReadWritePaths=/var/log/limpid
 - `ProtectSystem=strict` makes the filesystem read-only except for explicitly allowed paths
 - `RuntimeDirectory=limpid` ensures `/var/run/limpid/` exists for the control socket
 - `ExecReload=/bin/kill -HUP $MAINPID` triggers hot reload via SIGHUP
-- `ReadWritePaths` covers only this daemon's own state/log directories; `PrivateDevices=yes` means a `/dev/log` `unix_socket` input needs a `PrivateDevices=no` drop-in (see [systemd](./systemd.md#adding-write-paths))
+- `StateDirectory=limpid` and `RuntimeDirectory=limpid` provide `/var/lib/limpid` and `/var/run/limpid` writable; `ReadWritePaths=/var/log/limpid` covers the log directory. Operators using the `file` output to write elsewhere add a drop-in with the extra path.
+- `PrivateDevices=yes` means a `/dev/log` `unix_socket` input needs a `PrivateDevices=no` drop-in (see [systemd](./systemd.md#adding-write-paths))
 
 See [systemd](./systemd.md) for operational details.
 

--- a/docs/src/operations/packaging.md
+++ b/docs/src/operations/packaging.md
@@ -77,7 +77,7 @@ PrivateTmp=yes
 PrivateDevices=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 SystemCallFilter=@system-service
-ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid
+ReadWritePaths=/var/log/limpid
 ```
 
 - `CAP_NET_BIND_SERVICE` allows binding to privileged ports (514) without root

--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -46,7 +46,7 @@ RestrictSUIDSGID=yes
 LockPersonality=yes
 SystemCallFilter=@system-service
 UMask=0027
-ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid
+ReadWritePaths=/var/log/limpid
 
 [Install]
 WantedBy=multi-user.target
@@ -149,7 +149,7 @@ If your file outputs write to directories outside the defaults, add them to `Rea
 ```ini
 # /etc/systemd/system/limpid.service.d/override.conf
 [Service]
-ReadWritePaths=/var/log/limpid /path/to/other/output/dir
+ReadWritePaths=/path/to/other/output/dir
 ```
 
 If you configure a `unix_socket` input at `/dev/log` as a syslog(3) replacement, `PrivateDevices=yes` isolates limpid's socket in a private `/dev` that host processes writing to `/dev/log` can't reach — `BindPaths` doesn't fix this, since limpid *creates* the socket rather than connecting to an existing one. Disable device isolation for this unit instead:

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -106,14 +106,16 @@ UMask=0027
 # The control socket is created with explicit 0o660 permissions in
 # control.rs (see crates/limpid/src/control.rs:135,
 # std::fs::set_permissions after bind), so UMask does not affect it.
-ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid
-# Only /var/log/limpid (this daemon's own log directory) is writable by
-# default; ProtectSystem=strict makes the rest of the filesystem
-# read-only. Operators using the `file` output to write elsewhere must
-# add a drop-in, e.g.:
+# `StateDirectory=limpid` and `RuntimeDirectory=limpid` above already
+# mount `/var/lib/limpid` and `/var/run/limpid` writable under
+# ProtectSystem=strict, so listing them here would be redundant. Only
+# `/var/log/limpid` needs an explicit ReadWritePaths entry — the rest
+# of the filesystem stays read-only. Operators using the `file` output
+# to write elsewhere must add a drop-in, e.g.:
 #   /etc/systemd/system/limpid.service.d/override.conf:
 #     [Service]
-#     ReadWritePaths=/var/log/limpid /path/to/other/output/dir
+#     ReadWritePaths=/path/to/other/output/dir
+ReadWritePaths=/var/log/limpid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Code-quality follow-up from PR #92. `ReadWritePaths=/var/lib/limpid /var/run/limpid /var/log/limpid` listed three paths, but `StateDirectory=limpid` and `RuntimeDirectory=limpid` already make `/var/lib/limpid` and `/var/run/limpid` writable under `ProtectSystem=strict`. The neighbouring comment even claimed "only /var/log/limpid is writable by default" — directly contradicting the three-path declaration.
- Narrow `ReadWritePaths` to `/var/log/limpid` so unit and comment agree, and sync the docs' unit example and bullet alongside. No behavior change: systemd was already granting writable access to the state and runtime dirs via the `*Directory=` directives.

## Test plan
- [x] cargo build/clippy/fmt all pass (docs/unit change only, no code paths affected)
- [x] uchgs push-gate audit (8 scopes, iterated once for a companion docs bullet in packaging.md) — 6 pass, 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this change