### PR TITLE
Branch C: socket parent safety fail-closed + inode-cleanup defense-in-depth (3 findings from post-#116 audit)

### DIFF
--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -68,6 +68,13 @@ pub type InputInjectTarget = (mpsc::Sender<Event>, Arc<crate::metrics::InputMetr
 /// `RuntimeDirectoryMode` in the unit file) and already exists here; a
 /// pre-existing directory's permissions are deliberately left alone
 /// because they may be operator-managed.
+///
+/// Pre-existing parents whose mode fails
+/// [`parent_dir_mode_is_unsafe`] are handled elsewhere — see
+/// [`validate_control_socket_parent`], which is called from
+/// `Runtime::start` before this spawned task runs and bails the
+/// entire daemon rather than proceeding with a compromised bind→chmod
+/// window.
 fn ensure_socket_parent_dir(parent: &std::path::Path) {
     let preexisting = parent.exists();
     let _ = std::fs::create_dir_all(parent);
@@ -76,26 +83,93 @@ fn ensure_socket_parent_dir(parent: &std::path::Path) {
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o750));
     }
-    // A pre-existing parent dir (systemd's RuntimeDirectory, or an
-    // operator-managed path) keeps its own mode — the 0o750 tightening
-    // above only applies to dirs this call created. Rather than
-    // silently trust an inherited mode, warn when it is too loose to
-    // uphold the bind->chmod window's assumption that only the daemon's
-    // group can reach the socket inode. See `parent_dir_mode_is_unsafe`
-    // for exactly which bits break that, and why.
+}
+
+/// Startup-time validation for the control socket's parent
+/// directory. Called from `Runtime::start` before the control
+/// task is spawned, so an unsafe pre-existing parent aborts the
+/// whole daemon startup instead of letting a background task
+/// die silently with the daemon still running under a broken
+/// trust boundary.
+///
+/// - Parent absent → OK. The subsequent
+///   `ensure_socket_parent_dir` call from the control task
+///   creates it at 0o750 (bare / non-systemd runs), which
+///   passes the [`parent_dir_mode_is_unsafe`] predicate by
+///   construction.
+/// - Parent exists but is not a directory → bail. Almost
+///   always a config typo (`socket "/var/log/limpid.log"`
+///   instead of `.sock`).
+/// - Parent exists as a directory with an unsafe mode →
+///   bail with the observed mode and a remediation hint.
+///
+/// The custom-deploy contract this closes: an operator whose
+/// `control { socket "..." }` points into a directory they
+/// have not tightened (e.g. `0o755`, `0o770`, or worse) would
+/// previously have seen only a `warn!` line and a live daemon
+/// running on an insecure socket. That warn-only shape is now
+/// a fatal startup error, matching the equivalent shape from
+/// the DLQ preflight in `error_log::validate_at_startup`.
+///
+/// Under packaged systemd units (`RuntimeDirectory=limpid`
+/// with `RuntimeDirectoryMode=0750`) the parent is already
+/// safe and this validation is a no-op.
+pub fn validate_control_socket_parent(socket_path_config: Option<&str>) -> anyhow::Result<()> {
+    let socket_path = PathBuf::from(
+        socket_path_config
+            .map(str::to_string)
+            .unwrap_or_else(|| DEFAULT_SOCKET_PATH.to_string()),
+    );
+    let Some(parent) = socket_path.parent() else {
+        return Ok(());
+    };
+    let parent = if parent.as_os_str().is_empty() {
+        std::path::Path::new(".")
+    } else {
+        parent
+    };
     #[cfg(unix)]
-    if let Ok(meta) = std::fs::metadata(parent) {
+    {
         use std::os::unix::fs::PermissionsExt;
-        let mode = meta.permissions().mode() & 0o777;
-        if parent_dir_mode_is_unsafe(mode) {
-            warn!(
-                "control socket: parent dir {:?} has mode {:o} (group-writable and/or \
-                 world-traversable) — this weakens the bind-time TOCTOU mitigation; \
-                 expected 0o750 or tighter",
-                parent, mode
-            );
+        match std::fs::metadata(parent) {
+            Ok(meta) => {
+                if !meta.is_dir() {
+                    anyhow::bail!(
+                        "control socket: parent {:?} exists but is not a directory; \
+                         check the `control {{ socket \"...\" }}` value",
+                        parent
+                    );
+                }
+                let mode = meta.permissions().mode() & 0o777;
+                if parent_dir_mode_is_unsafe(mode) {
+                    anyhow::bail!(
+                        "control socket: parent dir {:?} has mode 0o{:o} — refusing to bind. \
+                         The control socket is a root-equivalent trust boundary and the \
+                         bind→chmod 0o660 window assumes only the daemon's group can \
+                         traverse to the socket inode. Tighten the parent to 0o750 or \
+                         stricter (`chmod 0750 {:?}`), or point `control {{ socket \"...\" }}` \
+                         at a packaged path (`/var/run/limpid/`, with \
+                         `RuntimeDirectoryMode=0750` under systemd).",
+                        parent,
+                        mode,
+                        parent
+                    );
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Parent will be created at 0o750 by the control
+                // task's `ensure_socket_parent_dir`. No pre-existing
+                // mode to check.
+            }
+            Err(e) => {
+                return Err(anyhow::Error::from(e).context(format!(
+                    "control socket: failed to stat parent {:?}",
+                    parent
+                )));
+            }
         }
     }
+    Ok(())
 }
 
 /// True when the parent dir's mode breaks either TOCTOU-mitigating
@@ -104,6 +178,13 @@ fn ensure_socket_parent_dir(parent: &std::path::Path) {
 /// execute (an outside-the-group user can traverse to and connect the
 /// socket inode during the bind->chmod window). Group execute is not
 /// flagged — group is the socket's own trusted access group.
+///
+/// **Not shared with the unix_socket input predicate**: that sink
+/// binds a world-writable (`0o666`) datagram socket at
+/// `/dev/log`-style paths, where other-execute on the parent is a
+/// requirement rather than a threat. Its own predicate lives in
+/// `crates/limpid/src/modules/input/unix_socket.rs` and flags
+/// group/other write only.
 #[cfg(unix)]
 fn parent_dir_mode_is_unsafe(mode: u32) -> bool {
     mode & 0o023 != 0
@@ -996,13 +1077,16 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn ensure_socket_parent_dir_warns_on_unsafe_preexisting_mode() {
-        // Regression pin for the loud-warn path: a pre-existing,
-        // group-writable parent dir must not be silently trusted.
-        // `tracing_test` isn't a dependency here, so this test only
-        // pins that the function doesn't panic/alter an unsafe mode
-        // (the warn! call itself is covered by the mode-detection unit
-        // test above); the mode-preservation contract still applies.
+    fn ensure_socket_parent_dir_preserves_unsafe_preexisting_mode() {
+        // `ensure_socket_parent_dir` is creation-only under the
+        // Branch C fail-closed contract: `validate_control_socket_parent`
+        // is authoritative for pre-existing parents and runs
+        // ahead of this function on the daemon startup path. If
+        // control still reaches `ensure_socket_parent_dir` with
+        // an unsafe pre-existing parent (a test invoking it in
+        // isolation), the function must not fail-fast or silently
+        // tighten an operator-managed dir — the operator's mode
+        // stays.
         use std::os::unix::fs::PermissionsExt;
         let base = tempfile::TempDir::new().unwrap();
         let parent = base.path().join("unsafe-run");
@@ -1012,7 +1096,88 @@ mod tests {
         let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
         assert_eq!(
             mode, 0o777,
-            "function must not fail-fast or silently tighten an operator-managed dir"
+            "creation-only helper must not silently tighten an operator-managed dir"
+        );
+    }
+
+    /// Fail-closed startup validation: a pre-existing parent
+    /// whose mode fails `parent_dir_mode_is_unsafe` must bail
+    /// with a diagnostic that names the observed mode and the
+    /// remediation. This is the whole daemon's startup guard;
+    /// the previous warn-only shape let the control socket
+    /// die silently while the daemon ran on.
+    #[test]
+    #[cfg(unix)]
+    fn validate_control_socket_parent_bails_on_unsafe_preexisting_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = tempfile::TempDir::new().unwrap();
+        let parent = base.path().join("bad-run");
+        std::fs::create_dir_all(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let socket = parent.join("control.sock");
+
+        let err = validate_control_socket_parent(Some(socket.to_str().unwrap())).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("0o777"),
+            "diagnostic must name the mode: {msg}"
+        );
+        assert!(
+            msg.contains("refusing to bind"),
+            "diagnostic must state the refusal: {msg}"
+        );
+    }
+
+    /// A pre-existing parent whose mode passes the predicate
+    /// (systemd's `RuntimeDirectory=limpid` with
+    /// `RuntimeDirectoryMode=0750`, or an operator that already
+    /// tightened the path) must not trigger any warning or
+    /// bail — this is the flagship packaged-deploy path and
+    /// must stay a silent no-op.
+    #[test]
+    #[cfg(unix)]
+    fn validate_control_socket_parent_accepts_safe_preexisting_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = tempfile::TempDir::new().unwrap();
+        let parent = base.path().join("good-run");
+        std::fs::create_dir_all(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o750)).unwrap();
+        let socket = parent.join("control.sock");
+
+        validate_control_socket_parent(Some(socket.to_str().unwrap())).unwrap();
+    }
+
+    /// An absent parent is OK — the subsequent
+    /// `ensure_socket_parent_dir` call in the control task
+    /// will create it at 0o750, which passes the predicate by
+    /// construction. This preserves the bare / non-systemd
+    /// developer workflow of pointing `control { socket "..." }`
+    /// at a path whose parent doesn't exist yet.
+    #[test]
+    fn validate_control_socket_parent_accepts_absent_parent() {
+        let base = tempfile::TempDir::new().unwrap();
+        let socket = base.path().join("missing-subdir").join("control.sock");
+        validate_control_socket_parent(Some(socket.to_str().unwrap())).unwrap();
+    }
+
+    /// A parent path that exists but isn't a directory (a
+    /// stray file left by a misconfigured operator) must bail
+    /// with a diagnostic naming the config value — a bind
+    /// attempt would otherwise fail with an opaque `ENOTDIR`
+    /// on the socket create.
+    #[test]
+    #[cfg(unix)]
+    fn validate_control_socket_parent_bails_when_parent_is_not_a_directory() {
+        let base = tempfile::TempDir::new().unwrap();
+        let file_at_parent = base.path().join("not-a-dir");
+        std::fs::write(&file_at_parent, b"oops").unwrap();
+        let socket = file_at_parent.join("control.sock");
+
+        let err = validate_control_socket_parent(Some(socket.to_str().unwrap())).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not a directory"),
+            "diagnostic must name the shape: {msg}"
         );
     }
 }

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1151,7 +1151,7 @@ mod tests {
     #[cfg(unix)]
     fn ensure_socket_parent_dir_preserves_unsafe_preexisting_mode() {
         // `ensure_socket_parent_dir` is creation-only under the
-        // Branch C fail-closed contract: `validate_control_socket_parent`
+        // startup fail-closed contract: `validate_control_socket_parent`
         // is authoritative for pre-existing parents and runs
         // ahead of this function on the daemon startup path. If
         // control still reaches `ensure_socket_parent_dir` with

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -297,6 +297,31 @@ impl ControlServer {
             }
         };
 
+        // Record (dev, ino) of the socket we just bound. Used at
+        // shutdown as a defense-in-depth check: refuse to unlink
+        // a node that has been swapped out from under us since
+        // bind. Primary trust boundary is
+        // `validate_control_socket_parent`'s fail-closed on
+        // group/other-writable parents — on a safe parent no
+        // outside-the-group writer can perform the swap. This
+        // check is the extra ring of safety, not the load-bearing
+        // guard.
+        #[cfg(unix)]
+        let bound_inode = {
+            use std::os::unix::fs::MetadataExt;
+            match std::fs::symlink_metadata(&self.socket_path) {
+                Ok(meta) => Some((meta.dev(), meta.ino())),
+                Err(e) => {
+                    warn!(
+                        "control socket: failed to stat bound socket for shutdown \
+                         defense-in-depth: {}",
+                        e
+                    );
+                    None
+                }
+            }
+        };
+
         // Restrict socket permissions to owner + group (0o660).
         //
         // TOCTOU note (security audit Low 3-3): between `bind` above
@@ -316,8 +341,10 @@ impl ControlServer {
         // gates who can reach the socket inode — daemon-created dirs are
         // 0o750 and packaged units pin `RuntimeDirectoryMode=0750`, so
         // an outside-the-group attacker cannot reach it during the
-        // window. `ensure_socket_parent_dir` warns when an inherited
-        // parent is too loose to hold that line.
+        // window. `validate_control_socket_parent` fails startup
+        // when an inherited parent is too loose to hold that
+        // line, so by the time we reach this point the parent
+        // mode has been vetted.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -393,8 +420,53 @@ impl ControlServer {
             }
         }
 
-        // Clean up socket file
-        let _ = std::fs::remove_file(&self.socket_path);
+        // Clean up socket file. Defense-in-depth: only unlink
+        // when the on-disk (dev, ino) still matches the socket
+        // we bound. `validate_control_socket_parent`'s
+        // fail-closed on writable parents is the load-bearing
+        // guard; this check refuses to remove a foreign inode
+        // even in the residual case where the parent contract
+        // was somehow broken after startup validation ran.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            match (bound_inode, std::fs::symlink_metadata(&self.socket_path)) {
+                (Some((dev, ino)), Ok(meta)) if meta.dev() == dev && meta.ino() == ino => {
+                    let _ = std::fs::remove_file(&self.socket_path);
+                }
+                (Some((dev, ino)), Ok(meta)) => {
+                    warn!(
+                        "control socket: path swapped since bind (bound dev/ino {}/{}, now \
+                         {}/{}); refusing to unlink foreign inode",
+                        dev,
+                        ino,
+                        meta.dev(),
+                        meta.ino()
+                    );
+                }
+                (Some(_), Err(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Already gone — nothing to unlink.
+                }
+                (Some(_), Err(e)) => {
+                    warn!(
+                        "control socket: failed to re-stat before shutdown unlink: {}",
+                        e
+                    );
+                }
+                (None, _) => {
+                    // We never recorded the bound inode (best-
+                    // effort at startup); fall back to a
+                    // path-based unlink under the safe-parent
+                    // assumption enforced by
+                    // `validate_control_socket_parent`.
+                    let _ = std::fs::remove_file(&self.socket_path);
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
     }
 }
 

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -606,9 +606,11 @@ mod tests {
     }
 
     /// Sticky bit + world-writable (`/tmp` at `0o1777`) is
-    /// **not** an escape hatch. Auditor sign-off: sticky
-    /// prevents non-owner unlink but not attacker-owned
-    /// replacement in a swap. `/tmp/foo.sock` is unsupported.
+    /// **not** an escape hatch: sticky prevents non-owner
+    /// unlink of files whose owner does not match, but a swap
+    /// attack plants an attacker-owned replacement node, so
+    /// sticky offers no protection here. `/tmp/foo.sock` is
+    /// unsupported for this input.
     #[test]
     #[cfg(unix)]
     fn parent_dir_mode_sticky_world_writable_is_unsafe() {

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -5,10 +5,11 @@
 //! Properties:
 //!   path   "/dev/log"   — required
 
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bytes::Bytes;
 use tokio::net::UnixDatagram;
 use tracing::{error, info, warn};
@@ -21,6 +22,98 @@ use crate::metrics::InputMetrics;
 use crate::modules::{HasMetrics, Input, Module};
 
 const UNIX_SOURCE: &str = "127.0.0.1:0";
+
+/// True when the parent dir's mode lets an outside-the-owner
+/// party plant or swap a node at the socket path.
+///
+/// The unix_socket input binds an intentionally world-writable
+/// (`0o666`) datagram socket at `/dev/log`-style paths — the
+/// standard `/dev` mode is `0o755`, and any local process must
+/// be able to `sendto` the inode, so **other-execute is a
+/// requirement, not a threat**. What we must refuse is a parent
+/// that grants **write** access outside the owner: a
+/// group-writable or world-writable parent lets an attacker
+/// swap the socket path for a symlink between shutdown and
+/// next bind, or between the stale-cleanup stat and the
+/// following `remove_file`.
+///
+/// Distinct predicate from `control.rs::parent_dir_mode_is_unsafe`,
+/// which additionally flags other-execute — the control
+/// socket's `0o660` bind→chmod window relies on non-group
+/// traversal that the input's `0o666` bind by design does not.
+///
+/// **Sticky bit + world-writable (`/tmp` at `0o1777`) is
+/// deliberately rejected**: the sticky bit only protects
+/// against non-owner unlink of files whose owner matches, but
+/// under a swap attack the attacker owns the replacement node,
+/// so sticky offers no protection here. `/tmp/foo.sock` is
+/// unsupported for this input; use `/dev/log` (path in a
+/// non-writable parent) or a packaged runtime directory
+/// instead.
+#[cfg(unix)]
+fn parent_dir_mode_is_unsafe_for_input(mode: u32) -> bool {
+    mode & 0o022 != 0
+}
+
+/// Startup-time validation of the unix_socket input's parent
+/// directory. Called from `UnixSocketInput::from_properties`
+/// so a fail-closed bail aborts daemon startup via
+/// `create_input` — matching the pipeline-side fatal shape of
+/// `control::validate_control_socket_parent` and
+/// `ErrorLogWriter::validate_at_startup`.
+///
+/// - Parent absent → bail. Unlike control, this input does
+///   not create its own parent (`/dev` is expected to exist);
+///   an absent parent almost always means a config typo.
+/// - Parent exists but is not a directory → bail.
+/// - Parent exists as a directory whose mode is group-writable
+///   or world-writable → bail. `/dev` at `0o755` passes.
+///   `/tmp` at `0o1777` does **not** — see the predicate doc
+///   for why sticky is not treated as protective here.
+fn validate_unix_socket_input_parent(path: &str) -> Result<()> {
+    let path = Path::new(path);
+    let Some(parent) = path.parent() else {
+        anyhow::bail!("input unix_socket: path {:?} has no parent directory", path);
+    };
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let meta = std::fs::metadata(parent).with_context(|| {
+            format!(
+                "input unix_socket: parent directory {:?} is not accessible (does it exist?)",
+                parent
+            )
+        })?;
+        if !meta.is_dir() {
+            anyhow::bail!(
+                "input unix_socket: parent {:?} exists but is not a directory; check the `path` value",
+                parent
+            );
+        }
+        let mode = meta.permissions().mode() & 0o7777;
+        if parent_dir_mode_is_unsafe_for_input(mode & 0o777) {
+            anyhow::bail!(
+                "input unix_socket: parent dir {:?} has mode 0o{:o} — refusing to bind. \
+                 The unix_socket input binds a world-writable (0o666) datagram socket, so a \
+                 group- or world-writable parent lets an outside-the-owner process swap the \
+                 socket path between shutdown and next bind (or between the stale-cleanup \
+                 stat and the follow-up unlink). Tighten the parent to 0o755 or stricter, or \
+                 point `path` at `/dev/log` (parent `/dev` is `0o755` on standard POSIX \
+                 systems). `/tmp` (`0o1777`) is **not** supported — sticky protects unlink \
+                 of files the attacker doesn't own, but a swap attack plants an attacker-owned \
+                 node.",
+                parent,
+                mode & 0o777,
+            );
+        }
+    }
+    Ok(())
+}
 
 const UNIX_SOCKET_INPUT_SCHEMA: &[PropertySpec] = &[PropertySpec {
     name: "path",
@@ -48,6 +141,15 @@ impl Module for UnixSocketInput {
         let properties = properties.user_properties();
         let path = props::get_string(properties, "path")
             .ok_or_else(|| anyhow::anyhow!("input '{}': unix_socket requires 'path'", name))?;
+        // Parent safety fail-closed: refuse startup when the
+        // configured path's parent is group-writable or
+        // world-writable. Symmetric with
+        // `control::validate_control_socket_parent`; the two
+        // predicates diverge because this input binds a
+        // world-writable socket where other-execute on the
+        // parent is a use-case requirement, not a threat.
+        validate_unix_socket_input_parent(&path)
+            .with_context(|| format!("input '{}': unix_socket startup validation failed", name))?;
         Ok(Self {
             path,
             metrics: Arc::new(InputMetrics::default()),
@@ -138,6 +240,33 @@ impl Input for UnixSocketInput {
         let socket = UnixDatagram::bind(&self.path)?;
         info!("unix_socket listening on {}", self.path);
 
+        // Record the (dev, ino) of the socket we just bound. Used
+        // at shutdown as a defense-in-depth check so the unlink
+        // path can refuse to remove a node that has been swapped
+        // out from under us since bind. This is best-effort: the
+        // primary trust boundary is
+        // `validate_unix_socket_input_parent`'s fail-closed on
+        // group/other-writable parents. On a safe parent no
+        // outside-the-owner writer exists; on an unsafe parent
+        // startup would have bailed and we would not be here.
+        // If the stat fails we log and continue with the same
+        // path-based unlink as before.
+        #[cfg(unix)]
+        let bound_inode = {
+            use std::os::unix::fs::MetadataExt;
+            match std::fs::symlink_metadata(&self.path) {
+                Ok(meta) => Some((meta.dev(), meta.ino())),
+                Err(e) => {
+                    warn!(
+                        "unix_socket {}: failed to stat bound socket for shutdown \
+                         defense-in-depth: {}",
+                        self.path, e
+                    );
+                    None
+                }
+            }
+        };
+
         // Make socket world-writable so any process can send (like /dev/log)
         #[cfg(unix)]
         {
@@ -162,7 +291,55 @@ impl Input for UnixSocketInput {
                 _ = shutdown.changed() => {
                     if *shutdown.borrow() {
                         info!("unix_socket {}: shutting down", self.path);
-                        let _ = std::fs::remove_file(&self.path);
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::MetadataExt;
+                            match (bound_inode, std::fs::symlink_metadata(&self.path)) {
+                                (Some((dev, ino)), Ok(meta))
+                                    if meta.dev() == dev && meta.ino() == ino =>
+                                {
+                                    // Same inode we bound at startup —
+                                    // safe to unlink.
+                                    let _ = std::fs::remove_file(&self.path);
+                                }
+                                (Some((dev, ino)), Ok(meta)) => {
+                                    warn!(
+                                        "unix_socket {}: path swapped since bind (bound dev/ino \
+                                         {}/{}, now {}/{}); refusing to unlink foreign inode",
+                                        self.path,
+                                        dev,
+                                        ino,
+                                        meta.dev(),
+                                        meta.ino()
+                                    );
+                                }
+                                (Some(_), Err(e))
+                                    if e.kind() == std::io::ErrorKind::NotFound =>
+                                {
+                                    // Already gone — nothing to unlink.
+                                }
+                                (Some(_), Err(e)) => {
+                                    warn!(
+                                        "unix_socket {}: failed to re-stat before shutdown \
+                                         unlink: {}",
+                                        self.path, e
+                                    );
+                                }
+                                (None, _) => {
+                                    // We never recorded the bound
+                                    // inode (best-effort at startup);
+                                    // fall back to a path-based
+                                    // unlink under the safe-parent
+                                    // assumption enforced by
+                                    // `validate_unix_socket_input_parent`.
+                                    let _ = std::fs::remove_file(&self.path);
+                                }
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            let _ = std::fs::remove_file(&self.path);
+                        }
                         break;
                     }
                 }
@@ -392,5 +569,118 @@ mod tests {
         assert_eq!(&event.ingress[..], b"<13>test message");
         let _ = sd_tx.send(true);
         let _ = handle.await;
+    }
+
+    // ---- parent-safety validation ----
+
+    /// Predicate scope: the input predicate treats parent write
+    /// access as unsafe (group/other write flag `0o022`), but
+    /// leaves other-execute alone — `/dev` at `0o755` is the
+    /// flagship `/dev/log` deploy shape and must pass.
+    #[test]
+    #[cfg(unix)]
+    fn parent_dir_mode_is_unsafe_for_input_flags_write_only() {
+        // Safe: no group/other write bit.
+        assert!(!parent_dir_mode_is_unsafe_for_input(0o755)); // `/dev` shape — flagship
+        assert!(!parent_dir_mode_is_unsafe_for_input(0o750));
+        assert!(!parent_dir_mode_is_unsafe_for_input(0o700));
+        assert!(!parent_dir_mode_is_unsafe_for_input(0o711)); // owner + traverse
+        // Unsafe: group or world writable.
+        assert!(parent_dir_mode_is_unsafe_for_input(0o775)); // group write
+        assert!(parent_dir_mode_is_unsafe_for_input(0o757)); // world write
+        assert!(parent_dir_mode_is_unsafe_for_input(0o777)); // both
+        assert!(parent_dir_mode_is_unsafe_for_input(0o770)); // group rwx
+    }
+
+    /// Sticky bit + world-writable (`/tmp` at `0o1777`) is
+    /// **not** an escape hatch. Auditor sign-off: sticky
+    /// prevents non-owner unlink but not attacker-owned
+    /// replacement in a swap. `/tmp/foo.sock` is unsupported.
+    #[test]
+    #[cfg(unix)]
+    fn parent_dir_mode_sticky_world_writable_is_unsafe() {
+        // Callers pass the low 9 permission bits, so `/tmp`'s
+        // 0o1777 arrives as 0o777 through
+        // `validate_unix_socket_input_parent`. Pin the low-bits
+        // shape here so a future caller that forgot to mask
+        // still trips the predicate.
+        assert!(parent_dir_mode_is_unsafe_for_input(0o777));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn from_properties_bails_on_group_writable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("group-writable");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o775)).unwrap();
+        let socket_path = parent.join("sock");
+        let err = validate_unix_socket_input_parent(socket_path.to_str().unwrap()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("0o775"),
+            "diagnostic must name the mode: {msg}"
+        );
+        assert!(
+            msg.contains("refusing to bind"),
+            "diagnostic must state the refusal: {msg}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn from_properties_accepts_dev_shaped_parent() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("dev-shaped");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let socket_path = parent.join("log");
+        validate_unix_socket_input_parent(socket_path.to_str().unwrap()).unwrap();
+    }
+
+    /// End-to-end: the run() shutdown path records the bound
+    /// (dev, ino) at bind time and refuses to unlink the path
+    /// if the on-disk node has been swapped out from under us.
+    /// The test simulates the swap by rebinding a fresh
+    /// standalone datagram socket at the same path before
+    /// triggering shutdown; the swap survives (input refuses
+    /// to unlink it).
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn shutdown_refuses_to_unlink_swapped_socket() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("sock");
+
+        let (handle, sd_tx, _rx) = spawn_with_path(&socket_path);
+        // Give the input a moment to bind.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let bound_meta_before = std::fs::symlink_metadata(&socket_path).unwrap();
+
+        // Simulate a swap: unlink and rebind a fresh socket
+        // (different inode) at the same path.
+        std::fs::remove_file(&socket_path).unwrap();
+        let squatter = StdUnixDatagram::bind(&socket_path).unwrap();
+        drop(squatter);
+        let swapped_meta = std::fs::symlink_metadata(&socket_path).unwrap();
+        assert!(
+            swapped_meta.ino() != bound_meta_before.ino(),
+            "test setup: swap must produce a fresh inode",
+        );
+
+        // Trigger shutdown. The input's dev/ino check should
+        // observe the inode mismatch and refuse to unlink.
+        let _ = sd_tx.send(true);
+        let _ = handle.await;
+
+        let post_meta =
+            std::fs::symlink_metadata(&socket_path).expect("swapped socket must survive shutdown");
+        assert_eq!(
+            post_meta.ino(),
+            swapped_meta.ino(),
+            "swapped inode must not have been unlinked by shutdown",
+        );
     }
 }

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -267,17 +267,30 @@ impl Input for UnixSocketInput {
             }
         };
 
-        // Make socket world-writable so any process can send (like /dev/log)
+        // Make socket world-writable so any process can send
+        // (like `/dev/log`). Failure here is fatal: the input's
+        // operator-facing contract is a `0o666` datagram
+        // socket, and running on with an umask-derived mode
+        // silently changes who can `sendto` the inode — an
+        // operator alarm signal, not a warn-and-continue. The
+        // just-bound socket inode is unlinked before we bail
+        // so the daemon can be restarted cleanly (the parent is
+        // safe by `validate_unix_socket_input_parent` and the
+        // inode is the one we just created, so `remove_file`
+        // cannot touch a foreign node).
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             if let Err(e) =
                 std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o666))
             {
-                warn!(
-                    "unix_socket {}: failed to set permissions: {}",
+                error!(
+                    "unix_socket {}: failed to set permissions to 0o666: {} — refusing to \
+                     listen on a socket whose mode does not match the operator-facing contract",
                     self.path, e
                 );
+                let _ = std::fs::remove_file(&self.path);
+                anyhow::bail!("unix_socket {}: chmod 0o666 failed: {}", self.path, e);
             }
         }
 

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -268,6 +268,14 @@ impl Runtime {
             .global_blocks
             .get("control")
             .and_then(|p| props::get_string(p, "socket"));
+        // Validate the control socket's parent BEFORE the control
+        // task is spawned. `ControlServer::run` returns `()` and is
+        // fire-and-forget from the runtime's perspective, so a
+        // fail-closed check inside the task would just make the
+        // control socket die silently while the daemon runs on.
+        // Bailing here stops the whole startup — the same shape as
+        // `ErrorLogWriter::validate_at_startup`.
+        crate::control::validate_control_socket_parent(control_path.as_deref())?;
         let started_at = std::time::Instant::now();
         let control = ControlServer::new(
             control_path,

--- a/docs/src/inputs/unix-socket.md
+++ b/docs/src/inputs/unix-socket.md
@@ -19,7 +19,9 @@ def input local {
 
 ## Notes
 
-- The socket file is created with mode `0666` (world-writable) so any local process can send messages.
+- The socket file is created with mode `0o666` (world-writable) so any local process can send messages. `chmod 0o666` failure at startup is **fatal** — the input refuses to listen on a socket whose mode does not match the operator-facing contract, rather than silently downgrading who can `sendto` the inode. Daemon startup fails with the underlying `set_permissions` error.
+- **Parent-directory safety** is enforced at daemon startup. The configured `path`'s parent must not be group-writable or world-writable — the input binds a world-writable socket, so a parent that lets an outside-the-owner process create files at that path would let an attacker swap the socket between shutdown and next bind. `/dev` (`0o755` on standard POSIX systems, for the flagship `/dev/log` deploy) passes. `/tmp` (`0o1777`) does **not**: sticky protects unlink of files the attacker doesn't own, but a swap attack plants an attacker-owned node. `/tmp/foo.sock` is unsupported — use `/dev/log` or a packaged runtime directory. Failure surfaces at startup with a diagnostic naming the observed mode and the remediation.
 - The stale-cleanup path only unlinks actual socket nodes at `path`. If the configured `path` points at a symlink, a regular file, a directory, a FIFO, or a device node, the input refuses to start with a diagnostic that names the observed shape — it will not follow a symlink or silently delete a real file that happens to share the path. Only a leftover socket inode from a previous run is replaced automatically.
+- At shutdown, the input records the `(dev, ino)` of the socket it bound and refuses to unlink the path if the on-disk inode has been swapped since bind. Under the safe-parent contract above no outside-the-owner writer can produce the swap; this check is defense-in-depth, not the load-bearing guard.
 - PRI validation is enforced on all messages.
 - Works with the `logger` command: `logger "hello from limpid"`

--- a/docs/src/operations/cli.md
+++ b/docs/src/operations/cli.md
@@ -114,6 +114,20 @@ limpidctl health --json
 |------|-------------|
 | `--socket <path>` | Control socket path (default: `/var/run/limpid/control.sock`) |
 
+### Control socket parent safety
+
+The control socket is a root-equivalent trust boundary, and its `bind → chmod 0o660` window relies on the parent directory keeping non-group traffic out. Daemon startup **refuses to start** when the configured `control { socket "..." }`'s parent already exists on disk and is group-writable, world-writable, or world-traversable (predicate `mode & 0o023 != 0`). Under packaged systemd units (`RuntimeDirectory=limpid` with `RuntimeDirectoryMode=0750`) the parent is already safe by construction and this check is a no-op.
+
+For custom deploys, tighten the parent to `0o750` (or `0o700` for owner-only) before starting the daemon:
+
+```sh
+chmod 0o750 /path/to/parent   # daemon user + group only
+```
+
+The failure diagnostic names the observed mode and remediation. If the parent does not exist yet, the control task creates it at `0o750` — no operator action needed.
+
+At shutdown, the control task records the `(dev, ino)` of the socket it bound and refuses to unlink the path if the on-disk inode has been swapped since bind. Under the safe-parent contract above no outside-the-group writer can produce the swap; this is defense-in-depth, not the load-bearing guard.
+
 ### Control socket limits
 
 The control socket is a local root-equivalent trust boundary (mode `0o660` in

--- a/docs/src/operations/cli.md
+++ b/docs/src/operations/cli.md
@@ -116,12 +116,12 @@ limpidctl health --json
 
 ### Control socket parent safety
 
-The control socket is a root-equivalent trust boundary, and its `bind → chmod 0o660` window relies on the parent directory keeping non-group traffic out. Daemon startup **refuses to start** when the configured `control { socket "..." }`'s parent already exists on disk and is group-writable, world-writable, or world-traversable (predicate `mode & 0o023 != 0`). Under packaged systemd units (`RuntimeDirectory=limpid` with `RuntimeDirectoryMode=0750`) the parent is already safe by construction and this check is a no-op.
+The control socket is a root-equivalent trust boundary, and its `bind → chmod 0o660` window relies on the parent directory keeping non-group traffic out. Daemon startup **refuses to start** when the configured `control { socket "..." }`'s parent already exists on disk and is group-writable, world-writable, or world-traversable (predicate `mode & 0o023 != 0`). Under packaged systemd units (`RuntimeDirectory=limpid` with `RuntimeDirectoryMode=0750` explicitly set in the unit file) the parent is already safe by construction and this check is a no-op.
 
 For custom deploys, tighten the parent to `0o750` (or `0o700` for owner-only) before starting the daemon:
 
 ```sh
-chmod 0o750 /path/to/parent   # daemon user + group only
+chmod 0750 /path/to/parent   # daemon user + group only
 ```
 
 The failure diagnostic names the observed mode and remediation. If the parent does not exist yet, the control task creates it at `0o750` — no operator action needed.

--- a/docs/src/operations/packaging.md
+++ b/docs/src/operations/packaging.md
@@ -82,7 +82,7 @@ ReadWritePaths=/var/log/limpid
 
 - `CAP_NET_BIND_SERVICE` allows binding to privileged ports (514) without root
 - `ProtectSystem=strict` makes the filesystem read-only except for explicitly allowed paths
-- `RuntimeDirectory=limpid` ensures `/var/run/limpid/` exists for the control socket. Pair with `RuntimeDirectoryMode=0750` (systemd's default): daemon startup refuses to run when the control socket's parent is group- or world-writable, so a laxer mode would fail-close and break the unit
+- `RuntimeDirectory=limpid` ensures `/var/run/limpid/` exists for the control socket. The packaged unit explicitly sets `RuntimeDirectoryMode=0750` — this is **not** systemd's default (systemd.exec picks `0755`), so operators who take a drop-in path must keep the `0750` value. Daemon startup refuses to run when the control socket's parent is group-writable, world-writable, or world-traversable, so a laxer mode fails-closed and breaks the unit
 - `ExecReload=/bin/kill -HUP $MAINPID` triggers hot reload via SIGHUP
 - `StateDirectory=limpid` and `RuntimeDirectory=limpid` provide `/var/lib/limpid` and `/var/run/limpid` writable; `ReadWritePaths=/var/log/limpid` covers the log directory. Operators using the `file` output to write elsewhere add a drop-in with the extra path.
 - `PrivateDevices=yes` means a `/dev/log` `unix_socket` input needs a `PrivateDevices=no` drop-in (see [systemd](./systemd.md#adding-write-paths))

--- a/docs/src/operations/packaging.md
+++ b/docs/src/operations/packaging.md
@@ -82,7 +82,7 @@ ReadWritePaths=/var/log/limpid
 
 - `CAP_NET_BIND_SERVICE` allows binding to privileged ports (514) without root
 - `ProtectSystem=strict` makes the filesystem read-only except for explicitly allowed paths
-- `RuntimeDirectory=limpid` ensures `/var/run/limpid/` exists for the control socket
+- `RuntimeDirectory=limpid` ensures `/var/run/limpid/` exists for the control socket. Pair with `RuntimeDirectoryMode=0750` (systemd's default): daemon startup refuses to run when the control socket's parent is group- or world-writable, so a laxer mode would fail-close and break the unit
 - `ExecReload=/bin/kill -HUP $MAINPID` triggers hot reload via SIGHUP
 - `StateDirectory=limpid` and `RuntimeDirectory=limpid` provide `/var/lib/limpid` and `/var/run/limpid` writable; `ReadWritePaths=/var/log/limpid` covers the log directory. Operators using the `file` output to write elsewhere add a drop-in with the extra path.
 - `PrivateDevices=yes` means a `/dev/log` `unix_socket` input needs a `PrivateDevices=no` drop-in (see [systemd](./systemd.md#adding-write-paths))


### PR DESCRIPTION
## Summary

Third and final branch addressing the 15-finding post-#116 comprehensive re-audit. This branch (**C**) closes the socket parent / cleanup findings — the custom-deploy trust boundary that packaged systemd defaults (`RuntimeDirectoryMode=0750`) already mitigate but which was warn-only for hand-rolled deployments.

Branch A (filesystem/DLQ contract) landed in [#117](https://github.com/naoto256/limpid/pull/117). Branch B (in-flight send disposition) landed in [#118](https://github.com/naoto256/limpid/pull/118). This closes the audit.

### Finding → commit mapping

| # | Severity | Fix commits | Summary |
|---|----------|-------|---------|
| **H4** | Major | [`a213101`](../commit/a213101) | Control socket parent unsafe → fail-closed at startup. Previously `ensure_socket_parent_dir` `warn!`d and let the control server bind on a compromised bind→chmod window. New `validate_control_socket_parent` runs from `Runtime::start` (before the control task is spawned, since `ControlServer::run` returns `()` fire-and-forget), bails the whole daemon on group-writable / world-writable / world-traversable parents. Packaged systemd units set `RuntimeDirectoryMode=0750` explicitly (systemd's own default is `0755`), so packaged deploys are a no-op; custom deploys get a diagnostic naming the observed mode and remediation. |
| **M9** | Medium | [`630ec5f`](../commit/630ec5f) | Symmetric parent-safety fail-closed on the `unix_socket` **input** (predicate `mode & 0o022 != 0` — group/other write only, since the input binds a world-writable socket where other-execute on the parent is required, not a threat; distinct predicate from control's `0o023`). `/dev` at `0o755` passes, `/tmp` at `0o1777` does not (sticky protects unlink of files the attacker doesn't own, but a swap plants an attacker-owned node). Shutdown paths on both sockets add `(dev, ino)` defense-in-depth: refuse to unlink the path if the on-disk inode has been swapped since bind. |
| **D14** | Low | [`841cebe`](../commit/841cebe) | `unix_socket` input chmod 0o666 failure fatal. Previously warn-and-continue silently downgraded who could `sendto` the inode; now bails with the underlying `set_permissions` error and unlinks the just-bound socket inode before exit (safe-parent enforced by the M9 fix, self-created inode so no risk of touching a foreign node). |
| — | — | [`0447526`](../commit/0447526) | Docs consolidation — `docs/src/inputs/unix-socket.md`, `docs/src/operations/cli.md`, `docs/src/operations/packaging.md` reflect the parent-safety fail-closed contract, the `chmod` remediation, and the dev/ino defense-in-depth. |
| — | — | [`2d906e0`](../commit/2d906e0) | Post-audit drift — internal milestone labels stripped from source comments, `packaging.md` corrected to state that `RuntimeDirectoryMode=0750` is the packaged unit's explicit choice (systemd default is `0755`), predicate scope narrowed to `group-writable, world-writable, or world-traversable` operator-facing. |

### Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p limpid --bin limpid --features kafka` — **807 pass / 0 fail / 1 ignored** on macOS local
- [x] `cargo test -p limpid --bin limpid` — **786 pass / 0 fail / 1 ignored** on aarch64 Ubuntu 24.04 (playground; kafka feature omitted for the ARM target)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo clippy --workspace --features kafka -- -D warnings` — clean
- [x] `cargo audit` — 0 advisories
- [x] New tests: control parent fail-closed (bails on unsafe / accepts safe / accepts absent / bails on non-dir), input parent predicate (write-only flags / sticky+world-writable rejected), input `from_properties` (bails on group-writable, accepts `/dev`-shaped), shutdown swap detection (refuses to unlink swapped inode).

### Contract changes (custom-deploy fail-closed)

- **Control socket parent**: `mode & 0o023 != 0` (group/other write or other-execute) → daemon startup fails. Previously warn-only. Packaged units are unaffected (already `0o750`).
- **unix_socket input parent**: `mode & 0o022 != 0` (group/other write only) → daemon startup fails. Previously no check. `/dev/log` deploys are unaffected (`/dev` is `0o755`).
- **unix_socket input chmod 0o666**: failure at bind time → daemon startup fails and the just-bound inode is unlinked. Previously warn-and-continue with the actual mode determined by process umask.
- **Both sockets shutdown**: `(dev, ino)` recorded at bind time; unlink at shutdown is skipped when the on-disk inode does not match. Defense-in-depth; the load-bearing guard is the parent-safety fail-closed.

### Scope

- **Custom-deploy oriented.** Packaged deploys (`RuntimeDirectory=limpid` with `RuntimeDirectoryMode=0750`, `/dev/log` for the input) are unaffected. The fix-closed shifts affect operators who hand-roll paths into non-tightened parents; the diagnostic points them at the specific parent mode and remediation.
- **Predicate distinction is deliberate.** Control's `0o023` and input's `0o022` reflect different threat models: control's `bind → chmod 0o660` window needs the parent to gate non-group traversal; the input's world-writable socket only cares about parent writers (who could swap the socket path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)