### PR TITLE
Fix syslog_udp steady-state events_written under-count + stdout consume_shutdown fold

### DIFF
--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -164,24 +164,23 @@ impl Output for StdoutOutput {
     }
 
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        match self.write_event(event) {
-            Ok(()) => {
-                self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                ack.resolve_delivered();
-            }
-            Err(e) => {
-                let reason = format!("shutdown write failed: {}", e);
-                let __dlq_outcome = crate::modules::route_event_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    event,
-                    &reason,
-                )
-                .await;
-                crate::modules::resolve_ack_from_dlq_outcome(ack, __dlq_outcome, &self.metrics);
-            }
-        }
+        // `write_event` is a synchronous write with no metric side
+        // effects, so the success + failure paths reduce to the
+        // canonical shape `finalize_shutdown_singleton_disposition`
+        // handles: bump events_written on Ok, route to DLQ on Err.
+        // Delegating removes the inline `route_event_to_dlq` +
+        // `resolve_ack_from_dlq_outcome` pair and lines up with the
+        // sibling sinks (syslog_tcp, syslog_udp, unix_socket, kafka)
+        // that already use the helper.
+        crate::modules::finalize_shutdown_singleton_disposition(
+            self.write_event(event),
+            self.error_log.as_ref(),
+            &self.metrics,
+            &self.name,
+            event,
+            ack,
+        )
+        .await;
         Ok(())
     }
 }

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -155,6 +155,15 @@ impl Output for SyslogUdpOutput {
             };
             match write_result {
                 Ok(()) => {
+                    // `write_payload_shutdown_aware` (and its transport-
+                    // only sibling `write_payload`) intentionally do NOT
+                    // bump `events_written`; disposition ownership lives
+                    // with the caller so the steady-state and shutdown
+                    // paths agree on a single "successful event" ==
+                    // "one bump" contract. Sibling `syslog_tcp` uses the
+                    // identical shape (see the comment at the analogous
+                    // `write_payload_shutdown_aware` return site).
+                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_delivered();
                     return Ok(());
                 }
@@ -225,43 +234,33 @@ impl Output for SyslogUdpOutput {
         let payload = SyslogPayload {
             egress: event.egress.clone(),
         };
-        let result = tokio::time::timeout(
+        // Delegate disposition (metric bump + ack resolution + DLQ
+        // route) to `finalize_shutdown_singleton_disposition` so the
+        // "successful shutdown-drain event == one `events_written`
+        // bump" contract is owned by the helper, not the sink.
+        // Sibling `syslog_tcp::consume_shutdown` uses the identical
+        // shape.
+        let result = match tokio::time::timeout(
             crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
             self.write_payload(payload),
         )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(anyhow::anyhow!(
+                "timed out after {:?}",
+                crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
+            )),
+        };
+        crate::modules::finalize_shutdown_singleton_disposition(
+            result,
+            self.error_log.as_ref(),
+            &self.metrics,
+            &self.name,
+            event,
+            ack,
+        )
         .await;
-        match result {
-            Ok(Ok(())) => {
-                ack.resolve_delivered();
-            }
-            Ok(Err(e)) => {
-                let reason = format!("shutdown write failed: {}", e);
-                let __dlq_outcome = crate::modules::route_event_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    event,
-                    &reason,
-                )
-                .await;
-                crate::modules::resolve_ack_from_dlq_outcome(ack, __dlq_outcome, &self.metrics);
-            }
-            Err(_) => {
-                let reason = format!(
-                    "shutdown write timed out after {:?}",
-                    crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
-                );
-                let __dlq_outcome = crate::modules::route_event_to_dlq(
-                    self.error_log.as_ref(),
-                    &self.metrics,
-                    &self.name,
-                    event,
-                    &reason,
-                )
-                .await;
-                crate::modules::resolve_ack_from_dlq_outcome(ack, __dlq_outcome, &self.metrics);
-            }
-        }
         Ok(())
     }
 }
@@ -434,10 +433,16 @@ impl SyslogUdpOutput {
     }
 
     /// Send one rendered datagram via the peer-rotation helper.
