### PR TITLE
docs(release-0.7.9): DLQ fallback wording + http.rs verbatim doc + fallback_str rename + CI cache-write gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
 # `Swatinem/rust-cache` works in read-only fallback without an explicit
 # `actions: write` grant — fine for a solo-dev workflow where the
 # cache hit rate is acceptable. No GitHub API writes from this job.
+#
+# Cache saves are gated on non-PR events (see `save-if:` on each
+# `Swatinem/rust-cache` step below). PR runs can still restore an
+# existing cache but cannot write one back, so a hostile PR cannot
+# poison the cache that a subsequent trusted `push` run would restore.
 permissions:
   contents: read
 
@@ -32,6 +37,8 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # pin-audit:2026-05-21 e18b497 | v2
+        with:
+          save-if: ${{ github.event_name != 'pull_request' }}
 
       - name: Build
         run: cargo build --workspace
@@ -94,6 +101,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # pin-audit:2026-05-21 e18b497 | v2
         with:
           key: kafka-journal
+          save-if: ${{ github.event_name != 'pull_request' }}
 
       - name: Build (kafka + journal)
         run: cargo build --workspace --features kafka,journal
@@ -131,6 +139,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # pin-audit:2026-05-21 e18b497 | v2
         with:
           key: supply-chain
+          save-if: ${{ github.event_name != 'pull_request' }}
 
       # 0.18.6 is the minimum that parses CVSS v4.0 advisories in
       # the RustSec database — 0.16.x errors on entries with the

--- a/crates/limpid/src/check/recovery_readiness.rs
+++ b/crates/limpid/src/check/recovery_readiness.rs
@@ -121,7 +121,7 @@ pub(super) fn analyze_all(config: &CompiledConfig, diags: &mut Vec<Diagnostic>) 
     // Warn — not error — because the shape harmlessly appears in
     // shared-template configs where individual environments
     // deactivate `error_log`.
-    if let Some(ref fallback_str) = fallback_str
+    if let Some(ref fallback_val) = fallback_str
         && !error_log_configured(config)
     {
         diags.push(Diagnostic {
@@ -134,7 +134,7 @@ pub(super) fn analyze_all(config: &CompiledConfig, diags: &mut Vec<Diagnostic>) 
                  metadata surface on the tracing side when the DLQ write itself \
                  fails), or remove control.error_log_fallback to silence this \
                  warning.",
-                fallback_str
+                fallback_val
             ),
             span: None,
             help: None,

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -1024,10 +1024,11 @@ pub(crate) fn emit_dlq_tracing_fallback(
                 fallback = "full",
                 event_record = %ctx.to_jsonl(),
                 reason = reason,
-                "{} '{}' (site '{}'): error_log write failed: {} — routing as Dropped \
-                 so the disk queue holds the cursor for replay; event_record below \
-                 carries the full JSONL (error_log_fallback = full — payload may \
-                 reach journald / log aggregation)",
+                "{} '{}' (site '{}'): error_log write failed: {} — routing as Dropped; \
+                 the final disposition (queue-cursor hold for replay vs. terminal \
+                 loss) depends on the queue backend and is applied on the ack side. \
+                 event_record below carries the full JSONL (error_log_fallback = \
+                 full — payload may reach journald / log aggregation)",
                 kind,
                 name,
                 site,

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -175,10 +175,12 @@ struct HttpPeer {
 }
 
 /// Transport policy plugged into the shared [`BatchedSink`] skeleton:
-/// render = lossy UTF-8 of `event.egress`, prepare = newline join +
-/// optional gzip, send = one attempt against the next rotation
-/// candidate. Buffering, retry, and the shutdown lifecycle live in
-/// `crate::modules::output::batched`.
+/// render = verbatim (byte-preserving) `event.egress` bytes,
+/// prepare = newline join + optional gzip, send = one attempt against
+/// the next rotation candidate. Buffering, retry, and the shutdown
+/// lifecycle live in `crate::modules::output::batched`. Binary payload
+/// fidelity is pinned by `http_output_forwards_non_utf8_egress_verbatim` —
+/// do NOT re-introduce a `from_utf8_lossy` here.
 struct HttpSinkPolicy {
     peers: Vec<HttpPeer>,
     /// Round-robin cursor + per-peer failure cooldown; one candidate


### PR DESCRIPTION
## Summary

Four narrow follow-ups from the aggregate review pass on release/0.7.9. All docs-shaped or CI-shaped — no functional change to the packaged binary.

- **`modules/mod.rs::emit_dlq_tracing_fallback`** — the `Full` arm's error line asserted "routing as Dropped so the disk queue holds the cursor for replay", but the helper is queue-agnostic and gets reached from memory-queue paths where `Dropped` is folded back to a recovered ack. The updated wording says the final disposition depends on the backend and is applied on the ack side. Deliberately worded without naming the ack-side helper so the structural pin test `ladder_helper_does_not_touch_ack_disposition` still holds.
- **`modules/output/http.rs::HttpSinkPolicy` doc** — `render = lossy UTF-8` was stale (the impl is `Ok(event.egress.clone())` and `http_output_forwards_non_utf8_egress_verbatim` pins verbatim behaviour). Docstring now says `render = verbatim (byte-preserving)` and names the pin test.
- **`check/recovery_readiness.rs::analyze_all`** — inner `if let Some(ref fallback_str) = fallback_str` shadowed the outer binding of the same name. Renamed to `fallback_val` for readability; behaviour unchanged.
- **`.github/workflows/ci.yml`** — three `Swatinem/rust-cache` steps (`check`, `check-kafka`, `supply-chain`) had no `save-if`, so PR runs could write cache that later trusted `push` runs would restore. Each now carries `save-if: ${{ github.event_name != 'pull_request' }}`. Comment near `permissions:` documents the asymmetry.

## Test plan

- [x] `cargo test -p limpid`: 846 passed / 0 failed / 1 ignored (`cli_check` 27/27)
- [x] `cargo clippy -p limpid --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] `cargo check -p limpid --features kafka`: clean
- [x] YAML parse (`.github/workflows/ci.yml`): PASS
- [ ] CI on this PR shows the `save-if` gate evaluated to `false` on the `pull_request` run (visible in the rust-cache step output)
