### PR TITLE
fix(output): write egress bytes verbatim instead of lossily transcoding through UTF-8

### DIFF
--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -491,11 +491,16 @@ impl FileOutput {
             }
         };
 
-        let msg = String::from_utf8_lossy(&payload.egress);
-        let mut buf = Vec::with_capacity(msg.len() + 1);
-        buf.extend_from_slice(msg.as_bytes());
-        buf.push(b'\n');
-        file.write_all(&buf).await?;
+        // Preserve the payload bytes verbatim. `String::from_utf8_lossy`
+        // would silently replace non-UTF-8 bytes with U+FFFD (`\xEF\xBF\xBD`),
+        // which is exactly the wrong default for a security telemetry
+        // pipeline that can carry binary payloads (rare vendor
+        // formats, base64-decoded blobs, etc.) — the docs promise
+        // "one line == the event's egress bytes plus a newline", and
+        // silent U+FFFD substitution breaks both replay fidelity and
+        // downstream forensic hashing.
+        file.write_all(&payload.egress).await?;
+        file.write_all(b"\n").await?;
         // Push the buffered bytes through tokio's fs::File to the OS
         // before we return "written". Without this, the data may still
         // sit in tokio's per-file buffer at drop time — Drop closes the
@@ -1265,6 +1270,42 @@ mod tests {
         );
         // The target file must be untouched.
         assert_eq!(std::fs::read(&target).unwrap(), b"pre-existing");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_payload_preserves_non_utf8_bytes_verbatim() {
+        // The docs promise the writer emits `egress` bytes verbatim.
+        // Payloads carrying non-UTF-8 sequences (rare vendor formats,
+        // base64-decoded blobs, binary tails on a mis-classified
+        // vendor stream) must land on disk unchanged rather than
+        // lossily rewritten to U+FFFD (`\xEF\xBF\xBD`). Pin the byte-
+        // preserving contract so a future refactor that reintroduces
+        // `String::from_utf8_lossy` on the write path trips this
+        // test.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bytes.log");
+
+        let raw: &[u8] = &[0xff, 0xfe, b'A', b'B', 0x80, 0x00, 0x0a, b'x'];
+        let out = make_output(ek(ExprKind::StringLit(path.display().to_string())));
+        out.write_payload(FilePayload {
+            egress: Bytes::from(raw.to_vec()),
+            path: path.display().to_string(),
+            is_dynamic: false,
+        })
+        .await
+        .expect("byte payload write must succeed");
+
+        let mut expected = raw.to_vec();
+        expected.push(b'\n');
+        let on_disk = std::fs::read(&path).unwrap();
+        assert_eq!(on_disk, expected, "bytes must survive verbatim");
+        // Belt-and-braces: the U+FFFD replacement sequence must NOT
+        // appear at any offset in the on-disk output.
+        assert!(
+            !on_disk.windows(3).any(|w| w == [0xef_u8, 0xbf, 0xbd]),
+            "U+FFFD (\\xEF\\xBF\\xBD) must not appear on disk"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -57,17 +57,24 @@ impl HasMetrics for StdoutOutput {
 impl StdoutOutput {
     /// Pure write step — extracted so `consume` can drive the retry
     /// loop without duplicating the print. Goes through
-    /// `io::stdout().lock()` + `writeln!` rather than the `println!`
-    /// macro: `println!` panics on a broken pipe (the canonical case
-    /// is `limpid | head` where `head` exits before draining stdout),
-    /// which would tear down the daemon mid-run. The locked-write
-    /// path surfaces the I/O error here instead so the retry / DLQ
-    /// path in `consume` decides the disposition.
+    /// `io::stdout().lock()` + `write_all` rather than the
+    /// `println!` macro: `println!` panics on a broken pipe (the
+    /// canonical case is `limpid | head` where `head` exits before
+    /// draining stdout), which would tear down the daemon mid-run.
+    /// The locked-write path surfaces the I/O error here instead so
+    /// the retry / DLQ path in `consume` decides the disposition.
+    ///
+    /// The bytes are written verbatim; using `writeln!` on a lossy
+    /// `String::from_utf8_lossy` view would silently replace
+    /// non-UTF-8 payload bytes with U+FFFD (`\xEF\xBF\xBD`) — a
+    /// silent corruption on a security telemetry pipeline that can
+    /// carry binary payloads.
     fn write_event(&self, event: &Event) -> Result<()> {
         use std::io::Write;
-        let msg = String::from_utf8_lossy(&event.egress);
         let mut out = std::io::stdout().lock();
-        writeln!(out, "{}", msg).context("stdout write failed")?;
+        out.write_all(&event.egress)
+            .and_then(|()| out.write_all(b"\n"))
+            .context("stdout write failed")?;
         Ok(())
     }
 }

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -202,8 +202,12 @@ impl PersistentConn for UnixSocketOutput {
     }
 
     async fn write_frame(&self, stream: &mut UnixStream, payload: &Bytes) -> Result<()> {
-        let msg = String::from_utf8_lossy(payload);
-        stream.write_all(msg.as_bytes()).await?;
+        // Write the payload verbatim. `String::from_utf8_lossy`
+        // would silently replace non-UTF-8 bytes with U+FFFD
+        // (`\xEF\xBF\xBD`), which is exactly the wrong default for
+        // a security telemetry pipeline shipping opaque payloads
+        // to a local collector.
+        stream.write_all(payload).await?;
         stream.write_all(b"\n").await?;
         stream.flush().await?;
         Ok(())

--- a/docs/src/outputs/file.md
+++ b/docs/src/outputs/file.md
@@ -121,6 +121,6 @@ Parent directories are created automatically for dynamic paths (templates with `
 
 ## Notes
 
-- Each line is one event's `egress` bytes followed by a newline.
+- Each line is the event's `egress` bytes verbatim followed by a `\n`. The writer is byte-preserving: non-UTF-8 payloads (rare vendor formats, base64-decoded blobs) are written unchanged rather than lossily normalised to U+FFFD.
 - For log rotation, use `logrotate` with `copytruncate` or `create` + SIGHUP.
 - Common queue / retry properties — see [Queue and retry](./README.md#queue-and-retry).

--- a/docs/src/outputs/stdout.md
+++ b/docs/src/outputs/stdout.md
@@ -16,7 +16,7 @@ None.
 
 ## Notes
 
-- Each event is written as one line (`egress` bytes + newline).
+- Each event is written as the `egress` bytes verbatim followed by a `\n`. Non-UTF-8 payloads are emitted unchanged (the writer does not lossily normalise to U+FFFD); the terminal's own rendering may still substitute for invalid sequences.
 - Not recommended for production use — use [file](./file.md) or [syslog_tcp](./syslog-tcp.md) instead.
 - Useful with `--test-pipeline` for seeing processed output.
 - Common queue / retry properties — see [Queue and retry](./README.md#queue-and-retry).

--- a/docs/src/outputs/unix-socket.md
+++ b/docs/src/outputs/unix-socket.md
@@ -19,6 +19,7 @@ def output local_forward {
 
 ## Notes
 
+- Each frame is the `egress` bytes verbatim followed by a `\n`. Non-UTF-8 payloads are written unchanged rather than lossily normalised to U+FFFD, so binary payloads round-trip to the peer without silent corruption.
 - Connection is established on first use and reused.
 - Automatically reconnects if the connection breaks.
 - Common queue / retry properties — see [Queue and retry](./README.md#queue-and-retry).


### PR DESCRIPTION
## Summary

`file`, `stdout`, and `unix_socket` funnelled the event's `egress`
bytes through `String::from_utf8_lossy(...)` before writing. That
call silently substitutes `U+FFFD` (`\xEF\xBF\xBD`) for any
non-UTF-8 byte sequence — exactly the wrong default for a
security telemetry pipeline that can carry binary payloads: rare
vendor formats, base64-decoded blobs, mis-classified binary tails
on a byte-oriented stream. The docs for each sink promised
"egress bytes + newline" as the wire contract; the implementation
broke that promise silently.

Write the payload bytes verbatim in all three sinks:

- `file.rs`:
  `file.write_all(&payload.egress).await?; file.write_all(b"\n").await?;`
- `stdout.rs`:
  `out.write_all(&event.egress).and_then(|()| out.write_all(b"\n"))`
- `unix_socket.rs`:
  `stream.write_all(payload).await?; stream.write_all(b"\n").await?;`

Each write path is byte-preserving by construction. The batched
sinks (`http`, `otlp_*`) were never on this path and continue to
serialise via their transport-specific encoders.

Docs are updated on `docs/src/outputs/file.md`, `stdout.md`, and
`unix-socket.md` to promise byte-verbatim explicitly (rather than
the ambiguous "egress bytes + newline"), so an operator reading
the wire-format guarantee sees the same contract the writer
enforces.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 751 + 27 + 3 + 14 pass on both
      macOS and aarch64 Ubuntu (pre-push validation on the
      playground, per the engraved rule). Includes new regression
      `write_payload_preserves_non_utf8_bytes_verbatim` in
      `file.rs`: writes `\xff\xfe A B \x80 \x00 \n x`, asserts the
      on-disk bytes match exactly (payload + trailing `\n`), and
      asserts the U+FFFD replacement byte sequence
      (`\xEF\xBF\xBD`) does not appear at any offset.
- [x] `cargo audit` — vulnerabilities: 0
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
      (duplicate-crate warnings are the existing baseline)