### PR TITLE
fix: audit round-6 followups (F1 batched shutdown lost-wake, F3 mode parser, F4 process-args drift)

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -16,8 +16,8 @@
 //!    via `error <expr>` or a process-internal failure.
 //! 2. **`(inline)`** — an inline `process { ... }` block raised
 //!    similarly.
-//! 3. **`(pipeline body)`** — `if`/`switch`/`error <expr>`/process-args
-//!    eval failed before reaching a process body.
+//! 3. **`(pipeline body)`** — `if`/`switch`/`error <expr>` eval
+//!    failed before reaching a process body.
 //! 4. **`(pipeline)`** — `error <expr>` at the pipeline (statement)
 //!    level raised.
 //!

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -552,10 +552,18 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                     // shutdown that fires *during* the sleep would
                     // otherwise be stuck until the sleep elapses
                     // (5s+ in practice, longer than the runtime
-                    // shutdown budget). `shutdown_notify.notify_waiters`
-                    // is called by `shutdown()`, so the sleep arm
-                    // here wakes immediately and the next iteration
-                    // sees `is_shutting_down=true` and breaks.
+                    // shutdown budget).
+                    //
+                    // Use `wait_until_shutdown()` (not a bare
+                    // `shutdown_notify.notified()`) so the lost-wake
+                    // window is closed: `shutdown()` first sets
+                    // `is_shutting_down` and *then* calls
+                    // `notify_waiters`. A raw `notified()` registered
+                    // between those two steps would miss the wake and
+                    // sleep the full backoff; `wait_until_shutdown`
+                    // does the load-notified-recheck dance so either
+                    // ordering wakes it. See `wait_until_shutdown`'s
+                    // docs for the argument.
                     //
                     // NOT `flush_notify`: a threshold-driven flush wake
                     // arriving mid-backoff would otherwise cut the
@@ -566,7 +574,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                     // is allowed to short-circuit it.
                     tokio::select! {
                         _ = tokio::time::sleep(wait) => {}
-                        _ = self.shutdown_notify.notified() => {}
+                        _ = self.wait_until_shutdown() => {}
                     }
                     wait = self.retry.next_wait(wait);
                 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -128,14 +128,33 @@ impl Module for FileOutput {
         }
 
         let mode = props::get_string(properties, "mode")
