### PR TITLE
fix: audit round-2 followups on the 0.7.9 release branch

### DIFF
--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -41,6 +41,16 @@ use tokio::sync::Semaphore;
 /// scrape gets a fresh attempt instead of waiting behind the old one.
 const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Hard upper bound on how long a single accepted HTTP connection is
+/// allowed to occupy a permit. This is the slowloris backstop — a peer
+/// that opens a TCP connection but never sends a complete request will
+/// otherwise sit in `serve_connection().await` forever, keeping its
+/// permit. Once every permit is held by such an idle peer, all future
+/// scrapes are refused at accept time and the exporter is effectively
+/// wedged. Capping the whole connection recycles the permit even if
+/// the peer never sends anything or leaves the socket half-open.
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// Maximum concurrent HTTP connections served at once. Mirrors the
 /// daemon's own control-socket cap (`MAX_CONTROL_CONNECTIONS` in
 /// limpid's control.rs): a scrape endpoint needs one connection per
@@ -48,7 +58,8 @@ const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 /// cap keeps a misbehaving peer (or a slowloris-style dribble of idle
 /// connections) from accumulating unbounded tasks. Excess connections
 /// are closed immediately; the next scrape gets a fresh slot as soon
-/// as an in-flight one finishes.
+/// as an in-flight one finishes — paired with `CONNECTION_TIMEOUT`,
+/// so an idle-forever peer can't perma-hold its slot.
 const MAX_CONCURRENT_CONNECTIONS: usize = 8;
 
 #[derive(Parser)]
@@ -78,12 +89,14 @@ async fn main() {
     eprintln!("limpid-prometheus listening on http://{}", cli.bind);
     eprintln!("  control socket: {:?}", cli.socket);
 
-    serve(listener, cli.socket).await;
+    serve(listener, cli.socket, CONNECTION_TIMEOUT).await;
 }
 
 /// Accept loop, split from `main` so the connection-cap behaviour is
-/// testable against an ephemeral listener.
-async fn serve(listener: TcpListener, socket: PathBuf) {
+/// testable against an ephemeral listener. `connection_timeout` is a
+/// parameter so tests can shrink it without waiting on the real
+/// 15-second bound; production callers pass `CONNECTION_TIMEOUT`.
+async fn serve(listener: TcpListener, socket: PathBuf, connection_timeout: Duration) {
     let conn_sem = Arc::new(Semaphore::new(MAX_CONCURRENT_CONNECTIONS));
 
     loop {
@@ -96,10 +109,11 @@ async fn serve(listener: TcpListener, socket: PathBuf) {
         };
 
         // At the cap: close the connection immediately (drop = RST/FIN)
-        // rather than queueing it. A stalled scrape already has
-        // QUERY_TIMEOUT bounding it, so slots recycle quickly; anything
-        // that keeps all 8 busy is a misbehaving peer, and the honest
-        // fix for the client is to retry the next scrape interval.
+        // rather than queueing it. A stalled scrape has QUERY_TIMEOUT
+        // bounding the control-socket round trip *and* CONNECTION_TIMEOUT
+        // bounding the whole HTTP conversation, so slots recycle within
+        // a bounded window; the honest fix for a client hitting the cap
+        // is to retry the next scrape interval.
         let permit = match Arc::clone(&conn_sem).try_acquire_owned() {
             Ok(p) => p,
             Err(_) => {
@@ -119,10 +133,27 @@ async fn serve(listener: TcpListener, socket: PathBuf) {
                 let socket = socket.clone();
                 async move { handle_request(req, &socket).await }
             });
-            if let Err(e) = http1::Builder::new().serve_connection(io, svc).await
-                && !e.is_incomplete_message()
-            {
-                eprintln!("connection error: {}", e);
+            // Wrap the whole `serve_connection` future in a timeout,
+            // not just the request handler. QUERY_TIMEOUT only bounds
+            // the control-socket round trip inside `handle_request`,
+            // so a peer that opens a TCP connection and then never
+            // sends a request header (classic slowloris) would sit
+            // in `serve_connection().await` indefinitely and never
+            // release its permit. Once every permit is held that way,
+            // scrapes accepted at the cap are dropped and the
+            // exporter is wedged from the outside. `CONNECTION_TIMEOUT`
+            // caps the whole conversation so an idle-forever peer
+            // still frees its slot within a bounded window.
+            let conn = http1::Builder::new().serve_connection(io, svc);
+            match tokio::time::timeout(connection_timeout, conn).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) if e.is_incomplete_message() => {}
+                Ok(Err(e)) => eprintln!("connection error: {}", e),
+                Err(_) => {
+                    // Timeout fired. Dropping `conn` shuts the socket
+                    // down and releases the permit at the end of this
+                    // task, which is the recovery signal for the cap.
+                }
             }
         });
     }
