### PR TITLE
fix: thread AckPosition through sink-side DLQ helpers so the ladder's Meta-arm position field carries the real queue position

### DIFF
--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -574,12 +574,14 @@ pub async fn finalize_shutdown_singleton_disposition(
         }
         Err(e) => {
             let reason = format!("shutdown send failed: {}", e);
+            let position = ack.position();
             let outcome = route_event_to_dlq(
                 error_log,
                 error_log_fallback,
                 metrics,
                 output_name,
                 event,
+                position,
                 &reason,
             )
             .await;
@@ -648,12 +650,14 @@ pub async fn finalize_shutdown_singleton_disposition_ambiguous(
             // Write the DLQ record for the operator's audit trail —
             // even though we're forcing `Dropped`, the record makes
             // reconciliation possible after next-start replay.
+            let position = ack.position();
             let _ = route_event_to_dlq(
                 error_log,
                 error_log_fallback,
                 metrics,
                 output_name,
                 event,
+                position,
                 &reason,
             )
             .await;
@@ -913,8 +917,14 @@ pub async fn route_shutdown_batch_ambiguous_to_dlq(
 /// - `size`: bytes of the recoverable payload — egress for Output,
 ///   ingress for Process (Meta only).
 /// - `position`: `AckPosition` debug form; queue kind + numeric
-///   offset/seq only, no filesystem path (Meta only, Output-flavor
-///   sites where a queue handle exists; `(none)` on the pipeline side).
+///   offset/seq only, no filesystem path (Meta only). Always
+///   present on sink-side callers — `route_event_to_dlq` /
+///   `finalize_shutdown_singleton_disposition{,_ambiguous}` /
+///   `route_shutdown_batch_to_dlq` / `route_shutdown_batch_ambiguous_to_dlq`
+///   all require a live `AckPosition` at the type level and pass
+///   `Some(position)` here. `(none)` only appears on the pipeline
+///   side (`runtime::write_errored_to_dlq`) where the event
+///   never entered an output queue and no `AckPosition` exists.
 ///
 /// # Excluded fields
 ///
@@ -1100,12 +1110,26 @@ pub enum DlqRouteOutcome {
 /// caller can choose between `resolve_recovered` (memory queue) and
 /// `resolve_dropped` (disk queue wedge). Does NOT touch the ack
 /// handle directly.
+///
+/// `position` is the queue-side `AckPosition` snapshot taken from the
+/// caller's `QueueAckHandle` *before* the ack is resolved. It is
+/// required — not `Option` — because this helper is the sink-side
+/// entry point and every sink call site holds an in-scope
+/// `QueueAckHandle` at the moment of dispatch (the immediate next
+/// statement resolves it via `resolve_ack_from_dlq_outcome`). The
+/// pipeline-side runtime path (`runtime::write_errored_to_dlq`)
+/// legitimately has no such handle and does not route through this
+/// helper — it delegates to `emit_dlq_tracing_fallback` directly
+/// with `position = None`. Requiring the argument here at the type
+/// level locks the sink-side plumbing so a future refactor cannot
+/// silently drop the `Meta`-arm `position` field back to `(none)`.
 pub async fn route_event_to_dlq(
     error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
     error_log_fallback: crate::error_log::ErrorLogFallback,
     metrics: &OutputMetrics,
     output_name: &str,
     event: &Event,
+    position: crate::queue::AckPosition,
     reason: &str,
 ) -> DlqRouteOutcome {
     use std::sync::atomic::Ordering;
@@ -1141,7 +1165,7 @@ pub async fn route_event_to_dlq(
                     /* error_log_configured */ true,
                     error_log_fallback,
                     &ctx,
-                    None,
+                    Some(position),
                     Some(&write_err),
                 );
                 metrics
@@ -1170,7 +1194,7 @@ pub async fn route_event_to_dlq(
             /* error_log_configured */ false,
             error_log_fallback,
             &ctx,
-            None,
+            Some(position),
             None,
         );
         DlqRouteOutcome::Recovered
@@ -1696,6 +1720,78 @@ mod output_dlq_tracing_fallback_ladder_tests {
                 "Meta arm must emit `{field}` structured field so \
                  operators can correlate the record with metrics / \
                  replay tooling"
+            );
+        }
+    }
+
+    /// Sink-side helpers require a live `AckPosition` at the type
+    /// level. Every route the ladder's `Meta` arm reaches from a
+    /// sink caller therefore has a real queue position to emit,
+    /// not `(none)`. This pin ensures a future refactor cannot
+    /// silently regress `route_event_to_dlq` /
+    /// `finalize_shutdown_singleton_disposition{,_ambiguous}` to
+    /// `Option<AckPosition>` (or drop the parameter) without
+    /// updating every call site — which is exactly what let the
+    /// previous sink-side plumbing drop `position` back to `(none)` on the
+    /// steady-state retry-exhausted path (the most common DLQ
+    /// route) despite the ladder docs promising it.
+    ///
+    /// Detection is source-level: grep the four public helper
+    /// signatures for `position: crate::queue::AckPosition,`
+    /// (required, not `Option`). If a future variant needs to
+    /// stay position-agnostic, add a separate helper — do not
+    /// weaken these four.
+    #[test]
+    fn sink_side_dlq_helpers_require_ack_position() {
+        let src = include_str!("mod.rs");
+
+        // `route_event_to_dlq` is the shared shape every sink's
+        // `consume` call reaches; the type-level requirement is
+        // the load-bearing part of the fix, so its signature must
+        // continue to require `AckPosition` directly (not `Option`).
+        let start = src
+            .find("pub async fn route_event_to_dlq(")
+            .expect("route_event_to_dlq must exist");
+        let sig_end = src[start..]
+            .find(") ->")
+            .expect("route_event_to_dlq must have a return arrow");
+        let sig = &src[start..start + sig_end];
+        assert!(
+            sig.contains("position: crate::queue::AckPosition,"),
+            "route_event_to_dlq must require an `AckPosition` (not \
+             `Option<...>`) so sink-side callers cannot silently drop \
+             the ladder's `Meta`-arm `position` field back to `(none)` \
+             — see the doc comment on `route_event_to_dlq`",
+        );
+        assert!(
+            !sig.contains("position: Option<crate::queue::AckPosition>"),
+            "route_event_to_dlq takes `AckPosition` directly; wrapping \
+             it in `Option` here defeats the type-level guarantee",
+        );
+
+        // `finalize_shutdown_singleton_disposition{,_ambiguous}` take
+        // the whole `QueueAckHandle` (they own the resolve) and extract
+        // position internally via `ack.position()` before handing it
+        // to `route_event_to_dlq`. Pin the extraction so a future edit
+        // cannot skip it and re-introduce the `(none)` regression.
+        for finalize_helper in [
+            "pub async fn finalize_shutdown_singleton_disposition(",
+            "pub async fn finalize_shutdown_singleton_disposition_ambiguous(",
+        ] {
+            let start = src
+                .find(finalize_helper)
+                .unwrap_or_else(|| panic!("{} must exist", finalize_helper));
+            // Find the closing brace at column 0 for the fn body.
+            let body_end = src[start..]
+                .find("\n}\n")
+                .unwrap_or_else(|| panic!("{} must have a closing brace", finalize_helper));
+            let body = &src[start..start + body_end];
+            assert!(
+                body.contains("let position = ack.position();"),
+                "{finalize_helper} must extract `let position = ack.position();` \
+                 before delegating to `route_event_to_dlq` so the `Meta`-arm \
+                 `position` field carries the real queue position rather than \
+                 `(none)`",
             );
         }
     }

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -593,6 +593,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                 &self.metrics,
                 &self.name,
                 &ev,
+                ack.position(),
                 &reason,
             )
             .await;
@@ -637,6 +638,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                 &self.metrics,
                 &self.name,
                 &ev,
+                ack.position(),
                 &reason,
             )
             .await;
@@ -673,6 +675,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                         &self.metrics,
                         &self.name,
                         &ev,
+                        ack.position(),
                         &reason,
                     )
                     .await;
