### PR TITLE
docs(error-log): document the standing bug/panic/shutdown-fallthrough drop as a known limitation

### DIFF
--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -440,6 +440,24 @@ Investigate immediately:
 
 Once the underlying issue is fixed, the next errored event lands in the file again and the counter stops increasing; existing records are unaffected.
 
+## Standing limitation: bug/panic/shutdown-fallthrough drops advance the cursor
+
+The DLQ contract described above assumes every event handed to an output either lands (`AckDisposition::Delivered` — cursor advances) or gets routed to `error_log` (`AckDisposition::Recovered` — cursor advances *after* the DLQ record is written). A third disposition exists — `AckDisposition::Dropped` — for the paths that resolve the ack handle without a matching `resolve_delivered()` / `resolve_recovered()` call:
+
+- A bug in an output's `consume` implementation that returns before signalling the handle (the handle's `Drop` then fires `Dropped`).
+- A panic inside `consume` while it holds the handle.
+- Residual shutdown-fallthrough shapes not yet covered by the shutdown-aware paths: the queue consumer's task is aborted mid-flight (SIGTERM budget exhausted) while a handle is still parked in an in-flight `write_payload` future, in a batched sink's buffer, or in the ack channel.
+
+When any of these fires, the handle's `Drop` sends `Dropped` down the ack channel, the queue consumer advances the cursor and bumps the output's `events_failed` counter — but **no DLQ record is written**, so replay tooling has nothing to reprocess.
+
+That "lost but no replay" behaviour is the current contract, marked *out of scope* in a per-line comment in `crates/limpid/src/queue/mod.rs` next to `receiver.ack_to(position)`. Full panic recovery (write the handle's carried event into the DLQ from the `Dropped` path, plus a queue-cursor rewind on a bounded lookahead window) is queued for a separate cycle: it needs `QueueAckHandle` to carry the event bytes long enough for the panic path to route them, plus a queue-cursor contract change so a rewind doesn't reorder events across pipelines.
+
+For operators, the practical implications:
+
+- **Watch `events_failed` at output granularity.** A step increase without a matching increase in `events_errored` or DLQ file size means events are dropping through this path. Cross-check `events_written + events_failed + retries` against upstream input rate to bound the loss.
+- **Watch daemon panics.** A `panicked at` line in the daemon's `tracing` output is the primary observable for the bug path. `RUST_BACKTRACE=1` in the systemd unit is worth the extra bytes.
+- **Shutdown-fallthrough is progressively narrowing.** Recent releases have brought the batched-sink retry loop, the unbatched-sink retry backoff sleep, and the unbatched-sink single send attempt all under a shutdown-race that DLQ-routes on time. The remaining exposure is limited to shapes where the ack channel or a batched-sink buffer still holds a handle at the SIGTERM deadline — rare in a healthy deployment, still a bug-attributed loss when it happens.
+
 ## Schema migration v1 → v2
 
 The 0.7.8 release introduces `schema_version: 2` as a **hard break**. v1 records (no `schema_version`, top-level `process` string field as the discriminator, no `kind`, no per-kind block) are not readable by v2 tooling, and v2 records are not readable by v1 tooling.


### PR DESCRIPTION
## Summary

Follow-up to [#111](https://github.com/naoto256/limpid/pull/111).
The DLQ semantics page currently describes the two supported ack
dispositions — `Delivered` (cursor advances) and `Recovered`
(cursor advances after the DLQ record is written) — and the two
counters (`events_errored`, `events_errored_unwritable`) an
operator watches for the DLQ path. It does not yet describe the
third disposition (`AckDisposition::Dropped`) and the shape of
loss that path represents.

Under `Dropped` the queue consumer advances the cursor and bumps
`events_failed`, but no DLQ record is written, so replay tooling
has nothing to reprocess. That "lost but no replay" behaviour has
been the standing contract since 0.7.7 (there is a per-line
out-of-scope comment on `receiver.ack_to(position)` in
`crates/limpid/src/queue/mod.rs`), and full panic recovery is a
separate cycle — it needs `QueueAckHandle` to carry the event
bytes long enough for the panic path to route them, plus a
queue-cursor rewind contract that doesn't reorder events across
pipelines.

Add a "Standing limitation" section adjacent to the existing
"When the DLQ write itself fails" block. It enumerates the three
sources of the `Dropped` path (bug in an output's `consume`,
panic inside a `consume` holding the handle, shutdown-fallthrough
where the runtime task is aborted with a handle still in flight),
points at the in-code out-of-scope marker, and sets operator
expectations:

- Watch `events_failed` at output granularity for step increases
  without matching `events_errored` movement.
- Watch daemon panics; `RUST_BACKTRACE=1` in the systemd unit is
  a cheap win.
- Note that the shutdown-fallthrough surface is progressively
  narrowing (batched-sink retry loop, unbatched-sink retry
  backoff sleep, and unbatched-sink single send attempt are now
  all shutdown-race-DLQ-routed via
  [#109](https://github.com/naoto256/limpid/pull/109) and
  [#111](https://github.com/naoto256/limpid/pull/111)), so the
  remaining exposure is the ack channel or a batched-sink buffer
  still holding a handle at the SIGTERM deadline.

## Test plan

- [x] docs-only change; no runtime touched.
- [x] `cargo test --workspace` — 747 + 27 + 3 + 14 pass on macOS
      (verified against the same worktree; playground validation
      was already run at PR #111 land).