### PR TITLE
fix(modules/input/journal): make match property actually filter events; add repeatable, load-time format validation, and empty-match-view seek fallback

### DIFF
--- a/crates/limpid/src/check/journal_match_format.rs
+++ b/crates/limpid/src/check/journal_match_format.rs
@@ -1,0 +1,179 @@
+//! Cross-cutting `--check` validator: every `match` filter on a
+//! `type journal` input must have `FIELD=value` shape.
+//!
+//! The runtime path already validates this at daemon startup
+//! (`JournalInput::from_properties`), so a malformed filter would
+//! fail-fast anyway — but that failure only surfaces the moment the
+//! daemon is asked to start, not at `--check` time. Operators
+//! running `limpid --check` on a config with `match "no_equals"` are
+//! entitled to see the error before deploy, so the same rule is
+//! applied on the analyzer side.
+//!
+//! Format validation stops at the `=` separator. libsystemd's own
+//! per-field rules (uppercase field names, no NUL, etc.) are still
+//! enforced at runtime by `sd_journal_add_match`; when it rejects a
+//! filter the reader terminates with a loud diagnostic — that
+//! semantics is not something `--check` can replicate without
+//! linking libsystemd on the analyzer path.
+
+use crate::dsl::ast::{Expr, ExprKind, Property};
+use crate::dsl::span::Span;
+use crate::pipeline::CompiledConfig;
+
+use super::{DiagKind, Diagnostic};
+
+pub(super) fn analyze_all(config: &CompiledConfig, diags: &mut Vec<Diagnostic>) {
+    for input_def in config.inputs.values() {
+        if input_def.properties.type_name() != "journal" {
+            continue;
+        }
+        for prop in input_def.properties.user_properties() {
+            if let Property::KeyValue {
+                key,
+                value:
+                    Expr {
+                        kind: ExprKind::StringLit(s),
+                        ..
+                    },
+                value_span,
+                ..
+            } = prop
+                && key == "match"
+                && !s.contains('=')
+            {
+                diags.push(diag_for_bad_match(&input_def.name, s, *value_span));
+            }
+        }
+    }
+}
+
+fn diag_for_bad_match(input_name: &str, offending: &str, span: Option<Span>) -> Diagnostic {
+    let msg = format!(
+        "input '{}': journal `match` requires `FIELD=value` shape (got \"{}\") — each match \
+         string must contain '='; see `docs/src/inputs/journal.md` for the filter combining rules",
+        input_name, offending
+    );
+    let mut d = Diagnostic::error_kind(DiagKind::PropertySchema, msg);
+    d.span = span;
+    d
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::check::analyze;
+    use crate::dsl::parser::parse_config;
+    use crate::dsl::span::SourceMap;
+
+    fn analyze_str(src: &str) -> Vec<Diagnostic> {
+        let cfg = parse_config(src).expect("config should parse");
+        let compiled = CompiledConfig::from_config(cfg).expect("compile");
+        let mut sm = SourceMap::new();
+        sm.add_anonymous(src);
+        analyze(&compiled, &sm)
+    }
+
+    fn match_format_errors(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+        diags
+            .iter()
+            .filter(|d| {
+                d.level == crate::check::Level::Error
+                    && d.message.contains("journal `match` requires `FIELD=value`")
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "journal")]
+    #[test]
+    fn rejects_match_string_without_equals() {
+        // Format validation is the whole point of this analyzer.
+        // `logger -t foo` is fine; the operator config is not.
+        let src = r#"
+def input j { type journal match "no_equals_here" }
+def output o { type file path "/tmp/o.log" }
+def pipeline p { input j; output o }
+"#;
+        let diags = analyze_str(src);
+        let errs = match_format_errors(&diags);
+        assert_eq!(errs.len(), 1, "got: {:?}", diags);
+        assert!(errs[0].message.contains("\"no_equals_here\""));
+    }
+
+    #[cfg(feature = "journal")]
+    #[test]
+    fn accepts_valid_match_string() {
+        let src = r#"
+def input j { type journal match "SYSLOG_IDENTIFIER=app" }
+def output o { type file path "/tmp/o.log" }
+def pipeline p { input j; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            match_format_errors(&diags).is_empty(),
+            "valid `FIELD=value` must not error; got: {:?}",
+            diags
+        );
+    }
+
+    #[cfg(feature = "journal")]
+    #[test]
+    fn accepts_multiple_valid_match_strings() {
+        // Repeatable `match` — every one must be validated.
+        let src = r#"
+def input j {
+    type journal
+    match "SYSLOG_IDENTIFIER=app1"
+    match "SYSLOG_IDENTIFIER=app2"
+    match "_UID=1000"
+}
+def output o { type file path "/tmp/o.log" }
+def pipeline p { input j; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            match_format_errors(&diags).is_empty(),
+            "all three valid match strings must pass; got: {:?}",
+            diags
+        );
+    }
+
+    #[cfg(feature = "journal")]
+    #[test]
+    fn rejects_mixed_valid_and_invalid_match_strings() {
+        // A valid earlier match must not mask a later malformed one —
+        // operators should see every bad filter in one pass.
+        let src = r#"
+def input j {
+    type journal
+    match "SYSLOG_IDENTIFIER=app"
+    match "typo_here"
+    match "_UID=1000"
+}
+def output o { type file path "/tmp/o.log" }
+def pipeline p { input j; output o }
+"#;
+        let diags = analyze_str(src);
+        let errs = match_format_errors(&diags);
+        assert_eq!(errs.len(), 1, "got: {:?}", diags);
+        assert!(errs[0].message.contains("\"typo_here\""));
+    }
+
+    #[test]
+    fn ignores_match_property_on_non_journal_inputs() {
+        // `match` is a journal-input-only property. The syslog / http
+        // / etc. modules do not have it; if they ever gain a
+        // similarly-named property with different semantics the
+        // analyzer must not misfire.
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type file path "/tmp/o.log" }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            match_format_errors(&diags).is_empty(),
+            "non-journal inputs must not trip the match format check; got: {:?}",
+            diags
+        );
+    }
+}

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -39,6 +39,8 @@ pub mod expr_types;
 mod function;
 mod global_props;
 pub mod graph;