@@ -820,6 +823,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                     &self.metrics,
                     &self.name,
                     &ev,
+                    ack.position(),
                     &reason,
                 )
                 .await;

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -219,6 +219,7 @@ impl Output for FileOutput {
                     &self.metrics,
                     &self.name,
                     event,
+                    ack.position(),
                     &reason,
                 )
                 .await;
@@ -270,6 +271,7 @@ impl Output for FileOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;
@@ -308,6 +310,7 @@ impl Output for FileOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;
@@ -345,6 +348,7 @@ impl Output for FileOutput {
                     &self.metrics,
                     &self.name,
                     event,
+                    ack.position(),
                     &reason,
                 )
                 .await;
@@ -382,6 +386,7 @@ impl Output for FileOutput {
                     &self.metrics,
                     &self.name,
                     event,
+                    ack.position(),
                     &reason,
                 )
                 .await;

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -514,6 +514,7 @@ impl Output for KafkaOutput {
                         &self.metrics,
                         &self.name,
                         event,
+                        ack.position(),
                         &reason,
                     )
                     .await;
@@ -532,6 +533,7 @@ impl Output for KafkaOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;
@@ -569,6 +571,7 @@ impl Output for KafkaOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -114,6 +114,7 @@ impl Output for StdoutOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;
@@ -151,6 +152,7 @@ impl Output for StdoutOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -376,6 +376,7 @@ impl Output for SyslogTcpOutput {
                         &self.metrics,
                         &self.name,
                         event,
+                        ack.position(),
                         &reason,
                     )
                     .await;
