### PR TITLE
fix(modules/output): read NSS lookup results via MaybeUninit::assume_init (CodeQL)

### DIFF
--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -1119,10 +1119,17 @@ fn resolve_uid(name: &str) -> Result<u32> {
     if result.is_null() {
         anyhow::bail!("user '{}' not found", name);
     }
-    // SAFETY: `result` is non-null and points into the `pwd` storage we
-    // just initialised via `getpwnam_r`; the pw_uid field is a plain
-    // numeric copy and outlives the borrow on `pwd`/`buf`.
-    Ok(unsafe { (*result).pw_uid })
+    // SAFETY: `getpwnam_r` returned success (`rc == 0`) and `result`
+    // is non-null, which by the contract of `getpwnam_r(3)`
+    // guarantees `pwd` has been fully written with a valid
+    // `libc::passwd` — `result` and `pwd.as_ptr()` point to the same
+    // memory. Reading through the initialised `MaybeUninit` (rather
+    // than dereferencing the raw `*result`) promotes the
+    // "libc initialised this" guarantee to the type system so static
+    // analysis (CodeQL, miri, etc.) can see the initialisation
+    // without having to reason about the FFI contract.
+    let pwd = unsafe { pwd.assume_init() };
+    Ok(pwd.pw_uid)
 }
 
 /// Resolve a group name to its gid via `getgrnam_r`. Same thread-
@@ -1149,8 +1156,14 @@ fn resolve_gid(name: &str) -> Result<u32> {
     if result.is_null() {
         anyhow::bail!("group '{}' not found", name);
     }
-    // SAFETY: same as in `resolve_uid`.
-    Ok(unsafe { (*result).gr_gid })
+    // SAFETY: same as in `resolve_uid`. `getgrnam_r(3)` has the
+    // identical `rc == 0 && !result.is_null() ⇒ storage initialised`
+    // contract as its `getpwnam_r` sibling; reading through the
+    // initialised `MaybeUninit` promotes the guarantee to the type
+    // system so static analysis (CodeQL, miri, etc.) can see the
+    // initialisation without having to reason about the FFI contract.
+    let grp = unsafe { grp.assume_init() };
+    Ok(grp.gr_gid)
 }
 
 #[cfg(test)]

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -406,9 +406,17 @@ fn resolve_uid(name: &str) -> Result<u32> {
     if result.is_null() {
         anyhow::bail!("user '{}' not found", name);
     }
-    // SAFETY: `result` is non-null and points into `pwd`; pw_uid is
-    // a plain numeric copy that outlives the borrow.
-    Ok(unsafe { (*result).pw_uid })
+    // SAFETY: `getpwnam_r` returned success (`rc == 0`) and `result`
+    // is non-null, which by the contract of `getpwnam_r(3)`
+    // guarantees `pwd` has been fully written with a valid
+    // `libc::passwd` — `result` and `pwd.as_ptr()` point to the same
+    // memory. Reading through the initialised `MaybeUninit` (rather
+    // than dereferencing the raw `*result`) promotes the
+    // "libc initialised this" guarantee to the type system so static
+    // analysis (CodeQL, miri, etc.) can see the initialisation
+    // without having to reason about the FFI contract.
+    let pwd = unsafe { pwd.assume_init() };
+    Ok(pwd.pw_uid)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

CodeQL flagged `crates/limpid/src/modules/output/unix_socket.rs:411`'s `Ok(unsafe { (*result).pw_uid })` as "access of invalid pointer". The identical shape exists in `crates/limpid/src/modules/output/file.rs` (`resolve_uid`, `resolve_gid`), so all three sites are updated together to avoid asymmetric safety-comment shapes and a second alert on the next scan.

The runtime behaviour of `getpwnam_r`/`getgrnam_r` is unchanged. `rc == 0 && !result.is_null()` still guards the read; the difference is that the read now goes through `MaybeUninit::assume_init()` rather than `unsafe { (*result).field }`. Both refer to the same caller-owned storage, but the `MaybeUninit` form promotes the "libc initialised this" guarantee to the type system so CodeQL / miri can see the initialisation without having to reason about the FFI contract.

## Sites changed

- `crates/limpid/src/modules/output/unix_socket.rs::resolve_uid` — CodeQL alert.
- `crates/limpid/src/modules/output/file.rs::resolve_uid` — same shape, would fire the same alert next scan.
- `crates/limpid/src/modules/output/file.rs::resolve_gid` — same shape with `libc::group` / `getgrnam_r`.

## Test plan

- [x] `cargo test -p limpid`: 846 passed / 0 failed / 1 ignored
- [x] `cargo clippy -p limpid --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check -p limpid`: clean
- [x] `grep -rn '(\*result)\.pw_\|(\*result)\.gr_' crates/limpid/src`: 0 hits
- [ ] CodeQL scan on this branch clears the "Access of invalid pointer" alert
