### PR TITLE
fix(output): race unbatched sinks' single send attempt against the shutdown signal

### DIFF
--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -74,6 +74,38 @@ pub async fn sleep_or_shutdown(
     }
 }
 
+/// Shared per-attempt helper for unbatched sinks: race a single
+/// send-attempt future against the runtime shutdown signal. Returns
+/// `Some(result)` if the attempt completed (either `Ok` or a
+/// transport `Err`), `None` if shutdown fired first — the caller
+/// should abandon the in-flight attempt, DLQ-route the pending
+/// event, resolve the ack handle as `Recovered`, and return so the
+/// queue consumer's `select!` reaches its drain arm inside the
+/// runtime shutdown budget. Companion to `sleep_or_shutdown`: that
+/// closes the retry backoff window; this closes the single-attempt
+/// I/O window (kafka's 30 s `message.timeout.ms`, syslog_tcp's
+/// per-peer 5+5+10 s per attempt, unix_socket's unbounded connect
+/// and write). A dropped shutdown sender is treated as
+/// "shutdown fired", same as `sleep_or_shutdown`.
+///
+/// Cancelling the attempt future may leave the transport in a
+/// partially-sent state (e.g. a half-written TCP frame). That is an
+/// intentional trade-off: the alternative is holding the queue
+/// consumer past the shutdown deadline and getting task-aborted
+/// mid-flight, which drops the ack handle and loses the event
+/// silently. A partial-line trailer is documented as the cost of
+/// prompt shutdown; downstream syslog / kafka receivers already
+/// tolerate resend-on-reconnect.
+pub async fn attempt_or_shutdown<F: std::future::Future>(
+    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    attempt: F,
+) -> Option<F::Output> {
+    tokio::select! {
+        r = attempt => Some(r),
+        _ = shutdown.wait_for(|s| *s) => None,
+    }
+}
+
 impl BuildContext {
     /// Test-only ctor with a no-op funcs registry, no error_log, and
     /// a shutdown receiver that never fires. Tests that need to
@@ -772,4 +804,60 @@ where
             })
         },
     );
+}
+
+#[cfg(test)]
+mod attempt_or_shutdown_tests {
+    use super::attempt_or_shutdown;
+    use std::time::Duration;
+
+    /// Happy path: the attempt future completes first, the shutdown
+    /// receiver is untouched, and the outcome is returned intact.
+    #[tokio::test]
+    async fn attempt_completes_before_shutdown_returns_the_outcome() {
+        let (_tx, mut rx) = tokio::sync::watch::channel(false);
+        let outcome = attempt_or_shutdown(&mut rx, async { 42u32 }).await;
+        assert_eq!(outcome, Some(42));
+    }
+
+    /// Shutdown fires while the attempt is still pending: the helper
+    /// returns `None` and the attempt future is dropped. Pin this on
+    /// wall time so a regression that dropped the shutdown arm would
+    /// hang and time out here — the assert bound (200 ms against a
+    /// 5 s sleep) is far under any plausible scheduler jitter.
+    #[tokio::test]
+    async fn shutdown_before_attempt_completes_returns_none() {
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        let helper = async move {
+            attempt_or_shutdown(&mut rx, tokio::time::sleep(Duration::from_secs(5)))
+                .await
+                .map(|_| ())
+        };
+        let handle = tokio::spawn(helper);
+        // Give the helper a chance to enter the select.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        tx.send(true).unwrap();
+        let started = std::time::Instant::now();
+        let outcome = handle.await.unwrap();
+        let elapsed = started.elapsed();
+        assert!(outcome.is_none(), "shutdown must produce None");
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "shutdown must preempt the sleep — took {elapsed:?}"
+        );
+    }
+
+    /// A dropped shutdown sender flips `wait_for` into a `RecvError`;
+    /// the helper treats that as "shutdown fired" (the sender is
+    /// only dropped when the runtime is tearing down). Pin the
+    /// contract so a future refactor that changed the RecvError
+    /// mapping would trip the test.
+    #[tokio::test]
+    async fn dropped_shutdown_sender_is_treated_as_fired() {
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        drop(tx);
+        let outcome =
+            attempt_or_shutdown(&mut rx, tokio::time::sleep(Duration::from_secs(5))).await;
+        assert!(outcome.is_none());
+    }
 }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -236,7 +236,39 @@ impl Output for FileOutput {
                 path: payload.path.clone(),
                 is_dynamic: payload.is_dynamic,
             };