+#[cfg(feature = "journal")]
+mod journal_match_format;
 mod module_props;
 mod outputs;
 mod parser_effects;
@@ -286,6 +288,8 @@ pub fn analyze(config: &CompiledConfig, _source_map: &SourceMap) -> Vec<Diagnost
     function::check_all_functions(config, &registry, &mut diagnostics);
     module_props::analyze_all(config, &module_registry, &mut diagnostics);
     global_props::analyze_all(config, &mut diagnostics);
+    #[cfg(feature = "journal")]
+    journal_match_format::analyze_all(config, &mut diagnostics);
     recovery_readiness::analyze_all(config, &mut diagnostics);
     tls_verify::analyze_all(config, &mut diagnostics);
     for (name, pipeline) in &config.pipelines {

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -55,7 +55,13 @@ const JOURNAL_INPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
         name: "match",
         required: false,
-        repeatable: false,
+        // Repeatable so operators can express both AND (across
+        // different fields) and OR (repeat the same field). libsystemd's
+        // `sd_journal_add_match` treats consecutive calls with the same
+        // FIELD name as disjunctive (OR) and calls across different
+        // FIELD names as conjunctive (AND); see `docs/src/inputs/journal.md`
+        // for the operator-facing summary.
+        repeatable: true,
         exclusive_group: None,
         kind: PropertyValueKind::String,
     },
