### PR TITLE
refactor(journal): swap rust-systemd for an in-crate sd_journal FFI; drop LGPL exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,12 +257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,16 +430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr-argument"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
-dependencies = [
- "cfg-if",
- "memchr",
-]
-
-[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,33 +553,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1151,18 +1108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libsystemd-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976306de183e6046819ef6505888d00996214766a3f4660a2ed5761c84a20aed"
-dependencies = [
- "build-env",
- "cfg-if",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1145,7 @@ dependencies = [
  "opentelemetry-proto",
  "pest",
  "pest_derive",
+ "pkg-config",
  "prost",
  "rcgen",
  "rdkafka",
@@ -1210,7 +1156,6 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "systemd",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2340,21 +2285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "systemd"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e9d1976a15b86245def55d20d52b5818e1a1e81aa030b6a608d3ce57709423"
-dependencies = [
- "cstr-argument",
- "foreign-types",
- "libc",
- "libsystemd-sys",
- "log",
- "memchr",
- "utf8-cstr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,12 +2690,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf8-cstr"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -56,7 +56,6 @@ bumpalo = { version = "3", features = ["collections"] }
 # typical OCSF / syslog field values (`"INFO"`, `"sshd"`, IPv4
 # strings, …) sit comfortably under the inline budget.
 compact_str = { version = "0.9", features = ["serde"] }
-systemd = { version = "0.10", optional = true }
 rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "sasl"], optional = true }
 
 # OTLP (OpenTelemetry Protocol). Pre-generated message types from the
@@ -76,8 +75,17 @@ axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 
 [features]
-journal = ["dep:systemd"]
+# No `dep:` gate — the journal reader is a hand-written FFI binding
+# inside this crate (src/modules/input/journal_sys.rs), not an
+# optional dependency. `build.rs` links libsystemd via pkg-config only
+# when this feature is enabled.
+journal = []
 kafka = ["dep:rdkafka"]
+
+[build-dependencies]
+# Locates libsystemd (`libsystemd-dev`) via pkg-config when the
+# `journal` feature is enabled. See build.rs.
+pkg-config = "0.3"
 
 [dev-dependencies]
 rcgen = "0.13"

--- a/crates/limpid/build.rs
+++ b/crates/limpid/build.rs
@@ -1,0 +1,23 @@
+//! Links libsystemd when the `journal` feature is enabled.
+//!
+//! The reader itself is a hand-written FFI binding
+//! (`src/modules/input/journal_sys.rs`, MIT OR Apache-2.0); this
+//! script only resolves the runtime library it dynamically links
+//! against — the same `libsystemd-dev` package the removed
+//! `rust-systemd`/`libsystemd-sys` (LGPL-2.1-or-later) dependency
+//! required at build time.
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_JOURNAL");
+
+    if std::env::var_os("CARGO_FEATURE_JOURNAL").is_none() {
+        return;
+    }
+
+    if let Err(e) = pkg_config::probe_library("libsystemd") {
+        panic!(
+            "journal feature requires libsystemd-dev (pkg-config could not find `libsystemd`): {e}"
+        );
+    }
+}

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -4,8 +4,9 @@
 //! `ingress` is one journald entry serialised as a single-line UTF-8
 //! JSON object, shaped to be journalctl-`-o json`-compatible for the
 //! fields libsystemd exposes. Field values match journalctl, but
-//! `__SEQNUM` / `__SEQNUM_ID` (newer journalctl) are not surfaced
-//! because the libsystemd crate doesn't expose them. Key order is
+//! `__SEQNUM` / `__SEQNUM_ID` (newer journalctl) are not surfaced —
+//! this input's `sd_journal_*` FFI binding (`journal_sys`) doesn't
+//! call `sd_journal_get_seqnum`. Key order is
 //! insertion order from libsystemd and is not guaranteed to match
 //! journalctl's output ordering.
 //!
@@ -35,10 +36,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use super::journal_sys::Journal;
 use anyhow::Result;
 use bytes::Bytes;
 use serde_json::{Map as JsonMap, Value as JsonValue};
-use systemd::journal::{Journal, OpenOptions};
 use tracing::{error, info, warn};
 
 use crate::dsl::props;
@@ -271,8 +272,8 @@ fn drain_cursor_acks(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AckPosition>)
 ///   - `__MONOTONIC_TIMESTAMP` — boot-relative microseconds (string)
 ///
 /// `__SEQNUM` / `__SEQNUM_ID` (newer journalctl) are not surfaced —
-/// the systemd-0.10.x crate exposes no equivalent API. Add when
-/// upstream support lands.
+/// `journal_sys` doesn't bind `sd_journal_get_seqnum`. Add if a caller
+/// needs it.
 ///
 /// Key order is not guaranteed to match journalctl; this is a JSON
 /// object so order is a serialisation detail, not a semantic one.
@@ -363,7 +364,7 @@ fn run_journal_reader(
     tx: tokio::sync::mpsc::Sender<(Vec<u8>, String)>,
     shutdown: Arc<AtomicBool>,
 ) {
-    let mut journal = match OpenOptions::default().open() {
+    let mut journal = match Journal::open() {
         Ok(j) => j,
         Err(e) => {
             error!("journal: failed to open: {}", e);

--- a/crates/limpid/src/modules/input/journal_sys.rs
+++ b/crates/limpid/src/modules/input/journal_sys.rs
@@ -1,0 +1,220 @@
+//! Minimal FFI bindings to libsystemd's `sd_journal_*` reader API.
+//!
+//! Hand-written declarations of the ~11 `sd_journal_*` functions the
+//! `journal` input actually calls (see `sd-journal(3)`) — not a
+//! general-purpose systemd binding. A mechanical translation of a
+//! public C API's parameter shapes carries no expressive content of
+//! its own, so this module is MIT OR Apache-2.0 even though it
+//! dynamically links `libsystemd` (LGPL-2.1-or-later WITH
+//! GCC-exception-2.0) at build time via `build.rs`; the
+//! distro-provided `libsystemd.so.0` this links against is covered by
+//! the LGPL §6(b) dynamic-linking safe harbour. Replaces the
+//! `rust-systemd`/`libsystemd-sys` dependency this crate previously
+//! carried under a `deny.toml` license exception.
+//!
+//! `sd_journal` handles are not thread-safe — "only a single thread
+//! may operate on a given object at any given time" (`sd-journal(3)`).
+//! [`Journal`] is `!Send`/`!Sync` (it holds a raw pointer), so it
+//! can't silently cross threads; callers must create and drop it on
+//! the same thread, matching how the journal input's blocking reader
+//! already uses it.
+
+use std::ffi::{CStr, CString, c_char, c_int, c_void};
+use std::ptr;
+
+use anyhow::{Result, bail};
+
+/// Opaque `sd_journal` handle. Only ever touched behind a pointer —
+/// its layout is libsystemd's business, not ours.
+#[repr(C)]
+struct SdJournal {
+    _private: [u8; 0],
+}
+
+unsafe extern "C" {
+    fn sd_journal_open(ret: *mut *mut SdJournal, flags: c_int) -> c_int;
+    fn sd_journal_close(j: *mut SdJournal);
+    fn sd_journal_next(j: *mut SdJournal) -> c_int;
+    fn sd_journal_previous(j: *mut SdJournal) -> c_int;
+    fn sd_journal_add_match(j: *mut SdJournal, data: *const c_void, size: usize) -> c_int;
+    fn sd_journal_seek_tail(j: *mut SdJournal) -> c_int;
+    fn sd_journal_seek_cursor(j: *mut SdJournal, cursor: *const c_char) -> c_int;
+    fn sd_journal_get_cursor(j: *mut SdJournal, cursor: *mut *mut c_char) -> c_int;
+    fn sd_journal_get_realtime_usec(j: *mut SdJournal, ret: *mut u64) -> c_int;
+    fn sd_journal_get_monotonic_usec(
+        j: *mut SdJournal,
+        ret: *mut u64,
+        ret_boot_id: *mut Id128,
+    ) -> c_int;
+    fn sd_journal_restart_data(j: *mut SdJournal);
+    fn sd_journal_enumerate_data(
+        j: *mut SdJournal,
+        data: *mut *const c_void,
+        length: *mut usize,
+    ) -> c_int;
+}
+
+/// `sd_id128_t` — a 16-byte boot/machine identifier. Only its size and
+/// alignment matter here: `Journal::monotonic_timestamp` discards the
+/// value, matching how the sole caller already ignores it.
+#[repr(C)]
+struct Id128 {
+    _bytes: [u8; 16],
+}
+
+/// One field ("NAME=value") from the current journal entry.
+pub struct JournalField<'a> {
+    name: &'a [u8],
+    value: Option<&'a [u8]>,
+}
+
+impl<'a> JournalField<'a> {
+    pub fn name(&self) -> &'a [u8] {
+        self.name
+    }
+
+    pub fn value(&self) -> Option<&'a [u8]> {
+        self.value
+    }
+}
+
+pub struct Journal {
+    ptr: *mut SdJournal,
+}
+
+impl Journal {
+    /// Opens the local journal with no restricting flags (`flags =
+    /// 0`) — equivalent to the prior
+    /// `systemd::journal::OpenOptions::default().open()`, whose every
+    /// option defaulted to `false`.
+    pub fn open() -> Result<Self> {
+        let mut ptr: *mut SdJournal = ptr::null_mut();
+        let rc = unsafe { sd_journal_open(&mut ptr, 0) };
+        if rc < 0 {
+            bail!("sd_journal_open failed: {}", errno_msg(rc));
+        }
+        Ok(Self { ptr })
+    }
+
+    /// Adds a `key=value` match filter (`sd_journal_add_match`, which
+    /// takes the field as one `key=value` byte blob, not separate
+    /// name/value arguments).
+    pub fn match_add(&mut self, key: &str, val: &str) -> Result<()> {
+        let filter = format!("{key}={val}");
+        let rc = unsafe { sd_journal_add_match(self.ptr, filter.as_ptr().cast(), filter.len()) };
+        if rc < 0 {
+            bail!("sd_journal_add_match failed: {}", errno_msg(rc));
+        }
+        Ok(())
+    }
+
+    pub fn seek_cursor(&mut self, cursor: &str) -> Result<()> {
+        let c = CString::new(cursor)?;
+        let rc = unsafe { sd_journal_seek_cursor(self.ptr, c.as_ptr()) };
+        if rc < 0 {
+            bail!("sd_journal_seek_cursor failed: {}", errno_msg(rc));
+        }
+        Ok(())
+    }
+
+    pub fn seek_tail(&mut self) -> Result<()> {
+        let rc = unsafe { sd_journal_seek_tail(self.ptr) };
+        if rc < 0 {
+            bail!("sd_journal_seek_tail failed: {}", errno_msg(rc));
+        }
+        Ok(())
+    }
+
+    /// `Ok(n)` mirrors `sd_journal_next`'s own contract: `n > 0` means
+    /// the read pointer advanced, `0` means end of journal.
+    pub fn next(&mut self) -> Result<c_int> {
+        let rc = unsafe { sd_journal_next(self.ptr) };
+        if rc < 0 {
+            bail!("sd_journal_next failed: {}", errno_msg(rc));
+        }
+        Ok(rc)
+    }
+
+    pub fn previous(&mut self) -> Result<c_int> {
+        let rc = unsafe { sd_journal_previous(self.ptr) };
+        if rc < 0 {
+            bail!("sd_journal_previous failed: {}", errno_msg(rc));
+        }
+        Ok(rc)
+    }
+
+    pub fn restart_data(&mut self) {
+        unsafe { sd_journal_restart_data(self.ptr) };
+    }
+
+    /// Reads the next field of the current entry. libsystemd returns
+    /// each field as one raw `NAME=value` blob; this splits it on the
+    /// first `=` the same way the prior crate's field type did.
+    pub fn enumerate_data(&mut self) -> Result<Option<JournalField<'_>>> {
+        let mut data: *const c_void = ptr::null();
+        let mut len: usize = 0;
+        let rc = unsafe { sd_journal_enumerate_data(self.ptr, &mut data, &mut len) };
+        if rc < 0 {
+            bail!("sd_journal_enumerate_data failed: {}", errno_msg(rc));
+        }
+        if rc == 0 {
+            return Ok(None);
+        }
+        let blob = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) };
+        let (name, value) = match blob.iter().position(|&b| b == b'=') {
+            Some(idx) => (&blob[..idx], Some(&blob[idx + 1..])),
+            None => (blob, None),
+        };
+        Ok(Some(JournalField { name, value }))
+    }
+
+    pub fn cursor(&mut self) -> Result<String> {
+        let mut out: *mut c_char = ptr::null_mut();
+        let rc = unsafe { sd_journal_get_cursor(self.ptr, &mut out) };
+        if rc < 0 || out.is_null() {
+            bail!("sd_journal_get_cursor failed: {}", errno_msg(rc));
+        }
+        let cursor = unsafe { CStr::from_ptr(out) }
+            .to_string_lossy()
+            .into_owned();
+        // sd_journal_get_cursor(3): the returned string is allocated
+        // via malloc(3) and the caller must free(3) it.
+        unsafe { libc::free(out.cast()) };
+        Ok(cursor)
+    }
+
+    pub fn timestamp_usec(&mut self) -> Result<u64> {
+        let mut usec: u64 = 0;
+        let rc = unsafe { sd_journal_get_realtime_usec(self.ptr, &mut usec) };
+        if rc < 0 {
+            bail!("sd_journal_get_realtime_usec failed: {}", errno_msg(rc));
+        }
+        Ok(usec)
+    }
+
+    /// Returns `(monotonic_usec, boot_id)`. The boot id is opaque and
+    /// unused — the sole caller already discards it (`_boot_id`) —
+    /// but `sd_journal_get_monotonic_usec` requires a valid out
+    /// pointer, so it's read into a local and dropped.
+    pub fn monotonic_timestamp(&mut self) -> Result<(u64, ())> {
+        let mut usec: u64 = 0;
+        let mut boot_id = Id128 { _bytes: [0; 16] };
+        let rc = unsafe { sd_journal_get_monotonic_usec(self.ptr, &mut usec, &mut boot_id) };
+        if rc < 0 {
+            bail!("sd_journal_get_monotonic_usec failed: {}", errno_msg(rc));
+        }
+        Ok((usec, ()))
+    }
+}
+
+impl Drop for Journal {
+    fn drop(&mut self) {
+        unsafe { sd_journal_close(self.ptr) };
+    }
+}
+
+/// `sd_journal_*` functions return `0`/positive on success or a
+/// negative errno-style code on failure (`sd-journal(3)`).
+fn errno_msg(rc: c_int) -> String {
+    std::io::Error::from_raw_os_error(-rc).to_string()
+}

