### PR TITLE
fix(error_log): tighten the DLQ contract on the shutdown drain, docs, and startup validation

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -248,13 +248,21 @@ impl ErrorLogWriter {
 
     /// Validate that the `error_log` path is reachable at startup.
     ///
-    /// Checks the parent directory exists and is writable by the
-    /// daemon user. Surfacing this at startup (rather than at first
-    /// failure) matches Principle 1 — operators see typo'd paths
-    /// before any event hits a process error.
+    /// Checks:
+    /// - The parent directory exists and is a directory.
+    /// - If the DLQ file already exists on disk (leftover from a
+    ///   prior run, logrotate output, or an operator tool), it is
+    ///   not a symlink and its mode is exactly `0o600`. The runtime
+    ///   `write` path refuses both conditions loudly, so an operator
+    ///   whose fresh deployment inherits a `0o644` file or a symlink
+    ///   would otherwise discover the mismatch only at the first
+    ///   real failure — after the pipeline has already lost the
+    ///   observability on that record. Surface it at startup so the
+    ///   fix (remove or `chmod` the file) happens before any events
+    ///   flow.
     ///
-    /// The file itself does not need to exist; `OpenOptions::create`
-    /// will materialise it on the first failure.
+    /// The file itself does not need to exist; the runtime write
+    /// path materialises it on the first failure with `mode(0o600)`.
     pub async fn validate_at_startup(&self) -> Result<()> {
         let parent = self.path.parent().ok_or_else(|| {
             anyhow::anyhow!(
@@ -279,6 +287,52 @@ impl ErrorLogWriter {
                 parent.display()
             );
         }
+
+        // If the DLQ file already exists on disk, refuse a symlink
+        // and refuse a mode other than 0o600 at startup so operators
+        // see the same contract failure they would hit at first
+        // write, but *before* any events reach a failure site.
+        // `symlink_metadata` inspects the link itself rather than
+        // following it, so we can distinguish symlink from regular
+        // file.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            match tokio::fs::symlink_metadata(&self.path).await {
+                Ok(meta) => {
+                    if meta.file_type().is_symlink() {
+                        anyhow::bail!(
+                            "error_log: '{}' is a symlink; the runtime refuses to follow it. \
+                             Remove the symlink before starting the daemon.",
+                            self.path.display()
+                        );
+                    }
+                    if meta.is_file() {
+                        let actual = meta.permissions().mode() & 0o7777;
+                        if actual != 0o600 {
+                            anyhow::bail!(
+                                "error_log: existing file '{}' has mode 0o{:o}, but the DLQ \
+                                 writer requires exactly 0o600. `chmod 0600 <path>` or remove \
+                                 the file so the runtime recreates it.",
+                                self.path.display(),
+                                actual
+                            );
+                        }
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // No file yet — the runtime will create it under
+                    // the correct mode on the first failure.
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::from(e).context(format!(
+                        "error_log: failed to stat '{}'",
+                        self.path.display()
+                    )));
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -548,6 +602,53 @@ mod tests {
         let w = ErrorLogWriter::new(dir.path().join("nope/errored.jsonl"));
         let err = w.validate_at_startup().await.unwrap_err().to_string();
         assert!(err.contains("not accessible"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn validate_at_startup_refuses_symlink_at_dlq_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        let target = dir.path().join("_hijacked.jsonl");
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        let w = ErrorLogWriter::new(path.clone());
+        let err = w.validate_at_startup().await.unwrap_err().to_string();
+        assert!(err.contains("is a symlink"), "got: {}", err);
+        assert!(
+            !target.exists(),
+            "symlink target must not have been touched"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn validate_at_startup_refuses_wrong_mode_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("errored.jsonl");
+        std::fs::write(&path, b"leftover\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let w = ErrorLogWriter::new(path.clone());
+        let err = w.validate_at_startup().await.unwrap_err().to_string();
+        assert!(err.contains("has mode 0o644"), "got: {}", err);
+        assert!(err.contains("0o600"), "got: {}", err);
+
+        // A file at the correct mode must pass.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        w.validate_at_startup().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn validate_at_startup_accepts_absent_file() {
+        // A path whose parent exists but whose file itself does not
+        // exist must pass — the runtime creates the file on first
+        // failure with the correct mode.
+        let dir = TempDir::new().unwrap();
+        let w = ErrorLogWriter::new(dir.path().join("errored.jsonl"));
+        w.validate_at_startup().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -338,32 +338,28 @@ impl Output for FileOutput {
                 return Ok(());
             }
         };
-        match tokio::time::timeout(
-            crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-            self.write_payload(payload),
-        )
-        .await
-        {
-            Ok(Ok(())) => {
+        // Unlike the network sinks, the file writer is NOT wrapped
+        // in a `tokio::time::timeout(SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
+        // ...)`. Cancelling `write_payload` mid-flight would leave a
+        // partial append on disk (`write_all` is not atomic across
+        // syscalls) and *simultaneously* route the event to DLQ as
+        // `Recovered`, so an operator replay would produce a
+        // partial-then-full duplicate. The steady-state `consume`
+        // path already made this trade-off; the shutdown drain
+        // inherits it. Local disk writes are typically <10 ms and
+        // finish well inside the shutdown budget; a truly hung
+        // filesystem here becomes a task-abort → `Dropped` (the
+        // "lost but no replay" contract documented under the
+        // Standing limitation section of
+        // `docs/src/operations/error-log.md`), which is worse than
+        // a partial-then-full duplicate on paper but at least does
+        // not double the operator's cleanup surface at replay time.
+        match self.write_payload(payload).await {
+            Ok(()) => {
                 ack.resolve_delivered();
             }
-            Ok(Err(e)) => {
+            Err(e) => {
                 let reason = format!("shutdown write failed: {}", e);
-                crate::modules::route_event_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.name,
-                    event,
-                    &reason,
-                )
-                .await;
-                self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
-                ack.resolve_recovered();
-            }
-            Err(_) => {
-                let reason = format!(
-                    "shutdown write timed out after {:?}",
-                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
-                );
                 crate::modules::route_event_to_dlq(
                     self.error_log.as_ref(),
                     &self.name,
@@ -656,10 +652,11 @@ impl FileOutput {
     /// the same inode `write_all` just touched. `path` here is only
     /// used to label warnings.
     ///
-    /// The `spawn_blocking` future is *not* cancel-safe: if the caller
-    /// (say `consume_shutdown` under a `timeout`) drops the awaiting
-    /// future, the blocking task keeps running while the outer `File`
-    /// gets dropped and closes its fd. A raw fd number is trivial for
+    /// The `spawn_blocking` future is *not* cancel-safe: if the outer
+    /// `write_payload` future is dropped mid-flight (a task-abort at
+    /// the runtime shutdown deadline is the concrete scenario),
+    /// the blocking task keeps running while the outer `File` gets
+    /// dropped and closes its fd. A raw fd number is trivial for
     /// the kernel to reuse for an unrelated `open`, and the leftover
     /// `fchmod`/`fchown` would then land on that other inode. Guard
     /// against that by `dup(2)`-ing the fd into an `OwnedFd` that the

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -55,13 +55,14 @@ A typical operator setup keeps the live file capped and the rotated archives com
     copytruncate
     notifempty
     missingok
-    create 0640 limpid adm
+    create 0600 limpid limpid
     maxsize 1G
 }
 ```
 
 Key choices:
 
+- `create 0600` — the DLQ writer's runtime contract is *exactly* `0o600` on the on-disk file. If logrotate creates the fresh post-rotation file at any other mode, the next DLQ write is refused with a `existing file mode 0o... does not match configured mode 0o600` error and `events_errored_unwritable` bumps until the operator aligns the file. Match the rotator's `create` mode with the runtime contract to avoid that failure.
 - `copytruncate` — limpid reopens the inode every write, so a normal rotate-and-rename works too, but `copytruncate` is the simplest setup that doesn't require any signal handshake.
 - `maxsize 1G` — caps the live file even when `daily` hasn't fired yet. A pipeline producing failures at 10k events/sec with 1 KiB records would fill 1 GiB in ~100 seconds; tune to your environment.
 - `rotate 14 + compress` — two weeks of rotated history is usually enough to catch and replay everything between an incident and the operator noticing it.
@@ -456,7 +457,7 @@ For operators, the practical implications:
 
 - **Watch `events_failed` at output granularity.** A step increase without a matching increase in `events_errored` or DLQ file size means events are dropping through this path. Cross-check `events_written + events_failed + retries` against upstream input rate to bound the loss.
 - **Watch daemon panics.** A `panicked at` line in the daemon's `tracing` output is the primary observable for the bug path. `RUST_BACKTRACE=1` in the systemd unit is worth the extra bytes.
-- **Shutdown-fallthrough is progressively narrowing.** Recent releases have brought the batched-sink retry loop, the unbatched-sink retry backoff sleep, and the unbatched-sink single send attempt all under a shutdown-race that DLQ-routes on time. The remaining exposure is limited to shapes where the ack channel or a batched-sink buffer still holds a handle at the SIGTERM deadline — rare in a healthy deployment, still a bug-attributed loss when it happens.
+- **Shutdown-fallthrough is progressively narrowing.** Recent releases have brought the batched-sink retry loop, the unbatched-sink retry backoff sleep, and the network unbatched-sinks' single send attempt (`kafka`, `syslog_*`, `unix_socket`) all under a shutdown-race that DLQ-routes on time. The remaining exposure covers the shapes where the runtime task is aborted with a handle still parked mid-flight: the ack channel, a batched-sink buffer at the SIGTERM deadline, or an in-flight `write_payload` on the `file` output (whose write attempt is deliberately *not* raced against shutdown to avoid the partial-append duplicate documented in `crates/limpid/src/modules/output/file.rs`). Rare in a healthy deployment, still a bug-attributed loss when it happens.
 
 ## Schema migration v1 → v2
 


### PR DESCRIPTION
## Summary

Four small follow-ups after the file-output partial-append fix on
the steady-state consume path
([#113](https://github.com/naoto256/limpid/pull/113)).

### 1. File output's shutdown drain no longer times out mid-write

`consume_shutdown` wrapped `write_payload` in
`tokio::time::timeout(SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT, ...)`. That
reproduced the same mid-write cancellation shape that was removed
from the steady-state `consume` path: a shutdown drain that hits
the timeout would leave a partial line on disk *and* route the
event to DLQ as `Recovered`, and an operator replay would produce
a partial-then-full duplicate. Drop the timeout; wait for the
write to complete or fail on its own. Local disk writes are
typically <10 ms and finish inside the shutdown budget; a truly
hung filesystem becomes a task-abort → `Dropped` (the "lost but
no replay" contract already documented in the Standing limitation
section of `docs/src/operations/error-log.md`), which is worse
than a bounded write on paper but does not double the operator's
cleanup surface at replay time.

### 2. Recommended logrotate template matches the runtime contract

`docs/src/operations/error-log.md` recommended `create 0640 limpid
adm` for the DLQ rotator. The runtime DLQ writer contract is
*exactly* `0o600` on the on-disk file, so following the old
recommendation would refuse every DLQ write after the first
post-rotation open until the operator aligned the mode. Change
the template to `create 0600 limpid limpid` and add a Key-choices
bullet spelling out why the mode has to match.

### 3. Standing limitation section acknowledges the file output shape

The narrowing bullet previously claimed the residual exposure was
"limited to shapes where the ack channel or a batched-sink buffer
still holds a handle at the SIGTERM deadline". That skipped an
in-flight `write_payload` on the `file` output, which is
deliberately not raced against shutdown (see fix #1 above).
Rewrite the bullet to name that exposure explicitly.

### 4. Startup validation catches inherited symlinks / wrong-mode files

`ErrorLogWriter::validate_at_startup` only inspected the parent
directory. If a fresh deployment inherited a leftover `0o644` DLQ
file or a symlink at the configured path, the runtime write path
would refuse both — but only at the first real failure, *after*
the pipeline had already lost the observability on that record.
Add a Unix-side `symlink_metadata` + mode check so the same
refusals fire at `validate_at_startup()` time (i.e. at `--check`
and at daemon start), matching Principle 1: operators see the
mistake before any event flows.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 750 + 27 + 3 + 14 pass on both
      macOS and aarch64 Ubuntu (pre-push validation on the
      playground, per the engraved rule). Includes new regressions:
      - `validate_at_startup_refuses_symlink_at_dlq_path`
      - `validate_at_startup_refuses_wrong_mode_existing_file`
      - `validate_at_startup_accepts_absent_file`
- [x] `cargo audit` — vulnerabilities: 0
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
      (duplicate-crate warnings are the existing baseline)

## Not in scope

`file`/`stdout`/`unix_socket` sinks pass `egress` bytes through
`String::from_utf8_lossy` before writing, silently replacing
non-UTF-8 with U+FFFD — a byte-integrity concern for security
telemetry that ships binary payloads. That fix lives on its own
branch because it touches three sinks' write paths and the two
docs pages that describe the wire format.