### PR TITLE
packaging+docs: ship snippet lib in deb, unify DLQ path + logrotate user, close trait/wording drift

### DIFF
--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -104,10 +104,19 @@ assets = [
     ["target/release/limpidctl", "usr/bin/", "755"],
     ["../../packaging/limpid.conf.example", "usr/share/limpid/limpid.conf.example", "644"],
     ["../../README.md", "usr/share/doc/limpid/README.md", "644"],
-    # The snippet library that lives under packaging/snippets/ ships in
-    # v0.6.0; the config loader already honours absolute includes under
-    # /usr/share/limpid/snippets/ via SYSTEM_SNIPPET_DIR (see config.rs)
-    # so the .deb just needs the directory once snippets exist.
+    # The snippet library under packaging/snippets/ is loaded by the
+    # daemon via SYSTEM_SNIPPET_DIR (`/usr/share/limpid/snippets/`,
+    # see config.rs). Every documented `include "snippets/..."`
+    # relies on this directory being present in the deb — without
+    # it, an operator following the docs verbatim gets an
+    # unresolved-include failure at startup. Ship the whole tree
+    # (README + composers/ filters/ functions/ parsers/) so the
+    # packaged surface matches what the docs promise.
+    ["../../packaging/snippets/README.md", "usr/share/limpid/snippets/README.md", "644"],
+    ["../../packaging/snippets/composers/*.limpid", "usr/share/limpid/snippets/composers/", "644"],
+    ["../../packaging/snippets/filters/*.limpid", "usr/share/limpid/snippets/filters/", "644"],
+    ["../../packaging/snippets/functions/*.limpid", "usr/share/limpid/snippets/functions/", "644"],
+    ["../../packaging/snippets/parsers/*.limpid", "usr/share/limpid/snippets/parsers/", "644"],
 ]
 maintainer-scripts = "../../packaging"
 # start = false preserves the existing "enable but don't start on first

--- a/crates/limpid/src/check/recovery_readiness.rs
+++ b/crates/limpid/src/check/recovery_readiness.rs
@@ -126,7 +126,7 @@ pub(super) fn analyze_all(config: &CompiledConfig, diags: &mut Vec<Diagnostic>) 
          DLQ (log rotation / filters / aggregation delays and no `limpidctl inject` \
          replay shortcut), so operator recovery is weaker without `error_log`. \
          To enable durable file-based recovery, add:\n    \
