### PR TITLE
Fix relative absent parent handling + retire stale docstring/test comment + docs metric-name wording

### DIFF
--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -60,16 +60,6 @@ const MAX_INJECT_BYTES: u64 = 16 * 1024 * 1024;
 /// Per-input inject target: event channel + metrics handle (for events_injected).
 pub type InputInjectTarget = (mpsc::Sender<Event>, Arc<crate::metrics::InputMetrics>);
 
-/// Create the control socket's parent directory if absent. When *this
-/// call* created it (bare / non-systemd runs), tighten it to 0o750 so
-/// only the daemon user and its group can reach the socket inode at
-/// all — this directory mode is the layer that covers the bind→chmod
-/// window in [`ControlServer::run`]. Under systemd the directory comes
-/// from `RuntimeDirectory=limpid` (mode pinned via
-/// `RuntimeDirectoryMode` in the unit file) and already exists here; a
-/// pre-existing directory's permissions are deliberately left alone
-/// because they may be operator-managed.
-///
 /// Startup-time validation and (when absent) creation of the control
 /// socket's parent directory. Called from `Runtime::start` before the
 /// control task is spawned, so an unsafe pre-existing parent — or a
@@ -348,6 +338,15 @@ fn ancestor_is_trusted_for_create(uid: u32, mode: u32, self_euid: u32) -> bool {
 /// by [`create_parent_under_trusted_ancestor`] to find the deepest
 /// existing ancestor whose identity we can verify before creating a
 /// new directory below it.
+///
+/// Relative paths anchor to the current working directory. On Unix,
+/// `Path::new("foo").parent()` returns `Some("")`, and
+/// `symlink_metadata` on an empty path fails with `ENOENT`, so the
+/// naive walk would then hit `Path::new("").parent() == None` and
+/// bail. Treating an empty candidate as `.` (the cwd) keeps a
+/// relative config like `control { socket "missing/control.sock" }`
+/// walking up to a real ancestor instead of raising a spurious
+/// "no existing ancestor" at startup.
 #[cfg(unix)]
 fn nearest_existing_ancestor(path: &std::path::Path) -> anyhow::Result<PathBuf> {
     let mut current = path;
@@ -355,8 +354,13 @@ fn nearest_existing_ancestor(path: &std::path::Path) -> anyhow::Result<PathBuf> 
         let Some(parent) = current.parent() else {
             anyhow::bail!("no existing ancestor for {:?}", path);
         };
-        if std::fs::symlink_metadata(parent).is_ok() {
-            return Ok(parent.to_path_buf());
+        let candidate: &std::path::Path = if parent.as_os_str().is_empty() {
+            std::path::Path::new(".")
+        } else {
+            parent
+        };
+        if std::fs::symlink_metadata(candidate).is_ok() {
+            return Ok(candidate.to_path_buf());
         }
         current = parent;
     }
@@ -1510,17 +1514,42 @@ mod tests {
         validate_control_socket_parent(Some(socket.to_str().unwrap())).unwrap();
     }
 
-    /// An absent parent is OK — the subsequent
-    /// `ensure_socket_parent_dir` call in the control task
-    /// will create it at 0o750, which passes the predicate by
-    /// construction. This preserves the bare / non-systemd
-    /// developer workflow of pointing `control { socket "..." }`
-    /// at a path whose parent doesn't exist yet.
+    /// An absent parent is OK — `validate_control_socket_parent`
+    /// creates it at 0o750 under the daemon's uid after verifying
+    /// the nearest existing ancestor is trusted, then re-verifies
+    /// via `symlink_metadata`. This preserves the bare /
+    /// non-systemd developer workflow of pointing
+    /// `control { socket "..." }` at a path whose parent does not
+    /// exist yet.
     #[test]
     fn validate_control_socket_parent_accepts_absent_parent() {
         let base = tempfile::TempDir::new().unwrap();
         let socket = base.path().join("missing-subdir").join("control.sock");
         validate_control_socket_parent(Some(socket.to_str().unwrap())).unwrap();
+    }
+
+    /// A relative socket path with an absent nested parent must not
+    /// bail with "no existing ancestor" — the walk anchors to `.`
+    /// when named ancestors run out. Regression against the shape
+    /// where `Path::new("foo").parent()` returns `Some("")` and
+    /// `symlink_metadata("")` fails with `ENOENT`, leaving the naive
+    /// walk with no candidate. Uses `set_current_dir` inside a
+    /// tempdir so the test does not litter the developer cwd.
+    #[test]
+    #[cfg(unix)]
+    fn validate_control_socket_parent_handles_relative_absent_parent() {
+        use std::sync::Mutex;
+        static CWD_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = CWD_LOCK.lock().unwrap();
+        let base = tempfile::TempDir::new().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(base.path()).unwrap();
+        let result = validate_control_socket_parent(Some("missing-subdir/control.sock"));
+        // Restore cwd before asserting so a panic-on-fail leaves a
+        // recoverable state for later tests running in the same
+        // process.
+        std::env::set_current_dir(&prev).unwrap();
+        result.unwrap();
     }
 
     /// A parent path that exists but isn't a directory (a

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1315,11 +1315,17 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn validate_creates_absent_parent_at_0o750_under_daemon_owned_ancestor() {
-        // Absent parent + ancestor owned by the daemon's euid (the
-        // tempdir default) → validate creates the parent at 0o750
-        // and passes.
+        // Absent parent + ancestor owned by the daemon's euid → validate
+        // creates the parent at 0o750 and passes. The tempdir is
+        // explicitly chmod'd to 0o755 so the test runs the same way
+        // regardless of the caller's umask; on Linux systems where the
+        // default umask is 0o002 the raw tempdir would land at 0o775
+        // (group-write set) and fail the `mode & 0o022 == 0` ancestor
+        // trust predicate — the operator-facing behaviour, not a bug
+        // the test wants to reproduce.
         use std::os::unix::fs::PermissionsExt;
         let base = tempfile::TempDir::new().unwrap();
+        std::fs::set_permissions(base.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         let parent = base.path().join("limpid-run");
         assert!(!parent.exists());
         let socket = parent.join("control.sock");
@@ -1517,13 +1523,16 @@ mod tests {
     /// An absent parent is OK — `validate_control_socket_parent`
     /// creates it at 0o750 under the daemon's uid after verifying
     /// the nearest existing ancestor is trusted, then re-verifies
-    /// via `symlink_metadata`. This preserves the bare /
-    /// non-systemd developer workflow of pointing
-    /// `control { socket "..." }` at a path whose parent does not
-    /// exist yet.
+    /// via `symlink_metadata`. Tempdir is chmod'd to 0o755 so the
+    /// ancestor trust check doesn't reject it under a Linux
+    /// 0o002-umask default that would leave the raw tempdir at
+    /// 0o775 (group-write bit set).
     #[test]
+    #[cfg(unix)]
     fn validate_control_socket_parent_accepts_absent_parent() {
+        use std::os::unix::fs::PermissionsExt;
         let base = tempfile::TempDir::new().unwrap();
+        std::fs::set_permissions(base.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         let socket = base.path().join("missing-subdir").join("control.sock");
         validate_control_socket_parent(Some(socket.to_str().unwrap())).unwrap();
     }
@@ -1534,14 +1543,18 @@ mod tests {
     /// where `Path::new("foo").parent()` returns `Some("")` and
     /// `symlink_metadata("")` fails with `ENOENT`, leaving the naive
     /// walk with no candidate. Uses `set_current_dir` inside a
-    /// tempdir so the test does not litter the developer cwd.
+    /// tempdir (chmod 0o755 so the ancestor trust predicate accepts
+    /// it independent of the caller's umask) so the test does not
+    /// litter the developer cwd.
     #[test]
     #[cfg(unix)]
     fn validate_control_socket_parent_handles_relative_absent_parent() {
+        use std::os::unix::fs::PermissionsExt;
         use std::sync::Mutex;
         static CWD_LOCK: Mutex<()> = Mutex::new(());
         let _guard = CWD_LOCK.lock().unwrap();
         let base = tempfile::TempDir::new().unwrap();
+        std::fs::set_permissions(base.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         let prev = std::env::current_dir().unwrap();
         std::env::set_current_dir(base.path()).unwrap();
         let result = validate_control_socket_parent(Some("missing-subdir/control.sock"));

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -404,7 +404,7 @@ increase(limpid_output_events_errored_unwritable_total[5m]) > 0
 increase(limpid_output_events_wedged_total[5m]) > 0
 ```
 
-(Confirm the exact exported metric names against your `limpid-prometheus` exporter; the in-process counter names are `events_errored`, `events_failed` (per output), `events_errored_unwritable` (both sides), and `events_wedged` (output-side only).)
+The Prometheus metric names above are the authoritative form emitted by `limpid-prometheus`; the equivalents on the JSON stats endpoint are `events_errored`, `events_failed` (per output), `events_errored_unwritable` (both pipeline and output sides), and `events_wedged` (output-side only).
 
 **Multi-instance DLQ aggregation.** When several limpid daemons each write their own `error_log` file, central triage means shipping each file to a single host and replaying from there. The simple shape: a `filebeat` / `vector` / `rsyslog` collector tails each daemon's DLQ and forwards the lines into a central archive bucket; replay runs against a `jq` query over the aggregated archive and injects back into the daemon whose `pipeline` (Process flavor) or `output.name` (Output flavor) matches. Detailed multi-instance topology is deferred to a separate runbook.
 


### PR DESCRIPTION
## Summary

Post-audit review at `release/0.7.9` tip `40159d8` surfaced 3 follow-ups after the parent symlink follow fix landed. All addressed across 2 commits.

### Medium — `nearest_existing_ancestor` fails on relative nested absent parent

`Path::new("missing-subdir").parent()` returns `Some("")`, `symlink_metadata` on an empty path fails with `ENOENT`, and the naive walk hits `Path::new("").parent() == None` and raises "no existing ancestor". A relative config like `control { socket "missing-subdir/control.sock" }` would bail startup unnecessarily.

`c6d2826` substitutes `.` for an empty parent candidate before the `symlink_metadata` probe, anchoring the walk to the process cwd. Behaviour on absolute paths is unchanged. Regression test uses a `Mutex`-guarded `set_current_dir` inside a tempdir and restores the cwd before asserting so a panic-on-fail leaves later tests in a recoverable state.

### Low — stale docstring / test comment

- `validate_control_socket_parent` carried a stale docstring prefix from the retired `ensure_socket_parent_dir`, including the flatly wrong "pre-existing directory's permissions are deliberately left alone" claim. Removed.
- `validate_control_socket_parent_accepts_absent_parent`'s doc referenced the retired `ensure_socket_parent_dir`. Rewritten to describe the current create-under-trusted-ancestor path.

### Low — docs metric-name wording

`docs/src/operations/error-log.md` asked operators to "confirm the exact exported metric names against your exporter", but the same doc and the exporter both name them authoritatively. Reworded to state the Prometheus names are authoritative and list the JSON-stats equivalents inline.

### Test-env fix (from playground validation)

`53a0703` fixes three `validate_control_socket_parent` tests that called `tempfile::TempDir::new()` and used the resulting directory as the create-ancestor without touching its mode. On Mac (umask 0o022) tempdirs land at 0o755 and the tests pass; on Linux (umask 0o002) the same tempdir lands at 0o775 and the `mode & 0o022 == 0` half of the ancestor trust predicate rejects it. Explicit `chmod 0o755` on the tempdir in each affected test pins the ancestor mode to the shape the test intends to exercise, independent of the caller's umask.

## Verification

- Local (Mac): `cargo build`, `cargo clippy --tests --no-deps -- -D warnings`, `cargo fmt --all -- --check`, `mdbook build docs` — all clean.
- Local tests: 800 (limpid) + 27 + 4 + 14 = 845 pass, 1 ignored.
- Playground (aarch64 Ubuntu 24.04, umask 0o002): full build + test suite pass at 800/1/0, matches Mac local.
- External push-gate audit: 6 PASS + 2 standing baseline confirmed at `53a0703`.

## Test plan

- [ ] CI: cargo fmt / clippy / test / cargo-deny / mdbook build
- [ ] Rebase-merge on release/0.7.9