### PR TITLE
fix: audit follow-ups for release/0.7.9 (DLQ perms, metadata TOCTOU, FFI, comments)

### DIFF
--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -44,4 +44,13 @@ assets = [
     ["target/release/limpid-prometheus", "usr/bin/", "755"],
     ["../../packaging/limpid-prometheus.default", "etc/default/limpid-prometheus", "644"],
 ]
-systemd-units = { unit-name = "limpid-prometheus", unit-scripts = "../../packaging" }
+# start = false mirrors limpid.service. Without it, cargo-deb's
+# dh_installsystemd port defaults `start` to true and would start the
+# exporter on install — and since limpid-prometheus.service declares
+# `Requires=limpid.service`, that would pull limpid.service up too,
+# defeating the deliberate `start = false` on the daemon (which exists
+# so a `#DEBHELPER#` start can't collide with rsyslog/syslog-ng still
+# holding the syslog ports on upgrade). enable = true (the default,
+# stated for parity with limpid) leaves the exporter to start with the
+# daemon on the next boot / explicit `systemctl start`.
+systemd-units = { unit-name = "limpid-prometheus", unit-scripts = "../../packaging", enable = true, start = false }

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -304,14 +304,13 @@ impl ErrorLogWriter {
         let _guard = self.write_lock.lock().await;
         let mut opts = OpenOptions::new();
         opts.create(true).append(true);
+        // Only applied when this open creates the file; an existing
+        // DLQ file keeps whatever mode it already has (operators can
+        // tighten a pre-existing file themselves). tokio's
+        // `OpenOptions::mode` is inherent (no OpenOptionsExt trait
+        // import needed).
         #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            // Only applied when this open creates the file; an existing
-            // DLQ file keeps whatever mode it already has (operators can
-            // tighten a pre-existing file themselves).
-            opts.mode(0o600);
-        }
+        opts.mode(0o600);
         let mut f = opts
             .open(&self.path)
             .await
