### PR TITLE
docs: align kafka + systemd docs with packaged unit; retire tracing-fallback false-assurance from source docstrings and peripheral guides

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -292,8 +292,12 @@ impl ErrorLogFallback {
 ///
 /// Built once at runtime startup from the `error_log` property in the
 /// `control { ... }` block. Wrapped in `Option` upstream — when not
-/// configured, the runtime falls back to a structured `tracing::error!`
-/// line so the failure data is never silently lost.
+/// configured, the operator has declared no durable recovery is
+/// required and the runtime emits a payload-free summary via the
+/// `error_log_fallback` ladder helper (`emit_dlq_tracing_fallback`).
+/// The ladder line is a best-effort operator signal, not a load-bearing
+/// recovery target; `error_log_fallback "full"` is the explicit
+/// opt-in for the pre-ladder `event_record` shape.
 pub struct ErrorLogWriter {
     path: PathBuf,
     /// Serialises concurrent `write()` calls so that records from

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -34,12 +34,14 @@ pub struct PipelineMetrics {
     pub events_discarded: AtomicU64,
     /// Events for which a `process` statement raised a runtime error
     /// (unknown identifier, type mismatch, regex compile failure, …).
-    /// The event is routed to the dead-letter queue (configured
-    /// `error_log` JSONL file, or a structured `tracing::error!` line
-    /// when no DLQ is configured) rather than forwarded with the
-    /// original ingress unchanged. Distinct from `events_discarded`
-    /// so operators can tell a config-bug-shaped routing miss apart
-    /// from a logic-bug-shaped runtime failure.
+    /// The event is routed to the dead-letter queue: the configured
+    /// `error_log` JSONL file when set, or — when unset — a
+    /// payload-free tracing summary via the `error_log_fallback`
+    /// ladder (`emit_dlq_tracing_fallback` helper; `Meta` / `Full`
+    /// upgrade the line only on explicit operator opt-in). Distinct
+    /// from `events_discarded` so operators can tell a config-bug-
+    /// shaped routing miss apart from a logic-bug-shaped runtime
+    /// failure.
     pub events_errored: AtomicU64,
     /// Subset of `events_errored` for which the configured
     /// `error_log` write itself failed (disk full, permissions,

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -411,7 +411,10 @@ pub struct PipelineRunResult {
     /// the runtime layer appends per-failed-output enqueue records
     /// (one per failed output). The runtime drains each record into
     /// the configured `error_log`, or — when none is configured —
-    /// emits one structured `tracing::error!` line per record.
+    /// delegates to the `error_log_fallback` ladder helper to emit a
+    /// payload-free operator signal by default (or `Meta` / `Full`
+    /// on explicit opt-in). The tracing line is best-effort, not
+    /// load-bearing recovery.
     pub errored: Vec<ErroredEventContext>,
 }
 

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -772,8 +772,11 @@ async fn process_event(
 }
 
 /// Persist an errored event to the dead-letter queue, or — if no
-/// `error_log` is configured — emit a structured tracing line so the
-/// record never disappears silently.
+/// `error_log` is configured — delegate to the `error_log_fallback`
+/// ladder helper so the failure surfaces as a payload-free operator
+/// signal by default (or as `Meta` / `Full` on explicit opt-in). The
+/// tracing line is best-effort, not a durable recovery trail; the
+/// DLQ file remains the load-bearing recovery target.
 ///
 /// Shared by both runtime-error shapes the orchestrator surfaces:
 /// `PipelineTermination::Errored` (a `process` raised an error mid-

--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -25,6 +25,7 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 RuntimeDirectory=limpid
+RuntimeDirectoryMode=0750
 StateDirectory=limpid
 ConfigurationDirectory=limpid
 
@@ -54,10 +55,14 @@ WantedBy=multi-user.target
 
 The full unit (`packaging/limpid.service`) carries a comment above each
 directive explaining why it's safe for limpid's inputs/outputs; this
-page shows the trimmed shape. Notably `PrivateDevices=yes` gives the
-unit a private `/dev` without the host's `/dev/log` — see [Adding write
-paths](#adding-write-paths) below for the `/dev/log` and extra
-`ReadWritePaths` drop-ins.
+page shows the trimmed shape but keeps the trust-boundary-relevant
+directives. `RuntimeDirectoryMode=0750` is one of those: the daemon's
+control-socket parent-directory preflight refuses to bind under a
+group- or world-writable parent, so the trimmed unit must set the mode
+explicitly rather than rely on systemd's `0755` default. Notably
+`PrivateDevices=yes` gives the unit a private `/dev` without the
+host's `/dev/log` — see [Adding write paths](#adding-write-paths)
+below for the `/dev/log` and extra `ReadWritePaths` drop-ins.
 
 ## Key features
 

--- a/docs/src/outputs/kafka.md
+++ b/docs/src/outputs/kafka.md
@@ -96,7 +96,11 @@ omit both for one-way TLS.
 
 The `password_file` is read once at daemon start; rotate it and restart
 the daemon to refresh credentials. `chmod 600` it and ensure the file
-is owned by the limpid user. A trailing newline is stripped (`\r\n`,
+is owned by (or at least readable by) the daemon's service user — under
+the packaged systemd unit that is `syslog` (`User=syslog Group=syslog`
+in `limpid.service`), so a `password_file` at `/etc/limpid/kafka.pw`
+should be `syslog:syslog 0600`. Custom deploys should substitute
+whichever user the daemon runs as. A trailing newline is stripped (`\r\n`,
 bare `\n`, and bare `\r` are all handled), so `echo "secret" >
 /etc/limpid/kafka.pw` works as expected and a CRLF-terminated file from
 a Windows host authenticates correctly. An empty file is rejected —
@@ -167,7 +171,7 @@ Routing decisions stay in the pipeline body; the output configs stay static and 
 ## Notes
 
 - rdkafka handles batching and compression internally — no manual batch configuration needed (unlike [http](./http.md)).
-- On shutdown, the producer flushes pending messages (up to 5 seconds).
+- On graceful shutdown (`SIGTERM`, `SIGHUP` reload, `systemctl stop`), the producer hands each pending message to librdkafka via `try_send`; the pending-envelope wait is bounded by librdkafka's own `queue_timeout` and `message.timeout.ms` (there is no additional outer 5-second wrapper — a previous version had one and it was removed because it cut librdkafka's delivery attempt short at the wire boundary, producing ambiguous outcomes). A message whose `try_send` cannot complete before shutdown routes through the ambiguous DLQ path — `Dropped` on a disk queue so the fail-stop wedge holds the cursor for next-start reconciliation, folded to `Recovered` on a memory queue for lack of a replay path. A DLQ record is written for reconciliation in either case.
 - The internal delivery timeout (`message.timeout.ms`) is 30 seconds. If a message can't be delivered within that time, it's returned as an error and the output's `retry { ... }` budget (driven inside `consume()`) handles re-delivery. On retry exhaustion the payload routes to `control { error_log "..." }` as an Output-flavor DLQ record; see [Outputs → Recovery (error_log)](./README.md#recovery-error_log).
 
 ## Example

--- a/docs/src/pipelines/drop-finish-error.md
+++ b/docs/src/pipelines/drop-finish-error.md
@@ -111,7 +111,7 @@ def pipeline main {
 
 In every case the event is *not* forwarded downstream — at the failure point the runtime has no way to produce a correct egress, and the pre-0.5 behaviour of forwarding the original `ingress` silently turned wrap / enrichment bugs into data-shape regressions at the receiving SIEM. Instead, the event is routed to the [error log](../operations/error-log.md) so operators can inspect, fix the offending config, and replay.
 
-`events_errored_unwritable` is the subset where the DLQ write itself failed (disk full, permissions, rotation race). The runtime falls back to a structured `tracing::error!` line, but operators should alarm on this counter — a non-zero value means the replay path may be incomplete.
+`events_errored_unwritable` is the subset where the DLQ write itself failed (disk full, permissions, rotation race). The tracing line the runtime emits on that path is shaped by the operator's `error_log_fallback` [ladder](../operations/error-log.md#tracing-fallback-ladder-error_log_fallback) — payload-free summary by default, `Meta` / `Full` only on explicit opt-in — so the counter is the operator alarm signal for the loss rather than a durable trace of the payload, and a non-zero value means the replay path may be incomplete regardless of the ladder state.
 
 ## Example: filtering + routing
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -184,9 +184,12 @@ DLQ on day one and decides whether to extend the snippet or update
 the upstream allow-list.
 
 The DLQ entries are JSONL via `control { error_log "..." }`; without
-that, errors fall back to a structured `tracing::error!` line.
-Configure the error log path explicitly so unsupported-vocabulary
-events don't silently scroll off journald.
+that, errors fall back to a payload-free `tracing::error!` summary
+line (the [`error_log_fallback`
+ladder](../operations/error-log.md#tracing-fallback-ladder-error_log_fallback)'s
+default). Set `error_log` explicitly so unsupported-vocabulary events
+land in a replayable file rather than a summary-only signal on
+journald.
 
 ## Per-parser status
 


### PR DESCRIPTION
## Summary

Pre-tag docs drift fixes surfaced by a post-CHANGELOG audit against `release/0.7.9` tip `cecb0db`. Two commits, both docs / docstring only. No behaviour change; the code and packaged unit are already correct.

### Commit 1 — Kafka user / shutdown envelope + systemd RuntimeDirectoryMode

- **Kafka `password_file` owner** (`docs/src/outputs/kafka.md`): "owned by the limpid user" → daemon service user (packaged unit runs as `syslog`, so `syslog:syslog 0600` is the copy-pasteable healthy shape). Hardware validation actually surfaced this — a tester's SASL password placed under a user home the packaged `syslog` daemon could not read failed at startup.
- **Kafka shutdown envelope** (`docs/src/outputs/kafka.md`): "up to 5 seconds" → librdkafka-owned wait via `queue_timeout` / `message.timeout.ms`, with shutdown-cancelled sends routing through the ambiguous DLQ path. Earlier in the cycle the outer 5-second wrapper was removed because it cut librdkafka's delivery attempt short at the wire boundary; a structural pin in the kafka module already forbids re-introducing it.
- **systemd trimmed unit** (`docs/src/operations/systemd.md`): `RuntimeDirectoryMode=0750` restored, with a sentence explaining why the trimmed unit still has to carry that directive (control-socket parent-directory preflight refuses to bind under a group- or world-writable parent, and systemd's default `RuntimeDirectory` mode is `0755`).

### Commit 2 — Source docstrings + peripheral docs false-assurance retirement

Four source docstrings and two operator-guide pages still promised "the failure data is never silently lost" / "the record never disappears silently" / "the runtime emits one structured tracing line per record" as if that were the recovery contract. Earlier commits on this branch replaced the pre-ladder unconditional `event_record` shape with the `error_log_fallback` ladder (default payload-free summary); the main docs and sink-side helper docstrings were rewritten alongside the code but these edge sites were not. This commit brings them into lockstep:

- `crates/limpid/src/error_log.rs` (`ErrorLogWriter` type doc)
- `crates/limpid/src/runtime.rs` (`write_errored_to_dlq` docstring)
- `crates/limpid/src/metrics.rs` (`PipelineMetrics::events_errored` field doc — highest-traffic reference since operators design alerting around it)
- `crates/limpid/src/pipeline.rs` (`PipelineRunResult::errored` field doc)
- `docs/src/pipelines/drop-finish-error.md` (`events_errored_unwritable` paragraph)
- `docs/src/snippets/README.md` (DLQ note)

## Test plan

- [x] `cargo test -p limpid` (macOS): 846 passed / 0 failed / 1 ignored
- [x] `cargo clippy -p limpid --all-targets -- -D warnings`: clean
- [x] `cargo check -p limpid --features kafka`: clean
- [x] `cargo fmt --check -p limpid`: clean
- [x] `mdbook build`: clean

`CHANGELOG.md` is intentionally not in this PR — it's being reshaped separately.
