### PR TITLE
fix(release-0.7.9): single-segment type ident, Id128 alignment, journal previous() Err no seek_head

### DIFF
--- a/crates/limpid/src/dsl/module_props.rs
+++ b/crates/limpid/src/dsl/module_props.rs
@@ -120,7 +120,11 @@ impl ModuleProperties {
                     value_span,
                     ..
                 } => {
-                    let Some(first) = parts.first() else {
+                    // Single-segment idents only. `type kafka.output` is
+                    // rejected as `NonIdent` — otherwise the multi-segment
+                    // `ident_path` from the grammar would silently truncate
+                    // to the first segment and resolve as `kafka`.
+                    let [first] = parts.as_slice() else {
                         return Err(ModulePropertyError::NonIdent { span: *value_span });
                     };
                     if type_name.is_some() {
@@ -244,6 +248,28 @@ mod tests {
     fn parse_rejects_non_ident_type_block() {
         // `type { ... }` — block instead of value
         let raw = vec![block("type")];
+        let err = ModuleProperties::parse(raw).expect_err("should fail");
+        assert!(matches!(err, ModulePropertyError::NonIdent { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_multi_segment_type_ident() {
+        // `type kafka.output` — the parser produces
+        // `ExprKind::Ident(vec!["kafka", "output"])` via the `ident_path`
+        // rule. `parse` must reject this rather than silently truncating
+        // to the first segment.
+        let raw = vec![kv(
+            "type",
+            ExprKind::Ident(vec!["kafka".into(), "output".into()]),
+        )];
+        let err = ModuleProperties::parse(raw).expect_err("should fail");
+        assert!(matches!(err, ModulePropertyError::NonIdent { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_empty_ident_path() {
+        // Defensive: `Ident(vec![])` should also fail as `NonIdent`.
+        let raw = vec![kv("type", ExprKind::Ident(vec![]))];
         let err = ModuleProperties::parse(raw).expect_err("should fail");
         assert!(matches!(err, ModulePropertyError::NonIdent { .. }));
     }

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -793,9 +793,17 @@ def pipeline p { input j; output o }
 /// returns `n > 0`), but silently fails when the view is empty
 /// (`previous` returns `0` and the read pointer is
 /// implementation-defined). Branch on `previous()`'s return so the
-/// empty-match-view case falls through to `seek_head()` — with no
-/// history to replay by definition, `seek_head` + poll-loop `next()`
-/// picks up the first future match cleanly.
+/// empty-match-view case (`Ok(0)`) falls through to `seek_head()` —
+/// with no history to replay by definition, `seek_head` + poll-loop
+/// `next()` picks up the first future match cleanly.
+///
+/// A `previous()` **error** is deliberately NOT treated the same way:
+/// `Err` does not imply an empty view — a non-empty view can also
+/// error here — and `seek_head` on a non-empty view would replay
+/// every past matching entry. On `Err` we keep the tail-anchored
+/// position established by the preceding `seek_tail()` and let the
+/// poll loop's `next()` advance from there; the operator sees the
+/// warn line.
 ///
 /// Errors are logged (`warn!`) but not fatal: `seek_tail` / `previous`
 /// / `seek_head` failing here means the reader will still call
@@ -834,20 +842,17 @@ fn anchor_at_tail_or_head(journal: &mut Journal) {
             }
         }
         Err(e) => {
-            // Journal-level error walking backward. Fall back to head
-            // for the same reason as the empty-view arm.
+            // Journal-level error walking backward. Do NOT fall back
+            // to `seek_head`: the view may be non-empty, and re-
+            // seeking to head would replay historical matching
+            // entries. Keep the tail-anchored position from
+            // `seek_tail()` and let the poll loop's `next()` advance
+            // from there.
             warn!(
-                "journal: previous() after seek_tail failed ({}) — falling back to seek_head so \
-                 new matching entries are picked up by the poll loop",
+                "journal: previous() after seek_tail failed ({}) — keeping the tail-anchored \
+                 position from seek_tail; poll loop will advance from there",
                 e
             );
-            if let Err(e) = journal.seek_head() {
-                warn!(
-                    "journal: seek_head fallback also failed: {} — poll loop may not detect new \
-                     matching entries reliably",
-                    e
-                );
-            }
         }
     }
 }

--- a/crates/limpid/src/modules/input/journal_sys.rs
+++ b/crates/limpid/src/modules/input/journal_sys.rs
@@ -55,13 +55,25 @@ unsafe extern "C" {
     ) -> c_int;
 }
 
-/// `sd_id128_t` — a 16-byte boot/machine identifier. Only its size and
-/// alignment matter here: `Journal::monotonic_timestamp` discards the
-/// value, matching how the sole caller already ignores it.
-#[repr(C)]
+/// `sd_id128_t` — a 16-byte boot/machine identifier. libsystemd
+/// defines it as `union { uint8_t bytes[16]; uint64_t qwords[2]; }`
+/// which picks up 8-byte alignment from the `uint64_t` arm. We mirror
+/// that alignment so out-parameters passed to functions like
+/// `sd_journal_get_monotonic_usec` observe the same ABI shape the C
+/// library expects — a plain `[u8; 16]` under `#[repr(C)]` is
+/// 1-byte-aligned and would be UB on strict-alignment targets when
+/// libc writes through it as a `uint64_t[2]`. Only size and alignment
+/// matter here: `Journal::monotonic_timestamp` discards the value,
+/// matching how the sole caller already ignores it.
+#[repr(C, align(8))]
 struct Id128 {
     _bytes: [u8; 16],
 }
+
+const _: () = {
+    assert!(std::mem::size_of::<Id128>() == 16);
+    assert!(std::mem::align_of::<Id128>() == 8);
+};
 
 /// One field ("NAME=value") from the current journal entry.
 pub struct JournalField<'a> {


### PR DESCRIPTION
## Summary

Three independent findings from the aggregate review pass on release/0.7.9. All narrow correctness / ABI tightenings against the same release cycle; folded into one PR because they validate together as a group.

- **`dsl/module_props::parse` — reject multi-segment `type` idents.** `parse` stored only `parts.first()`, so `type kafka.output` silently truncated to `kafka` and resolved as an unrelated module type. Pattern-match as `[first] = parts.as_slice()`, fall through to the existing `NonIdent` error for empty and multi-segment idents. Two new tests pin the behaviour (`parse_rejects_multi_segment_type_ident`, `parse_rejects_empty_ident_path`).
- **`modules/input/journal_sys::Id128` — match `sd_id128_t`'s 8-byte alignment.** libsystemd defines `sd_id128_t` as `union { uint8_t bytes[16]; uint64_t qwords[2]; }`, 8-byte-aligned. The Rust binding was `#[repr(C)]` (1-byte-aligned). `Journal::monotonic_timestamp` passes it by out-pointer to `sd_journal_get_monotonic_usec`, which writes as `uint64_t[2]` — UB on strict-alignment targets. Struct now `#[repr(C, align(8))]` with a compile-time size/align assertion.
- **`modules/input/journal::anchor_at_tail_or_head` — do not `seek_head()` on `previous()` errors.** The `Ok(0)` (empty match view) fallback to `seek_head` is safe because no history exists. The `Err(_)` arm was doing the same, but `Err` does not imply an empty view — a non-empty view can hit the same error, and `seek_head` there replays every past matching entry once the poll loop starts. Fix: `Err(_)` keeps the tail-anchored position from the preceding `seek_tail()` and lets the poll loop advance from there. Outer docstring separates the two cases explicitly.

## Test plan

- [x] `cargo test -p limpid` (macOS default features): 848 passed / 0 failed / 1 ignored (+2 from the new `module_props` tests; prior baseline 846)
- [x] `cargo clippy -p limpid --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] Playground aarch64 Ubuntu:
  - `cargo test -p limpid --features journal`: 862 passed / 0 failed / 1 ignored
  - Non-empty match view smoke: 3 pre-existing entries not replayed at reader start (past-1 count 0, past-2 count 0, new count 1)
  - Empty match view smoke: P3-3 behaviour preserved (2 new entries picked up, cursor persisted, DLQ 0)
  - `cargo build -p limpid --features kafka,journal`: PASS
  - `cargo deb -p limpid --features journal,kafka`: PASS