@@ -409,7 +440,11 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         // Control socket path deliberately nonexistent — /health would
         // 503, but the idle connections never send a request at all.
-        let server = tokio::spawn(serve(listener, PathBuf::from("/nonexistent/control.sock")));
+        let server = tokio::spawn(serve(
+            listener,
+            PathBuf::from("/nonexistent/control.sock"),
+            CONNECTION_TIMEOUT,
+        ));
 
         // Fill every slot with idle connections. Connect sequentially:
         // the accept loop acquires the permit synchronously right
@@ -435,6 +470,77 @@ mod tests {
 
         server.abort();
         drop(held);
+    }
+
+    #[tokio::test]
+    async fn idle_connections_release_their_permits_after_connection_timeout() {
+        // Regression: without a whole-connection timeout, a slowloris
+        // peer that opens a TCP connection and never sends a request
+        // header would sit inside `serve_connection().await` forever
+        // and hold its permit. Fill every slot with such peers, wait
+        // past the (short) connection timeout, then require that a new
+        // client can grab a slot and receive a valid HTTP response.
+        // Uses a real (short) connection_timeout so real network I/O
+        // and the timeout live in the same clock.
+        use tokio::io::AsyncWriteExt;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("control.sock");
+        // 250 ms is long enough that a normal HTTP round trip isn't
+        // race-timed out, short enough that the test finishes in ~1 s.
+        let short_timeout = Duration::from_millis(250);
+        let server = tokio::spawn(serve(listener, sock, short_timeout));
+
+        // Fill every slot with idle connections. Each parked TCP
+        // connection keeps its `serve_connection` future suspended
+        // pre-fix; the timeout must free the slot on the fix side.
+        let mut idle = Vec::new();
+        for _ in 0..MAX_CONCURRENT_CONNECTIONS {
+            idle.push(TcpStream::connect(addr).await.unwrap());
+        }
+
+        // Sanity check the pre-recycle state: one more connection is
+        // accepted at the TCP layer, then immediately closed because
+        // the cap holds. Give the loop a moment to run the drop.
+        {
+            let mut over = TcpStream::connect(addr).await.unwrap();
+            let mut buf = [0u8; 1];
+            let read = tokio::time::timeout(Duration::from_millis(500), over.read(&mut buf)).await;
+            assert!(
+                matches!(read, Ok(Ok(0)) | Ok(Err(_))),
+                "over-cap connection must be closed while permits are held, got {read:?}"
+            );
+        }
+
+        // Wait past the connection timeout so every `serve_connection`
+        // future times out and its permit drops. A small margin over
+        // the timeout absorbs scheduler jitter.
+        tokio::time::sleep(short_timeout + Duration::from_millis(150)).await;
+
+        // Recovery client: after the timeout window, a fresh
+        // connection must reach `handle_request` and see a real HTTP
+        // reply (503 for /health with no daemon on the other end is
+        // fine — the point is we weren't refused at the cap).
+        let mut recovery = TcpStream::connect(addr).await.unwrap();
+        recovery
+            .write_all(b"GET /health HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .expect("write recovery request");
+        let mut buf = [0u8; 12];
+        let n = tokio::time::timeout(Duration::from_secs(2), recovery.read(&mut buf))
+            .await
+            .expect("recovery response must not block")
+            .expect("recovery response read must succeed");
+        assert!(n > 0, "recovery client must receive HTTP status bytes");
+        assert!(
+            buf[..n].starts_with(b"HTTP/1."),
+            "recovery response must be HTTP, got: {:?}",
+            &buf[..n]
+        );
+
+        server.abort();
+        drop(idle);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -20,7 +20,10 @@
 //!
 //! - **Normal operation (`shutdown()`)**: NEVER aborts the actor. It
 //!   signals cooperative shutdown via `is_shutting_down` +
-//!   `flush_notify.notify_waiters()` and joins it bounded by
+//!   `flush_notify.notify_waiters()` (to wake the actor loop) and
+//!   `shutdown_notify.notify_waiters()` (to wake retry backoff /
+//!   `wait_until_shutdown` without conflating them with threshold
+//!   flushes), then joins the actor bounded by
 //!   `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`. The actor resolves every
 //!   stack-local handle (Delivered / Recovered via DLQ) before
 //!   exiting.
@@ -144,8 +147,18 @@ pub(crate) struct SinkShared<P: BatchSinkPolicy> {
     metrics: Arc<OutputMetrics>,
     /// Threshold-driven flush trigger. `consume()` calls
     /// `notify_one()` when the buffer crosses `batch_size`; the
-    /// flusher actor's `select!` wakes and drains.
+    /// flusher actor's `select!` wakes and drains. **Never** used to
+    /// wake the retry backoff — see `shutdown_notify` for that.
     flush_notify: Notify,
+    /// Shutdown broadcast. `shutdown()` calls `notify_waiters()`
+    /// after setting `is_shutting_down`. Kept distinct from
+    /// `flush_notify` so that a threshold flush can't short-circuit a
+    /// retry backoff: if the retry sleep raced against `flush_notify`,
+    /// a new event arriving mid-backoff would wake the sleep and
+    /// re-fire the failing send immediately, ignoring the configured
+    /// backoff. Retry sleeps race only against this notify (and the
+    /// `is_shutting_down` check that follows).
+    shutdown_notify: Notify,
     /// Co-operative cancel flag. `shutdown()` sets this to true
     /// before notifying the actor; both the actor loop and the
     /// in-flight `flush_events` retry loop check it so they exit
@@ -175,6 +188,7 @@ impl<P: BatchSinkPolicy> BatchedSink<P> {
             error_log,
             metrics,
             flush_notify: Notify::new(),
+            shutdown_notify: Notify::new(),
             is_shutting_down: AtomicBool::new(false),
         });
         let actor_handle = if tokio::runtime::Handle::try_current().is_ok() {
@@ -232,11 +246,15 @@ impl<P: BatchSinkPolicy> BatchedSink<P> {
         //    propagates to the actor's outer `select!`, to the
         //    retry sleep race, and (via the transport-cancel race
         //    in `flush_events`) to the in-flight send call itself.
-        //    `notify_waiters` wakes every current `.notified()`
-        //    awaiter so a stalled peer's transport future is dropped
-        //    immediately rather than blocking until its read timeout.
+        //    Two notifies: `flush_notify` wakes the actor loop's
+        //    `select!`, and `shutdown_notify` wakes anything else
+        //    waiting on the shutdown signal (retry backoff sleep,
+        //    `wait_until_shutdown`). Keeping them separate lets a
+        //    threshold flush arrive without collapsing the retry
+        //    backoff — see the `shutdown_notify` field doc.
         self.inner.is_shutting_down.store(true, Ordering::Release);
         self.inner.flush_notify.notify_waiters();
+        self.inner.shutdown_notify.notify_waiters();
 
         // 2. Bounded join of the flusher actor. The actor's invariant
         //    is that EVERY stack-local `(Event, QueueAckHandle)` it
@@ -278,11 +296,12 @@ impl<P: BatchSinkPolicy> Drop for BatchedSink<P> {
         // without an explicit `shutdown()` call, e.g. config
         // teardown in tests). The actor's stack-local batch on a
         // bare abort would drop handles unresolved; setting
-        // `is_shutting_down` and `notify_waiters` here gives it a
+        // `is_shutting_down` and both notifies here gives it a
         // chance to exit cleanly first, even though we cannot await
         // its completion from a sync Drop.
         self.inner.is_shutting_down.store(true, Ordering::Release);
         self.inner.flush_notify.notify_waiters();
+        self.inner.shutdown_notify.notify_waiters();
         if let Some(h) = self.actor_handle.get_mut().take() {
             h.abort();
         }
@@ -357,7 +376,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
             if self.is_shutting_down.load(Ordering::Acquire) {
                 return;
             }
-            let notified = self.flush_notify.notified();
+            let notified = self.shutdown_notify.notified();
             if self.is_shutting_down.load(Ordering::Acquire) {
                 return;
             }
@@ -533,13 +552,21 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                     // shutdown that fires *during* the sleep would
                     // otherwise be stuck until the sleep elapses
                     // (5s+ in practice, longer than the runtime
-                    // shutdown budget). `flush_notify.notify_waiters`
+                    // shutdown budget). `shutdown_notify.notify_waiters`
                     // is called by `shutdown()`, so the sleep arm
                     // here wakes immediately and the next iteration
                     // sees `is_shutting_down=true` and breaks.
+                    //
+                    // NOT `flush_notify`: a threshold-driven flush wake
+                    // arriving mid-backoff would otherwise cut the
+                    // backoff short and re-fire the failing send
+                    // instantly, hammering a failing collector and
+                    // ignoring the configured retry pacing. Retry
+                    // pacing survives incoming traffic; only shutdown
+                    // is allowed to short-circuit it.
                     tokio::select! {
                         _ = tokio::time::sleep(wait) => {}
-                        _ = self.flush_notify.notified() => {}
+                        _ = self.shutdown_notify.notified() => {}
                     }
                     wait = self.retry.next_wait(wait);
                 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -349,14 +349,16 @@ impl FileOutput {
             );
         }
 
-        let first_create = {
-            let mut guard = self.created_paths.lock().await;
-            if !path.exists() && !guard.contains(&path) {
-                guard.insert(path.clone());
-                true
-            } else {
-                false
-            }
+        // Sample the "have we ever created this path" flag *before*
+        // opening the file — we can't record the create yet because
+        // `open` and `write_all` may still fail (O_NOFOLLOW → ELOOP,
+        // ENOSPC, permission errors, etc.), and marking it created
+        // pre-open would leave a permanently-broken output whose
+        // mode/owner never gets applied on the next successful write.
+        // The record happens only after the write actually lands.
+        let is_new_path = {
+            let guard = self.created_paths.lock().await;
+            !path.exists() && !guard.contains(&path)
         };
 
         // Fourth safety pass, complementing the three path-rendering
@@ -392,6 +394,25 @@ impl FileOutput {
         buf.push(b'\n');
         file.write_all(&buf).await?;
         self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+
+        // Only after the write actually succeeded do we (a) mark the
+        // path as created for this output's lifetime and (b) apply
+        // mode/owner. Doing (b) inside the same critical section as
+        // (a) means a concurrent second write for the same path can't
+        // sneak past — the first successful writer wins the
+        // metadata-apply slot, and everyone else sees the path in
+        // `created_paths` and skips it.
+        let first_create = if is_new_path {
+            let mut guard = self.created_paths.lock().await;
+            if guard.insert(path.clone()) {
+                true
+            } else {
+                // Another concurrent writer beat us to it.
+                false
+            }
+        } else {
+            false
+        };
 
         if first_create {
             // Apply mode/owner through the open fd rather than the path.
@@ -1146,6 +1167,63 @@ mod tests {
         assert!(
             !path.exists(),
             "never-polled write_payload future must not create the target file"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn failed_first_write_does_not_skip_mode_on_the_retry() {
+        // Regression pin: the `first_create` bookkeeping used to
+        // record the path *before* `open`/`write_all`. That meant a
+        // failed first attempt — e.g. O_NOFOLLOW hitting a
+        // pre-planted symlink — still marked the path as "created",
+        // so the operator's fix (remove the symlink) succeeded but
+        // the subsequent write treated the file as not-first-create
+        // and silently skipped mode/owner application. Pin that the
+        // configured mode lands on the file that eventually gets
+        // created.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("guarded.log");
+        // Point a symlink at a target somewhere outside the tempdir
+        // so `open(O_NOFOLLOW)` fails with ELOOP on the first try.
+        let symlink_target = dir.path().join("_would_be_hijacked.log");
+        std::os::unix::fs::symlink(&symlink_target, &path).unwrap();
+
+        let out = make_output_with(
+            ek(ExprKind::StringLit(path.display().to_string())),
+            Some(0o640),
+        );
+
+        // First write must fail with the symlink refusal.
+        let err = out
+            .write_payload(FilePayload {
+                egress: Bytes::from("first"),
+                path: path.display().to_string(),
+                is_dynamic: false,
+            })
+            .await
+            .expect_err("symlink at output path must be refused on first write");
+        assert!(err.to_string().contains("refusing to follow symlink"));
+
+        // Operator removes the symlink and retries.
+        std::fs::remove_file(&path).unwrap();
+        out.write_payload(FilePayload {
+            egress: Bytes::from("second"),
+            path: path.display().to_string(),
+            is_dynamic: false,
+        })
+        .await
+        .expect("second write must succeed after removing the symlink");
+
+        // The retry must be treated as first-create so the configured
+        // mode lands on the newly opened file. Pre-fix this returned
+        // 0644 (umask default) because `created_paths` already
+        // contained the path from the failed attempt.
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o640,
+            "post-fix: metadata contract must apply on the first successful write, not on the first attempt"
         );
     }
 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -93,8 +93,19 @@ pub struct FileOutput {
     mode: Option<u32>,
     owner: Option<String>,
     group: Option<String>,
-    /// Tracks which paths have been created (for applying mode/owner/group once)
+    /// Paths this output has finished applying mode/owner/group to.
+    /// Membership is only inserted *after* `apply_file_metadata_to_fd`
+    /// returns, so it is authoritative: presence == metadata obligation
+    /// satisfied.
     created_paths: Mutex<HashSet<PathBuf>>,
+    /// Paths where this output has successfully opened the file at
+    /// least once but has not yet promoted them to `created_paths`.
+    /// Used to survive a write_all failure or a cancellation between
+    /// write_all and apply — either case leaves an on-disk file this
+    /// output owes metadata to. Presence here forces the next
+    /// successful write to re-apply mode/owner even though
+    /// `path.exists()` is now true.
+    metadata_obligations: Mutex<HashSet<PathBuf>>,
     funcs: Arc<FunctionRegistry>,
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
@@ -153,6 +164,7 @@ impl Module for FileOutput {
             owner,
             group,
             created_paths: Mutex::new(HashSet::new()),
+            metadata_obligations: Mutex::new(HashSet::new()),
             funcs,
             retry,
             error_log,
@@ -349,16 +361,32 @@ impl FileOutput {
             );
         }
 
-        // Sample the "have we ever created this path" flag *before*
-        // opening the file — we can't record the create yet because
-        // `open` and `write_all` may still fail (O_NOFOLLOW → ELOOP,
-        // ENOSPC, permission errors, etc.), and marking it created
-        // pre-open would leave a permanently-broken output whose
-        // mode/owner never gets applied on the next successful write.
-        // The record happens only after the write actually lands.
-        let is_new_path = {
-            let guard = self.created_paths.lock().await;
-            !path.exists() && !guard.contains(&path)
+        // Decide whether this write owes metadata to the target
+        // path, sampled *before* the open. Two orthogonal signals:
+        //
+        //   * `already_applied` — a prior write for this path ran
+        //     apply_file_metadata_to_fd to completion. Nothing more
+        //     to do.
+        //   * `has_prior_obligation` — a prior write got as far as a
+        //     successful `open` for this path but did not finish the
+        //     apply (write_all failed, or the apply await was
+        //     cancelled). We still owe metadata; the on-disk file
+        //     exists but the obligation is outstanding.
+        //
+        // For "path exists but neither flag is set" — a pre-existing
+        // file some other producer created — we deliberately skip
+        // metadata: this output has never touched it, so overriding
+        // its mode/owner would surprise operators. The obligation
+        // path only kicks in once we've opened the file at least once
+        // ourselves.
+        let (path_preexisted, has_prior_obligation, already_applied) = {
+            let created = self.created_paths.lock().await;
+            let obligations = self.metadata_obligations.lock().await;
+            (
+                path.exists(),
+                obligations.contains(&path),
+                created.contains(&path),
+            )
         };
 
         // Fourth safety pass, complementing the three path-rendering
@@ -388,6 +416,19 @@ impl FileOutput {
             anyhow::Error::from(e)
         })?;
 
+        // We now hold an fd for the target. If this write is going to
+        // owe metadata, record the obligation *before* write_all — the
+        // open may have just created a fresh file on disk, and if
+        // write_all fails or is cancelled we must remember to finish
+        // the apply on the next attempt (otherwise `path.exists()`
+        // above would silently drop us into the "pre-existing" arm on
+        // the next call).
+        let should_apply = !already_applied && (has_prior_obligation || !path_preexisted);
+        if should_apply && !has_prior_obligation {
+            let mut obligations = self.metadata_obligations.lock().await;
+            obligations.insert(path.clone());
+        }
+
         let msg = String::from_utf8_lossy(&payload.egress);
         let mut buf = Vec::with_capacity(msg.len() + 1);
         buf.extend_from_slice(msg.as_bytes());
@@ -395,26 +436,7 @@ impl FileOutput {
         file.write_all(&buf).await?;
         self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
 
-        // Only after the write actually succeeded do we (a) mark the
-        // path as created for this output's lifetime and (b) apply
-        // mode/owner. Doing (b) inside the same critical section as
-        // (a) means a concurrent second write for the same path can't
-        // sneak past — the first successful writer wins the
-        // metadata-apply slot, and everyone else sees the path in
-        // `created_paths` and skips it.
-        let first_create = if is_new_path {
-            let mut guard = self.created_paths.lock().await;
-            if guard.insert(path.clone()) {
-                true
-            } else {
-                // Another concurrent writer beat us to it.
-                false
-            }
-        } else {
-            false
-        };
-
-        if first_create {
+        if should_apply {
             // Apply mode/owner through the open fd rather than the path.
             // The path is already guarded by O_NOFOLLOW at open time, but
             // set_permissions()/chown() would re-resolve the path and
@@ -422,7 +444,21 @@ impl FileOutput {
             // metadata call — closing that TOCTOU window means the mode
             // and ownership always land on the same inode we just wrote
             // to, never a different one.
+            //
+            // apply_file_metadata_to_fd is cancel-safe (dup fd +
+            // spawn_blocking): if this await returns at all, the
+            // fchmod/fchown have run. So once we get past it we can
+            // promote the path from "obligation outstanding" to
+            // "obligation satisfied". A concurrent second writer may
+            // have observed should_apply=true and re-applied in
+            // parallel — fchmod/fchown are idempotent so the extra
+            // call is harmless, and the insert below de-duplicates
+            // future callers.
             self.apply_file_metadata_to_fd(&file, &path).await;
+            let mut created = self.created_paths.lock().await;
+            let mut obligations = self.metadata_obligations.lock().await;
+            created.insert(path.clone());
+            obligations.remove(&path);
         }
 
         Ok(())
@@ -798,6 +834,7 @@ mod tests {
             owner: None,
             group: None,
             created_paths: Mutex::new(HashSet::new()),
+            metadata_obligations: Mutex::new(HashSet::new()),
             funcs: funcs(),
             retry: RetryConfig::default(),
             error_log: None,
@@ -1224,6 +1261,103 @@ mod tests {
         assert_eq!(
             mode, 0o640,
             "post-fix: metadata contract must apply on the first successful write, not on the first attempt"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn outstanding_metadata_obligation_reapplies_on_next_write() {
+        // Regression pin for the "write_all failed or the apply await
+        // was cancelled between open and apply_file_metadata_to_fd"
+        // shape (audit round-2, boundary-contract / security). Before
+        // the fix, the metadata obligation was tracked only through
+        // `path.exists()` — once the file existed on disk (which
+        // `open(create=true)` guarantees the moment it returns), any
+        // subsequent call landed in the "not first create" arm and
+        // silently skipped mode/owner. We simulate that shape by
+        // seeding `metadata_obligations` directly: it is what a prior
+        // aborted attempt would have left behind.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("obligation.log");
+
+        // Pretend a previous attempt got as far as `open` (creating
+        // the file) but was cancelled before apply. On disk that
+        // looks like: file exists with umask-default mode; obligation
+        // still registered.
+        std::fs::write(&path, b"partial\n").unwrap();
+        let out = make_output_with(
+            ek(ExprKind::StringLit(path.display().to_string())),
+            Some(0o600),
+        );
+        out.metadata_obligations.lock().await.insert(path.clone());
+
+        // Next successful write must honour the obligation.
+        out.write_payload(FilePayload {
+            egress: Bytes::from("retry"),
+            path: path.display().to_string(),
+            is_dynamic: false,
+        })
+        .await
+        .expect("retry write must succeed");
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "outstanding metadata obligation must trigger apply on the next successful write"
+        );
+        assert!(
+            out.metadata_obligations.lock().await.is_empty(),
+            "obligation must be cleared once apply has landed"
+        );
+        assert!(
+            out.created_paths.lock().await.contains(&path),
+            "successful apply must promote the path to created_paths"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn preexisting_file_from_another_producer_keeps_its_mode() {
+        // Semantic pin, complementing the obligation test above: a
+        // file that existed *before* this output ever touched it, and
+        // therefore carries no obligation, must not have its mode
+        // overwritten on our first append. The mode contract is
+        // scoped to files this output creates (or has an outstanding
+        // obligation on); rewriting an unrelated producer's file
+        // would surprise operators.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("foreign.log");
+
+        std::fs::write(&path, b"not ours\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let out = make_output_with(
+            ek(ExprKind::StringLit(path.display().to_string())),
+            Some(0o600),
+        );
+
+        out.write_payload(FilePayload {
+            egress: Bytes::from("append"),
+            path: path.display().to_string(),
+            is_dynamic: false,
+        })
+        .await
+        .expect("append to a preexisting file must succeed");
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o644,
+            "pre-existing file with no obligation must keep its mode"
+        );
+        assert!(
+            out.metadata_obligations.lock().await.is_empty(),
+            "no obligation should have been recorded for a preexisting file"
+        );
+        assert!(
+            !out.created_paths.lock().await.contains(&path),
+            "no metadata was applied, so nothing should have promoted to created_paths"
         );
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -1884,6 +1884,101 @@ def output o {{
         );
     }
 
+    /// Regression pin: the retry backoff sleep must NOT wake early when
+    /// a fresh `consume()` fires a threshold flush notification. Before
+    /// the fix the retry loop raced the sleep against `flush_notify`,
+    /// which `consume()` also pings when the buffer crosses
+    /// `batch_size`. Under continuous traffic that turned every retry
+    /// backoff into an instant re-send — hammering a failing collector
+    /// and ignoring `initial_wait`. Now the retry sleep only races
+    /// against `shutdown_notify`, so a new event arriving mid-backoff
+    /// enqueues silently until the sleep elapses on its own.
+    #[tokio::test]
+    async fn retry_backoff_survives_threshold_notify_race() {
+        let (addr, post_count, server) = run_counting_failing_collector().await;
+        let url = format!("http://{}/", addr);
+        // 400 ms backoff between attempts. Long enough that we can
+        // reliably observe "second attempt hasn't fired yet" through a
+        // scheduling window, short enough that the whole test finishes
+        // in about a second even without the wake bug.
+        let slow_retry = Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 2),
+                prop_str("initial_wait", "400ms"),
+                prop_str("max_wait", "400ms"),
+                Property::KeyValue {
+                    key: "backoff".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
+                    value_span: None,
+                },
+            ],
+        };
+        let output = HttpOutput::from_properties(
+            "test",
+            &mp(&[peer_block(&url), prop_int("batch_size", 1), slow_retry]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+
+        // Kick off the first send. `batch_size=1` means the actor
+        // flushes immediately; the server 500s, and the retry loop
+        // enters `sleep(400ms)`.
+        output
+            .consume(&event_with("first"), event_ack())
+            .await
+            .unwrap();
+
+        // Wait long enough for the first attempt to reach the server
+        // and for the retry loop to be sitting in its backoff. The
+        // 400 ms window here has to comfortably cover a request round
+        // trip plus a few scheduler hops.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        let after_first = post_count.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            after_first, 1,
+            "expected exactly the initial attempt to have hit the server before the notify race, got {after_first}"
+        );
+
+        // Fire the threshold-flush notify while the retry loop is
+        // asleep. Pre-fix this cut the backoff short and re-fired the
+        // send within milliseconds; post-fix it must not.
+        output
+            .consume(&event_with("second"), event_ack())
+            .await
+            .unwrap();
+
+        // Give the actor plenty of time to react to the notify but
+        // still stay under the 400 ms backoff floor.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let mid_backoff = post_count.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            mid_backoff, 1,
+            "threshold-flush notify must not wake the retry backoff — expected 1 attempt still, got {mid_backoff}",
+        );
+
+        // Now wait past the 400 ms floor and let the retry actually
+        // fire. The exact count depends on how the two batches are
+        // scheduled, but the retry MUST have fired by now.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let post_backoff = post_count.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            post_backoff >= 2,
+            "retry must have fired after the backoff elapsed — got only {post_backoff}",
+        );
+
+        server.abort();
+    }
+
+    /// Cheap ack handle that discards its disposition — the sleep-race
+    /// regression above doesn't need to inspect it.
+    fn event_ack() -> crate::queue::QueueAckHandle {
+        let (h, _) = crate::queue::QueueAckHandle::for_test();
+        h
+    }
+
     /// Regression for the 0.7.8 shutdown panic / silent loss: at shutdown
     /// the batched flush MUST NOT consume the steady-state retry budget.
     /// We configure `max_attempts=5` with `200ms` waits — a budget that,

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -705,8 +705,8 @@ async fn process_event(
 /// Shared by both runtime-error shapes the orchestrator surfaces:
 /// `PipelineTermination::Errored` (a `process` raised an error mid-
 /// pipeline) and an `Err` return from `run_pipeline` itself
-/// (expression evaluation under `error`/`if`/`switch`/process args
-/// raised an error). Keeping the two on the same routing helper
+/// (expression evaluation under `error`/`if`/`switch` or a process
+/// body expression raised an error). Keeping the two on the same routing helper
 /// guarantees the operator-visible behaviour stays in lockstep:
 /// same JSONL on disk, same `events_errored` counter, same
 /// `events_errored_unwritable` semantics when the DLQ write itself

--- a/docs/src/inputs/journal.md
+++ b/docs/src/inputs/journal.md
@@ -36,9 +36,9 @@ Off The Land). One journal entry → one `Event`, with `ingress` carrying a
 single-line UTF-8 JSON object. The shape matches `journalctl -o json` on
 field set and values, with two known divergences: `__SEQNUM` /
 `__SEQNUM_ID` (newer `journalctl`) are **not surfaced** because the
-systemd-0.10.x crate exposes no equivalent API, and JSON object key order
-is libsystemd's insertion order — not guaranteed to byte-match
-`journalctl -o json`.
+in-crate `journal_sys` FFI doesn't bind `sd_journal_get_seqnum`, and
+JSON object key order is libsystemd's insertion order — not guaranteed
+to byte-match `journalctl -o json`.
 
 ```
 {"__CURSOR":"s=abc...","__REALTIME_TIMESTAMP":"1714400000000000",

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -130,7 +130,7 @@ A sink-side failure (retry budget exhausted, batched-output shutdown drain, runt
 
 | Field | Meaning |
 |-------|---------|
-| `process` | `{ "name": "<site>" }` block. `name` is the failing `def process` name, `(inline)` for an inline `process { ... }` block, `(pipeline)` for a pipeline-statement `error <expr>`, or `(pipeline body)` for a pipeline-skeleton expression failure (`if` / `switch` / `error <expr>` arg / `process` function args). |
+| `process` | `{ "name": "<site>" }` block. `name` is the failing `def process` name, `(inline)` for an inline `process { ... }` block, `(pipeline)` for a pipeline-statement `error <expr>`, or `(pipeline body)` for a pipeline-skeleton expression failure (`if` condition, `switch` scrutinee, `error <expr>` argument, or a body expression evaluated inside the pipeline). |
 
 `event` carries only `{ source, received_at, ingress }` — no `egress`, no `workspace`. Replay re-runs the pipeline from scratch on `ingress`.
 


### PR DESCRIPTION
## Summary

Follow-ups from the round-2 audit against the `release/0.7.9` branch after
[#103](https://github.com/naoto256/limpid/pull/103) merged. Five focused
fixes — four originally surfaced by the audit, plus one more prompted by
the round-2 push-gate re-audit that noticed the initial `file.rs` change
still missed the "opened, then write/apply failed or was cancelled" case.

- **batched sink retry backoff**: separate the shutdown wake from the flush
  wake so a threshold-triggered flush notify can't cut a retry sleep short.
- **file output metadata**: two-step fix. First move the `created_paths`
  insert to run only after `write_all` succeeds (kills the "recorded on a
  failed attempt" leak); then, in the follow-up, add a
  `metadata_obligations` set so that if `open` succeeded but `write_all`
  failed or the `apply_file_metadata_to_fd` await was cancelled, the next
  successful write picks the obligation up and finishes the apply. Files
  this output has never touched keep their mode/owner — only the
  obligation path re-applies.
- **prometheus HTTP conversation timeout**: wrap the whole
  `serve_connection` future in a `tokio::time::timeout`, so an idle
  attacker holding the socket half-open no longer keeps a
  semaphore permit forever.
- **docs drift**: drop stale `systemd-0.10.x crate` wording (the crate was
  swapped for an in-crate `journal_sys` FFI in [#103](https://github.com/naoto256/limpid/pull/103)), and remove
  `process function args` from the DLQ label enumeration (the grammar no
  longer accepts process-call arguments).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 731 + 27 + 3 + 14 pass, includes three
      new regression tests:
      - `retry_backoff_survives_threshold_notify_race`
      - `outstanding_metadata_obligation_reapplies_on_next_write`
      - `preexisting_file_from_another_producer_keeps_its_mode`
      - `idle_connections_release_their_permits_after_connection_timeout`
      - `failed_first_write_does_not_skip_mode_on_the_retry`
- [x] `cargo audit` — clean
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
      (duplicate-crate warnings are the existing baseline)