### PR TITLE
fix(output): cancel unbatched retry backoff on shutdown so consumer clears the budget

### DIFF
--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -42,15 +42,56 @@ use crate::metrics::{InputMetrics, OutputMetrics};
 pub struct BuildContext {
     pub funcs: Arc<crate::functions::FunctionRegistry>,
     pub error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
+    /// Runtime-level shutdown broadcast. Unbatched sinks clone this
+    /// receiver and race their retry backoff sleep against it — if
+    /// shutdown fires mid-sleep, the sink breaks out of the retry
+    /// loop, routes the pending event to DLQ, and returns Ok(())
+    /// instead of blocking the queue consumer's select! for up to
+    /// `retry.max_wait`. Without this, a steady-state `consume()`
+    /// stuck in exponential backoff (1+2+4+8s = 15s under defaults)
+    /// outlasts the runtime's 10s shutdown budget and the runtime
+    /// task-aborts the consumer, dropping any handles in flight.
+    /// Batched sinks have their own actor-local shutdown notify and
+    /// do not need this receiver.
+    pub shutdown_signal: tokio::sync::watch::Receiver<bool>,
+}
+
+/// Shared retry-backoff helper for unbatched sinks: sleep `wait`, but
+/// abort the sleep if the runtime shutdown signal fires. Returns
+/// `true` if shutdown fired mid-sleep (caller should DLQ-route the
+/// pending event and return), `false` if the sleep completed
+/// normally (caller should continue the retry loop). Also treats a
+/// dropped shutdown sender (RecvError from `wait_for`) as
+/// "shutdown fired" — the sender is only dropped when the runtime
+/// is tearing down.
+pub async fn sleep_or_shutdown(
+    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    wait: std::time::Duration,
+) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(wait) => false,
+        _ = shutdown.wait_for(|s| *s) => true,
+    }
 }
 
 impl BuildContext {
-    /// Test-only ctor with a no-op funcs registry and no error_log.
+    /// Test-only ctor with a no-op funcs registry, no error_log, and
+    /// a shutdown receiver that never fires. Tests that need to
+    /// script a mid-consume shutdown build their own
+    /// `watch::channel` and populate `shutdown_signal` directly.
     #[cfg(test)]
     pub fn for_testing() -> Self {
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        // Leak the sender so the receiver stays open for the whole
+        // test — dropping it would flip the receiver to
+        // `RecvError` on the first `wait_for`, which the sinks
+        // treat as a shutdown fire (correct in production but not
+        // what the ambient test setup wants).
+        Box::leak(Box::new(_tx));
         Self {
             funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: None,
+            shutdown_signal: rx,
         }
     }
 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -95,6 +95,12 @@ pub struct FileOutput {
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    /// Runtime shutdown broadcast. Cloned inside the `consume` retry
+    /// loop so the exponential backoff sleep races against it: a
+    /// shutdown fired mid-sleep terminates the retry and routes the
+    /// pending event to DLQ instead of extending past the runtime's
+    /// shutdown budget and getting the consumer task-aborted.
+    shutdown_signal: tokio::sync::watch::Receiver<bool>,
 }
 
 impl Module for FileOutput {
@@ -171,6 +177,7 @@ impl Module for FileOutput {
             retry,
             error_log,
             metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
 }
@@ -219,6 +226,7 @@ impl Output for FileOutput {
 
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
+        let mut shutdown = self.shutdown_signal.clone();
         loop {
             // Clone the payload's path/dynamic flag for each attempt;
             // `egress` is a refcounted `Bytes` so the actual buffer
@@ -258,7 +266,31 @@ impl Output for FileOutput {
                         e,
                         wait
                     );
-                    tokio::time::sleep(wait).await;
+                    // Race the backoff sleep against shutdown. If the
+                    // runtime signals shutdown mid-sleep, do NOT keep
+                    // retrying — the retry budget (default 1+2+4+8 =
+                    // 15 s) can outlast the runtime's 10 s shutdown
+                    // budget, and if we don't return the queue
+                    // consumer's select! never gets back to its
+                    // shutdown arm. Route the pending event to DLQ,
+                    // resolve `Recovered`, and return.
+                    if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        let reason = format!(
+                            "output write failed and shutdown observed mid-retry \
+                             after {} attempts: {}",
+                            attempt, e
+                        );
+                        crate::modules::route_event_to_dlq(
+                            self.error_log.as_ref(),
+                            &self.name,
+                            event,
+                            &reason,
+                        )
+                        .await;
+                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                        ack.resolve_recovered();
+                        return Ok(());
+                    }
                     wait = self.retry.next_wait(wait);
                 }
             }
@@ -964,6 +996,7 @@ mod tests {
             retry: RetryConfig::default(),
             error_log: None,
             metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: crate::modules::BuildContext::for_testing().shutdown_signal,
         }
     }
 