@@ -393,7 +392,12 @@ mod tests {
         let path = dir.path().join("errored.jsonl");
         let w = ErrorLogWriter::new(path.clone());
         w.write(&ctx()).await.unwrap();
-        let mode = tokio::fs::metadata(&path).await.unwrap().permissions().mode() & 0o777;
+        let mode = tokio::fs::metadata(&path)
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(mode, 0o600, "DLQ file must be created 0o600, got {mode:o}");
     }
 

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -289,13 +289,30 @@ impl ErrorLogWriter {
     /// way in CI, where a subsequent `tokio::fs::read_to_string`
     /// occasionally saw an empty file. Shutdown-then-drop also nudges
     /// the file toward on-disk durability, which matters for a DLQ.
+    ///
+    /// The DLQ record carries the failed event's `ingress` / `egress`
+    /// verbatim (UTF-8 payloads land as plain text, not base64), so a
+    /// line that happened to contain a secret or PII is written through
+    /// unchanged. Create the file `0o600` on Unix so it is not
+    /// world-readable when the daemon runs under a permissive umask —
+    /// the `file` output already exposes a `mode` knob for the same
+    /// reason, and the DLQ (which operators don't opt into per-record)
+    /// should default at least as tight.
     pub async fn write(&self, ctx: &ErroredEventContext) -> Result<()> {
         let mut line = ctx.to_jsonl();
         line.push('\n');
         let _guard = self.write_lock.lock().await;
-        let mut f = OpenOptions::new()
-            .create(true)
-            .append(true)
+        let mut opts = OpenOptions::new();
+        opts.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            // Only applied when this open creates the file; an existing
+            // DLQ file keeps whatever mode it already has (operators can
+            // tighten a pre-existing file themselves).
+            opts.mode(0o600);
+        }
+        let mut f = opts
             .open(&self.path)
             .await
             .with_context(|| format!("error_log: failed to open {}", self.path.display()))?;
@@ -363,6 +380,21 @@ mod tests {
             assert!(event.get("egress").is_none());
             assert!(event.get("workspace").is_none());
         }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn dlq_file_is_created_owner_only() {
+        // The DLQ can carry secrets from a failed event's payload, so
+        // a file this writer creates must not be world/group-readable
+        // regardless of the daemon's umask.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let w = ErrorLogWriter::new(path.clone());
+        w.write(&ctx()).await.unwrap();
+        let mode = tokio::fs::metadata(&path).await.unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "DLQ file must be created 0o600, got {mode:o}");
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/input/journal_sys.rs
+++ b/crates/limpid/src/modules/input/journal_sys.rs
@@ -160,6 +160,14 @@ impl Journal {
         if rc == 0 {
             return Ok(None);
         }
+        // `rc > 0` means libsystemd populated (data, len) with a valid
+        // buffer, so `data` is non-null under the sd-journal(3) contract.
+        // Guard anyway: `slice::from_raw_parts` is UB on a null pointer
+        // even when `len == 0`, and treating a contract violation as
+        // "no more fields" degrades gracefully instead of invoking UB.
+        if data.is_null() {
+            return Ok(None);
+        }
         let blob = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) };
         let (name, value) = match blob.iter().position(|&b| b == b'=') {
             Some(idx) => (&blob[..idx], Some(&blob[idx + 1..])),

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -394,7 +394,14 @@ impl FileOutput {
         self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
 
         if first_create {
-            self.apply_file_metadata(&path).await;
+            // Apply mode/owner through the open fd rather than the path.
+            // The path is already guarded by O_NOFOLLOW at open time, but
+            // set_permissions()/chown() would re-resolve the path and
+            // could follow a symlink pre-planted between open and the
+            // metadata call — closing that TOCTOU window means the mode
+            // and ownership always land on the same inode we just wrote
+            // to, never a different one.
+            self.apply_file_metadata_to_fd(&file, &path).await;
         }
 
         Ok(())
@@ -533,26 +540,43 @@ fn check_no_traversal(s: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 impl FileOutput {
-    async fn apply_file_metadata(&self, path: &Path) {
-        use std::os::unix::fs::PermissionsExt;
+    /// Apply the configured `mode`/`owner`/`group` to the just-created
+    /// file via `fchmod(2)`/`fchown(2)` on the open fd — never through
+    /// the path. The path-based `set_permissions`/`chown` we used
+    /// before could be redirected by a symlink pre-planted between
+    /// `open(O_NOFOLLOW)` and the metadata call; operating on the fd
+    /// makes that impossible, and keeps the mode/ownership riding on
+    /// the same inode `write_all` just touched. `path` here is only
+    /// used to label warnings.
+    async fn apply_file_metadata_to_fd(&self, file: &tokio::fs::File, path: &Path) {
+        use std::os::unix::io::AsRawFd;
 
-        if let Some(mode) = self.mode
-            && let Err(e) =
-                tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).await
-        {
-            tracing::warn!(
-                "output file '{}': failed to set mode: {}",
-                path.display(),
-                e
-            );
+        let mode = self.mode;
+        let owner = self.owner.clone();
+        let group = self.group.clone();
+        if mode.is_none() && owner.is_none() && group.is_none() {
+            return;
         }
+        let path = path.to_path_buf();
+        let fd = file.as_raw_fd();
 
-        if self.owner.is_some() || self.group.is_some() {
-            let owner = self.owner.clone();
-            let group = self.group.clone();
-            let path = path.to_path_buf();
+        // `spawn_blocking` runs the libc calls off the async runtime.
+        // The `File` (and therefore the fd) is borrowed by this future,
+        // and we `await` the join handle below before returning, so the
+        // fd stays valid for the entire duration of the blocking task.
+        tokio::task::spawn_blocking(move || {
+            if let Some(mode) = mode {
+                let rc = unsafe { libc::fchmod(fd, mode as libc::mode_t) };
+                if rc != 0 {
+                    tracing::warn!(
+                        "output file '{}': fchmod failed: {}",
+                        path.display(),
+                        std::io::Error::last_os_error()
+                    );
+                }
+            }
 
-            tokio::task::spawn_blocking(move || {
+            if owner.is_some() || group.is_some() {
                 let uid = owner.as_deref().and_then(|name| {
                     resolve_uid(name)
                         .inspect_err(|e| {
@@ -577,15 +601,26 @@ impl FileOutput {
                         })
                         .ok()
                 });
-                if (uid.is_some() || gid.is_some())
-                    && let Err(e) = std::os::unix::fs::chown(&path, uid, gid)
-                {
-                    tracing::warn!("output file '{}': failed to chown: {}", path.display(), e);
+                if uid.is_some() || gid.is_some() {
+                    // `fchown(-1, -1)` is a no-op, so map "not
+                    // configured" or "lookup failed" to -1 and let
+                    // libc decide whether either coordinate needs
+                    // changing.
+                    let uid_arg = uid.unwrap_or(u32::MAX);
+                    let gid_arg = gid.unwrap_or(u32::MAX);
+                    let rc = unsafe { libc::fchown(fd, uid_arg, gid_arg) };
+                    if rc != 0 {
+                        tracing::warn!(
+                            "output file '{}': fchown failed: {}",
+                            path.display(),
+                            std::io::Error::last_os_error()
+                        );
+                    }
                 }
-            })
-            .await
-            .ok();
-        }
+            }
+        })
+        .await
+        .ok();
     }
 }
 
@@ -700,10 +735,14 @@ mod tests {
     }
 
     fn make_output(path: Expr) -> FileOutput {
+        make_output_with(path, None)
+    }
+
+    fn make_output_with(path: Expr, mode: Option<u32>) -> FileOutput {
         FileOutput {
             name: "test".into(),
             path,
-            mode: None,
+            mode,
             owner: None,
             group: None,
             created_paths: Mutex::new(HashSet::new()),
@@ -990,5 +1029,54 @@ mod tests {
             .expect("regular file write must succeed");
         }
         assert_eq!(std::fs::read(&path).unwrap(), b"hello\nhello\n");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_payload_applies_mode_via_fchmod_to_created_file() {
+        // Regression pin for the fd-based metadata application: the
+        // configured mode must land on the file the writer just opened,
+        // and the path used to label warnings must not participate in
+        // the actual mode change (it goes through fchmod on the open
+        // fd).
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("modeful.log");
+
+        let out = make_output_with(
+            ek(ExprKind::StringLit(path.display().to_string())),
+            Some(0o640),
+        );
+        out.write_payload(FilePayload {
+            egress: Bytes::from("hi"),
+            path: path.display().to_string(),
+            is_dynamic: false,
+        })
+        .await
+        .expect("first write must succeed");
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o640,
+            "fchmod must land the configured mode on the created file"
+        );
+
+        // A second write must not re-apply the mode — apply_file_metadata
+        // is gated on first_create. Externally tightening the mode
+        // between writes stays sticky, which is the operator-friendly
+        // behaviour.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        out.write_payload(FilePayload {
+            egress: Bytes::from("again"),
+            path: path.display().to_string(),
+            is_dynamic: false,
+        })
+        .await
+        .expect("second write must succeed");
+        let mode2 = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode2, 0o600,
+            "second write must not re-apply mode; operator tightening stays sticky"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -1113,71 +1113,39 @@ mod tests {
 
     #[tokio::test]
     #[cfg(unix)]
-    async fn apply_file_metadata_survives_outer_future_cancellation() {
-        // Regression pin: `spawn_blocking` isn't cancel-safe, so if a
-        // caller drops `write_payload`'s future mid-await (shutdown
-        // timeout etc.), the blocking task keeps running while the
-        // source `File` gets closed. Before we duped the fd, that
-        // window let the leftover `fchmod`/`fchown` land on an
-        // unrelated inode when the kernel reused the fd number. Pin
-        // that even under aggressive cancellation the mode still
-        // lands on the file we wrote to — or, if the future was
-        // dropped before `apply_file_metadata_to_fd` even ran, no
-        // stray metadata escapes.
-        use std::os::unix::fs::PermissionsExt;
+    async fn dropping_never_polled_write_payload_leaves_no_side_effects() {
+        // Narrow regression pin: constructing `write_payload`'s future
+        // and dropping it without ever polling must not touch the
+        // filesystem. This is not the same shape as "future was polled,
+        // reached apply_file_metadata_to_fd, then got cancelled" — Rust
+        // async futures are lazy, so a never-polled future runs no
+        // code. Verifying the mid-await cancellation shape would need
+        // a test-only barrier inside `write_payload` to hold the future
+        // at a known suspension point; the fd-lifetime argument for the
+        // cancel-safe path lives in the module-level comment and in
+        // this commit's message. What this test *does* pin is that
+        // wiring the payload alone has no observable side effect, so a
+        // caller that speculatively builds a write and then abandons it
+        // doesn't leak file/state.
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("cancel.log");
+        let path = dir.path().join("never_polled.log");
 
-        let out = std::sync::Arc::new(make_output_with(
+        let out = make_output_with(
             ek(ExprKind::StringLit(path.display().to_string())),
             Some(0o600),
-        ));
-
-        // Kick off write_payload but drop the future immediately.
-        // Whatever happens under the covers, the outcome must be
-        // either "no file exists" or "file has mode 0o600" — never a
-        // different inode carrying our chmod.
-        let out2 = out.clone();
-        let path_str = path.display().to_string();
-        let fut = out2.write_payload(FilePayload {
-            egress: Bytes::from("cancelled"),
-            path: path_str,
+        );
+        let fut = out.write_payload(FilePayload {
+            egress: Bytes::from("never"),
+            path: path.display().to_string(),
             is_dynamic: false,
         });
         drop(fut);
 
-        // Yield a couple of times so any spawned blocking work runs.
-        for _ in 0..5 {
-            tokio::task::yield_now().await;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        if let Ok(meta) = std::fs::metadata(&path) {
-            let mode = meta.permissions().mode() & 0o777;
-            assert_eq!(
-                mode, 0o600,
-                "if the file exists after cancellation, its mode must be the one we asked for"
-            );
-        }
-        // If the file doesn't exist yet, we cancelled early enough
-        // that write never landed — also fine.
-
-        // And a follow-up "normal" write must still apply mode as
-        // expected, i.e. the previous cancellation didn't corrupt the
-        // metadata state.
-        let path2 = dir.path().join("normal.log");
-        make_output_with(
-            ek(ExprKind::StringLit(path2.display().to_string())),
-            Some(0o640),
-        )
-        .write_payload(FilePayload {
-            egress: Bytes::from("ok"),
-            path: path2.display().to_string(),
-            is_dynamic: false,
-        })
-        .await
-        .expect("normal follow-up write must succeed");
-        let mode2 = std::fs::metadata(&path2).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode2, 0o640);
+        // Nothing was polled, so no `open` happened. The file must not
+        // exist and no other state must have changed.
+        assert!(
+            !path.exists(),
+            "never-polled write_payload future must not create the target file"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -548,7 +548,20 @@ impl FileOutput {
     /// makes that impossible, and keeps the mode/ownership riding on
     /// the same inode `write_all` just touched. `path` here is only
     /// used to label warnings.
+    ///
+    /// The `spawn_blocking` future is *not* cancel-safe: if the caller
+    /// (say `consume_shutdown` under a `timeout`) drops the awaiting
+    /// future, the blocking task keeps running while the outer `File`
+    /// gets dropped and closes its fd. A raw fd number is trivial for
+    /// the kernel to reuse for an unrelated `open`, and the leftover
+    /// `fchmod`/`fchown` would then land on that other inode. Guard
+    /// against that by `dup(2)`-ing the fd into an `OwnedFd` that the
+    /// blocking closure owns for its whole lifetime — the syscalls run
+    /// against a fd that stays live even if the outer future is
+    /// cancelled, and the `OwnedFd`'s `Drop` closes it deterministically
+    /// on task exit (success, panic, or otherwise).
     async fn apply_file_metadata_to_fd(&self, file: &tokio::fs::File, path: &Path) {
+        use std::os::fd::{FromRawFd, OwnedFd};
         use std::os::unix::io::AsRawFd;
 
         let mode = self.mode;
@@ -558,13 +571,27 @@ impl FileOutput {
             return;
         }
         let path = path.to_path_buf();
-        let fd = file.as_raw_fd();
 
-        // `spawn_blocking` runs the libc calls off the async runtime.
-        // The `File` (and therefore the fd) is borrowed by this future,
-        // and we `await` the join handle below before returning, so the
-        // fd stays valid for the entire duration of the blocking task.
+        // `dup(2)` returns a fresh fd referring to the same open file
+        // description. The `OwnedFd` moves into the closure so it stays
+        // live for the duration of the blocking task even if the outer
+        // future — and therefore the source `File` — is dropped.
+        let duped: i32 = unsafe { libc::dup(file.as_raw_fd()) };
+        if duped < 0 {
+            tracing::warn!(
+                "output file '{}': dup failed, skipping metadata apply: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+        // SAFETY: `duped >= 0` was just returned by `libc::dup` and no
+        // other Rust type owns it yet, so this transfers exclusive
+        // ownership to the `OwnedFd`.
+        let owned_fd: OwnedFd = unsafe { OwnedFd::from_raw_fd(duped) };
+
         tokio::task::spawn_blocking(move || {
+            let fd = owned_fd.as_raw_fd();
             if let Some(mode) = mode {
                 let rc = unsafe { libc::fchmod(fd, mode as libc::mode_t) };
                 if rc != 0 {
@@ -618,6 +645,10 @@ impl FileOutput {
                     }
                 }
             }
+            // `owned_fd` drops here at end-of-closure, so `close(2)`
+            // runs deterministically whether the closure returned
+            // normally or panicked — cancellation of the outer future
+            // doesn't reach in here.
         })
         .await
         .ok();
@@ -1078,5 +1109,75 @@ mod tests {
             mode2, 0o600,
             "second write must not re-apply mode; operator tightening stays sticky"
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn apply_file_metadata_survives_outer_future_cancellation() {
+        // Regression pin: `spawn_blocking` isn't cancel-safe, so if a
+        // caller drops `write_payload`'s future mid-await (shutdown
+        // timeout etc.), the blocking task keeps running while the
+        // source `File` gets closed. Before we duped the fd, that
+        // window let the leftover `fchmod`/`fchown` land on an
+        // unrelated inode when the kernel reused the fd number. Pin
+        // that even under aggressive cancellation the mode still
+        // lands on the file we wrote to — or, if the future was
+        // dropped before `apply_file_metadata_to_fd` even ran, no
+        // stray metadata escapes.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("cancel.log");
+
+        let out = std::sync::Arc::new(make_output_with(
+            ek(ExprKind::StringLit(path.display().to_string())),
+            Some(0o600),
+        ));
+
+        // Kick off write_payload but drop the future immediately.
+        // Whatever happens under the covers, the outcome must be
+        // either "no file exists" or "file has mode 0o600" — never a
+        // different inode carrying our chmod.
+        let out2 = out.clone();
+        let path_str = path.display().to_string();
+        let fut = out2.write_payload(FilePayload {
+            egress: Bytes::from("cancelled"),
+            path: path_str,
+            is_dynamic: false,
+        });
+        drop(fut);
+
+        // Yield a couple of times so any spawned blocking work runs.
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        if let Ok(meta) = std::fs::metadata(&path) {
+            let mode = meta.permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o600,
+                "if the file exists after cancellation, its mode must be the one we asked for"
+            );
+        }
+        // If the file doesn't exist yet, we cancelled early enough
+        // that write never landed — also fine.
+
+        // And a follow-up "normal" write must still apply mode as
+        // expected, i.e. the previous cancellation didn't corrupt the
+        // metadata state.
+        let path2 = dir.path().join("normal.log");
+        make_output_with(
+            ek(ExprKind::StringLit(path2.display().to_string())),
+            Some(0o640),
+        )
+        .write_payload(FilePayload {
+            egress: Bytes::from("ok"),
+            path: path2.display().to_string(),
+            is_dynamic: false,
+        })
+        .await
+        .expect("normal follow-up write must succeed");
+        let mode2 = std::fs::metadata(&path2).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode2, 0o640);
     }
 }

--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -160,7 +160,7 @@ If you configure a `unix_socket` input at `/dev/log` as a syslog(3) replacement,
 PrivateDevices=no
 ```
 
-(`/dev/log` is also commonly a symlink on the host; the `unix_socket` input refuses to bind over one, so remove it first if present.)
+(`/dev/log` is also commonly a symlink on the host; the `unix_socket` input refuses to remove a symlink at its target and fails to start, so remove the symlink first if present.)
 
 Then reload systemd:
 

--- a/packaging/limpid-prometheus.service
+++ b/packaging/limpid-prometheus.service
@@ -19,7 +19,7 @@ RestartSec=5
 # of running as the shared `syslog` account; SupplementaryGroups=syslog
 # is the one thing still needed from that account, since the control
 # socket at /var/run/limpid is group-owned syslog with mode 0o660
-# (crates/limpid/src/control.rs:135) and this process must read it.
+# (set by ControlServer::run in control.rs) and this process must read it.
 DynamicUser=yes
 SupplementaryGroups=syslog
 

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -65,7 +65,9 @@ ProtectHome=yes
 #     [Service]
 #     PrivateDevices=no
 # (/dev/log is also commonly a symlink on the host, which the
-# unix_socket input refuses to bind over — remove it first if present.)
+# unix_socket input refuses to remove a symlink at its target and
+# fails to start, so bind is never reached — remove the symlink first
+# if present.)
 PrivateTmp=yes
 PrivateDevices=yes
 ProtectKernelTunables=yes

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -104,8 +104,8 @@ SystemCallFilter=@system-service
 # hardware.
 UMask=0027
 # The control socket is created with explicit 0o660 permissions in
-# control.rs (see crates/limpid/src/control.rs:135,
-# std::fs::set_permissions after bind), so UMask does not affect it.
+# control.rs (ControlServer::run calls set_permissions right after
+# bind), so UMask does not affect it.
 # `StateDirectory=limpid` and `RuntimeDirectory=limpid` above already
 # mount `/var/lib/limpid` and `/var/run/limpid` writable under
 # ProtectSystem=strict, so listing them here would be redundant. Only

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -9,8 +9,11 @@ if ! getent passwd syslog >/dev/null 2>&1; then
     useradd --system --no-create-home --shell /usr/sbin/nologin -g syslog syslog
 fi
 
-# Refuse to proceed if any target is a symlink (would let a pre-staged
-# symlink redirect config/state writes outside the intended tree).
+# Refuse to proceed if the terminal directory itself is a symlink
+# (would let a pre-staged symlink redirect config/state writes
+# elsewhere). Only the leaf is checked — a symlinked parent (`/etc`,
+# `/var/lib`, `/var/log`) is dpkg/debhelper's own trust boundary and
+# out of scope here.
 for d in /etc/limpid /var/lib/limpid /var/log/limpid; do
     if [ -L "$d" ]; then
         echo "ERROR: $d is a symlink; refusing to install over it." >&2


### PR DESCRIPTION
## Summary
Follow-up branch addressing findings from the cumulative structure + security + operational audit run against the release/0.7.9 diff. 9 commits, each a self-contained fix with commit-gate confidentiality and (aggregate) push-gate audit both delegated to a Codex partner.

- **fix(error_log)**: DLQ file created `0o600` on Unix. The record carries the failed event's ingress/egress verbatim as text (base64 only for non-UTF-8), so a payload with a secret or PII was landing in a umask-default (typically world-readable) file. Fresh follow-up: dropped a stray `OpenOptionsExt` import and reflowed with rustfmt so `-D warnings` and `--check` stay green.
- **fix(output file)**: `apply_file_metadata` now runs `fchmod(2)`/`fchown(2)` on the fd rather than the path, closing a metadata TOCTOU that `set_permissions`/`chown` left open next to `O_NOFOLLOW`. On top of that, the fd handed to `spawn_blocking` is `dup(2)`ed into an `OwnedFd` first — the outer future is cancelled under shutdown-timeout, and without dup a re-used fd number would have let the leftover blocking call land on a different inode. Regression test narrowed to what it actually pins (never-polled future has no side effect); the fd-lifetime argument lives inline.
- **fix(journal)**: defensive null-guard for `sd_journal_enumerate_data`'s `(data, len)` before `slice::from_raw_parts` (contract violation would be UB even for `len == 0`; libsystemd shouldn't hit it but the check is one branch).
- **docs(packaging)**: `control.rs:135` references in both unit files point at unrelated code after the security branch's reshuffle; switched them to `ControlServer::run` symbol references that don't drift. Symlink-guard wording in postinst and the `/dev/log` note in limpid.service / systemd.md narrowed to describe what the guard/refusal actually does.
- **packaging(prometheus)**: mirror the daemon's `enable = true, start = false` on the exporter. Without it, cargo-deb's default `start = true` would kick the exporter on install; with `Requires=limpid.service` that pulls the daemon up too, defeating the `start = false` intent that exists so a `#DEBHELPER#` start can't collide with rsyslog/syslog-ng on upgrade.

## Test plan
- [x] cargo build/test/clippy/fmt all pass (727+27+2+14)
- [x] `cargo deny check`: advisories/licenses/bans/sources ok
- [x] `cargo audit`: 0 vulnerabilities
- [x] uchgs push-gate audit (8 scopes) — 6 pass with boundary-contract/security specifically reviewing the fd-dup lifetime fix, 2 pre-existing baseline findings (cicd-pipeline, rust) confirmed by owner as unrelated to this branch
- [x] uchgs commit-gate confidentiality audit passed on each of the 9 commits (all delegated to Codex partner per repo protocol)