### PR TITLE
fix(error_log): await shutdown() so DLQ writes are visible on return

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -226,8 +226,8 @@ pub struct ErrorLogWriter {
     /// Serialises concurrent `write()` calls so that records from
     /// different pipeline workers cannot interleave when a single
     /// JSONL line exceeds `PIPE_BUF`. The lock is held only across
-    /// the open + write_all sequence — not around `to_jsonl()` which
-    /// is pure CPU work.
+    /// the open + write_all + shutdown sequence — not around
+    /// `to_jsonl()` which is pure CPU work.
     write_lock: Mutex<()>,
 }
 
@@ -278,6 +278,17 @@ impl ErrorLogWriter {
     /// Append one JSONL record for `ctx`. Errors here are surfaced to
     /// the caller (runtime layer) which counts them in
     /// `events_errored_unwritable` and falls back to tracing.
+    ///
+    /// The trailing `shutdown().await` closes the underlying handle
+    /// synchronously with this future rather than leaving it to
+    /// `Drop`. `tokio::fs::File`'s `Drop` fires the close on the
+    /// blocking pool and returns immediately, so without an explicit
+    /// shutdown a caller that observes `write()` returning `Ok(())` is
+    /// not guaranteed the record is visible to a subsequent open/read
+    /// on another task — the flake this closes surfaced exactly that
+    /// way in CI, where a subsequent `tokio::fs::read_to_string`
+    /// occasionally saw an empty file. Shutdown-then-drop also nudges
+    /// the file toward on-disk durability, which matters for a DLQ.
     pub async fn write(&self, ctx: &ErroredEventContext) -> Result<()> {
         let mut line = ctx.to_jsonl();
         line.push('\n');
@@ -291,6 +302,9 @@ impl ErrorLogWriter {
         f.write_all(line.as_bytes())
             .await
             .with_context(|| format!("error_log: failed to write to {}", self.path.display()))?;
+        f.shutdown()
+            .await
+            .with_context(|| format!("error_log: failed to close {}", self.path.display()))?;
         Ok(())
     }
 }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -904,10 +904,11 @@ mod tests {
         write_errored_to_dlq(&err_ctx, &metrics, Some(&writer)).await;
 
         // Errored counter is bumped at the caller (worker.metrics);
-        // the helper itself only writes. Verify the JSONL is on
-        // disk. Use the async reader to share tokio's view of the
-        // file — the synchronous std::fs::read can race the async
-        // close on a busier CI scheduler.
+        // the helper itself only writes. Verify the JSONL is on disk.
+        // `ErrorLogWriter::write` now awaits `shutdown()` on the file
+        // handle before returning, so the record is visible by the
+        // time the helper's future resolves — but keep the async
+        // reader for symmetry with the runtime path.
         let contents = tokio::fs::read_to_string(&log_path).await.unwrap();
         assert!(
             contents.contains("simulated runtime error"),


### PR DESCRIPTION
## Summary
Permanent fix for the `write_errored_to_dlq_writes_to_configured_error_log` CI flake (previously narrowed by `d3e9e35` but not closed).

- `tokio::fs::File`'s `Drop` fires the underlying close on the blocking pool and returns immediately — no await, no synchronisation with the current future. That leaves a window where `write()` has awaited `write_all()` and returned `Ok(())`, but a subsequent open/read on another task can still see an empty file until the deferred close lands. Under CI load this was surfacing as an empty read on the just-written JSONL.
- Await `f.shutdown()` before dropping the handle. After this change `write()`'s completion actually means "the record is on disk and any subsequent open sees it". For a DLQ that also nudges the record toward durability across a crash — a strictly desirable property.
- The internal `Mutex` already serialises open + write, so the extra await stays inside the same critical section and doesn't reduce concurrency. Comment on the mutex updated to include `shutdown` in the sequence it guards. Runtime-side test comment refreshed to reflect the new visibility guarantee.

## Test plan
- [x] cargo build/test/clippy/fmt all pass (722+27+2+14)
- [x] `write_errored_to_dlq_writes_to_configured_error_log` looped 50× under a full-workspace test run — pass rate 50/50, no regression in other tests. Locally the flake was hard to reproduce (Linux CI scheduler was the observable trigger), so the correctness argument is code-analytical; CI runs on this PR will provide the additional data point.
- [x] uchgs push-gate audit (8 scopes) — 6 pass with boundary-contract and security specifically reviewed for the completion-contract strengthening, 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this change