@@ -1731,5 +1764,77 @@ mod tests {
                 "diagnostic must name the constraint: {msg}"
             );
         }
+    }
+
+    /// Regression pin for the unbatched-sink shutdown race. A steady-
+    /// state `consume` that fails and enters its retry backoff must
+    /// not sleep past the runtime's shutdown budget: if the runtime
+    /// signals shutdown mid-sleep, the sink breaks out, routes the
+    /// pending event to DLQ, resolves `Recovered`, and returns
+    /// promptly so the queue consumer's select! can proceed with the
+    /// drain. Without this the retry sleep (default 1+2+4+8 = 15 s)
+    /// held the consumer past the 10 s runtime shutdown budget and
+    /// the task was aborted mid-flight — the exact class of loss
+    /// PR #84 closed for batched sinks.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn consume_short_circuits_retry_backoff_on_shutdown() {
+        use crate::queue::{AckDisposition, BackoffStrategy, QueueAckHandle};
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let dir = tempfile::TempDir::new().unwrap();
+        // Point at a non-existent parent so every write_payload fails
+        // with ENOENT — the retry loop has to actually visit the
+        // backoff sleep for the test to observe the race.
+        let path = dir.path().join("does_not_exist").join("file.log");
+
+        let out = FileOutput {
+            name: "test".into(),
+            path: ek(ExprKind::StringLit(path.display().to_string())),
+            mode: None,
+            owner: None,
+            group: None,
+            funcs: funcs(),
+            // Long backoff floor so an untouched sleep would obviously
+            // hold the consume past the assertion window.
+            retry: crate::queue::RetryConfig {
+                max_attempts: 5,
+                initial_wait: std::time::Duration::from_secs(5),
+                max_wait: std::time::Duration::from_secs(5),
+                backoff: BackoffStrategy::Fixed,
+            },
+            error_log: None,
+            metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: shutdown_rx,
+        };
+
+        let (ack, mut ack_rx) = QueueAckHandle::for_test();
+        let event = event_with_workspace();
+        let out = Arc::new(out);
+        let out_clone = Arc::clone(&out);
+        let started = std::time::Instant::now();
+        let consume = tokio::spawn(async move { out_clone.consume(&event, ack).await });
+
+        // Let the first attempt fail and the retry loop reach the sleep.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        shutdown_tx.send(true).unwrap();
+
+        let res = consume.await.unwrap();
+        let elapsed = started.elapsed();
+        res.expect("consume must return Ok after shutdown-driven exit");
+        assert!(
+            elapsed < std::time::Duration::from_millis(1500),
+            "consume must short-circuit the retry sleep — took {elapsed:?} against a 5s floor"
+        );
+
+        // The handle must resolve as `Recovered`, not `Dropped` — the
+        // event was routed to DLQ, not silently lost.
+        let (_pos, disposition) = ack_rx
+            .try_recv()
+            .expect("ack channel must have carried the resolution");
+        assert!(
+            matches!(disposition, AckDisposition::Recovered),
+            "expected Recovered, got {disposition:?}"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -1460,8 +1460,8 @@ def output o {{
             fast_retry_block(),
         ];
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = HttpOutput::from_properties("test", &mp(&props), &ctx).unwrap();
 
@@ -1635,8 +1635,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = HttpOutput::from_properties(
             "myout",
@@ -2064,8 +2064,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let retry = Property::Block {
             key: "retry".into(),
@@ -2160,8 +2160,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = HttpOutput::from_properties(
             "myout",
@@ -2221,8 +2221,8 @@ def output o {{
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
 
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = HttpOutput::from_properties(
             "test",
@@ -2267,8 +2267,8 @@ def output o {{
             dir.path().join("errored.jsonl"),
         ));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = HttpOutput::from_properties(
             "test",
@@ -2330,8 +2330,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         // Long retry waits so a non-cancelled budget would clearly
         // exceed SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT (3s).
@@ -2468,8 +2468,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         // Short timer wake + large batch_size so the actor (not
         // consume itself) is the path that calls `send`.
@@ -2561,8 +2561,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = Arc::new(
             HttpOutput::from_properties(
@@ -2645,8 +2645,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = Arc::new(
             HttpOutput::from_properties(

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -320,6 +320,7 @@ pub struct KafkaOutput {
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    shutdown_signal: tokio::sync::watch::Receiver<bool>,
 }
 
 /// Which event-intrinsic field to use as the Kafka partition key.
@@ -444,6 +445,7 @@ impl Module for KafkaOutput {
             retry,
             error_log,
             metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
 }
@@ -460,6 +462,7 @@ impl Output for KafkaOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
+        let mut shutdown = self.shutdown_signal.clone();
         loop {
             match self.try_send(event).await {
                 Ok(()) => {
@@ -492,7 +495,30 @@ impl Output for KafkaOutput {
                         e,
                         wait
                     );
-                    tokio::time::sleep(wait).await;
+                    // Race the backoff sleep against shutdown. If the runtime
+                    // signals shutdown mid-sleep, do NOT keep retrying — the
+                    // retry budget (default 1+2+4+8 = 15 s) can outlast the
+                    // runtime's 10 s shutdown budget, and if we don't return
+                    // the queue consumer's select! never gets back to its
+                    // shutdown arm. Route the pending event to DLQ, resolve
+                    // `Recovered`, and return.
+                    if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        let reason = format!(
+                            "output write failed and shutdown observed mid-retry \
+                             after {} attempts: {}",
+                            attempt, e
+                        );
+                        crate::modules::route_event_to_dlq(
+                            self.error_log.as_ref(),
+                            &self.name,
+                            event,
+                            &reason,
+                        )
+                        .await;
+                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                        ack.resolve_recovered();
+                        return Ok(());
+                    }
                     wait = self.retry.next_wait(wait);
                 }
             }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -1295,8 +1295,8 @@ mod tests {
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = OtlpGrpcOutput::from_properties("myout", &mp(&props), &ctx).unwrap();
         buffer_two(&output).await;
@@ -1406,8 +1406,8 @@ mod tests {
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
 
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = OtlpGrpcOutput::from_properties(
             "test",

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -1843,8 +1843,8 @@ def output o {{
         let path = dir.path().join("errored.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path.clone()));
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = OtlpHttpOutput::from_properties("myout", &mp(&props), &ctx).unwrap();
         buffer_two(&output).await;
@@ -1946,8 +1946,8 @@ def output o {{
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(path));
 
         let ctx = crate::modules::BuildContext {
-            funcs: Arc::new(crate::functions::FunctionRegistry::new()),
             error_log: Some(Arc::clone(&writer)),
+            ..crate::modules::BuildContext::for_testing()
         };
         let output = OtlpHttpOutput::from_properties(
             "test",

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -23,6 +23,7 @@ pub struct StdoutOutput {
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    shutdown_signal: tokio::sync::watch::Receiver<bool>,
 }
 
 impl Module for StdoutOutput {
@@ -41,6 +42,7 @@ impl Module for StdoutOutput {
             retry,
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
 }
@@ -75,6 +77,7 @@ impl Output for StdoutOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
+        let mut shutdown = self.shutdown_signal.clone();
         loop {
             match self.write_event(event) {
                 Ok(()) => {
@@ -107,7 +110,30 @@ impl Output for StdoutOutput {
                         e,
                         wait
                     );
-                    tokio::time::sleep(wait).await;
+                    // Race the backoff sleep against shutdown. If the runtime
+                    // signals shutdown mid-sleep, do NOT keep retrying — the
+                    // retry budget (default 1+2+4+8 = 15 s) can outlast the
+                    // runtime's 10 s shutdown budget, and if we don't return
+                    // the queue consumer's select! never gets back to its
+                    // shutdown arm. Route the pending event to DLQ, resolve
+                    // `Recovered`, and return.
+                    if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        let reason = format!(
+                            "output write failed and shutdown observed mid-retry \
+                             after {} attempts: {}",
+                            attempt, e
+                        );
+                        crate::modules::route_event_to_dlq(
+                            self.error_log.as_ref(),
+                            &self.name,
+                            event,
+                            &reason,
+                        )
+                        .await;
+                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                        ack.resolve_recovered();
+                        return Ok(());
+                    }
                     wait = self.retry.next_wait(wait);
                 }
             }

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -175,6 +175,7 @@ pub struct SyslogTcpOutput {
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    shutdown_signal: tokio::sync::watch::Receiver<bool>,
 }
 
 impl Module for SyslogTcpOutput {
@@ -218,6 +219,7 @@ impl Module for SyslogTcpOutput {
             retry,
             error_log,
             metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
 }
@@ -348,6 +350,7 @@ impl Output for SyslogTcpOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
+        let mut shutdown = self.shutdown_signal.clone();
         loop {
             let payload = SyslogPayload {
                 egress: event.egress.clone(),
@@ -383,7 +386,30 @@ impl Output for SyslogTcpOutput {
                         e,
                         wait
                     );
-                    tokio::time::sleep(wait).await;
+                    // Race the backoff sleep against shutdown. If the runtime
+                    // signals shutdown mid-sleep, do NOT keep retrying — the
+                    // retry budget (default 1+2+4+8 = 15 s) can outlast the
+                    // runtime's 10 s shutdown budget, and if we don't return
+                    // the queue consumer's select! never gets back to its
+                    // shutdown arm. Route the pending event to DLQ, resolve
+                    // `Recovered`, and return.
+                    if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        let reason = format!(
+                            "output write failed and shutdown observed mid-retry \
+                             after {} attempts: {}",
+                            attempt, e
+                        );
+                        crate::modules::route_event_to_dlq(
+                            self.error_log.as_ref(),
+                            &self.name,
+                            event,
+                            &reason,
+                        )
+                        .await;
+                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                        ack.resolve_recovered();
+                        return Ok(());
+                    }
                     wait = self.retry.next_wait(wait);
                 }
             }

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -66,6 +66,7 @@ pub struct SyslogUdpOutput {
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    shutdown_signal: tokio::sync::watch::Receiver<bool>,
 }
 
 impl Module for SyslogUdpOutput {
@@ -87,6 +88,7 @@ impl Module for SyslogUdpOutput {
             retry,
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
 }
@@ -121,6 +123,7 @@ impl Output for SyslogUdpOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
+        let mut shutdown = self.shutdown_signal.clone();
         loop {
             let payload = SyslogPayload {
                 egress: event.egress.clone(),
@@ -155,7 +158,30 @@ impl Output for SyslogUdpOutput {
                         e,
                         wait
                     );
-                    tokio::time::sleep(wait).await;
+                    // Race the backoff sleep against shutdown. If the runtime
+                    // signals shutdown mid-sleep, do NOT keep retrying — the
+                    // retry budget (default 1+2+4+8 = 15 s) can outlast the
+                    // runtime's 10 s shutdown budget, and if we don't return
+                    // the queue consumer's select! never gets back to its
+                    // shutdown arm. Route the pending event to DLQ, resolve
+                    // `Recovered`, and return.
+                    if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        let reason = format!(
+                            "output write failed and shutdown observed mid-retry \
+                             after {} attempts: {}",
+                            attempt, e
+                        );
+                        crate::modules::route_event_to_dlq(
+                            self.error_log.as_ref(),
+                            &self.name,
+                            event,
+                            &reason,
+                        )
+                        .await;
+                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                        ack.resolve_recovered();
+                        return Ok(());
+                    }
                     wait = self.retry.next_wait(wait);
                 }
             }

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -38,6 +38,7 @@ pub struct UnixSocketOutput {
     retry: RetryConfig,
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
+    shutdown_signal: tokio::sync::watch::Receiver<bool>,
 }
 
 impl Module for UnixSocketOutput {
@@ -61,6 +62,7 @@ impl Module for UnixSocketOutput {
             retry,
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
 }
@@ -77,6 +79,7 @@ impl Output for UnixSocketOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
+        let mut shutdown = self.shutdown_signal.clone();
         loop {
             match write_with_reconnect(self, &self.conn, &self.metrics, &event.egress).await {
                 Ok(()) => {
@@ -108,7 +111,30 @@ impl Output for UnixSocketOutput {
                         e,
                         wait
                     );
-                    tokio::time::sleep(wait).await;
+                    // Race the backoff sleep against shutdown. If the runtime
+                    // signals shutdown mid-sleep, do NOT keep retrying — the
+                    // retry budget (default 1+2+4+8 = 15 s) can outlast the
+                    // runtime's 10 s shutdown budget, and if we don't return
+                    // the queue consumer's select! never gets back to its
+                    // shutdown arm. Route the pending event to DLQ, resolve
+                    // `Recovered`, and return.
+                    if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        let reason = format!(
+                            "output write failed and shutdown observed mid-retry \
+                             after {} attempts: {}",
+                            attempt, e
+                        );
+                        crate::modules::route_event_to_dlq(
+                            self.error_log.as_ref(),
+                            &self.name,
+                            event,
+                            &reason,
+                        )
+                        .await;
+                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                        ack.resolve_recovered();
+                        return Ok(());
+                    }
                     wait = self.retry.next_wait(wait);
                 }
             }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -90,6 +90,7 @@ impl Runtime {
         let build_ctx = crate::modules::BuildContext {
             funcs: Arc::clone(&func_registry),
             error_log: error_log.as_ref().map(Arc::clone),
+            shutdown_signal: shutdown_rx.clone(),
         };
 
         // --- 1. Create outputs (each output owns its own OutputMetrics) ---


### PR DESCRIPTION
## Summary

Follow-up to [#108](https://github.com/naoto256/limpid/pull/108).
The unbatched sinks — file, stdout, syslog_udp, syslog_tcp,
unix_socket, kafka — drove their steady-state `consume()` retry
loop with a bare `tokio::time::sleep(wait).await`. The queue
consumer's `select!` cannot preempt an active `consume()` future,
so an in-flight retry sleep runs regardless of the shutdown
signal. With the default budget (`max_attempts=5`, exponential
1+2+4+8 = 15 s) the consumer therefore outlasts the runtime's
10 s shutdown budget, gets task-aborted mid-flight, and the
pending `QueueAckHandle` is dropped unresolved — silent loss
attributed to a bug, the same class PR
[#84](https://github.com/naoto256/limpid/pull/84) closed for the
batched path.

Plumb the runtime shutdown signal into every unbatched sink via a
new `BuildContext::shutdown_signal:
tokio::sync::watch::Receiver<bool>` field. Each sink clones the
receiver at consume start and races its backoff sleep against it
through a shared helper, `crate::modules::sleep_or_shutdown`. When
shutdown fires mid-sleep, the sink routes the pending event to
DLQ, resolves the ack as `Recovered`, and returns Ok(()) so the
queue consumer's `select!` gets back to its drain arm well inside
budget.

BatchedSink outputs (http, otlp_http, otlp_grpc) are unaffected —
they already race their own actor-local `shutdown_notify` inside
`flush_events`.

## Scope note

This change handles the retry-sleep component of the F2 finding —
the 15 s window that most reliably outlasts the shutdown budget.
An individual transport `.await` inside `write_payload` / `send`
is *not* wrapped: those tend to complete or fail well inside the
budget, and bounding them is a separate contract change with
different error semantics.

## Also in this branch

- Common helper: `crate::modules::sleep_or_shutdown` collapses the
  same select-race across six sinks.
- Test-side BuildContext literals (14 sites in
  http / otlp_http / otlp_grpc tests) are refactored to
  `..BuildContext::for_testing()` struct-update form so future
  BuildContext fields land without touching each site.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 740 + 27 + 3 + 14 pass on both
      macOS and aarch64 Ubuntu (pre-push validation on the
      playground, per the engraved rule). Includes new regression:
      `consume_short_circuits_retry_backoff_on_shutdown` — pins
      that with `initial_wait=5s` and shutdown fired ~150 ms into
      the sleep, `consume` returns under 1.5 s and the ack
      disposition is `Recovered`, not `Dropped`.
- [x] `cargo audit` — vulnerabilities: 0
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
      (duplicate-crate warnings are the existing baseline)