@@ -401,6 +402,7 @@ impl Output for SyslogTcpOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;
@@ -438,6 +440,7 @@ impl Output for SyslogTcpOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -149,6 +149,7 @@ impl Output for SyslogUdpOutput {
                         &self.metrics,
                         &self.name,
                         event,
+                        ack.position(),
                         &reason,
                     )
                     .await;
@@ -182,6 +183,7 @@ impl Output for SyslogUdpOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;
@@ -219,6 +221,7 @@ impl Output for SyslogUdpOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -179,6 +179,7 @@ impl Output for UnixSocketOutput {
                         &self.metrics,
                         &self.name,
                         event,
+                        ack.position(),
                         &reason,
                     )
                     .await;
@@ -210,6 +211,7 @@ impl Output for UnixSocketOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;
@@ -247,6 +249,7 @@ impl Output for UnixSocketOutput {
                             &self.metrics,
                             &self.name,
                             event,
+                            ack.position(),
                             &reason,
                         )
                         .await;


### PR DESCRIPTION
## Summary

Hardware validation of the `error_log_fallback` ladder on `release/0.7.9` surfaced a drift: the ladder's `Meta` arm was documented to emit a `position` structured field carrying the queue's `AckPosition`, but under a disk queue the most common DLQ route (steady-state retry-exhausted `route_event_to_dlq` from a sink's `consume` body) rendered `position="(none)"` instead of `Disk { seq, offset }`.

Root cause was the sink-side helper's signature. `route_event_to_dlq` never took an `AckPosition` argument, so every one of the ~19 sink call sites passed nothing — even though each of them held a live `QueueAckHandle` on the very next statement (`resolve_ack_from_dlq_outcome(ack, ...)`). The structural pins were passing because the helper faithfully rendered whatever `Option<AckPosition>` the caller handed it; the callers just handed it `None`.

The fix promotes `position` to a required parameter of the sink-side helper trio so the type system enforces the plumbing:

- `route_event_to_dlq(..., position: AckPosition, ...)` — required, not `Option`.
- `finalize_shutdown_singleton_disposition{,_ambiguous}` own the ack resolve internally; both extract `let position = ack.position();` before delegating.
- `emit_dlq_tracing_fallback` retains `Option<AckPosition>` because the pipeline-side runtime error path (`runtime::write_errored_to_dlq`) legitimately passes `None` — its event never entered an output queue.

A new structural pin `sink_side_dlq_helpers_require_ack_position` locks the invariant at the source level so a future refactor cannot silently regress the signature back to `Option`, and pins that both finalize helpers extract `let position = ack.position();` before delegating.

**Confidentiality invariance.** Payload / filesystem-path leaks are unchanged. `AckPosition` debug output is `Memory` or `Disk { seq: N, offset: M }` — queue kind + numeric fields only, no path. The `Meta` vs. `Full` boundary is intact; this fix only makes the `Meta` field carry the value the docs already promised.

## Test plan

- [x] `cargo test -p limpid` (macOS): 846 passed / 0 failed / 1 ignored (+1 new structural pin)
- [x] `cargo clippy -p limpid --all-targets -- -D warnings`: clean
- [x] `cargo check -p limpid --features kafka`: clean
- [x] `cargo fmt --check -p limpid`: clean
- [ ] Hardware re-validation on playground (P0-2 `Meta` arm re-run): position field must render `Disk { seq: N, offset: M }` under disk queue config — deferred to post-merge