--- a/crates/limpid/src/modules/input/mod.rs
+++ b/crates/limpid/src/modules/input/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "journal")]
 pub mod journal;
+#[cfg(feature = "journal")]
+mod journal_sys;
 pub mod otlp;
 pub mod rate_limit;
 pub mod syslog_tcp;

--- a/deny.toml
+++ b/deny.toml
@@ -77,29 +77,12 @@ allow = [
     # attribution license for datasets — compatible with limpid's
     # redistribution posture.
     "CDLA-Permissive-2.0",
-    # Unlicense: public-domain dedication with a permissive fallback —
-    # same obligations-free family as 0BSD / CC0. Reached via
-    # cstr-argument <- systemd (journal feature). Compatible with
-    # limpid's redistribution posture.
-    "Unlicense",
 ]
 
 # Per-crate exceptions: licenses accepted for a specific crate only,
 # without admitting them workspace-wide. Each entry MUST carry a
 # rationale comment and the condition under which it can be removed.
-#
-# systemd / libsystemd-sys (LGPL-2.1-or-later WITH GCC-exception-2.0):
-# the `journal` feature is opt-in; these crates are thin binding
-# wrappers around libsystemd, which stays dynamically linked — only the
-# wrapper code itself is statically linked into limpid. The
-# workspace-wide LGPL-avoidance policy above is unchanged; this is a
-# deliberate two-crate exception, not a policy shift. Remove both
-# entries if/when the journald reader migrates to an MIT/Apache-family
-# implementation.
-exceptions = [
-    { crate = "systemd", allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"] },
-    { crate = "libsystemd-sys", allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"] },
-]
+exceptions = []
 
 [advisories]
 # RustSec database — checked at every audit. `version = 2` is the


### PR DESCRIPTION
## Summary
Remove the last non-permissive dependency from the workspace by writing the ~11 `sd_journal_*` calls the `journal` input actually uses as an in-tree FFI binding, licensed MIT OR Apache-2.0 like the rest of the crate. `libsystemd` itself is still dynamically linked at runtime, resolved via `pkg-config` in a new `build.rs` when the `journal` feature is enabled — the same `libsystemd-dev` package the removed `rust-systemd` / `libsystemd-sys` dependencies already required.

- **`journal_sys.rs`** (new, 220 lines): raw declarations for the calls we use, `Journal` handle typed `!Send`/`!Sync` so `sd-journal(3)`'s "one thread per handle" rule is enforced by the type system, explicit `libc::free` on the malloc'd cursor per the man page, errno mapping.
- **`build.rs`** (new, 23 lines): `pkg_config::probe_library("libsystemd")` gated on `CARGO_FEATURE_JOURNAL`; no-op otherwise.
- **`journal.rs`**: switch imports from the removed crate to the in-crate binding. 6/7-line consumer diff — the `Journal::open` / `next` / `enumerate_data` / `cursor` / timestamp shape mirrors what the old crate exposed, so nothing else changes.
- **`Cargo.toml` / `Cargo.lock`**: drop `systemd = "0.10"` dep, add `pkg-config` build-dep; `journal` feature no longer uses `dep:` gating. Lockfile shrinks by ~78 lines as `systemd` / `libsystemd-sys` / `cstr-argument` (LGPL-2.1-or-later / Unlicense) come out of the graph.
- **`deny.toml`**: with those crates gone, drop the per-crate LGPL exceptions and the workspace Unlicense allowlist entry pulled in via `cstr-argument`. `exceptions = []` again — the workspace-wide LGPL-avoidance policy no longer needs an escape hatch.

## License posture
Mechanical translation of a public C API's parameter shapes carries no expressive content of its own, so the in-tree declarations are MIT OR Apache-2.0 like the rest of the crate. The runtime `libsystemd.so.0` link stays covered by LGPL §6(b)'s dynamic-linking safe harbour, i.e. the same posture users of this feature already accept. Not a legal determination — a distribution posture.

## Test plan
- [x] `cargo build/test/clippy/fmt` (no `--features journal`) — 722+27+2+14 pass
- [x] `cargo deny check licenses / bans / sources` — all pass, `exceptions = []`
- [ ] `--features journal` Linux build — requires `libsystemd-dev`, will exercise on release workflow CI
- [x] uchgs push-gate audit (8 scopes) — 6 pass with abstraction and security specifically reviewed for the FFI boundary (raw pointer / cursor free / borrowed field lifetime), 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this change