-            .map(|s| {
-                let s = s.trim_start_matches('0');
-                u32::from_str_radix(s, 8).with_context(|| {
+            .map(|raw| {
+                // Parse as octal directly. Do NOT strip leading zeros
+                // first: `"0"` and `"0000"` are both valid Unix modes
+                // and must survive the parse; stripping to `""` used
+                // to turn them into a load-time error.
+                let parsed = u32::from_str_radix(&raw, 8).with_context(|| {
                     format!(
                         "output '{}': invalid mode (expected octal, e.g. \"0640\")",
                         name
                     )
-                })
+                })?;
+                // Enforce the same 12-bit mask the write path checks
+                // via `fstat` (setuid / setgid / sticky + rwx). A
+                // value above 0o7777 could never be honoured — the
+                // `fchmod` on create silently masks the extras, and
+                // the fstat verify on subsequent writes would report
+                // a permanent mismatch. Reject at load time so the
+                // operator sees the mistake in the daemon startup
+                // log rather than at first write.
+                if parsed > 0o7777 {
+                    anyhow::bail!(
+                        "output '{}': mode 0o{:o} exceeds the 12-bit permission range 0o7777",
+                        name,
+                        parsed
+                    );
+                }
+                Ok(parsed)
             })
             .transpose()?;
 
@@ -1655,5 +1674,62 @@ mod tests {
             0o644,
             "no metadata contract means the existing file's mode is untouched"
         );
+    }
+
+    fn mp(props: &[crate::dsl::ast::Property]) -> crate::dsl::module_props::ModuleProperties {
+        crate::dsl::module_props::ModuleProperties::from_parts("file", props.to_vec())
+    }
+
+    fn prop_str(key: &str, val: &str) -> crate::dsl::ast::Property {
+        crate::dsl::ast::Property::KeyValue {
+            key: key.to_string(),
+            key_span: None,
+            value: Expr::spanless(ExprKind::StringLit(val.to_string())),
+            value_span: None,
+        }
+    }
+
+    #[test]
+    fn mode_parser_accepts_all_zero_forms() {
+        // `0o0000` is a legitimate Unix mode (no permission bits set).
+        // The parser used to `trim_start_matches('0')` first, which
+        // turned `"0"` and `"0000"` into an empty string and then a
+        // parse error. Pin both spellings as accepted so future
+        // refactors don't reintroduce the strip.
+        for raw in ["0", "0000"] {
+            let props = mp(&[prop_str("path", "/tmp/nowhere.log"), prop_str("mode", raw)]);
+            let out = FileOutput::from_properties(
+                "t",
+                &props,
+                &crate::modules::BuildContext::for_testing(),
+            )
+            .unwrap_or_else(|e| panic!("mode {raw:?} must parse: {e:#}"));
+            assert_eq!(out.mode, Some(0o0000), "mode {raw:?}");
+        }
+    }
+
+    #[test]
+    fn mode_parser_rejects_values_above_the_permission_mask() {
+        // A value above 0o7777 could never be honoured by the fstat
+        // verify (which masks to 0o7777). Reject at load time so the
+        // mistake surfaces in the startup log, not as a permanent
+        // "mode does not match" refusal on every subsequent write.
+        for raw in ["10000", "17777"] {
+            let props = mp(&[prop_str("path", "/tmp/nowhere.log"), prop_str("mode", raw)]);
+            let res = FileOutput::from_properties(
+                "t",
+                &props,
+                &crate::modules::BuildContext::for_testing(),
+            );
+            let err = match res {
+                Ok(_) => panic!("mode {raw:?} exceeds 0o7777 and must be rejected"),
+                Err(e) => e,
+            };
+            let msg = err.to_string();
+            assert!(
+                msg.contains("exceeds the 12-bit permission range"),
+                "diagnostic must name the constraint: {msg}"
+            );
+        }
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -1972,6 +1972,77 @@ def output o {{
         server.abort();
     }
 
+    /// Regression pin: `shutdown()` fired while a retry backoff sleep
+    /// is in progress must short-circuit that sleep promptly, even
+    /// under the lost-wake window. The previous implementation
+    /// awaited a bare `shutdown_notify.notified()` inside the retry
+    /// `tokio::select!`. If `shutdown()` ran between the pre-sleep
+    /// `is_shutting_down.load()` and the `notified()` registration
+    /// (a real race — those steps aren't atomic), the wake was
+    /// lost and the retry loop slept the full `max_wait`. With
+    /// `max_wait` defaulting to 60 s and the runtime's shutdown
+    /// budget at 10 s, that stranded actor state past the join and
+    /// forced a task abort — the same class of leak that PR #84
+    /// closed for the steady-state path.
+    ///
+    /// This test can't atomically script the "shutdown fires
+    /// between the outer load and the inner notified()" ordering.
+    /// It instead pins the observable outcome: with a long backoff
+    /// (`max_wait=5s`) and shutdown fired ~150 ms into the sleep,
+    /// `shutdown()` must return well under `max_wait`. Pre-fix this
+    /// occasionally slept the full 5 s; post-fix it is always
+    /// prompt because `wait_until_shutdown()`'s load-notified-
+    /// recheck pattern catches either ordering.
+    #[tokio::test]
+    async fn shutdown_short_circuits_the_retry_backoff() {
+        let (addr, _post_count, server) = run_counting_failing_collector().await;
+        let url = format!("http://{}/", addr);
+        // A very long floor makes it unambiguous: any prompt
+        // shutdown return is thanks to the wake, not the sleep
+        // elapsing on its own.
+        let slow_retry = Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 5),
+                prop_str("initial_wait", "5s"),
+                prop_str("max_wait", "5s"),
+                Property::KeyValue {
+                    key: "backoff".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
+                    value_span: None,
+                },
+            ],
+        };
+        let output = HttpOutput::from_properties(
+            "test",
+            &mp(&[peer_block(&url), prop_int("batch_size", 1), slow_retry]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+
+        output
+            .consume(&event_with("first"), event_ack())
+            .await
+            .unwrap();
+
+        // Let the actor reach the retry sleep.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Fire shutdown. Measure the wall time to return; it must
+        // be far less than the 5 s max_wait floor.
+        let started = std::time::Instant::now();
+        output.shutdown(None).await.unwrap();
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(1500),
+            "shutdown must short-circuit the retry sleep — took {elapsed:?} against a 5s floor"
+        );
+
+        server.abort();
+    }
+
     /// Cheap ack handle that discards its disposition — the sleep-race
     /// regression above doesn't need to inspect it.
     fn event_ack() -> crate::queue::QueueAckHandle {

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -670,8 +670,8 @@ async fn process_event(
             Err(e) => {
                 // Pipeline body raised a runtime error that wasn't
                 // caught by `process` (= came out of expression
-                // evaluation in `error <expr>`, process arguments,
-                // switch discriminant/pattern, or `if` condition).
+                // evaluation in `error <expr>`, switch discriminant/
+                // pattern, or `if` condition).
                 // Pre-fix this branch only logged and the event
                 // disappeared without an `events_errored` increment
                 // or a DLQ entry — operators had no replay path,

--- a/docs/src/functions/README.md
+++ b/docs/src/functions/README.md
@@ -1,6 +1,6 @@
 # Functions
 
-Functions return values. They appear in conditions, on the right-hand side of assignments, inside `${...}` interpolations, in HashLit values, as `process` arguments, and as bare statements inside a `process` body (where the returned object is merged into `workspace`).
+Functions return values. They appear in conditions, on the right-hand side of assignments, inside `${...}` interpolations, in HashLit values, and as bare statements inside a `process` body (where the returned object is merged into `workspace`).
 
 limpid distinguishes two forms by where the implementation lives, but the call surface is identical for both:
 

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -151,7 +151,7 @@ Process flavor (4 sites — replay via `inject input`):
 
 1. **`<process_name>`** — an explicit `process` body raised via `error <expr>` or a process-internal failure.
 2. **`(inline)`** — an inline `process { ... }` block raised the same way.
-3. **`(pipeline body)`** — an `if` condition / `switch` discriminant / explicit `error <expr>` argument / `process` function argument failed to evaluate before reaching a process body.
+3. **`(pipeline body)`** — an `if` condition / `switch` discriminant / explicit `error <expr>` argument failed to evaluate before reaching a process body.
 4. **`(pipeline)`** — `error <expr>` at the pipeline (statement) level raised, including the dispatcher pattern where a snippet routes on an unrecognised subtype.
 
 Output flavor (3 sites — replay via `inject output`):


### PR DESCRIPTION
## Summary

Three focused fixes, in scope of the "(b) branch-split" plan that
keeps F2 (unbatched consume shutdown race) as a separate branch
because its blast radius covers the queue-consumer / Output trait
boundary.

- **F1 — batched retry-sleep lost-wake at shutdown**
  ([crates/limpid/src/modules/output/batched.rs](crates/limpid/src/modules/output/batched.rs))
  The retry `tokio::select!` awaited a bare
  `shutdown_notify.notified()`. Between the pre-sleep
  `is_shutting_down.load()` and the `notified()` future's
  registration, `shutdown()` can set the flag and call
  `notify_waiters` — the wake is lost and the sleep runs to
  `max_wait` (default 60 s), past the runtime's 10 s shutdown
  budget. That stranded the actor and forced a task abort,
  reintroducing the class of loss PR
  [#84](https://github.com/naoto256/limpid/pull/84) closed for the
  steady-state path. Swap in `wait_until_shutdown()`, which does
  the load-notified-recheck dance and catches either interleaving.
  New regression: `shutdown_short_circuits_the_retry_backoff`.

- **F3 — file-output `mode` parser contract gaps**
  ([crates/limpid/src/modules/output/file.rs](crates/limpid/src/modules/output/file.rs))
  `trim_start_matches('0')` before `from_str_radix` turned
  `mode "0"` and `mode "0000"` into an empty string → parse error,
  even though 0o0000 is a valid Unix mode. No upper bound, so
  `mode "10000"` (above the 12-bit permission mask) passed the
  parse but was silently masked by the create-time `fchmod`, then
  reported by the subsequent-write fstat verify as a permanent
  mismatch on every event. Parse the raw string directly as octal
  and reject values above `0o7777` at load time. New regression
  tests pin both accept and reject sides.

- **F4 — stale `process` argument wording in docs / comments**
  (`docs/src/functions/README.md`, `docs/src/operations/error-log.md`,
  `crates/limpid/src/error_log.rs`, `crates/limpid/src/runtime.rs`)
  The DSL grammar removed process-call arguments earlier; four
  wording sites still enumerated them as places a function can
  appear or as a `(pipeline body)` DLQ label source. Trim each to
  the current enumeration (`error <expr>` + switch discriminant /
  pattern + `if` condition). Wording-only; no runtime change.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 739 + 27 + 3 + 14 pass on both
      macOS and aarch64 Ubuntu (pre-push validation on the
      playground per the engraved rule; see the round-5 followup).
      Includes new regressions:
      - `shutdown_short_circuits_the_retry_backoff` (F1)
      - `mode_parser_accepts_all_zero_forms` (F3)
      - `mode_parser_rejects_values_above_the_permission_mask` (F3)
- [x] `cargo audit` — vulnerabilities: 0
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
      (duplicate-crate warnings are the existing baseline)

## Not in scope

F2 (`unbatched consume() is not shutdown-aware`) will be addressed
on a separate branch. Its fix touches the Output trait, every
unbatched sink (file / kafka / stdout / syslog_udp / syslog_tcp /
unix_socket), and the queue consumer — a much larger blast radius
than any of F1/F3/F4.