### PR TITLE
refactor(dsl): drop process-call arguments from grammar and runtime

### DIFF
--- a/crates/limpid/src/check/graph.rs
+++ b/crates/limpid/src/check/graph.rs
@@ -116,7 +116,7 @@ fn build_pipeline_graph(name: &str, pipeline: &crate::dsl::ast::PipelineDef) -> 
                 for elem in elements {
                     proc_counter += 1;
                     let (id, label) = match elem {
-                        ProcessChainElement::Named(pname, _args) => (
+                        ProcessChainElement::Named(pname) => (
                             format!("{}_proc_{}_{}", name, proc_counter, sanitize(pname)),
                             format!("process {}", pname),
                         ),

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -421,10 +421,7 @@ fn analyze_chain_element(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     match elem {
-        ProcessChainElement::Named(name, args) => {
-            for a in args {
-                expr_types::check_types(a, pipeline_name, bindings, registry, None, diagnostics);
-            }
+        ProcessChainElement::Named(name) => {
             if let Some(pdef) = config.processes.get(name) {
                 analyze_process_body(pdef, pipeline_name, registry, bindings, diagnostics);
             } else {
@@ -548,10 +545,7 @@ pub(super) fn analyze_process_stmt(
         ProcessStatement::ExprStmt(e) => {
             expr_types::check_types(e, pipeline_name, bindings, registry, None, diagnostics);
         }
-        ProcessStatement::ProcessCall(_name, args) => {
-            for a in args {
-                expr_types::check_types(a, pipeline_name, bindings, registry, None, diagnostics);
-            }
+        ProcessStatement::ProcessCall(_name) => {
             // Process bodies were validated separately when the named
             // process was defined; we don't recurse from here.
         }

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -468,7 +468,7 @@ fn collect_pipeline_tap_points(
             PipelineStatement::ProcessChain(chain) => {
                 for elem in chain {
                     match elem {
-                        ProcessChainElement::Named(name, _) => {
+                        ProcessChainElement::Named(name) => {
                             if !processes.contains(name) {
                                 processes.push(name.clone());
                             }

--- a/crates/limpid/src/dsl/ast.rs
+++ b/crates/limpid/src/dsl/ast.rs
@@ -106,8 +106,9 @@ pub enum ProcessStatement {
     /// visible for the rest of the enclosing process body. Locals are
     /// bare identifiers (`name`), distinct from `workspace.name`.
     LetBinding(String, Expr),
-    /// `process name` or `process name(args...)`
-    ProcessCall(String, Vec<Expr>),
+    /// `process name` — invoke a named process. Process definitions
+    /// don't declare parameters, so calls don't carry any.
+    ProcessCall(String),
     /// `drop`
     Drop,
     /// `error` / `error <expr>` — explicit failure routing. The
@@ -239,8 +240,10 @@ pub enum PipelineStatement {
 /// An element within a `process a | b | { ... }` chain in a pipeline.
 #[derive(Debug, Clone)]
 pub enum ProcessChainElement {
-    /// Named process reference, optionally with arguments: `parse_cef`, `geoip("source")`
-    Named(String, Vec<Expr>),
+    /// Named process reference: `parse_cef`. Processes don't declare
+    /// parameters — see `ProcessDef` — so a chain-element call can't
+    /// pass any either.
+    Named(String),
     /// Inline (anonymous) process block: `{ ... }`
     Inline(Vec<ProcessStatement>),
 }

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -42,7 +42,6 @@ pub trait ProcessRegistry {
     fn call<'bump>(
         &self,
         name: &str,
-        args: &[Value<'bump>],
         event: BorrowedEvent<'bump>,
         arena: &'bump EventArena<'bump>,
     ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError>;
@@ -127,13 +126,7 @@ fn exec_process_stmt<'bump>(
             Ok(ExecResult::Continue(event))
         }
 
-        ProcessStatement::ProcessCall(name, args) => {
-            let mut evaluated_args =
-                bumpalo::collections::Vec::with_capacity_in(args.len(), arena.bump());
-            for a in args {
-                evaluated_args.push(eval_expr_with_scope(a, &event, funcs, scope, arena)?);
-            }
-
+        ProcessStatement::ProcessCall(name) => {
             // Callee processes start with their own fresh LocalScope
             // inside the registry implementation (see `exec_process_body`
             // above). Our `scope` here belongs to the caller and is
@@ -159,7 +152,7 @@ fn exec_process_stmt<'bump>(
             // recovery body with the original error message exposed
             // via `workspace._error`.
             registry
-                .call(name, &evaluated_args, event, arena)
+                .call(name, event, arena)
                 .map(|opt_event| match opt_event {
                     Some(e) => ExecResult::Continue(e),
                     None => ExecResult::Dropped,
@@ -440,7 +433,6 @@ mod tests {
         fn call<'bump>(
             &self,
             _name: &str,
-            _args: &[Value<'bump>],
             event: BorrowedEvent<'bump>,
             _arena: &'bump crate::dsl::arena::EventArena<'bump>,
         ) -> Result<Option<BorrowedEvent<'bump>>, ProcessError> {
@@ -454,7 +446,6 @@ mod tests {
         fn call<'bump>(
             &self,
             _name: &str,
-            _args: &[Value<'bump>],
             _event: BorrowedEvent<'bump>,
             _arena: &'bump crate::dsl::arena::EventArena<'bump>,
         ) -> Result<Option<BorrowedEvent<'bump>>, ProcessError> {
@@ -640,7 +631,7 @@ mod tests {
         let arena = crate::dsl::arena::EventArena::new(&_bump);
         let event = make_event();
         let bevent = event.view_in(&arena);
-        let stmts = vec![ProcessStatement::ProcessCall("failing".into(), vec![])];
+        let stmts = vec![ProcessStatement::ProcessCall("failing".into())];
         let result = exec_process_body(&stmts, bevent, &FailRegistry, &make_funcs(), &arena);
         match result {
             Err(e) => assert!(
@@ -667,7 +658,7 @@ mod tests {
         let event = make_event();
         let bevent = event.view_in(&arena);
         let stmts = vec![ProcessStatement::TryCatch(
-            vec![ProcessStatement::ProcessCall("failing".into(), vec![])],
+            vec![ProcessStatement::ProcessCall("failing".into())],
             vec![ProcessStatement::Assign(
                 AssignTarget::Workspace(vec!["caught".into()]),
                 e(ExprKind::BoolLit(true)),

--- a/crates/limpid/src/dsl/limpid.pest
+++ b/crates/limpid/src/dsl/limpid.pest
@@ -172,7 +172,7 @@ process_switch_arm = {
 }
 
 process_call = {
-    kw_process ~ ident ~ ("(" ~ func_args ~ ")")?
+    kw_process ~ ident
 }
 
 process_assign = {
@@ -248,9 +248,13 @@ process_chain_element = {
   | process_ref
 }
 
-// Named process reference with optional arguments
+// Named process reference. Process definitions don't declare
+// parameters — see `def_process` — so a call site can't pass any
+// either. An older grammar accepted `foo(...)` here and the runtime
+// silently discarded the arguments after evaluating them; that
+// language surface is gone.
 process_ref = {
-    ident ~ ("(" ~ func_args ~ ")")?
+    ident
 }
 
 // Inline (anonymous) process: `{ ... }`

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -204,19 +204,14 @@ fn parse_process_error(pair: Pair<Rule>, file_id: u32) -> Result<ProcessStatemen
     Ok(ProcessStatement::Error(msg))
 }
 
-fn parse_process_call(pair: Pair<Rule>, file_id: u32) -> Result<ProcessStatement> {
-    let mut inner = pair.into_inner();
-    let name = inner
+fn parse_process_call(pair: Pair<Rule>, _file_id: u32) -> Result<ProcessStatement> {
+    let name = pair
+        .into_inner()
         .next()
         .expect("pest grammar invariant")
         .as_str()
         .to_string();
-    let args = if let Some(args_pair) = inner.next() {
-        parse_func_args(args_pair, file_id)?
-    } else {
-        vec![]
-    };
-    Ok(ProcessStatement::ProcessCall(name, args))
+    Ok(ProcessStatement::ProcessCall(name))
 }
 
 fn parse_process_let(pair: Pair<Rule>, file_id: u32) -> Result<ProcessStatement> {
@@ -414,18 +409,13 @@ fn parse_chain_element(pair: Pair<Rule>, file_id: u32) -> Result<ProcessChainEle
     let inner = first_inner(pair)?;
     match inner.as_rule() {
         Rule::process_ref => {
-            let mut parts = inner.into_inner();
-            let name = parts
+            let name = inner
+                .into_inner()
                 .next()
                 .expect("pest grammar invariant")
                 .as_str()
                 .to_string();
-            let args = if let Some(args_pair) = parts.next() {
-                parse_func_args(args_pair, file_id)?
-            } else {
-                vec![]
-            };
-            Ok(ProcessChainElement::Named(name, args))
+            Ok(ProcessChainElement::Named(name))
         }
         Rule::inline_process => {
             let body = inner
@@ -1161,7 +1151,7 @@ def process parse_and_enrich {
     process parse_cef
 
     if workspace.src != null {
-        process geoip("src")
+        process geoip
     }
 
     if workspace.device_vendor == "HealthCheck" {
@@ -1980,5 +1970,40 @@ def process p {
             },
             _ => panic!("expected process"),
         }
+    }
+
+    #[test]
+    fn process_call_with_arguments_is_a_parse_error_in_pipeline_chain() {
+        // Regression pin: `def process` declares no parameters, so a
+        // caller can't pass any either. An older grammar accepted
+        // `process foo("src")` and the runtime silently evaluated the
+        // arguments only to discard them — that misusage now hits the
+        // parser instead of vanishing at runtime.
+        let input = r#"
+def pipeline p {
+    input i
+    process geoip("src")
+    output o
+}
+"#;
+        assert!(
+            parse_config(input).is_err(),
+            "expected process foo(\"src\") to be a parse error in a pipeline chain"
+        );
+    }
+
+    #[test]
+    fn process_call_with_arguments_is_a_parse_error_in_process_body() {
+        // Same rule applied to the `process foo` statement inside a
+        // `def process` body.
+        let input = r#"
+def process wrap {
+    process helper("x")
+}
+"#;
+        assert!(
+            parse_config(input).is_err(),
+            "expected process helper(\"x\") to be a parse error in a process body"
+        );
     }
 }

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -23,7 +23,6 @@ use crate::dsl::arena::EventArena;
 use crate::dsl::ast::*;
 use crate::dsl::eval::{eval_expr, select_if_branch, select_switch_arm, value_to_string};
 use crate::dsl::exec::{ExecResult, ProcessError, ProcessRegistry, exec_process_body};
-use crate::dsl::value::Value;
 use crate::event::{BorrowedEvent, OwnedEvent};
 use crate::functions::FunctionRegistry;
 use crate::tap::TapRegistry;
@@ -161,7 +160,7 @@ impl CompiledConfig {
             }
             PipelineStatement::ProcessChain(chain) => {
                 for element in chain {
-                    if let ProcessChainElement::Named(proc_name, _) = element
+                    if let ProcessChainElement::Named(proc_name) = element
                         && !self.processes.contains_key(proc_name)
                     {
                         bail!(
@@ -426,7 +425,6 @@ impl ProcessRegistry for DslProcessRegistry<'_> {
     fn call<'bump>(
         &self,
         name: &str,
-        _args: &[Value<'bump>],
         event: BorrowedEvent<'bump>,
         arena: &'bump EventArena<'bump>,
     ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError> {
@@ -667,37 +665,17 @@ fn exec_pipeline_stmt<'bump>(
             let mut current = event;
             for element in chain {
                 match element {
-                    ProcessChainElement::Named(name, args) => {
-                        let mut evaluated_args = bumpalo::collections::Vec::with_capacity_in(
-                            args.len(),
-                            ctx.arena.bump(),
-                        );
-                        for a in args {
-                            evaluated_args.push(eval_expr(a, &current, ctx.funcs, ctx.arena)?);
-                        }
-
+                    ProcessChainElement::Named(name) => {
                         // Snapshot the heap-owned form before the
                         // registry consumes the borrowed event — the
                         // Err arm needs a stable, arena-independent
                         // event for the DLQ context.
                         let backup_owned = current.to_owned();
-                        match ctx.registry.call(name, &evaluated_args, current, ctx.arena) {
+                        match ctx.registry.call(name, current, ctx.arena) {
                             Ok(Some(e)) => {
-                                // `arg_repr` (a `Vec<String>` built via
-                                // `Value::to_string`) is only needed
-                                // for the trace label, so it's built
-                                // inside the closure — skipped
-                                // entirely when `out.trace` is `None`
-                                // (the daemon hot path).
                                 out.push_trace(|| TraceEntry {
                                     stage: "process".into(),
-                                    label: if args.is_empty() {
-                                        name.clone()
-                                    } else {
-                                        let arg_repr: Vec<String> =
-                                            evaluated_args.iter().map(|v| v.to_string()).collect();
-                                        format!("{}({})", name, arg_repr.join(", "))
-                                    },
+                                    label: name.clone(),
                                     detail: "ok".into(),
                                 });
                                 current = e;


### PR DESCRIPTION
## Summary
Close a latent gap in the DSL. `def process foo { … }` never declared parameters, but the grammar accepted `process foo(args…)` at both call sites (`process_call` inside a process body and `process_ref` inside a pipeline chain), and the runtime dutifully evaluated the argument expressions before silently discarding them. A pure argument vanished without a trace; an argument with side effects fired those side effects and then evaporated — a latent debugging trap. `--check` was no help either: the analyzer arm only type-checked each argument expression and didn't reject it.

The grammar drops the `("(" ~ func_args ~ ")")?` clause at both sites. `ProcessStatement::ProcessCall` and `ProcessChainElement::Named` drop their now-empty `Vec<Expr>` field, and the `ProcessRegistry::call` trait, its two concrete impls, the pipeline executor's `evaluated_args` allocation, the analyzer's argument loop, and the tracer's `arg_repr` all fall away with it. Two regression tests pin the new parse error at both call sites so this can't quietly come back.

## Test plan
- [x] cargo build/test/clippy/fmt all pass (724 unit tests — 722 baseline + 2 new regression pins)
- [x] uchgs push-gate audit (8 scopes) — 6 pass with boundary-contract, abstraction, and security specifically reviewed for grammar/parser/AST/executor consistency and the removal of the silent-side-effect trap; 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this change