-         control {{\n        error_log \"/var/log/limpid/error_log.jsonl\"\n    }}",
+         control {{\n        error_log \"/var/log/limpid/errored.jsonl\"\n    }}",
         summary,
     );
 
@@ -220,7 +220,7 @@ def pipeline p { input i; output o }
     #[test]
     fn no_warning_when_error_log_configured() {
         let src = r#"
-control { error_log "/var/log/limpid/error_log.jsonl" }
+control { error_log "/var/log/limpid/errored.jsonl" }
 def input i { type syslog_tcp bind "0.0.0.0:514" }
 def output o {
     type syslog_tcp

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -299,8 +299,24 @@ pub trait Output: HasMetrics<Stats = OutputMetrics> + Send + Sync + 'static {
     /// (disk queue) or count it lost (memory queue on shutdown).
     ///
     /// - On successful delivery: call `ack.resolve_delivered()`.
-    /// - On DLQ recovery (retry exhausted / render error / shutdown
-    ///   leftover): call `ack.resolve_recovered()`.
+    /// - On failure (retry exhausted / render error / DLQ-adjacent
+    ///   path): route through `route_event_to_dlq` and dispatch the
+    ///   returned `DlqRouteOutcome` through
+    ///   `resolve_ack_from_dlq_outcome`. The dispatcher owns the
+    ///   backend-aware terminal disposition: `Recovered` on any queue
+    ///   when the DLQ record was durably written (or when the JSONL
+    ///   tracing fallback ran because `error_log` was unset),
+    ///   `Dropped` on a disk queue when the configured DLQ file
+    ///   write itself failed (which triggers the fail-stop wedge so
+    ///   the disk cursor holds for next-start replay), and memory
+    ///   queues fold `Dropped` back to `Recovered` internally
+    ///   because they have no replay path. Sinks that resolve the
+    ///   handle themselves must call one of `resolve_delivered` /
+    ///   `resolve_recovered` / `resolve_dropped` directly, but the
+    ///   dispatcher is the standard shape — it keeps
+    ///   `events_failed` bumped exactly once per failure and picks
+    ///   the correct disposition per backend without per-sink
+    ///   duplication.
     ///
     /// `Ok(())` does NOT mean the event was delivered — it means the
     /// output accepted ownership of the lifecycle. Actual disposition
@@ -646,8 +662,10 @@ pub async fn route_shutdown_batch_to_dlq(
             };
             tracing::error!(
                 event_record = %ctx.to_jsonl(),
-                "output '{}': shutdown-drain event dropped (no error_log); configure \
-                 `control {{ error_log \"...\" }}` for file-based DLQ",
+                "output '{}': shutdown-drain event emitted as tracing fallback (no error_log \
+                 configured); disposition is Recovered, payload is grep/journalctl-recoverable \
+                 via the event_record field. Configure `control {{ error_log \"...\" }}` for \
+                 file-based DLQ and `limpidctl inject output` replay",
                 output_name
             );
             resolve_ack_from_dlq_outcome(ack, DlqRouteOutcome::Recovered, metrics);
@@ -911,7 +929,10 @@ pub async fn route_event_to_dlq(
         };
         tracing::error!(
             event_record = %ctx.to_jsonl(),
-            "output '{}': dropping event (no error_log); configure `control {{ error_log \"...\" }}` for file-based DLQ",
+            "output '{}': event emitted as tracing fallback (no error_log configured); \
+             payload is grep/journalctl-recoverable via the event_record field. Configure \
+             `control {{ error_log \"...\" }}` for file-based DLQ and `limpidctl inject \
+             output` replay",
             output_name
         );
         DlqRouteOutcome::Recovered

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -60,7 +60,7 @@ include "pipelines/*.limpid"
 
 control {
     socket "/var/run/limpid/control.sock"
-    error_log "/var/log/limpid/error_log.jsonl"
+    error_log "/var/log/limpid/errored.jsonl"
 }
 ```
 

--- a/docs/src/operations/cli.md
+++ b/docs/src/operations/cli.md
@@ -140,8 +140,10 @@ At shutdown, the control task records the `(dev, ino)` of the socket it bound an
 ### Control socket limits
 
 The control socket is a local root-equivalent trust boundary (mode `0o660` in
-a root-owned directory), but limpid still enforces these limits as defense
-in depth:
+a daemon-owned runtime directory — the packaged unit provisions
+`/var/run/limpid/` at `User=syslog` via `RuntimeDirectory=limpid` +
+`RuntimeDirectoryMode=0750`), but limpid still enforces these limits as
+defense in depth:
 
 | Limit | Value | Behaviour on breach |
 |-------|-------|---------------------|

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -59,14 +59,14 @@ A typical operator setup keeps the live file capped and the rotated archives com
     copytruncate
     notifempty
     missingok
-    create 0600 limpid limpid
+    create 0600 syslog syslog
     maxsize 1G
 }
 ```
 
 Key choices:
 
-- `create 0600` — the DLQ writer's runtime contract is *exactly* `0o600` on the on-disk file. If logrotate creates the fresh post-rotation file at any other mode, the next DLQ write is refused with a `existing file mode 0o... does not match configured mode 0o600` error and `events_errored_unwritable` bumps until the operator aligns the file. Match the rotator's `create` mode with the runtime contract to avoid that failure.
+- `create 0600 syslog syslog` — the packaged unit runs limpid as `User=syslog` / `Group=syslog`, and the DLQ writer's runtime contract is *exactly* `0o600` on the on-disk file **owned by the daemon's euid** (the fstat re-verify refuses a foreign-uid inode, see [Trust boundaries](./error-log.md#trust-boundaries) if you have configured a different user). For custom deploys running under a different user, substitute `<daemon-user>:<daemon-group>` in both places. If logrotate creates the fresh post-rotation file at any other mode or owner, the next DLQ write is refused with a `existing file mode 0o... does not match configured mode 0o600` or `existing file is owned by uid ...` diagnostic and `events_errored_unwritable` bumps until the operator aligns the file. Match the rotator's `create` mode + owner with the runtime contract to avoid that failure.
 - `copytruncate` — limpid reopens the inode every write, so a normal rotate-and-rename works too, but `copytruncate` is the simplest setup that doesn't require any signal handshake.
 - `maxsize 1G` — caps the live file even when `daily` hasn't fired yet. A pipeline producing failures at 10k events/sec with 1 KiB records would fill 1 GiB in ~100 seconds; tune to your environment.
 - `rotate 14 + compress` — two weeks of rotated history is usually enough to catch and replay everything between an incident and the operator noticing it.
@@ -446,7 +446,7 @@ Investigate immediately:
 
 - Is the parent directory writable by the daemon user?
 - Is the disk full? (`df`)
-- Did rotation leave an incompatible node or mode/owner at the path? The DLQ writer opens a fresh fd per write (`create_new` + `fstat` verify), so rotation does not need a `SIGHUP` reload — but if the rotator recreated the file at a different mode (`0o644` instead of `0o600`) or owner, the fstat check refuses to append. Use `copytruncate` (which preserves the inode and its mode), or `create 0600 limpid limpid` matching the DLQ's runtime contract exactly. `nocreate` also works but leaves the runtime to materialise the file on the next failure, which pushes the deploy check onto the failure path.
+- Did rotation leave an incompatible node or mode/owner at the path? The DLQ writer opens a fresh fd per write (`create_new` + `fstat` verify), so rotation does not need a `SIGHUP` reload — but if the rotator recreated the file at a different mode (`0o644` instead of `0o600`) or a different owner (a foreign uid, or a group other than the daemon's), the fstat check refuses to append. Use `copytruncate` (which preserves the inode and its mode + owner), or `create 0600 syslog syslog` matching the packaged unit's runtime contract exactly (substitute `<daemon-user>:<daemon-group>` for custom deploys). `nocreate` also works but leaves the runtime to materialise the file on the next failure, which pushes the deploy check onto the failure path.
 - Is the file path on a network filesystem with intermittent connectivity?
 
 Once the underlying issue is fixed, the next errored event lands in the file again and the counter stops increasing; existing records are unaffected.

--- a/docs/src/operations/packaging.md
+++ b/docs/src/operations/packaging.md
@@ -39,6 +39,7 @@ cargo deb -p limpid -- --features journal,kafka
 | `/usr/bin/limpidctl` | Control and debug CLI |
 | `/usr/share/limpid/limpid.conf.example` | Example configuration |
 | `/usr/share/doc/limpid/README.md` | Documentation |
+| `/usr/share/limpid/snippets/` | Shipped snippet library (`composers/`, `filters/`, `functions/`, `parsers/`) — resolved by absolute-`include` under `SYSTEM_SNIPPET_DIR`. See [Snippet Library](../snippets/README.md). |
 | `/etc/systemd/system/limpid.service` | systemd unit file |
 
 The post-install script (`packaging/postinst`) runs on first install:
@@ -115,10 +116,11 @@ sudo systemctl restart limpid-prometheus
 ├── processes/
 └── pipelines/
 
-/var/lib/limpid/          # Disk queue data
-/var/log/limpid/          # Default file output location
+/usr/share/limpid/snippets/  # Shipped snippet library (composers/, filters/, functions/, parsers/)
+/var/lib/limpid/             # Disk queue data
+/var/log/limpid/             # Default file output location
 /var/run/limpid/
-└── control.sock          # Control socket (created at runtime)
+└── control.sock             # Control socket (created at runtime)
 ```
 
 ## Upgrading

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -173,7 +173,7 @@ include "pipelines/*.limpid"
 
 control {
     socket "/var/run/limpid/control.sock"
-    error_log "/var/log/limpid/error_log.jsonl"
+    error_log "/var/log/limpid/errored.jsonl"
 }
 ```
 


### PR DESCRIPTION
Closes the operator-facing packaging and documentation gaps that Codex flagged as pending after the runtime (J1) and filesystem trust (J2) rounds. Three focused commits — one packaging fix, two documentation / wording alignments — plus no source-behaviour change.

## Behaviour changes

- **Snippet library ships with the deb.** `crates/limpid/Cargo.toml` adds glob asset entries for `packaging/snippets/{composers,filters,functions,parsers}/*.limpid` plus the README, so `apt install limpid_*.deb` now lands `/usr/share/limpid/snippets/` — matching `SYSTEM_SNIPPET_DIR` in `config.rs` and every documented `include "/usr/share/limpid/snippets/..."` path across the site. Previously, the docs promised the library was shipped but the deb was missing it, and the daemon would fail to start on any config that used the documented snippets.
- **Canonical DLQ file name unified on `errored.jsonl`.** The recovery-readiness `--check` warning, getting-started walkthrough, and tutorial all suggested `error_log.jsonl` while the runbook, logrotate defaults, and every trust-boundary diagnostic used `errored.jsonl`. Pick the runbook name — no operator now has to pick between two paths.
- **Logrotate example aligned to the packaged unit.** `create 0600 limpid limpid` never matched the packaged `User=syslog` — a rotator that recreated the DLQ file at a foreign uid tripped the J2 fstat owner-refusal. Update the two rotation-guidance sites to `create 0600 syslog syslog` and add a `<daemon-user>:<daemon-group>` placeholder for custom deploys.
- **`Output::consume` trait docstring updated to the dispatcher contract.** The failure arm still summarised as "call `ack.resolve_recovered()`" — accurate at 0.7.7 but not since the DLQ dispatcher landed. Rewrite the arm around `route_event_to_dlq` + `resolve_ack_from_dlq_outcome` so a new implementation learns the current backend-aware terminal-disposition rules directly from the doc.
- **`cli.md` control-socket wording.** "Root-owned directory" retired in favour of "daemon-owned runtime directory" — matches what the daemon actually enforces (the trust-boundary preflight refuses a root-owned parent under a non-root daemon).
- **No-`error_log` tracing lines renamed.** `route_event_to_dlq` and `route_shutdown_batch_to_dlq` both said "dropping event (no error_log)" even though both emit the full failure JSONL on the `event_record` structured field and resolve the ack as `Recovered`. Alarms tuned on "dropping" would have read those lines as data loss. Rewrite as "emitted as tracing fallback (no error_log configured)" and point at the `limpidctl inject output` replay path.

## Test plan

- [x] macOS local: `cargo fmt --all -- --check`
- [x] macOS local: `cargo clippy --all-targets --features kafka -- -D warnings`
- [x] macOS local: `cargo test --workspace --features kafka` — 899 passed, 0 failed, 1 ignored
- [x] macOS local: `mdbook build` clean
- [x] Linux playground: `cargo test --workspace --features kafka` — 899 passed, 0 failed, 1 ignored
- [x] Linux playground: `cargo deb -p limpid --no-build` produces a deb whose `dpkg -c` shows the full `usr/share/limpid/snippets/` tree (README + composers + filters + functions + parsers)