-            match self.write_payload(attempt_payload).await {
+            // Race the single write attempt against shutdown. On
+            // shutdown mid-attempt, abandon the future (drop cancels
+            // it), route the pending event to DLQ, resolve
+            // `Recovered`, and return. Without this the write
+            // attempt itself (open + apply + write + flush on a
+            // slow disk) can hold the queue consumer past the
+            // runtime shutdown budget just as the retry sleep did
+            // before shutdown-race wrapping.
+            let outcome = match crate::modules::attempt_or_shutdown(
+                &mut shutdown,
+                self.write_payload(attempt_payload),
+            )
+            .await
+            {
+                Some(r) => r,
+                None => {
+                    let reason = format!(
+                        "output '{}': write attempt abandoned on shutdown",
+                        self.name
+                    );
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        event,
+                        &reason,
+                    )
+                    .await;
+                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                    ack.resolve_recovered();
+                    return Ok(());
+                }
+            };
+            match outcome {
                 Ok(()) => {
                     ack.resolve_delivered();
                     return Ok(());

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -464,7 +464,31 @@ impl Output for KafkaOutput {
         let mut wait = self.retry.initial_wait;
         let mut shutdown = self.shutdown_signal.clone();
         loop {
-            match self.try_send(event).await {
+            let outcome = match crate::modules::attempt_or_shutdown(
+                &mut shutdown,
+                self.try_send(event),
+            )
+            .await
+            {
+                Some(r) => r,
+                None => {
+                    let reason = format!(
+                        "output '{}': write attempt abandoned on shutdown",
+                        self.name
+                    );
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        event,
+                        &reason,
+                    )
+                    .await;
+                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                    ack.resolve_recovered();
+                    return Ok(());
+                }
+            };
+            match outcome {
                 Ok(()) => {
                     self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_delivered();

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -355,7 +355,31 @@ impl Output for SyslogTcpOutput {
             let payload = SyslogPayload {
                 egress: event.egress.clone(),
             };
-            match self.write_payload(payload).await {
+            let outcome = match crate::modules::attempt_or_shutdown(
+                &mut shutdown,
+                self.write_payload(payload),
+            )
+            .await
+            {
+                Some(r) => r,
+                None => {
+                    let reason = format!(
+                        "output '{}': write attempt abandoned on shutdown",
+                        self.name
+                    );
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        event,
+                        &reason,
+                    )
+                    .await;
+                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                    ack.resolve_recovered();
+                    return Ok(());
+                }
+            };
+            match outcome {
                 Ok(()) => {
                     self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_delivered();

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -128,7 +128,31 @@ impl Output for SyslogUdpOutput {
             let payload = SyslogPayload {
                 egress: event.egress.clone(),
             };
-            match self.write_payload(payload).await {
+            let outcome = match crate::modules::attempt_or_shutdown(
+                &mut shutdown,
+                self.write_payload(payload),
+            )
+            .await
+            {
+                Some(r) => r,
+                None => {
+                    let reason = format!(
+                        "output '{}': write attempt abandoned on shutdown",
+                        self.name
+                    );
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        event,
+                        &reason,
+                    )
+                    .await;
+                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                    ack.resolve_recovered();
+                    return Ok(());
+                }
+            };
+            match outcome {
                 Ok(()) => {
                     ack.resolve_delivered();
                     return Ok(());

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -81,7 +81,31 @@ impl Output for UnixSocketOutput {
         let mut wait = self.retry.initial_wait;
         let mut shutdown = self.shutdown_signal.clone();
         loop {
-            match write_with_reconnect(self, &self.conn, &self.metrics, &event.egress).await {
+            let outcome = match crate::modules::attempt_or_shutdown(
+                &mut shutdown,
+                write_with_reconnect(self, &self.conn, &self.metrics, &event.egress),
+            )
+            .await
+            {
+                Some(r) => r,
+                None => {
+                    let reason = format!(
+                        "output '{}': write attempt abandoned on shutdown",
+                        self.name
+                    );
+                    crate::modules::route_event_to_dlq(
+                        self.error_log.as_ref(),
+                        &self.name,
+                        event,
+                        &reason,
+                    )
+                    .await;
+                    self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                    ack.resolve_recovered();
+                    return Ok(());
+                }
+            };
+            match outcome {
                 Ok(()) => {
                     ack.resolve_delivered();
                     return Ok(());


### PR DESCRIPTION
## Summary

Follow-up to [#109](https://github.com/naoto256/limpid/pull/109).
That PR brought the *retry backoff sleep* under the runtime
shutdown signal, so the between-attempts sleep (up to 15 s
default) can no longer outlast the 10 s shutdown budget. The
single send attempt itself was still unbounded from the queue
consumer's point of view:

- `kafka` producer.send() uses rdkafka's internal
  `message.timeout.ms=30000` — a 30 s hang before an error
  surfaces.
- `syslog_tcp` per-peer attempt is 5 s connect + 5 s TLS + 10 s
  write, worst-case 20 s+ before it returns.
- `syslog_udp` chains lookup + connect + write timeouts on the
  same order.
- `unix_socket` has no timeout at all on connect or write.

The queue consumer's `select!` cannot preempt a
`writer.consume().await` inside its send attempt, so any of these
attempts can hold the consumer past the shutdown deadline and get
task-aborted mid-flight — dropping the `QueueAckHandle`
unresolved, the exact class of loss PR
[#84](https://github.com/naoto256/limpid/pull/84) closed for the
batched path.

Add a shared `crate::modules::attempt_or_shutdown` helper: race a
single send-attempt future against the runtime shutdown watch
receiver, return `Some(result)` if the attempt completed, `None`
if shutdown fired first. Wire it into the per-attempt call site
in `file`, `syslog_udp`, `syslog_tcp`, `unix_socket`, and `kafka`.
`stdout` writes through synchronous stdlib and has no `.await` to
race, so it is intentionally not wrapped. On the `None` path each
sink routes the pending event to DLQ, resolves the ack handle as
`Recovered`, and returns `Ok(())` so the queue consumer's
`select!` reaches its drain arm inside the shutdown budget.

Cancelling the attempt future may leave the transport with a
partial byte sent (a half-written TCP frame, an incomplete
syslog line). That is the documented cost of a bounded shutdown:
the alternative is silent loss via task abort. Downstream syslog
/ kafka receivers already tolerate resend-on-reconnect, and the
ack is resolved as `Recovered` (not `Delivered`) so replay
tooling picks the record back up.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 747 + 27 + 3 + 14 pass on both
      macOS and aarch64 Ubuntu (pre-push validation on the
      playground, per the engraved rule). Helper unit tests pin
      the three outcomes:
      - `attempt_completes_before_shutdown_returns_the_outcome`
      - `shutdown_before_attempt_completes_returns_none`
      - `dropped_shutdown_sender_is_treated_as_fired`
      Each sink's wiring lives adjacent to the existing
      `sleep_or_shutdown` retry-race, and the sleep-race
      regression pin in file output
      (`consume_short_circuits_retry_backoff_on_shutdown`)
      continues to cover the between-attempts window.
- [x] `cargo audit` — vulnerabilities: 0
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
      (duplicate-crate warnings are the existing baseline)

## Not in scope

- The queue-consumer `AckDisposition::Dropped` cursor-advance
  contract (bug/panic/shutdown fallthrough → lost but no replay)
  is a standing limitation with an explicit out-of-scope comment;
  it will be captured as a release-note entry rather than a code
  change on this branch.