-    /// Private — used only by [`Output::consume`] and unit tests that
-    /// drive the transport directly without constructing an `Event`.
+    /// Transport-only — does NOT mutate `OutputMetrics`. The disposition
+    /// owner ([`Output::consume`]'s Delivered arm for steady-state, or
+    /// [`finalize_shutdown_singleton_disposition`][crate::modules::finalize_shutdown_singleton_disposition]
+    /// for shutdown drain) bumps `events_written` on success. Private —
+    /// called from [`Output::consume_shutdown`] and unit tests that
+    /// drive the transport directly without constructing an `Event`;
+    /// the steady-state `Output::consume` uses
+    /// [`Self::write_payload_shutdown_aware`] so its pre-send DNS /
+    /// bind / connect phase can race the shutdown signal.
     async fn write_payload(&self, payload: SyslogPayload) -> Result<()> {
-        let metrics = Arc::clone(&self.metrics);
         let result = self
             .peers
             .write_with_rotation_now(move |_idx, peer, state| {
@@ -545,13 +550,7 @@ impl SyslogUdpOutput {
             })
             .await;
 
-        match result {
-            Ok(()) => {
-                metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
-            Err(err) => Err(anyhow::anyhow!("{}", err)),
-        }
+        result.map_err(|err| anyhow::anyhow!("{}", err))
     }
 }
 
@@ -791,6 +790,128 @@ mod tests {
             matches!(src, SocketAddr::V6(_)),
             "peer source must be v6, got {:?}",
             src
+        );
+
+        // The transport helper is metric-free by contract — the
+        // steady-state `consume` and the shutdown-drain helper are the
+        // sole owners of the `events_written` bump. Pin that so a
+        // future refactor that re-adds a bump to `write_payload` is
+        // caught here.
+        assert_eq!(
+            output.metrics.events_written.load(Ordering::Relaxed),
+            0,
+            "write_payload must not mutate events_written; disposition owner bumps"
+        );
+    }
+
+    /// Steady-state success (delivered via `consume`) bumps
+    /// `events_written` exactly once. Regression against the
+    /// under-count where `write_payload_shutdown_aware` returning
+    /// `Delivered` left the counter untouched, so normal traffic
+    /// reported `events_written == 0` while shutdown-drain success
+    /// counted.
+    #[tokio::test]
+    async fn steady_state_consume_success_bumps_events_written_once() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+        use bytes::Bytes;
+
+        let listener = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().unwrap();
+        let port = addr.port() as i64;
+
+        let output = SyslogUdpOutput::build(
+            "u",
+            &mp(&[block(
+                "peer",
+                vec![
+                    kv("host", ExprKind::StringLit("127.0.0.1".into())),
+                    kv("port", ExprKind::IntLit(port)),
+                ],
+            )]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("build");
+
+        let event = Event::new(
+            Bytes::from_static(b"<134>hello"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+        output.consume(&event, ack).await.expect("consume");
+
+        // Drain the datagram off the listener so the test doesn't
+        // race the socket's send-buffer flush.
+        let mut buf = [0u8; 64];
+        let _ = tokio::time::timeout(Duration::from_secs(1), listener.recv_from(&mut buf))
+            .await
+            .expect("timed out waiting for datagram")
+            .expect("recv_from");
+
+        assert_eq!(
+            output.metrics.events_written.load(Ordering::Relaxed),
+            1,
+            "steady-state consume success must bump events_written exactly once"
+        );
+        assert_eq!(
+            output.metrics.events_failed.load(Ordering::Relaxed),
+            0,
+            "successful send must not bump events_failed"
+        );
+    }
+
+    /// Shutdown-drain success bumps `events_written` exactly once,
+    /// via `finalize_shutdown_singleton_disposition`. Regression to
+    /// pin that the fold to the helper preserves the one-bump-per-
+    /// successful-event contract on the shutdown path.
+    #[tokio::test]
+    async fn shutdown_consume_success_bumps_events_written_once() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+        use bytes::Bytes;
+
+        let listener = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().unwrap();
+        let port = addr.port() as i64;
+
+        let output = SyslogUdpOutput::build(
+            "u",
+            &mp(&[block(
+                "peer",
+                vec![
+                    kv("host", ExprKind::StringLit("127.0.0.1".into())),
+                    kv("port", ExprKind::IntLit(port)),
+                ],
+            )]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("build");
+
+        let event = Event::new(
+            Bytes::from_static(b"<134>shutdown"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+        output
+            .consume_shutdown(&event, ack)
+            .await
+            .expect("consume_shutdown");
+
+        let mut buf = [0u8; 64];
+        let _ = tokio::time::timeout(Duration::from_secs(1), listener.recv_from(&mut buf))
+            .await
+            .expect("timed out waiting for datagram")
+            .expect("recv_from");
+
+        assert_eq!(
+            output.metrics.events_written.load(Ordering::Relaxed),
+            1,
+            "consume_shutdown success must bump events_written exactly once via helper"
+        );
+        assert_eq!(
+            output.metrics.events_failed.load(Ordering::Relaxed),
+            0,
+            "successful drain must not bump events_failed"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fable review of the Output subsystem's shutdown-drain / helper-fold pattern turned up a real bug hiding behind what an earlier architectural survey had described as a cosmetic drift: **syslog_udp under-counts `events_written` during normal steady-state traffic**. Cross-check across every other sink confirmed the bug is unique to syslog_udp; sibling sinks (syslog_tcp, unix_socket, kafka, file, stdout, http, otlp_*) all follow the correct one-bump-per-successful-event contract.

## Fix (G-C1, `0202e98`)

syslog_udp had two divergent metric-owning shapes:

- `write_payload_shutdown_aware` (called from `Output::consume` in the steady-state path) returned `Delivered` **without** bumping `events_written`. Nothing else on the steady-state path bumped either.
- `write_payload` (called only from `Output::consume_shutdown` in the drain path) bumped `events_written` inside its own success arm.

Result: a healthy syslog_udp pipeline reported `events_written == 0` indefinitely, with only shutdown flushes ever incrementing the counter. This broke Prometheus alerting, `limpidctl stats` visibility, and the `received - written - failed ≈ queued` queue-depth heuristic.

Sibling `syslog_tcp` uses the identical shutdown-aware split but is correct: its `Output::consume` bumps `events_written` at the Delivered arm after the transport helper returns, and its `Output::consume_shutdown` delegates to `finalize_shutdown_singleton_disposition` which owns the shutdown-path bump. The comment at that site documents "helper does not bump, caller is the owner". syslog_udp's implementation diverged from this pattern.

The fix lands three changes as an atomic set (splitting them would leave a new bug in the intermediate state — removing the `write_payload` bump before folding `consume_shutdown` would leave the drain path with no bump at all):

1. Remove `events_written.fetch_add` inside `write_payload`. The transport helper is now metric-free by contract; its docstring is updated to say so and to name the disposition owners on both paths.
2. Add `events_written.fetch_add` on the Delivered arm of `Output::consume` so steady-state successful sends increment the counter exactly once. Comment cross-references the syslog_tcp shape.
3. Fold `Output::consume_shutdown` onto `finalize_shutdown_singleton_disposition`. Wrap the transport call in `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT`, fold `Ok`/`Err`/`Elapsed` into a `Result`, and hand the result to the helper. The helper is now the sole owner of the shutdown-path metric bump and disposition, matching syslog_tcp / unix_socket / kafka.

Three regression tests pin the invariants:

- `write_payload` leaves `events_written` at 0 (transport helper is metric-free).
- `Output::consume` success bumps `events_written` to exactly 1 (the under-count that motivated this commit).
- `Output::consume_shutdown` success bumps `events_written` to exactly 1 via the helper (fold behaviour).

## DRY (G-C2, `cae37e7`)

stdout's `consume_shutdown` implemented the same success-bumps-events_written / failure-routes-to-DLQ shape inline that `finalize_shutdown_singleton_disposition` owns for the other unbatched sinks. `write_event` is synchronous with no metric side effects, so the fold reduces to handing the `Result` to the helper. Zero behavior change; removes one more divergent shape.

## Verification

- Local (Mac): `cargo build`, `cargo clippy --tests --no-deps -- -D warnings`, `cargo fmt --all -- --check` — all clean.
- Local tests: 802 (limpid) + 27 + 4 + 14 = 847 pass, 1 ignored. 802 is up from 800 with the two new syslog_udp regression tests.
- Playground (aarch64 Ubuntu 24.04): `cargo test -p limpid --bin limpid syslog_udp` = 15/15 pass. e2e daemon test not required — the three regression unit tests exercise the exact code paths that would matter operator-facing.
- External push-gate audit: 6 PASS + 2 standing baseline confirmed at `cae37e7`.

## Test plan

- [ ] CI: cargo fmt / clippy / test / cargo-deny / mdbook build
- [ ] Rebase-merge on release/0.7.9