### PR TITLE
test(cli_check): drain daemon stdio concurrently so try_wait can observe exit on macOS

### DIFF
--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -772,6 +772,20 @@ fn run_daemon_attempt(config: &std::path::Path) -> std::process::Output {
     // would block the suite indefinitely. The poll interval is short
     // enough that the happy (= reject) path still finishes in tens of
     // ms.
+    //
+    // Concurrent pipe drain (not `wait_with_output` at the end): the
+    // daemon's diagnostic renderer writes several hundred bytes of
+    // analyzer diagnostic to stderr just before exit. On macOS the
+    // default pipe buffer + Rust's stdio buffering interact in a way
+    // that lets `try_wait()` observe `None` even after the child
+    // process has finished writing — the child is really blocked in
+    // `close(2)` cleanup on the parent side, but from `try_wait`'s
+    // POV it looks like the process is still alive. Running
+    // `wait_with_output` *after* the poll loop breaks a
+    // `try_wait`-only observer because the reader never keeps up
+    // with the writer. Draining stdout/stderr concurrently in
+    // separate threads clears the pipe as fast as the child writes
+    // it, so exit is observed as soon as the child actually closes.
     let mut child = Command::new(limpid_bin())
         .arg("--config")
         .arg(config)
@@ -780,14 +794,23 @@ fn run_daemon_attempt(config: &std::path::Path) -> std::process::Output {
         .spawn()
         .expect("failed to spawn limpid");
 
+    let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut stdout_pipe, &mut buf).ok();
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut stderr_pipe, &mut buf).ok();
+        buf
+    });
+
     let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
+    let status = loop {
         match child.try_wait() {
-            Ok(Some(_)) => {
-                return child
-                    .wait_with_output()
-                    .expect("failed to capture daemon output");
-            }
+            Ok(Some(s)) => break s,
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = child.kill();
@@ -801,6 +824,18 @@ fn run_daemon_attempt(config: &std::path::Path) -> std::process::Output {
             }
             Err(e) => panic!("try_wait error: {}", e),
         }
+    };
+
+    let stdout = stdout_handle
+        .join()
+        .expect("stdout drain thread must not panic");
+    let stderr = stderr_handle
+        .join()
+        .expect("stderr drain thread must not panic");
+    std::process::Output {
+        status,
+        stdout,
+        stderr,
     }
 }
 


### PR DESCRIPTION
Fixes the pre-existing `cli_check::daemon_startup_*` / `daemon_and_check_*` test flake that both J1 and J2 push-gate audits surfaced as a standing `ci-precheck` finding.

## Cause

`run_daemon_attempt` spawned the daemon with `Stdio::piped()` on both stdout and stderr and polled `try_wait()` at 25 ms intervals without reading from either pipe. On macOS the pipe buffer + Rust's stdio buffering interact so that `try_wait()` observes `None` even after the child has finished writing every byte of its diagnostic and is really blocked in `close(2)` cleanup on the parent side — the process is exiting, but the parent-side observer cannot see it until the pipes are drained. Three tests panicked at the 5 s deadline even though the daemon exited within milliseconds.

Reproduces identically on `1b56684` (the release/0.7.9 base commit that predates the shutdown-drain and trust-boundary branches), so this is a test-harness bug rather than a regression from any behaviour change.

## Fix

Replace the deferred `wait_with_output()` with two eager drain threads that read stdout / stderr into byte buffers as fast as the child writes them. The main thread still polls `try_wait()` for the same 5 s deadline, so the analyzer-regression guard the test was written for (a daemon that unexpectedly accepts a config we expected it to reject and proceeds to bind listeners) stays in place — but pipe cleanup now runs concurrently with the poll loop so the exit observation is prompt.

## Test plan

- [x] macOS local (`cargo clean` fresh): `cargo test --workspace --features kafka` — 899 passed, 0 failed, 1 ignored
- [x] macOS local: `cli_check` 27/27 stable across repeated runs
- [x] Linux playground: `cli_check` 27/27 pass, no regression
- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets --features kafka -- -D warnings`