### PR TITLE
Fix output data-integrity: kafka mid-send cancellation, unix_socket shutdown double-count, output-side DLQ JSONL fallback

### DIFF
--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -508,9 +508,18 @@ pub async fn route_shutdown_batch_to_dlq(
             let outcome = match writer.write(&ctx).await {
                 Ok(()) => DlqRouteOutcome::Recovered,
                 Err(write_err) => {
-                    tracing::warn!(
+                    // Same shutdown-drain JSONL fallback contract as
+                    // `route_event_to_dlq`: emit the full record via
+                    // `event_record` so the operator has a manual-
+                    // recovery trail alongside the counter bump. The
+                    // configured DLQ file remains the load-bearing
+                    // recovery; this is best-effort.
+                    tracing::error!(
+                        event_record = %ctx.to_jsonl(),
                         "output '{}': error_log write during shutdown failed: {} — routing as \
-                         Dropped so the disk queue holds the cursor for replay",
+                         Dropped so the disk queue holds the cursor for replay; event_record \
+                         below is a best-effort tracing fallback (a healthy `error_log` file \
+                         is the load-bearing recovery)",
                         output_name,
                         write_err
                     );
@@ -651,9 +660,24 @@ pub async fn route_event_to_dlq(
                 // the cursor on a disk queue (disk-queue fail-stop wedge)
                 // rather than advance past an event that has no
                 // durable trail.
-                tracing::warn!(
+                //
+                // Also emit the full JSONL via a structured
+                // `event_record` field on `tracing::error!` so the
+                // operator still has a manual-recovery trail even
+                // when the configured DLQ file is unhealthy. This
+                // is best-effort (subject to log rotation /
+                // filters / aggregation) — a healthy DLQ file
+                // remains the load-bearing recovery contract —
+                // but on a memory queue this fallback is the only
+                // durable trace left, and on a disk queue it
+                // supplements the wedge for out-of-band operator
+                // triage. Matches the pipeline-side
+                // `write_errored_to_dlq` shape in runtime.rs.
+                tracing::error!(
+                    event_record = %ctx.to_jsonl(),
                     "output '{}': error_log write failed: {} — routing as Dropped so the disk \
-                     queue holds the cursor for replay",
+                     queue holds the cursor for replay; event_record below is a best-effort \
+                     tracing fallback (a healthy `error_log` file is the load-bearing recovery)",
                     output_name,
                     write_err
                 );
@@ -1107,5 +1131,83 @@ mod resolve_ack_from_dlq_outcome_tests {
         resolve_ack_from_dlq_outcome(ack, DlqRouteOutcome::Dropped, &metrics);
         assert_eq!(rx.recv().await, Some((position, AckDisposition::Dropped)));
         assert_eq!(metrics.events_failed.load(Ordering::Relaxed), 0);
+    }
+}
+
+/// Structural pins for the output-side DLQ write-failure JSONL
+/// fallback contract. The pipeline-side `runtime::write_errored_to_dlq`
+/// emits a full `event_record` via `tracing::error!` when the
+/// configured DLQ file write itself fails, so operators still have a
+/// manual-recovery trail out of journald. Historically the output-
+/// side routes (`route_event_to_dlq`, `route_shutdown_batch_to_dlq`)
+/// emitted only a `tracing::warn!` on that path, and the parity
+/// claim in docs was fiction. This module now emits the same
+/// `event_record` field; the tests below prevent that fix from
+/// silently regressing.
+#[cfg(test)]
+mod output_dlq_jsonl_fallback_tests {
+    /// `route_event_to_dlq`'s configured-writer write-failure arm
+    /// must emit `event_record = %ctx.to_jsonl()`. Detection is
+    /// source-level (grep the module for the arm's `event_record`
+    /// field); the alternative — attaching a tracing subscriber and
+    /// asserting on captured fields — requires infrastructure the
+    /// workspace's unit tests do not yet share.
+    #[test]
+    fn route_event_to_dlq_configured_failure_emits_event_record() {
+        let src = include_str!("mod.rs");
+        let fn_start = src
+            .find("pub async fn route_event_to_dlq(")
+            .expect("route_event_to_dlq must exist");
+        // Bound the search at the next top-level `pub async fn` or
+        // `pub fn` to keep the grep scoped to this function's body.
+        let fn_end_candidates = [
+            src[fn_start + 32..].find("\npub async fn "),
+            src[fn_start + 32..].find("\npub fn "),
+        ];
+        let fn_end = fn_end_candidates
+            .into_iter()
+            .flatten()
+            .min()
+            .expect("a following pub fn must exist");
+        let body = &src[fn_start..fn_start + 32 + fn_end];
+        assert!(
+            body.contains("event_record ="),
+            "route_event_to_dlq must emit `event_record = %ctx.to_jsonl()` in its \
+             configured-writer write-failure arm so operators have a journald fallback \
+             when the DLQ file is unhealthy"
+        );
+        assert!(
+            body.contains("events_errored_unwritable"),
+            "route_event_to_dlq must still bump events_errored_unwritable on the same arm"
+        );
+    }
+
+    /// Same structural pin for the shutdown-batch route.
+    #[test]
+    fn route_shutdown_batch_to_dlq_configured_failure_emits_event_record() {
+        let src = include_str!("mod.rs");
+        let fn_start = src
+            .find("pub async fn route_shutdown_batch_to_dlq(")
+            .expect("route_shutdown_batch_to_dlq must exist");
+        let fn_end_candidates = [
+            src[fn_start + 42..].find("\npub async fn "),
+            src[fn_start + 42..].find("\npub fn "),
+        ];
+        let fn_end = fn_end_candidates
+            .into_iter()
+            .flatten()
+            .min()
+            .expect("a following pub fn must exist");
+        let body = &src[fn_start..fn_start + 42 + fn_end];
+        assert!(
+            body.contains("event_record ="),
+            "route_shutdown_batch_to_dlq must emit `event_record = %ctx.to_jsonl()` in \
+             its configured-writer write-failure arm so shutdown-drain failures leave a \
+             journald fallback when the DLQ file is unhealthy"
+        );
+        assert!(
+            body.contains("events_errored_unwritable"),
+            "route_shutdown_batch_to_dlq must still bump events_errored_unwritable"
+        );
     }
 }

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -642,10 +642,19 @@ impl KafkaOutput {
     /// before the `producer.send(...)` call — that recheck is
     /// where the side-effect boundary sits.
     ///
-    /// The recheck is best-effort: if shutdown flips between the
-    /// borrow and the `producer.send(...)` call the record ships;
-    /// the caller's outer race and the disk-queue fail-stop wedge
-    /// cover that case.
+    /// If shutdown flips *between* this recheck and the
+    /// `producer.send(...)` call the record ships. There is no
+    /// outer race in `Output::consume` that could catch this: the
+    /// caller `await`s `try_send` directly, deliberately, to avoid
+    /// letting a `tokio::select!` shutdown arm cancel the
+    /// `producer.send(...)` future mid-flight (that would produce
+    /// duplicate delivery — record on the broker AND in the DLQ).
+    /// The remaining unavoidable gap is covered by two operator-
+    /// visible mechanisms: the delivery future's own
+    /// `queue_timeout` / `message.timeout.ms` bounds the wait, and
+    /// on a disk queue a shutdown-driven Dropped disposition
+    /// triggers the fail-stop wedge so the cursor holds for
+    /// replay on next start.
     async fn try_send(
         &self,
         event: &Event,

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -464,52 +464,38 @@ impl Output for KafkaOutput {
         let mut wait = self.retry.initial_wait;
         let mut shutdown = self.shutdown_signal.clone();
         loop {
-            // Pre-send shutdown check. Kafka's side-effect boundary
-            // is the `producer.send(...)` call itself (see
-            // `try_send`): librdkafka's `FutureProducer::send`
-            // synchronously enqueues the record into the internal
-            // producer queue, and dropping the returned future
-            // waits-side only — the record still ships to the
-            // broker. `try_send` therefore rechecks the shutdown
-            // signal one last time immediately before calling
-            // `send`, and the outer race here is best-effort: if
-            // shutdown flips between this check and the internal
-            // recheck we still return `Recovered` (the shutdown
-            // arm below), but the internal recheck is the
-            // load-bearing guard.
-            // Clone the shutdown receiver for the inner recheck
-            // BEFORE we take the mutable borrow for the outer
-            // race. The inner recheck is where the load-bearing
-            // guard sits (immediately before `producer.send(...)`);
-            // the outer race exists so a shutdown during in-process
-            // prep still returns None promptly rather than waiting
-            // for the recheck.
-            let inner_shutdown = shutdown.clone();
-            let outcome = match crate::modules::pre_send_or_shutdown(
-                &mut shutdown,
-                self.try_send(event, inner_shutdown),
-            )
-            .await
-            {
-                Some(r) => r,
-                None => {
-                    let reason = format!(
-                        "output '{}': write attempt abandoned on shutdown (pre-send)",
-                        self.name
-                    );
-                    let __dlq_outcome = crate::modules::route_event_to_dlq(
-                        self.error_log.as_ref(),
-                        &self.metrics,
-                        &self.name,
-                        event,
-                        &reason,
-                    )
-                    .await;
-                    crate::modules::resolve_ack_from_dlq_outcome(ack, __dlq_outcome, &self.metrics);
-                    return Ok(());
-                }
-            };
-            match outcome {
+            // Kafka's side-effect boundary is the
+            // `producer.send(...)` call inside `try_send`:
+            // librdkafka's `FutureProducer::send` synchronously
+            // enqueues the record into the internal producer queue,
+            // and dropping the returned future waits-side only — the
+            // record still ships to the broker.
+            //
+            // No `pre_send_or_shutdown` wrapper here. Wrapping
+            // `try_send` in one would let a `tokio::select!`
+            // cancel the `producer.send(...).await` mid-flight, drop
+            // the delivery future, and return `None` — while the
+            // record is still on its way to the broker. The caller
+            // would then route the event to DLQ as `Recovered`, so
+            // one send attempt would produce both a broker delivery
+            // AND a replayable DLQ record (duplicate delivery).
+            //
+            // Instead, `try_send` is entirely synchronous up to a
+            // final `shutdown.borrow_and_update()` recheck
+            // immediately before `producer.send(...)`. That recheck
+            // is the sole load-bearing shutdown boundary for
+            // steady-state consume: if shutdown was already observed
+            // when the prep finishes, `try_send` returns
+            // `PreSendShutdown` and no send is started; if shutdown
+            // flips *after* `producer.send(...)` is entered, the
+            // send runs to completion under librdkafka's own
+            // `queue_timeout` / `message.timeout.ms` — the runtime
+            // shutdown budget does not truncate it here. A
+            // shutdown that fires between the pre-send prep and the
+            // recheck is a legitimate race that resolves in favour
+            // of "send happens" and is caught by the next iteration
+            // or by the runtime SIGTERM budget.
+            match self.try_send(event, shutdown.clone()).await {
                 Ok(KafkaTrySendOutcome::Delivered) => {
                     self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_delivered();
@@ -1067,5 +1053,97 @@ mod tests {
             ],
         )];
         pre_check_plain_requires_tls("k", &props, None).unwrap();
+    }
+
+    /// Structural regression pin for the duplicate-delivery bug: the
+    /// steady-state `consume` MUST NOT wrap `try_send` in a
+    /// `pre_send_or_shutdown` (or any other `select!`-shaped
+    /// construct). Doing so lets a mid-`producer.send(...).await`
+    /// shutdown drop the delivery future while librdkafka has
+    /// already accepted the record, producing both a broker
+    /// delivery AND a DLQ-replayable record. The load-bearing
+    /// shutdown boundary is the `borrow_and_update()` recheck
+    /// immediately before `producer.send(...)` inside `try_send`
+    /// — this is the single, atomic pre-send guard.
+    ///
+    /// Detection strategy: read this source file at test time and
+    /// assert that no `consume`-scoped `pre_send_or_shutdown` call
+    /// exists. A grep-shaped structural test is unusual, but the
+    /// alternative — wiring up a real `FutureProducer` to observe
+    /// a mid-send cancellation — requires a Kafka broker in the
+    /// test harness. The regression this pins is a shape, not a
+    /// value, so a source-level pin is honest.
+    #[test]
+    fn consume_does_not_wrap_try_send_in_pre_send_or_shutdown() {
+        let src = include_str!("kafka.rs");
+        // Extract the body of `Output::consume` (up to
+        // `consume_shutdown` which is the next `async fn`).
+        let consume_start = src
+            .find("async fn consume(")
+            .expect("consume fn must exist");
+        let consume_end = src[consume_start..]
+            .find("async fn consume_shutdown(")
+            .expect("consume_shutdown fn must follow");
+        let consume_body = &src[consume_start..consume_start + consume_end];
+        // Match a call, not a bare mention: an in-body reference in
+        // a doc comment (e.g. "No pre_send_or_shutdown wrapper here")
+        // must not trip the pin, but the actual function call
+        // `crate::modules::pre_send_or_shutdown(...)` must.
+        assert!(
+            !consume_body.contains("pre_send_or_shutdown("),
+            "Output::consume must not wrap try_send in pre_send_or_shutdown; that lets a \
+             mid-producer.send shutdown drop the delivery future while librdkafka has \
+             already accepted the record, producing duplicate delivery. The load-bearing \
+             pre-send guard lives inside try_send at the borrow_and_update recheck."
+        );
+    }
+
+    /// Functional pin for the pre-send load-bearing guard: with the
+    /// shutdown receiver already set to `true`, `try_send` must
+    /// return `PreSendShutdown` without touching `producer.send`.
+    /// This is the shutdown boundary the outer-wrapper removal
+    /// relies on — losing it would let a shutdown observed before
+    /// the send start still result in a broker delivery.
+    #[tokio::test]
+    async fn try_send_short_circuits_when_shutdown_already_set() {
+        use crate::event::Event;
+        use bytes::Bytes;
+
+        let (tx, rx) = tokio::sync::watch::channel(true); // pre-set
+        Box::leak(Box::new(tx)); // keep sender alive for the test
+
+        // Build a minimal KafkaOutput. `client.create()` synchronously
+        // returns a `FutureProducer` handle; librdkafka defers all
+        // broker connection to the first produce call, which we
+        // never reach because the shutdown recheck short-circuits.
+        let mut client = ClientConfig::new();
+        client
+            .set("bootstrap.servers", "127.0.0.1:1") // unreachable, unused
+            .set("message.timeout.ms", "5000");
+        let producer: FutureProducer = client.create().expect("build producer");
+        let output = KafkaOutput {
+            name: "k".into(),
+            producer,
+            topic: "t".into(),
+            key_field: None,
+            queue_timeout: Duration::from_secs(1),
+            retry: RetryConfig::default(),
+            error_log: None,
+            metrics: Arc::new(OutputMetrics::default()),
+            shutdown_signal: rx.clone(),
+        };
+        let event = Event::new(
+            Bytes::from_static(b"payload"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let outcome = output.try_send(&event, rx).await.expect("try_send Ok arm");
+        assert!(
+            matches!(outcome, KafkaTrySendOutcome::PreSendShutdown),
+            "try_send with pre-set shutdown must return PreSendShutdown, got {:?}",
+            match outcome {
+                KafkaTrySendOutcome::Delivered => "Delivered",
+                KafkaTrySendOutcome::PreSendShutdown => "PreSendShutdown",
+            }
+        );
     }
 }

--- a/crates/limpid/src/modules/output/persistent_conn.rs
+++ b/crates/limpid/src/modules/output/persistent_conn.rs
@@ -17,14 +17,9 @@
 //! Kept `pub(crate)` — internal implementation detail of the output
 //! layer, not part of the module contract.
 
-use std::sync::Arc;
-use std::sync::atomic::Ordering;
-
 use anyhow::Result;
 use bytes::Bytes;
 use tokio::sync::Mutex;
-
-use crate::metrics::OutputMetrics;
 
 /// Policy trait implemented by each persistent-connection output. The
 /// concrete stream type and the framed-write routine stay in the
@@ -51,7 +46,11 @@ pub(crate) trait PersistentConn: Sync {
 }
 
 /// Write `payload` through a persistent stream, reconnecting once if
-/// the cached stream is stale. Bumps `events_written` on success.
+/// the cached stream is stale. Transport-only — does NOT mutate
+/// `OutputMetrics`. Disposition ownership (the `events_written` bump
+/// on success, or the DLQ route on failure) lives with the caller;
+/// unifying it there keeps steady-state consume and shutdown-drain
+/// success from double-counting under `finalize_shutdown_singleton_disposition`.
 ///
 /// On the fast path (cached stream, write succeeds) `connect` is never
 /// invoked. A single failed write triggers one reconnect attempt; if
@@ -69,7 +68,6 @@ pub(crate) trait PersistentConn: Sync {
 pub(crate) async fn write_with_reconnect<P>(
     policy: &P,
     conn: &Mutex<Option<P::Stream>>,
-    metrics: &Arc<OutputMetrics>,
     payload: &Bytes,
 ) -> Result<()>
 where
@@ -80,10 +78,7 @@ where
     // Fast path: reuse an existing connection.
     if guard.is_some() {
         match policy.write_frame(guard.as_mut().unwrap(), payload).await {
-            Ok(()) => {
-                metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                return Ok(());
-            }
+            Ok(()) => return Ok(()),
             Err(_) => {
                 // Broken pipe / reset — drop and reconnect below.
                 *guard = None;
@@ -95,7 +90,6 @@ where
     let stream = policy.connect().await?;
     *guard = Some(stream);
     policy.write_frame(guard.as_mut().unwrap(), payload).await?;
-    metrics.events_written.fetch_add(1, Ordering::Relaxed);
     Ok(())
 }
 
@@ -109,7 +103,12 @@ where
 /// `Recovered` on shutdown or spin an extra retry attempt after
 /// the runtime has already asked them to stop.
 pub(crate) enum WriteReconnectOutcome {
-    /// Payload was written and `events_written` bumped.
+    /// Payload was written. Metric ownership is the caller's — this
+    /// helper is transport-only, and the caller (steady-state
+    /// `consume` for the shutdown-aware path, or
+    /// `finalize_shutdown_singleton_disposition` for the shutdown
+    /// drain path via `write_with_reconnect`) bumps `events_written`
+    /// exactly once per delivered event.
     Delivered,
     /// A pre-send phase (connect, or a mutex-guard scoped shutdown
     /// check that fires before `write_frame` runs) observed the
@@ -155,7 +154,6 @@ pub(crate) enum WriteReconnectOutcome {
 pub(crate) async fn write_with_reconnect_shutdown_aware<P>(
     policy: &P,
     conn: &Mutex<Option<P::Stream>>,
-    metrics: &Arc<OutputMetrics>,
     payload: &Bytes,
     shutdown: &mut tokio::sync::watch::Receiver<bool>,
 ) -> WriteReconnectOutcome
@@ -176,10 +174,7 @@ where
             return WriteReconnectOutcome::PreSendShutdown;
         }
         match policy.write_frame(guard.as_mut().unwrap(), payload).await {
-            Ok(()) => {
-                metrics.events_written.fetch_add(1, Ordering::Relaxed);
-                return WriteReconnectOutcome::Delivered;
-            }
+            Ok(()) => return WriteReconnectOutcome::Delivered,
             Err(_) => {
                 // Broken pipe / reset — drop the cached stream and
                 // fall through to the reconnect path below. Some
@@ -207,10 +202,7 @@ where
         return WriteReconnectOutcome::PreSendShutdown;
     }
     match policy.write_frame(guard.as_mut().unwrap(), payload).await {
-        Ok(()) => {
-            metrics.events_written.fetch_add(1, Ordering::Relaxed);
-            WriteReconnectOutcome::Delivered
-        }
+        Ok(()) => WriteReconnectOutcome::Delivered,
         Err(e) => {
             *guard = None;
             WriteReconnectOutcome::Err(e)

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -93,7 +93,6 @@ impl Output for UnixSocketOutput {
             let write_result = match write_with_reconnect_shutdown_aware(
                 self,
                 &self.conn,
-                &self.metrics,
                 &event.egress,
                 &mut shutdown,
             )
@@ -120,6 +119,13 @@ impl Output for UnixSocketOutput {
             };
             match write_result {
                 Ok(()) => {
+                    // Metric ownership stays with the caller so
+                    // `finalize_shutdown_singleton_disposition` on the
+                    // shutdown-drain path (which also owns the
+                    // success bump) does not double-count against the
+                    // transport helper. Sibling syslog_udp uses the
+                    // identical shape after the previous fix.
+                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
                     ack.resolve_delivered();
                     return Ok(());
                 }
@@ -189,7 +195,7 @@ impl Output for UnixSocketOutput {
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
         let result = match tokio::time::timeout(
             crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT,
-            write_with_reconnect(self, &self.conn, &self.metrics, &event.egress),
+            write_with_reconnect(self, &self.conn, &event.egress),
         )
         .await
         {
@@ -241,5 +247,98 @@ impl PersistentConn for UnixSocketOutput {
         stream.write_all(&buf).await?;
         stream.flush().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::Event;
+    use crate::queue::QueueAckHandle;
+    use bytes::Bytes;
+    use std::os::unix::net::UnixListener as StdUnixListener;
+    use tempfile::TempDir;
+
+    /// Steady-state `consume` success bumps `events_written` exactly
+    /// once. Regression against a metric-ownership drift that would
+    /// double-count with the transport helper or leave it at zero.
+    #[tokio::test]
+    async fn steady_state_consume_success_bumps_events_written_once() {
+        let dir = TempDir::new().unwrap();
+        let socket_path = dir.path().join("out.sock");
+        let listener = StdUnixListener::bind(&socket_path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let _listener = tokio::net::UnixListener::from_std(listener).unwrap();
+
+        let output = build_test_output(&socket_path).await;
+        let event = Event::new(
+            Bytes::from_static(b"payload"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _rx) = QueueAckHandle::for_test();
+        output.consume(&event, ack).await.expect("consume");
+
+        assert_eq!(
+            output.metrics.events_written.load(Ordering::Relaxed),
+            1,
+            "steady-state consume success must bump events_written exactly once"
+        );
+        assert_eq!(
+            output.metrics.events_failed.load(Ordering::Relaxed),
+            0,
+            "successful send must not bump events_failed"
+        );
+    }
+
+    /// Shutdown-drain success via `finalize_shutdown_singleton_disposition`
+    /// bumps `events_written` exactly once (previously double: once
+    /// inside `write_with_reconnect` and once in the helper).
+    #[tokio::test]
+    async fn shutdown_consume_success_bumps_events_written_once() {
+        let dir = TempDir::new().unwrap();
+        let socket_path = dir.path().join("out.sock");
+        let listener = StdUnixListener::bind(&socket_path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let _listener = tokio::net::UnixListener::from_std(listener).unwrap();
+
+        let output = build_test_output(&socket_path).await;
+        let event = Event::new(
+            Bytes::from_static(b"payload"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _rx) = QueueAckHandle::for_test();
+        output
+            .consume_shutdown(&event, ack)
+            .await
+            .expect("consume_shutdown");
+
+        assert_eq!(
+            output.metrics.events_written.load(Ordering::Relaxed),
+            1,
+            "consume_shutdown success must bump events_written exactly once (via helper)"
+        );
+        assert_eq!(
+            output.metrics.events_failed.load(Ordering::Relaxed),
+            0,
+            "successful drain must not bump events_failed"
+        );
+    }
+
+    async fn build_test_output(socket_path: &std::path::Path) -> UnixSocketOutput {
+        use crate::dsl::ast::{Expr, ExprKind, Property};
+        use crate::dsl::module_props::ModuleProperties;
+        let props = ModuleProperties::from_parts(
+            "unix_socket",
+            vec![Property::KeyValue {
+                key: "path".into(),
+                key_span: None,
+                value: Expr::spanless(ExprKind::StringLit(
+                    socket_path.to_str().unwrap().to_string(),
+                )),
+                value_span: None,
+            }],
+        );
+        UnixSocketOutput::from_properties("u", &props, &crate::modules::BuildContext::for_testing())
+            .expect("build")
     }
 }


### PR DESCRIPTION
## Summary

Three operator-facing data-integrity fixes surfaced by the post-#123 audit round. Each was verified against the actual code paths (Fable review + Opus cross-check) before implementation. Docs / trait-comment drift and control-socket chmod fatalization surfaced in the same audit are deferred to a follow-up branch to keep this PR focused on the correctness-critical fixes.

### 1. Kafka mid-send cancellation → duplicate delivery (`1a96f86`)

`kafka::consume` wrapped `try_send` in `pre_send_or_shutdown(&mut shutdown, ...)` — a `tokio::select!` over the future and a shutdown watch. If shutdown fired while `producer.send(record, queue_timeout).await` was in flight, the shutdown arm won, the delivery future was dropped, and `consume` routed the event to DLQ as `Recovered`.

Problem: librdkafka's `FutureProducer::send` synchronously enqueues the record into the internal producer queue before returning the future. Dropping the future only stops the caller from observing the delivery report; the record still ships. Result: one send attempt produced both a broker delivery AND a DLQ-replayable record — **duplicate delivery**.

`try_send`'s internal `borrow_and_update()` recheck immediately before `producer.send(...)` is (and was already) the load-bearing pre-send guard — all prep before it is synchronous, no `.await`. So the fix is to stop wrapping `try_send` altogether: `consume` now `awaits` `self.try_send(event, shutdown.clone())` directly.

Once `producer.send(...)` is entered, the send runs to completion under librdkafka's `queue_timeout` / `message.timeout.ms` — a runtime shutdown flip past that boundary does not cancel it. The retry-backoff `sleep_or_shutdown` is a separate path and remains unchanged.

Two regression tests:
- Functional: `try_send` with shutdown pre-set returns `PreSendShutdown` without touching `producer.send`.
- Structural pin: `Output::consume` body must not contain `pre_send_or_shutdown(` — a future refactor that re-adds the wrapper (and the duplicate-delivery bug with it) fails this test.

### 2. unix_socket shutdown-drain `events_written` double-count (`f6f67e3`)

`unix_socket::consume_shutdown` called `write_with_reconnect` (persistent_conn transport helper) which bumped `events_written` on successful write, then handed the `Ok(())` to `finalize_shutdown_singleton_disposition` — which also bumps on `Ok(())`. One shutdown-drain unix_socket delivery reported `events_written += 2`.

Sibling sinks that use `finalize_shutdown_singleton_disposition` keep the transport helper metric-free and let the disposition owner bump exactly once. persistent_conn was the last family still holding the bump inside the transport.

Atomic 3-change fix:
- `persistent_conn::write_with_reconnect` and `write_with_reconnect_shutdown_aware` are now transport-only (four bump sites removed; `metrics` parameter dropped).
- `unix_socket::consume` bumps `events_written` in its `Delivered` arm.
- `unix_socket::consume_shutdown` already delegates to `finalize_shutdown_singleton_disposition`, which now owns the shutdown-path bump.

Two regression tests (steady-state and shutdown-drain, both pin `events_written == 1`).

### 3. Output-side DLQ write failure JSONL fallback (`7eff083`)

`runtime::write_errored_to_dlq` (pipeline-side) emits `event_record = %err_ctx.to_jsonl()` via `tracing::error!` when the configured `error_log` write itself fails, giving operators a manual-recovery trail out of journald.

`route_event_to_dlq` / `route_shutdown_batch_to_dlq` (output-side) only emitted `tracing::warn!` on the same arm — no `event_record`. On a memory queue this was silent loss (no queue replay, no DLQ record, no journald fallback). Docs at `error-log.md:443` overstated parity with the pipeline-side.

Both output-side routes now emit the full JSONL via `event_record = %ctx.to_jsonl()` on `tracing::error!` in the configured-writer failure arm, alongside the existing `events_errored_unwritable` bump and `Dropped` disposition. Disk-queue fail-stop wedge still holds the cursor for file-based recovery once the DLQ file is healthy again.

Two structural regression tests grep the module for `event_record =` in each function's write-failure arm.

### 4. Kafka `try_send` docstring drift (`491f22d`)

Follow-up to (1): removed "the caller's outer race" from the `try_send` doc after the wrapper was gone. New wording names the honest contract — direct await from `consume`, final pre-send recheck, `queue_timeout` / `message.timeout.ms` and disk wedge as the remaining envelope.

## Deferred to next branch

Same audit surfaced pre-existing drift not fixed here:
- `Output::consume_shutdown` trait docstring hardcodes `resolve_recovered()` (I-F5).
- `check/recovery_readiness.rs` warning says "dropped silently" — obsolete since JSONL fallback exists (I-F4).
- `docs/src/outputs/http.md` / `otlp_http.md` / `otlp_grpc.md` describe 0.7.7 "warn + drop" fallback (I-F4).
- `docs/src/operations/cli.md` + `control.rs` diagnostics reference `User=limpid` but packaging uses `User=syslog` (I-F7).
- `limpid-prometheus` HELP for `limpid_output_events_failed_total` is narrower than actual scope (I-F8).
- `control.rs` control-socket chmod failure is warn-and-continue rather than fatal (I-F6).

Owner-confirmed on the push gate as deferred to a follow-up branch; the data-integrity fixes above are the load-bearing subset and should not wait on docs / comment sync.

## Verification

- Local (Mac): `cargo build --features kafka`, `cargo clippy --tests --no-deps --features kafka -- -D warnings`, `cargo fmt --all -- --check` — all clean.
- Local tests: 829 (limpid `--features kafka`) + 27 + 4 + 14 = 874 pass, 1 ignored. Six new regression tests (kafka 2, unix_socket 2, DLQ JSONL 2).
- External push-gate audit: 2 PASS + 6 owner-confirmed (2 standing baseline + 4 deferred to follow-up).

## Test plan

- [ ] CI: cargo fmt / clippy / test / cargo-deny / mdbook build
- [ ] Rebase-merge on release/0.7.9