@@ -93,9 +99,41 @@ impl Module for JournalInput {
         _ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let properties = properties.user_properties();
-        let mut matches = Vec::new();
-        if let Some(m) = props::get_string(properties, "match") {
-            matches.push(m);
+        // Repeatable `match` — walk every occurrence so multi-filter
+        // configs (`match "F=a" match "F=b"` for OR, `match "F=a"
+        // match "G=b"` for AND) are all threaded through to
+        // `sd_journal_add_match` at reader start.
+        let matches: Vec<String> = properties
+            .iter()
+            .filter_map(|p| match p {
+                crate::dsl::ast::Property::KeyValue { key, value, .. } if key == "match" => {
+                    match &value.kind {
+                        crate::dsl::ast::ExprKind::StringLit(s) => Some(s.clone()),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Load-time format validation: each match must be
+        // `FIELD=value`. A malformed entry here becomes a hard config
+        // error at daemon startup / `--check` time so operators do
+        // not discover the typo at runtime as an "reader terminated"
+        // log line. `libsystemd` will still reject any well-formed
+        // string it doesn't like (lowercase field name, empty field,
+        // NUL bytes, etc.) at the runtime `match_add` boundary — that
+        // path is handled below in `run_journal_reader`.
+        for m in &matches {
+            if !m.contains('=') {
+                anyhow::bail!(
+                    "input '{}': journal `match` requires `FIELD=value` shape (got \"{}\") — \
+                     each match string must contain '='; see \
+                     `docs/src/inputs/journal.md` for the filter combining rules",
+                    _name,
+                    m
+                );
+            }
         }
 
         let state_file = props::get_string(properties, "state_file").map(PathBuf::from);
@@ -372,36 +410,73 @@ fn run_journal_reader(
         }
     };
 
-    // Apply match filters (format: "FIELD=value")
+    // Apply match filters. Format was validated at load time
+    // (`from_properties` rejects any string without '='), so
+    // `split_once('=')` here is defensively resolved as `else { … }`
+    // rather than `unwrap()`. libsystemd's `sd_journal_add_match`
+    // rejects field names it doesn't recognise (lowercase, empty,
+    // NUL-containing, etc.) — we collect every rejection so the
+    // operator sees the full list in one pass and terminate the
+    // reader if any filter failed. Semantics: a filter that
+    // libsystemd cannot install matches nothing, so the reader
+    // exiting with zero events *is* the configured behaviour — the
+    // `error!` line is only there so the operator knows which
+    // filter string was refused. Other inputs are unaffected.
+    let mut match_add_failed = false;
     for m in &matches {
-        if let Some((key, val)) = m.split_once('=') {
-            if let Err(e) = journal.match_add(key, val) {
-                warn!("journal: failed to add match '{}': {}", m, e);
-            }
-        } else {
-            warn!(
-                "journal: invalid match format '{}', expected 'FIELD=value'",
+        let Some((key, val)) = m.split_once('=') else {
+            error!(
+                "journal input: match '{}' has no '=' separator — should have been rejected at \
+                 load time; reader terminating",
                 m
             );
+            return;
+        };
+        if let Err(e) = journal.match_add(key, val) {
+            error!(
+                "journal input: match_add rejected filter '{}': {} — this filter cannot be \
+                 satisfied by any journal entry",
+                m, e
+            );
+            match_add_failed = true;
         }
     }
+    if match_add_failed {
+        error!(
+            "journal input: one or more match filters were rejected by libsystemd; reader \
+             terminating (semantics: no journal entry can satisfy the specified configuration, \
+             so zero events is the correct output — fix the offending filter(s) and restart)"
+        );
+        return;
+    }
 
-    // Seek to saved cursor or end
+    // Seek to saved cursor or end.
+    //
+    // First-start (no `state_file` or an empty one) is the case
+    // hardware validation caught previously: with a `match` filter
+    // whose view of the journal is empty at daemon start
+    // (e.g. a brand-new `SYSLOG_IDENTIFIER` that has never been
+    // logged before), `sd_journal_seek_tail` + `sd_journal_previous`
+    // leaves the read pointer in an implementation-defined state and
+    // the poll loop below never advances to new arrivals. Branch on
+    // `previous()`'s return value: on `> 0` we anchored at the last
+    // matching entry (the historical working path); on `0` (empty
+    // match view) fall back to `seek_head` — with no past matching
+    // entries there is no history to replay, and `next()` in the
+    // poll loop cleanly advances to the first newly-arrived entry.
     if let Some(cursor) = state_file.as_ref().and_then(load_cursor) {
         if let Err(e) = journal.seek_cursor(&cursor) {
             warn!(
                 "journal: failed to seek to cursor, starting from end: {}",
                 e
             );
-            let _ = journal.seek_tail();
-            let _ = journal.previous();
+            anchor_at_tail_or_head(&mut journal);
         } else {
-            // Skip the entry at the cursor (already processed)
+            // Skip the entry at the cursor (already processed).
             let _ = journal.next();
         }
     } else {
-        let _ = journal.seek_tail();
-        let _ = journal.previous();
+        anchor_at_tail_or_head(&mut journal);
     }
 
     loop {
@@ -556,6 +631,124 @@ mod tests {
         }
     }
 
+    /// Build a `ModuleProperties` for `type journal` from a raw DSL
+    /// input body — the parser's normal path with the `type` prefix
+    /// stripped by `ModuleProperties`, so `from_properties` sees the
+    /// same shape it does at daemon startup.
+    fn journal_properties_from_body(body: &str) -> crate::dsl::module_props::ModuleProperties {
+        let src = format!(
+            "def input j {{ type journal {} }} def output o {{ type file path \"/tmp/o.log\" }} \
+             def pipeline p {{ input j; output o }}",
+            body
+        );
+        let config = crate::dsl::parser::parse_config(&src).expect("parse should succeed");
+        for def in &config.definitions {
+            if let crate::dsl::ast::Definition::Input(input) = def
+                && input.name == "j"
+            {
+                return input.properties.clone();
+            }
+        }
+        panic!("input 'j' must exist");
+    }
+
+    #[test]
+    fn from_properties_accepts_multiple_match_filters() {
+        // Repeatable `match` — libsystemd combines same-field entries
+        // as OR and different-field entries as AND. The load-time
+        // parser must accept every occurrence so both semantics are
+        // available to operators.
+        let props = journal_properties_from_body(
+            r#"match "SYSLOG_IDENTIFIER=app1" match "SYSLOG_IDENTIFIER=app2" match "_UID=1000""#,
+        );
+        let input = JournalInput::from_properties(
+            "j",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("valid config should parse");
+        assert_eq!(input.matches.len(), 3);
+        assert_eq!(input.matches[0], "SYSLOG_IDENTIFIER=app1");
+        assert_eq!(input.matches[1], "SYSLOG_IDENTIFIER=app2");
+        assert_eq!(input.matches[2], "_UID=1000");
+    }
+
+    #[test]
+    fn from_properties_rejects_match_without_equals_separator() {
+        // Every `match` string must contain `=` (FIELD=value shape).
+        // A typo like `match "SYSLOG_IDENTIFIER app"` (space instead
+        // of `=`) must fail at load time so operators do not
+        // discover the mistake at runtime as a terminated reader.
+        let props = journal_properties_from_body(r#"match "no_equals_separator""#);
+        let err = match JournalInput::from_properties(
+            "j",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        ) {
+            Ok(_) => panic!("malformed match must reject at load time"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no_equals_separator") && msg.contains("FIELD=value"),
+            "reject message must name the offending value and remediation; got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn from_properties_rejects_mixed_valid_and_invalid_match_filters() {
+        // Reject at the first malformed entry even if earlier ones
+        // parse cleanly — an operator with a typo in the second
+        // filter should not have to notice the loud diagnostic buried
+        // between valid ones.
+        let props =
+            journal_properties_from_body(r#"match "SYSLOG_IDENTIFIER=app" match "typo_here""#);
+        let err = match JournalInput::from_properties(
+            "j",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        ) {
+            Ok(_) => panic!("malformed match must reject at load time"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("typo_here"));
+    }
+
+    #[test]
+    fn schema_rejects_unknown_property_on_journal_input() {
+        // Regression pin for the `cursor_file` typo (the correct
+        // property name is `state_file`). Schema validation must
+        // reject any property not listed in `JOURNAL_INPUT_SCHEMA`;
+        // the analyzer produces a `Level::Error` diagnostic
+        // that both `--check` and daemon startup surface.
+        use crate::check::analyze;
+        use crate::dsl::span::SourceMap;
+        use crate::pipeline::CompiledConfig;
+
+        let src = r#"
+def input j { type journal cursor_file "/tmp/j.cursor" }
+def output o { type file path "/tmp/o.log" }
+def pipeline p { input j; output o }
+"#;
+        let config = crate::dsl::parser::parse_config(src).expect("parse should succeed");
+        let compiled = CompiledConfig::from_config(config).expect("compile should succeed");
+        let mut sm = SourceMap::new();
+        sm.add_anonymous(src);
+        let diags = analyze(&compiled, &sm);
+        let unknown_cursor_file = diags.iter().any(|d| {
+            d.level == crate::check::Level::Error
+                && d.message.contains("cursor_file")
+                && d.message.contains("unknown property")
+        });
+        assert!(
+            unknown_cursor_file,
+            "--check must reject `cursor_file` (the correct property is `state_file`) with a \
+             Level::Error diagnostic; got: {:?}",
+            diags
+        );
+    }
+
     #[test]
     fn save_cursor_then_load_round_trips() {
         // The cursor watermark must survive a write+read round-trip.
@@ -588,6 +781,74 @@ mod tests {
             "should not over-sleep wildly; took {:?}",
             elapsed
         );
+    }
+}
+
+/// Anchor the journal read pointer at "just after the last matching
+/// entry" — so the poll loop's `next()` advances to the FIRST entry
+/// that arrives after daemon start, and no history is replayed.
+///
+/// The obvious `seek_tail()` + `previous()` sequence works when the
+/// active `match` view has at least one past entry (`previous`
+/// returns `n > 0`), but silently fails when the view is empty
+/// (`previous` returns `0` and the read pointer is
+/// implementation-defined). Branch on `previous()`'s return so the
+/// empty-match-view case falls through to `seek_head()` — with no
+/// history to replay by definition, `seek_head` + poll-loop `next()`
+/// picks up the first future match cleanly.
+///
+/// Errors are logged (`warn!`) but not fatal: `seek_tail` / `previous`
+/// / `seek_head` failing here means the reader will still call
+/// `next()` in the poll loop against whatever cursor state the
+/// journal actually holds, and the operator will see the log line.
+/// Terminating the reader on a seek error would be stricter than
+/// necessary — the caller already made match_add work, and a poll
+/// loop against an inherited cursor is safer than crashing.
+fn anchor_at_tail_or_head(journal: &mut Journal) {
+    if let Err(e) = journal.seek_tail() {
+        warn!(
+            "journal: seek_tail failed, poll loop will start from whatever position the journal \
+             defaulted to: {}",
+            e
+        );
+        return;
+    }
+    match journal.previous() {
+        Ok(n) if n > 0 => {
+            // Anchored at the last matching entry; the poll loop's
+            // `next()` will advance past it into new arrivals.
+        }
+        Ok(_) => {
+            // Empty match view — no past matching entries. `seek_tail`
+            // may have left the read pointer in an implementation-
+            // defined state, so re-anchor at head. Since the match
+            // view is empty by construction there is no history to
+            // replay; the very next `next()` in the poll loop will
+            // wait until a matching entry actually appears.
+            if let Err(e) = journal.seek_head() {
+                warn!(
+                    "journal: seek_head fallback failed after empty-match previous(); poll loop \
+                     may not detect new matching entries reliably: {}",
+                    e
+                );
+            }
+        }
+        Err(e) => {
+            // Journal-level error walking backward. Fall back to head
+            // for the same reason as the empty-view arm.
+            warn!(
+                "journal: previous() after seek_tail failed ({}) — falling back to seek_head so \
+                 new matching entries are picked up by the poll loop",
+                e
+            );
+            if let Err(e) = journal.seek_head() {
+                warn!(
+                    "journal: seek_head fallback also failed: {} — poll loop may not detect new \
+                     matching entries reliably",
+                    e
+                );
+            }
+        }
     }
 }
 

--- a/crates/limpid/src/modules/input/journal_sys.rs
+++ b/crates/limpid/src/modules/input/journal_sys.rs
@@ -38,6 +38,7 @@ unsafe extern "C" {
     fn sd_journal_previous(j: *mut SdJournal) -> c_int;
     fn sd_journal_add_match(j: *mut SdJournal, data: *const c_void, size: usize) -> c_int;
     fn sd_journal_seek_tail(j: *mut SdJournal) -> c_int;
+    fn sd_journal_seek_head(j: *mut SdJournal) -> c_int;
     fn sd_journal_seek_cursor(j: *mut SdJournal, cursor: *const c_char) -> c_int;
     fn sd_journal_get_cursor(j: *mut SdJournal, cursor: *mut *mut c_char) -> c_int;
     fn sd_journal_get_realtime_usec(j: *mut SdJournal, ret: *mut u64) -> c_int;
@@ -121,6 +122,19 @@ impl Journal {
         let rc = unsafe { sd_journal_seek_tail(self.ptr) };
         if rc < 0 {
             bail!("sd_journal_seek_tail failed: {}", errno_msg(rc));
+        }
+        Ok(())
+    }
+
+    /// Position the read pointer before the first (matching) journal
+    /// entry. Used by the first-start anchoring fallback when the
+    /// active `match` view has no past entries — see
+    /// `run_journal_reader::anchor_at_tail_or_head` for the seek
+    /// semantics rationale.
+    pub fn seek_head(&mut self) -> Result<()> {
+        let rc = unsafe { sd_journal_seek_head(self.ptr) };
+        if rc < 0 {
+            bail!("sd_journal_seek_head failed: {}", errno_msg(rc));
         }
         Ok(())
     }

--- a/docs/src/inputs/journal.md
+++ b/docs/src/inputs/journal.md
@@ -24,9 +24,21 @@ def input system {
 
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `match` | no | none | Journal match filter (e.g., `SYSLOG_FACILITY=10`) |
+| `match` | no | none | Journal match filter (`FIELD=value`, e.g. `SYSLOG_FACILITY=10`). Repeatable — see [match combining rules](#match-combining-rules) for AND / OR semantics. |
 | `state_file` | no | none | Path to persist journal cursor (survives restarts) |
 | `poll_interval` | no | `1s` | How often to poll for new entries |
+
+### `match` combining rules
+
+`match` is repeatable. libsystemd's `sd_journal_add_match` combines
+consecutive filters by the field name:
+
+- **Same field name → OR.** `match "SYSLOG_IDENTIFIER=app1" match "SYSLOG_IDENTIFIER=app2"` matches entries whose `SYSLOG_IDENTIFIER` is either `app1` or `app2`.
+- **Different field names → AND.** `match "SYSLOG_IDENTIFIER=app" match "_UID=1000"` matches only entries whose `SYSLOG_IDENTIFIER` is `app` **and** whose `_UID` is `1000`.
+
+Field names are the ones journald uses internally (`SYSLOG_IDENTIFIER`, `_UID`, `_SYSTEMD_UNIT`, `PRIORITY`, `MESSAGE`, …) — see `systemd.journal-fields(7)`. `journalctl -o json` shows the full field set for any entry you want to filter on.
+
+Format is validated at daemon startup / `--check` time — every match string must contain `=`, and each token before / after the separator is treated as an opaque byte sequence handed to libsystemd. libsystemd rejects field names it doesn't accept (lowercase, empty, non-printable, NUL-containing, etc.) at the runtime `sd_journal_add_match` boundary; the journal input **logs the rejected filter and terminates the reader** rather than continuing without the filter (a filter that libsystemd cannot install matches nothing, so zero events is the semantically correct output — fix the filter and restart the daemon).
 
 ## Wire format
 


### PR DESCRIPTION
## Summary

Hardware validation surfaced a case where the journal input's `match` property silently produced zero events. Config passed `--check`, daemon started, `journal input started` was logged, then nothing arrived at the output — even when `journalctl -t <tag>` clearly showed the expected records.

Investigation isolated three separate bugs; this PR fixes all three plus adds load-time / `--check`-time format validation.

### Bug 1 — empty match view leaves the read pointer in an implementation-defined state (root cause)

The reader's first-start anchoring did `seek_tail()` + `previous()` and swallowed both return values. With a `match` filter whose view of the journal has no past matching entries (e.g. a brand-new `SYSLOG_IDENTIFIER` that has never been logged), `previous()` returns `0` and the read pointer's state is undefined. The poll loop's subsequent `next()` never surfaces new arrivals.

Fix: branch on `previous()`'s return value. `> 0` keeps the historical working path; `0` falls through to `sd_journal_seek_head()`, which is safe by construction (empty match view has no history to replay) and gives the poll loop a well-defined starting cursor.

### Bug 2 — `match_add` failure was warn-then-continue, meaning unfiltered over-delivery

`sd_journal_add_match` rejects field names it doesn't accept (lowercase, empty, non-printable, etc.). The pre-fix code logged a `warn!` and continued into the poll loop **without the filter applied**, so a rejected filter for one application quietly expanded into the whole host's log stream.

Fix: collect every failed `match_add` in one pass, emit `error!` naming each rejected filter string, then terminate the reader. Semantic model: if libsystemd can't install the filter, no journal entry can ever satisfy it — so the correct output is zero events, not "everything unfiltered". The reader terminates rather than the daemon shutting down; per-input config bugs don't take out unrelated inputs.

### Bug 3 — `match` was single-valued at the schema layer

`repeatable: false` limited configs to one filter. libsystemd's combining rules (same field OR, different field AND) are the standard way operators express "SYSLOG_IDENTIFIER=app1 OR app2" or "SYSLOG_IDENTIFIER=app AND _UID=1000". Flipped to `repeatable: true` and documented the AND/OR semantics in `docs/src/inputs/journal.md` — otherwise the change would just be a new silent surprise.

### Load-time / `--check`-time format validation

Every `match` must be `FIELD=value`. Validation runs at two boundaries: `JournalInput::from_properties` (daemon startup fail-fast) and a new analyzer `check::journal_match_format` gated behind `--features journal` (catches typos in CI). Matches the `error_log_fallback` value-validation pattern added earlier this cycle.

### FFI addition

`journal_sys` gains a `seek_head` binding to `sd_journal_seek_head`, mirroring the existing `seek_tail`. Needed by the empty-match-view fallback in the fix.

## Test plan

- [x] `cargo test -p limpid` (macOS): 846 passed / 0 failed / 1 ignored
- [x] `cargo test -p limpid --features journal` (playground aarch64 Ubuntu): 862 passed / 0 failed / 1 ignored (+8 new)
- [x] `cargo clippy -p limpid --all-targets -- -D warnings`: clean
- [x] `cargo check -p limpid --features kafka`: clean
- [x] `cargo fmt --check -p limpid`: clean
- [x] `mdbook build`: clean
- [x] Playground real-journald validation: `match "SYSLOG_IDENTIFIER=<unique-never-logged-tag>"` + fresh daemon start + `logger -t <tag>` → output file receives records (pre-fix: 0 records, post-fix: 2/2 records)
