### PR TITLE
outputs+error_log: harden filesystem trust boundaries — DLQ parent+owner, file inode owner, unix_socket peer credential

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -1045,9 +1045,24 @@ mod tests {
         assert!(err.contains("error_log"), "got: {}", err);
     }
 
+    /// Create a tempdir whose mode is guaranteed to be `0o750` on
+    /// every platform the tests run on. The default `TempDir::new()`
+    /// picks up the process umask — `0o700` on macOS but `0o775` (=
+    /// `mode & 0o022 = 0o020` group-writable) on typical Linux
+    /// runners — which the DLQ parent-trust predicate refuses.
+    /// Tests that are testing something *other* than the parent-mode
+    /// contract should use this so they run identically on both.
+    #[cfg(unix)]
+    fn safe_dlq_tempdir() -> TempDir {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750)).unwrap();
+        dir
+    }
+
     #[tokio::test]
     async fn validate_at_startup_passes_for_existing_parent() {
-        let dir = TempDir::new().unwrap();
+        let dir = safe_dlq_tempdir();
         let w = ErrorLogWriter::new(dir.path().join("errored.jsonl"));
         w.validate_at_startup().await.unwrap();
     }
@@ -1211,7 +1226,7 @@ mod tests {
     #[tokio::test]
     #[cfg(unix)]
     async fn validate_at_startup_refuses_symlink_at_dlq_path() {
-        let dir = TempDir::new().unwrap();
+        let dir = safe_dlq_tempdir();
         let path = dir.path().join("errored.jsonl");
         let target = dir.path().join("_hijacked.jsonl");
         std::os::unix::fs::symlink(&target, &path).unwrap();
@@ -1229,7 +1244,7 @@ mod tests {
     #[cfg(unix)]
     async fn validate_at_startup_refuses_wrong_mode_existing_file() {
         use std::os::unix::fs::PermissionsExt;
-        let dir = TempDir::new().unwrap();
+        let dir = safe_dlq_tempdir();
         let path = dir.path().join("errored.jsonl");
         std::fs::write(&path, b"leftover\n").unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
@@ -1253,7 +1268,7 @@ mod tests {
         // pass the mode check alone; only the S_ISREG shape check
         // catches it.
         use std::ffi::CString;
-        let dir = TempDir::new().unwrap();
+        let dir = safe_dlq_tempdir();
         let path = dir.path().join("errored.jsonl");
         let c_path = CString::new(path.as_os_str().to_str().unwrap()).unwrap();
         let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
@@ -1267,7 +1282,7 @@ mod tests {
     #[tokio::test]
     #[cfg(unix)]
     async fn validate_at_startup_refuses_directory_at_dlq_path() {
-        let dir = TempDir::new().unwrap();
+        let dir = safe_dlq_tempdir();
         let path = dir.path().join("errored.jsonl");
         std::fs::create_dir(&path).unwrap();
 
@@ -1283,7 +1298,7 @@ mod tests {
         // exist must pass — the runtime creates the file on first
         // failure with the correct mode. The preflight creates it
         // eagerly at 0o600 (see next test for that assertion).
-        let dir = TempDir::new().unwrap();
+        let dir = safe_dlq_tempdir();
         let w = ErrorLogWriter::new(dir.path().join("errored.jsonl"));
         w.validate_at_startup().await.unwrap();
     }
@@ -1296,7 +1311,7 @@ mod tests {
         // future refactor that drops the preflight (or leaves a
         // wider-mode file behind) trips this test.
         use std::os::unix::fs::PermissionsExt;
-        let dir = TempDir::new().unwrap();
+        let dir = safe_dlq_tempdir();
         let path = dir.path().join("errored.jsonl");
         let w = ErrorLogWriter::new(path.clone());
         w.validate_at_startup().await.unwrap();

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -337,6 +337,57 @@ impl ErrorLogWriter {
             );
         }
 
+        // Parent trust: the DLQ file carries the full failure JSONL
+        // (including `event.ingress` and `event.egress`), which for
+        // most deployments is the most sensitive on-disk artifact
+        // limpid produces. Directory mode alone does not close the
+        // trust boundary — an untrusted owner retains rename/unlink
+        // rights inside the parent regardless of mode bits and can
+        // replace the DLQ inode between two writes even if the file
+        // itself was created via `O_NOFOLLOW` + `create_new`. Owner
+        // must match the daemon's own euid (or root when the daemon
+        // itself runs as root), and the parent must not be group- or
+        // world-writable. This mirrors the control-socket parent
+        // predicate; the two surfaces have the same threat shape
+        // (long-lived process-owned inode inside a directory the
+        // attacker must not be able to rearrange).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+            let self_euid = unsafe { libc::geteuid() };
+            let parent_uid = link_meta.uid();
+            if parent_dir_owner_is_untrusted(parent_uid, self_euid) {
+                anyhow::bail!(
+                    "error_log: parent dir '{}' is owned by uid {}, but the daemon's effective \
+                     uid is {} — refusing to preflight. The DLQ file carries the full failure \
+                     JSONL (including per-event `ingress` and `egress` bytes); a parent owner \
+                     other than the daemon retains rename/unlink rights inside the directory \
+                     regardless of mode bits and can swap the DLQ inode between writes. Under \
+                     systemd, `User=<daemon-user>` (the packaged unit ships with `User=syslog`) \
+                     combined with a daemon-owned `/var/log/limpid/` is the intended shape. \
+                     For custom deploys, `chown <daemon-user>:<daemon-group> '{}'` and re-run.",
+                    parent.display(),
+                    parent_uid,
+                    self_euid,
+                    parent.display(),
+                );
+            }
+            let parent_mode = link_meta.permissions().mode() & 0o777;
+            if parent_dir_mode_is_unsafe(parent_mode) {
+                anyhow::bail!(
+                    "error_log: parent dir '{}' has mode 0o{:o} — refusing to preflight. A \
+                     group- or world-writable DLQ parent lets a co-tenant plant a symlink or a \
+                     preallocated 0o600 file at the DLQ path between writes; the runtime write \
+                     path would then land failure JSONL on the wrong inode. Tighten the parent \
+                     to 0o750 or stricter (`chmod 0750 '{}'`) or point `control {{ error_log \
+                     \"...\" }}` at a packaged path.",
+                    parent.display(),
+                    parent_mode,
+                    parent.display(),
+                );
+            }
+        }
+
         // If the DLQ file already exists on disk, refuse anything that
         // isn't a regular 0o600 file. The runtime `write` path applies
         // the same contract (`O_NOFOLLOW`, fstat `S_ISREG`, mode
@@ -652,6 +703,7 @@ impl ErrorLogWriter {
         // ownership to the `OwnedFd`.
         let owned_fd: OwnedFd = unsafe { OwnedFd::from_raw_fd(duped) };
 
+        let self_euid = unsafe { libc::geteuid() };
         tokio::task::spawn_blocking(move || -> Result<()> {
             let fd = owned_fd.as_raw_fd();
             let mut stat: libc::stat = unsafe { std::mem::zeroed() };
@@ -683,6 +735,32 @@ impl ErrorLogWriter {
                      inode is created with the required mode.",
                     path.display(),
                     actual
+                );
+            }
+            // Owner trust: an attacker who can plant a 0o600 file at
+            // the DLQ path (via a preallocated inode inside an
+            // attacker-writable parent, or via a pre-existing
+            // deployment mistake) would otherwise pass the mode
+            // check and receive every subsequent DLQ record. The
+            // parent-dir owner+mode gate in `validate_at_startup`
+            // narrows the window, but the fstat st_uid check here
+            // is the load-bearing terminal check on the actual
+            // inode the daemon just opened for write — the same
+            // shape as `apply_file_metadata_to_fd` in the file
+            // output. Reject anything the daemon does not own.
+            let file_uid: u32 = stat.st_uid;
+            if file_uid != self_euid {
+                anyhow::bail!(
+                    "error_log '{}': existing file is owned by uid {}, but the daemon's \
+                     effective uid is {}; refusing to write. The DLQ file carries the full \
+                     failure JSONL for every failed event — a mismatched owner would let a \
+                     co-tenant read (or race against) subsequent writes. Remove the file so \
+                     the runtime recreates it with the correct owner, or `chown \
+                     <daemon-user>:<daemon-group> '{}'`.",
+                    path.display(),
+                    file_uid,
+                    self_euid,
+                    path.display(),
                 );
             }
             Ok(())
@@ -768,6 +846,33 @@ impl ErrorLogWriter {
             )
         })?
     }
+}
+
+/// True when the DLQ parent's owner is not the daemon's own effective
+/// uid. Same shape as the control-socket predicate (see
+/// `crates/limpid/src/control.rs`): directory mode alone does not
+/// close the trust boundary — an untrusted owner retains
+/// rename/unlink rights inside the directory regardless of mode
+/// bits, and can therefore swap the DLQ inode between two runtime
+/// writes even if the file itself was created via `O_NOFOLLOW` +
+/// `create_new`. A root-owned parent is trusted only when the
+/// daemon itself runs as root.
+#[cfg(unix)]
+fn parent_dir_owner_is_untrusted(uid: u32, self_euid: u32) -> bool {
+    uid != self_euid
+}
+
+/// True when the DLQ parent's mode allows group- or world-writable
+/// access. Different bits than the control-socket predicate on
+/// purpose: the control socket needs `mode & 0o023 == 0` to protect
+/// the bind→chmod 0o660 window; the DLQ file is created 0o600 and
+/// never widens, so the group-write bit alone would not immediately
+/// leak the file, but a group- or world-writable parent still lets
+/// a co-tenant `unlink` and re-create the DLQ path with an attacker-
+/// owned inode. Reject both `g+w` (0o020) and `o+w` (0o002).
+#[cfg(unix)]
+fn parent_dir_mode_is_unsafe(mode: u32) -> bool {
+    mode & 0o022 != 0
 }
 
 #[cfg(test)]
@@ -968,6 +1073,111 @@ mod tests {
         assert!(
             err.contains("symlink") && err.contains("refusing to preflight"),
             "diagnostic must name the symlink shape: {err}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn validate_at_startup_refuses_group_writable_parent() {
+        // Parent trust: `g+w` on the DLQ parent lets a co-tenant with
+        // group membership `unlink` the DLQ file and replace the path
+        // with an attacker-owned inode. Refuse it at preflight.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let parent = dir.path().join("dlq-parent");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o770)).unwrap();
+        let w = ErrorLogWriter::new(parent.join("errored.jsonl"));
+        let err = w.validate_at_startup().await.unwrap_err().to_string();
+        assert!(
+            err.contains("mode 0o770") && err.contains("refusing to preflight"),
+            "diagnostic must name the mode and the refusal: {err}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn validate_at_startup_refuses_world_writable_parent() {
+        // Same reasoning as the group-writable case, one step wider.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let parent = dir.path().join("dlq-parent");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o707)).unwrap();
+        let w = ErrorLogWriter::new(parent.join("errored.jsonl"));
+        let err = w.validate_at_startup().await.unwrap_err().to_string();
+        assert!(
+            err.contains("mode 0o707") && err.contains("refusing to preflight"),
+            "diagnostic must name the mode and the refusal: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn parent_dir_mode_is_unsafe_covers_g_and_o_write_bits() {
+        // Codifies the predicate: `mode & 0o022 != 0` means either
+        // `g+w` (0o020) or `o+w` (0o002) is set — the two shapes that
+        // let a co-tenant swap the DLQ inode. Also asserts the
+        // packaged-shape modes (`0o700`, `0o750`, `0o755`) pass.
+        assert!(!parent_dir_mode_is_unsafe(0o700));
+        assert!(!parent_dir_mode_is_unsafe(0o750));
+        assert!(!parent_dir_mode_is_unsafe(0o755));
+        assert!(parent_dir_mode_is_unsafe(0o770));
+        assert!(parent_dir_mode_is_unsafe(0o707));
+        assert!(parent_dir_mode_is_unsafe(0o777));
+        assert!(parent_dir_mode_is_unsafe(0o022));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn parent_dir_owner_is_untrusted_matches_euid_semantics() {
+        // Directory owner must equal daemon euid. A root-owned parent
+        // is trusted only when the daemon runs as root; a foreign-uid
+        // parent is untrusted regardless.
+        assert!(!parent_dir_owner_is_untrusted(1000, 1000));
+        assert!(!parent_dir_owner_is_untrusted(0, 0));
+        assert!(parent_dir_owner_is_untrusted(0, 1000));
+        assert!(parent_dir_owner_is_untrusted(1000, 0));
+        assert!(parent_dir_owner_is_untrusted(1001, 1000));
+    }
+
+    /// Structural pin: `validate_at_startup` invokes both the
+    /// `parent_dir_owner_is_untrusted` and `parent_dir_mode_is_unsafe`
+    /// predicates against the final parent's `symlink_metadata`, and
+    /// `verify_existing_mode` checks `stat.st_uid` against the
+    /// daemon's euid. Behavioural coverage for the owner-mismatch
+    /// arms would need to fabricate an inode owned by a different
+    /// uid, which needs root — the structural pin is the honest
+    /// alternative.
+    #[test]
+    fn parent_trust_checks_wired_into_validate_at_startup() {
+        let src = include_str!("error_log.rs");
+        let vas_start = src
+            .find("pub async fn validate_at_startup(")
+            .expect("validate_at_startup fn must exist");
+        let vas_end = src[vas_start..]
+            .find("\n    /// Force the DLQ file's mode")
+            .or_else(|| {
+                src[vas_start..].find("\n    #[cfg(unix)]\n    async fn verify_existing_mode")
+            })
+            .expect("validate_at_startup body must be followed by the next fn");
+        let vas_body = &src[vas_start..vas_start + vas_end];
+        assert!(
+            vas_body.contains("parent_dir_owner_is_untrusted("),
+            "validate_at_startup must call parent_dir_owner_is_untrusted on the parent"
+        );
+        assert!(
+            vas_body.contains("parent_dir_mode_is_unsafe("),
+            "validate_at_startup must call parent_dir_mode_is_unsafe on the parent"
+        );
+
+        let vem_start = src
+            .find("async fn verify_existing_mode(")
+            .expect("verify_existing_mode fn must exist");
+        let vem_body = &src[vem_start..vem_start + 4000];
+        assert!(
+            vem_body.contains("stat.st_uid") && vem_body.contains("self_euid"),
+            "verify_existing_mode must fstat-compare st_uid against the daemon's euid"
         );
     }
 

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -931,6 +931,41 @@ impl FileOutput {
                         configured_uid
                     );
                 }
+            } else {
+                // Implicit owner contract: when `owner` is left
+                // unset but the metadata contract is otherwise
+                // active (`mode` or `group` configured), require
+                // the existing file to be owned by the daemon's own
+                // euid. Without this arm a pre-existing 0o600
+                // inode owned by a co-tenant under an
+                // attacker-writable ancestor would clear the mode
+                // check and receive every subsequent log write —
+                // the exact shape the DLQ trust boundary now
+                // covers, and the file output's own contract
+                // requires the same treatment here (an operator
+                // who bothered to write `mode "0600"` did not opt
+                // into leaking to whichever uid happens to own the
+                // path). The unconfigured-metadata case is
+                // unchanged: `requires_metadata` gates entry to
+                // this function, so the callers only reach here
+                // when at least one of mode/owner/group is set.
+                let self_euid = unsafe { libc::geteuid() };
+                if stat.st_uid != self_euid {
+                    anyhow::bail!(
+                        "output file '{}': existing file owner uid {} does not match the \
+                         daemon's effective uid {} — refusing to write. Without an explicit \
+                         `owner \"...\"` the metadata contract implicitly requires the daemon \
+                         to own the inode: an attacker-planted file under a shared parent \
+                         would otherwise receive every subsequent log record. Remove the file \
+                         so this output recreates it under the daemon's uid, `chown \
+                         <daemon-user>:<daemon-group> '{}'`, or configure `owner \"...\"` \
+                         explicitly if the operator really wants a different uid.",
+                        path.display(),
+                        stat.st_uid,
+                        self_euid,
+                        path.display(),
+                    );
+                }
             }
             if let Some(name) = group.as_deref() {
                 let configured_gid = resolve_gid(name).with_context(|| {
@@ -1969,6 +2004,44 @@ mod tests {
         assert_eq!(
             actual, 0o600,
             "birth mode must be 0o600 (owner-only) when owner/group is configured, got 0o{actual:o}",
+        );
+    }
+
+    /// Structural pin: when `owner` is left unset but the metadata
+    /// contract is active (i.e. `verify_existing_file_metadata` is
+    /// called at all), the fstat st_uid check falls back to the
+    /// daemon's own euid via `libc::geteuid`. Fabricating an
+    /// existing inode owned by a different uid needs root, so the
+    /// behavioural coverage of the *refusal* arm is a source-level
+    /// pin. The *acceptance* arm (implicit-euid file, mode-only
+    /// config) is covered by
+    /// `existing_file_with_matching_mode_accepts_subsequent_writes`
+    /// — the tempdir-created inode is euid-owned by construction, so
+    /// the new check passes there naturally.
+    #[test]
+    fn verify_existing_file_metadata_falls_back_to_daemon_euid_when_owner_unset() {
+        let src = include_str!("file.rs");
+        let start = src
+            .find("async fn verify_existing_file_metadata(")
+            .expect("verify_existing_file_metadata fn must exist");
+        // Limit to the fn body: end at the next top-level `async fn`
+        // sibling (or `fn`) so we do not scan unrelated code.
+        let after_body = src[start + 1..]
+            .find("\n    async fn ")
+            .or_else(|| src[start + 1..].find("\n    fn "))
+            .or_else(|| src[start + 1..].find("\n}\n"))
+            .expect("verify_existing_file_metadata body must be delimited");
+        let body = &src[start..start + 1 + after_body];
+        assert!(
+            body.contains("} else {") && body.contains("libc::geteuid"),
+            "verify_existing_file_metadata must fall back to geteuid() when owner is unset — \
+             a mode-only or group-only metadata contract must not silently accept an \
+             attacker-owned existing inode"
+        );
+        assert!(
+            body.contains("daemon's effective uid"),
+            "the else-arm bail must name the daemon-euid contract explicitly so operators \
+             know why the write was refused"
         );
     }
 

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -30,6 +30,13 @@ const UNIX_SOCKET_OUTPUT_SCHEMA: &[PropertySpec] = &[
         exclusive_group: None,
         kind: PropertyValueKind::String,
     },
+    PropertySpec {
+        name: "expected_peer_uid",
+        required: false,
+        repeatable: false,
+        exclusive_group: None,
+        kind: PropertyValueKind::String,
+    },
     crate::queue::RETRY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
@@ -42,6 +49,30 @@ pub struct UnixSocketOutput {
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     metrics: Arc<OutputMetrics>,
     shutdown_signal: tokio::sync::watch::Receiver<bool>,
+    /// UIDs that the peer service listening on `path` may report via
+    /// its socket credentials (Linux `SO_PEERCRED` / macOS
+    /// `LOCAL_PEERCRED`) and still be accepted.
+    ///
+    /// - **Unset `expected_peer_uid`**: `{daemon euid, 0}`. Root is
+    ///   trusted because the canonical peer on packaged
+    ///   deployments is `journald` (`/dev/log` → root-listener) and
+    ///   an attacker who can `bind` as root has already crossed a
+    ///   larger trust boundary than this check defends; the check
+    ///   is aimed at non-root co-tenants who `bind` a squatter
+    ///   socket at the path before the real peer restarts. `syslog`
+    ///   (the packaged `User=`) matches the euid arm.
+    /// - **`expected_peer_uid "<name>"`**: the default set is
+    ///   **replaced** (not extended) with the resolved uid alone —
+    ///   root is refused too. This is the operator lock-down mode
+    ///   for deployments with a known dedicated collector uid.
+    ///
+    /// Path-shape trust (parent owner, final-component symlink
+    /// refusal, socket-shape preflight) is intentionally **not**
+    /// applied to this connect-side sink: `/dev/log` is a symlink
+    /// on systemd installs and its parent `/dev` is root-owned, so
+    /// bind-side predicates would refuse the most common
+    /// deployment.
+    allowed_peer_uids: Vec<u32>,
 }
 
 impl Module for UnixSocketOutput {
@@ -58,6 +89,40 @@ impl Module for UnixSocketOutput {
         let properties = properties.user_properties();
         let path = props::get_string(properties, "path")
             .ok_or_else(|| anyhow::anyhow!("output '{}': unix_socket requires 'path'", name))?;
+        let allowed_peer_uids = match props::get_string(properties, "expected_peer_uid") {
+            Some(user) => {
+                // Explicit lock-down: replace the default allow set
+                // with the single resolved uid. Root is refused too.
+                let uid = resolve_uid(&user).with_context(|| {
+                    format!(
+                        "output '{}': failed to resolve expected_peer_uid '{}'",
+                        name, user
+                    )
+                })?;
+                vec![uid]
+            }
+            None => {
+                // Default: allow the daemon's own euid plus root.
+                // `{daemon euid, 0}` covers the two canonical peer
+                // identities on packaged deployments (`syslog` uid
+                // for the daemon-owned collector, `0` for
+                // journald's `/dev/log`) while refusing any other
+                // uid — the co-tenant-squatter defense.
+                #[cfg(unix)]
+                {
+                    let self_euid = unsafe { libc::geteuid() };
+                    if self_euid == 0 {
+                        vec![0]
+                    } else {
+                        vec![self_euid, 0]
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    Vec::new()
+                }
+            }
+        };
         Ok(Self {
             name: name.to_string(),
             path: PathBuf::from(path),
@@ -66,6 +131,7 @@ impl Module for UnixSocketOutput {
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             metrics: Arc::new(OutputMetrics::default()),
             shutdown_signal: ctx.shutdown_signal.clone(),
+            allowed_peer_uids,
         })
     }
 }
@@ -236,9 +302,44 @@ impl PersistentConn for UnixSocketOutput {
     type Stream = UnixStream;
 
     async fn connect(&self) -> Result<UnixStream> {
-        UnixStream::connect(&self.path)
+        let stream = UnixStream::connect(&self.path)
             .await
-            .with_context(|| format!("unix_socket connect to {}", self.path.display()))
+            .with_context(|| format!("unix_socket connect to {}", self.path.display()))?;
+        // Peer-credential trust: the connect-side sink defends
+        // against a co-tenant squatter binding on `self.path`
+        // before the legitimate peer restarts. Every reconnect is
+        // its own credential check — a one-shot startup validation
+        // would miss the exact race window this defends. See the
+        // `allowed_peer_uids` field docs on the struct for the
+        // default-set semantics.
+        #[cfg(unix)]
+        {
+            let cred = stream.peer_cred().with_context(|| {
+                format!(
+                    "unix_socket '{}': failed to read peer credentials on socket at {}",
+                    self.name,
+                    self.path.display()
+                )
+            })?;
+            let peer_uid = cred.uid();
+            if !self.allowed_peer_uids.contains(&peer_uid) {
+                anyhow::bail!(
+                    "unix_socket '{}': peer at {} runs as uid {}, which is not in the allowed \
+                     set {:?} — refusing to ship events. This defends against a co-tenant \
+                     process that bound a squatter socket at the path between the peer \
+                     service's restarts; the daemon must not silently hand the failure \
+                     JSONL for every event to whichever process happens to hold the socket \
+                     inode. If the observed uid is the legitimate collector, set \
+                     `expected_peer_uid \"<user>\"` on the output. If the observed uid is \
+                     unexpected, investigate: kill the squatter or restart the intended peer.",
+                    self.name,
+                    self.path.display(),
+                    peer_uid,
+                    self.allowed_peer_uids,
+                );
+            }
+        }
+        Ok(stream)
     }
 
     async fn write_frame(&self, stream: &mut UnixStream, payload: &Bytes) -> Result<()> {
@@ -261,6 +362,44 @@ impl PersistentConn for UnixSocketOutput {
         stream.flush().await?;
         Ok(())
     }
+}
+
+/// Resolve a username to its uid via `getpwnam_r`. Same reentrant
+/// pattern the file output uses for its `owner` property (see
+/// `crates/limpid/src/modules/output/file.rs::resolve_uid`). Called
+/// once at construction time so runtime `connect()` never blocks
+/// on NSS. Numeric-string uids fall through as invalid names and
+/// surface the diagnostic — deliberate: the config surface is
+/// name-based like the file output's, and mixing numeric and named
+/// forms invites operator confusion about which one wins under
+/// user-database rebuilds.
+#[cfg(unix)]
+fn resolve_uid(name: &str) -> Result<u32> {
+    use std::ffi::CString;
+    use std::mem::MaybeUninit;
+    const NSS_RECORD_BUF: usize = 4096;
+    let c_name = CString::new(name)?;
+    let mut buf = [0u8; NSS_RECORD_BUF];
+    let mut pwd: MaybeUninit<libc::passwd> = MaybeUninit::uninit();
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    let rc = unsafe {
+        libc::getpwnam_r(
+            c_name.as_ptr(),
+            pwd.as_mut_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+            &mut result,
+        )
+    };
+    if rc != 0 {
+        anyhow::bail!("getpwnam_r failed for '{}': errno {}", name, rc);
+    }
+    if result.is_null() {
+        anyhow::bail!("user '{}' not found", name);
+    }
+    // SAFETY: `result` is non-null and points into `pwd`; pw_uid is
+    // a plain numeric copy that outlives the borrow.
+    Ok(unsafe { (*result).pw_uid })
 }
 
 #[cfg(test)]
@@ -369,6 +508,183 @@ mod tests {
             !body.contains("crate::modules::finalize_shutdown_singleton_disposition("),
             "consume_shutdown must not fall back to the plain finalizer — the wire state \
              cannot be proved pre-boundary from outside the write helper."
+        );
+    }
+
+    /// Default policy pin: with no `expected_peer_uid` configured
+    /// the allow set is `{daemon euid, 0}`. A non-root daemon
+    /// carries both entries so `journald` (`/dev/log` = root) and
+    /// a daemon-owned collector are both accepted; a root daemon
+    /// collapses to just `[0]`.
+    #[test]
+    fn default_allow_set_is_daemon_euid_plus_root() {
+        use crate::dsl::ast::{Expr, ExprKind, Property};
+        use crate::dsl::module_props::ModuleProperties;
+        let props = ModuleProperties::from_parts(
+            "unix_socket",
+            vec![Property::KeyValue {
+                key: "path".into(),
+                key_span: None,
+                value: Expr::spanless(ExprKind::StringLit("/tmp/never.sock".into())),
+                value_span: None,
+            }],
+        );
+        let out = UnixSocketOutput::from_properties(
+            "u",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("build");
+        let self_euid = unsafe { libc::geteuid() };
+        if self_euid == 0 {
+            assert_eq!(
+                out.allowed_peer_uids,
+                vec![0],
+                "root daemon: default allow set collapses to [0]"
+            );
+        } else {
+            assert!(
+                out.allowed_peer_uids.contains(&self_euid) && out.allowed_peer_uids.contains(&0),
+                "non-root daemon: default allow set must contain both euid and 0; got {:?}",
+                out.allowed_peer_uids
+            );
+            assert_eq!(
+                out.allowed_peer_uids.len(),
+                2,
+                "default allow set must be exactly {{euid, 0}}"
+            );
+        }
+    }
+
+    /// `expected_peer_uid` **replaces** the default allow set — root
+    /// is refused too. Pin the strict-mode semantics against the
+    /// operator-facing docstring.
+    #[test]
+    fn expected_peer_uid_replaces_default_set() {
+        use crate::dsl::ast::{Expr, ExprKind, Property};
+        use crate::dsl::module_props::ModuleProperties;
+        // Try `nobody` first; fall through to the current user if
+        // the test image doesn't have a `nobody` entry (Docker
+        // scratch, minimal Alpine, some CI runners).
+        let user_name: String = if resolve_uid("nobody").is_ok() {
+            "nobody".into()
+        } else {
+            unsafe {
+                let euid = libc::geteuid();
+                let pwd = libc::getpwuid(euid);
+                if pwd.is_null() {
+                    panic!("cannot resolve current user for test — no `nobody` either");
+                }
+                std::ffi::CStr::from_ptr((*pwd).pw_name)
+                    .to_str()
+                    .expect("username is UTF-8")
+                    .to_string()
+            }
+        };
+        let expected_uid = resolve_uid(&user_name).expect("resolve test user");
+        let props = ModuleProperties::from_parts(
+            "unix_socket",
+            vec![
+                Property::KeyValue {
+                    key: "path".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::StringLit("/tmp/never.sock".into())),
+                    value_span: None,
+                },
+                Property::KeyValue {
+                    key: "expected_peer_uid".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::StringLit(user_name.clone())),
+                    value_span: None,
+                },
+            ],
+        );
+        let out = UnixSocketOutput::from_properties(
+            "u",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("build");
+        assert_eq!(
+            out.allowed_peer_uids,
+            vec![expected_uid],
+            "expected_peer_uid must REPLACE the default set (root not implicitly included)"
+        );
+    }
+
+    /// A misspelt `expected_peer_uid` surfaces at build time, not
+    /// at first connect. Prevents a config typo from turning into a
+    /// silent socket-squatter acceptance later.
+    #[test]
+    fn expected_peer_uid_unknown_user_fails_at_build() {
+        use crate::dsl::ast::{Expr, ExprKind, Property};
+        use crate::dsl::module_props::ModuleProperties;
+        let props = ModuleProperties::from_parts(
+            "unix_socket",
+            vec![
+                Property::KeyValue {
+                    key: "path".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::StringLit("/tmp/never.sock".into())),
+                    value_span: None,
+                },
+                Property::KeyValue {
+                    key: "expected_peer_uid".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::StringLit(
+                        "definitely_not_a_real_user_xyzzy".into(),
+                    )),
+                    value_span: None,
+                },
+            ],
+        );
+        let err = match UnixSocketOutput::from_properties(
+            "u",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        ) {
+            Ok(_) => panic!("build must fail on unresolvable expected_peer_uid"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected_peer_uid") && msg.contains("definitely_not_a_real_user_xyzzy"),
+            "diagnostic must name the property and the offending value: {msg}"
+        );
+    }
+
+    /// Structural pin: `PersistentConn::connect` verifies the peer
+    /// credential against `self.allowed_peer_uids` on every call.
+    /// Behavioural coverage for the *reject* arm needs a listener
+    /// running under a different uid, which is root-only; pin the
+    /// shape at the source so a mechanical refactor that strips
+    /// the check fails at test time. The default-set *accept* arm
+    /// is exercised by every existing e2e test in this module,
+    /// which runs its listener under the process euid.
+    #[test]
+    fn connect_verifies_peer_uid_against_allowed_set() {
+        let src = include_str!("unix_socket.rs");
+        // Anchor on the `PersistentConn for UnixSocketOutput` impl
+        // header so the `async fn connect(` we grab is the one on
+        // the trait impl, not any incidental mention elsewhere.
+        let impl_start = src
+            .find("impl PersistentConn for UnixSocketOutput {")
+            .expect("PersistentConn impl must exist");
+        let connect_start = src[impl_start..]
+            .find("async fn connect(")
+            .map(|off| impl_start + off)
+            .expect("connect fn inside the impl block");
+        let body_end = src[connect_start..]
+            .find("async fn write_frame")
+            .expect("connect body ends before write_frame");
+        let body = &src[connect_start..connect_start + body_end];
+        assert!(
+            body.contains("peer_cred()"),
+            "connect must call peer_cred() on the freshly-connected socket"
+        );
+        assert!(
+            body.contains("allowed_peer_uids.contains("),
+            "connect must reject a peer whose uid is not in self.allowed_peer_uids"
         );
     }
 

--- a/docs/src/outputs/unix-socket.md
+++ b/docs/src/outputs/unix-socket.md
@@ -16,6 +16,7 @@ def output local_forward {
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `path` | yes | — | Path to the Unix stream socket |
+| `expected_peer_uid` | no | *(daemon euid + root)* | Username the socket's listener must run as. See [Peer credential trust](#peer-credential-trust). |
 
 ## Notes
 
@@ -23,3 +24,16 @@ def output local_forward {
 - Connection is established on first use and reused.
 - Automatically reconnects if the connection breaks.
 - Common queue / retry properties — see [Queue and retry](./README.md#queue-and-retry).
+
+## Peer credential trust
+
+The `unix_socket` output is a **connect-side** sink — the daemon connects to a socket that belongs to another service (systemd `journald` at `/dev/log`, `rsyslogd`, a local collector, …). The bind-side trust boundaries used by the DLQ file, the file output, and the control / input `unix_socket` (parent directory owner, refusal of symlinked paths) do **not** apply here: the peer service owns its socket path, and typical packaged deployments break every bind-side predicate — `/dev/log` is a symlink to `/run/systemd/journal/dev-log` on systemd systems, and its parent `/dev` is root-owned. Path-shape checks would refuse the most common shape.
+
+Instead, defence lives at the socket credential surface. On every `connect(2)` — including the reconnects `write_with_reconnect` performs after a peer restart — the daemon reads the listener's uid via `SO_PEERCRED` (Linux) / `LOCAL_PEERCRED` (macOS) and refuses the connection if that uid is not in the allowed set. This defends against a **non-root co-tenant** who binds a squatter socket at the configured `path` in the window between two peer-service restarts and would otherwise capture every subsequent event's payload.
+
+The allowed set is:
+
+- **`expected_peer_uid` unset** (default): `{daemon euid, root}`. `journald` runs as root, so `/dev/log` is accepted; a daemon-owned collector matches the euid arm. Root is trusted here because an attacker who can already `bind` as root has crossed a larger boundary than this check defends.
+- **`expected_peer_uid "syslog"`** (or any user name): the default set is **replaced**, not extended. Root is refused too. Use this lock-down mode when the deployment has a known dedicated collector uid and the operator wants a socket-squatter-by-root to also be refused. Numeric-string uids are rejected — configure by name, matching the file output's `owner` semantics.
+
+If a `connect()` observes an unexpected uid it fails loudly (structured error with the observed uid, the allowed set, and the `expected_peer_uid` remedy). The failure flows through the normal retry / DLQ path so nothing is silently dropped.


### PR DESCRIPTION
Tightens three filesystem-adjacent trust surfaces that the daemon
crosses in normal operation. Each was previously validated at the
shape level (symlink refusal, mode check) but not at the identity
level (owner uid), which under an attacker-writable ancestor or a
non-root co-tenant let the daemon silently write sensitive data
into an attacker-controlled inode — or, for `unix_socket` output,
ship every event to a socket-squatter listener.

## Behaviour changes

- **DLQ parent-owner + parent-mode + existing-file owner checks**
  (`error_log`). `validate_at_startup` now refuses a parent
  directory that is not owned by the daemon's euid or has any
  group/other write bit set. `verify_existing_mode` extends its
  existing regular-file + 0o600 fstat with an `st_uid == self_euid`
  check on the opened fd. Matches the discipline the control-socket
  parent already applied, adjusted for the DLQ threat model
  (`mode & 0o022` rather than `mode & 0o023` — the DLQ file itself
  never widens, so the group-write bit alone doesn't leak the
  file, but any writable parent still lets a co-tenant swap the
  inode).
- **File output implicit owner-euid contract.** When
  `verify_existing_file_metadata` is called (= the operator
  configured at least one of `mode` / `owner` / `group`) but no
  explicit `owner` is set, the existing inode must be owned by the
  daemon's own euid. A configuration like `mode "0600"` no longer
  silently accepts an attacker-planted 0o600 file at the target
  path. The birth-create branch is unaffected because the daemon
  creates the inode itself; the no-metadata-contract path is
  unchanged.
- **`unix_socket` output peer-credential trust.** Every
  `connect(2)` — including the reconnects `write_with_reconnect`
  performs after a peer restart — validates the listener's uid via
  `SO_PEERCRED` (Linux) / `LOCAL_PEERCRED` (macOS) against an
  allow set. Default set is `{daemon euid, 0}` — the two canonical
  peer identities on packaged deployments (`journald` at
  `/dev/log`, a daemon-owned collector). New `expected_peer_uid`
  property **replaces** the default set with a single resolved
  uid (root refused too), for operators who want strict lock-down.
  Path-shape predicates (parent trust, final-component symlink
  refusal, socket-shape preflight) are deliberately **not**
  applied: `/dev/log` is a symlink on systemd systems and its
  parent `/dev` is root-owned, so bind-side predicates would refuse
  the canonical shape.

## Docs

`docs/src/outputs/unix-socket.md` gains a *Peer credential trust*
section that spells out why path-shape predicates do not apply to
this connect-side sink, documents the default-set + replace
semantics, and shows the `expected_peer_uid` lock-down example.

## Testing note

A cross-platform tempdir helper (`safe_dlq_tempdir`) is added to
the `error_log` tests so seven pre-existing tests that pin
non-parent-mode contracts (symlink refusal, wrong mode, FIFO
refusal, etc.) still pass on Linux runners, whose `TempDir::new()`
inherits the process umask (`0o775`) and would otherwise trip the
new parent-mode predicate. No source-code shift, testing
infrastructure only.

## Test plan

- [x] macOS local: `cargo fmt --all -- --check`
- [x] macOS local: `cargo clippy --all-targets --features kafka -- -D warnings`
- [x] macOS local: `cargo test --workspace --features kafka` — 899 passed, 0 failed, 1 ignored (pre-existing `cli_check` macOS flake tracked as separate follow-up)
- [x] Linux playground: `cargo test --workspace --features kafka` — 899 passed, 0 failed, 1 ignored
- [x] Linux playground: `mdbook build`

## Design notes captured during review

- The bind-side pattern used by C1 / C3 does not transfer to the
  `unix_socket` output. `/dev/log` under systemd is a symlink to
  `/run/systemd/journal/dev-log` and its parent `/dev` is
  root-owned, so refusing symlinked paths or foreign-owned parents
  refuses the canonical shape. Fable review caught the mismatch;
  peer credential trust replaced the path-shape predicate as the
  connect-side defense.
- `expected_peer_uid` **replaces** the default allow set rather
  than extending it — the strict-lockdown semantics an operator
  actually wants when they bother to configure it.