### PR TITLE
perf(runtime): snapshot OutputEvent (not full OwnedEvent) before enqueue send

### DIFF
--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -580,19 +580,28 @@ async fn run_pipeline_with_outputs(
     // `events_finished` / `events_discarded` decision still observes
     // the original semantics (Finished AND emitted ≥1 output → finished).
     let outputs = std::mem::take(&mut result.outputs);
-    // Each failed enqueue carries the per-output `OwnedEvent`
-    // snapshot so the DLQ record reflects the value the pipeline
-    // produced for that sink. The input event the function received
-    // is not equivalent: the pipeline may have produced a different
-    // egress for the output, and `inject output` replay must
-    // preserve the bytes the sink would have shipped.
-    let mut failed_outputs: Vec<(String, crate::event::OwnedEvent)> = Vec::new();
+    // Each failed enqueue carries a per-output snapshot of just the
+    // fields the DLQ record actually stores (`OutputEvent`:
+    // `source`, `received_at`, `ingress`, `egress` — the same shape
+    // `inject output` replay needs). Snapshotting `OutputEvent` here
+    // rather than the whole `OwnedEvent` avoids the workspace
+    // `HashMap<String, OwnedValue>` deep clone on every success:
+    // pre-fix this ran unconditionally before `sender.send(event)`
+    // because the send consumed `event`, and populated workspaces
+    // dominated the runtime hot path (see the `634cbd0` perf
+    // regression thread). The input event the function received is
+    // not equivalent to a per-output snapshot: the pipeline may have
+    // produced a different `egress` per output, and replay must
+    // preserve the bytes the sink would have shipped — which is why
+    // the snapshot is per-`(output_name, event)`, not one shared
+    // capture at function entry.
+    let mut failed_outputs: Vec<(String, crate::pipeline::OutputEvent)> = Vec::new();
     for (output_name, event) in outputs {
         if let Some(sender) = ctx.output_senders.get(&output_name) {
-            // Clone before send: the sender consumes `event`. `OwnedEvent`
-            // clone is cheap (Bytes are refcounted; workspace cost
-            // scales with the per-event populated keys).
-            let snapshot = event.clone();
+            // Snapshot the DLQ-relevant fields before the send
+            // consumes `event`. Cheap: four Copy scalars + two
+            // `Bytes` refcount bumps; workspace is not touched.
+            let snapshot = crate::pipeline::OutputEvent::from_owned(&event);
             if let Err(e) = sender.send(event).await {
                 // QueueSender::send already bumped per-output
                 // `events_failed` on the Err branch — that gives the
@@ -614,7 +623,10 @@ async fn run_pipeline_with_outputs(
                 "pipeline '{}': output '{}' not found",
                 pipeline.name, output_name
             );
-            failed_outputs.push((output_name, event));
+            failed_outputs.push((
+                output_name,
+                crate::pipeline::OutputEvent::from_owned(&event),
+            ));
         }
     }
 
@@ -645,7 +657,7 @@ async fn run_pipeline_with_outputs(
                     site: format!("{} enqueue", output_name),
                     reason: reason.clone(),
                     output_name: output_name.clone(),
-                    event: crate::pipeline::OutputEvent::from_owned(&snapshot),
+                    event: snapshot,
                 });
         }
     }


### PR DESCRIPTION
## Summary

Fix the sibling half of the D-shape throughput regression identified between `v0.7.7` and `v0.7.8`. The pipeline-side enqueue loop was `event.clone()`-ing the full `OwnedEvent` (workspace included) on every success path so the DLQ code could project an `OutputEvent` on the failure branch — but that projection only ever stores four fields (`source`, `received_at`, `ingress`, `egress`), so the workspace deep-clone was pure overhead.

The primary contribution — the `output` statement's own workspace clone — is addressed separately.

### Change

- `Vec<(String, OwnedEvent)>` → `Vec<(String, OutputEvent)>` for the enqueue-failure buffer in `runtime::process_event`.
- Snapshot via `OutputEvent::from_owned(&event)` (four scalar copies + two `Bytes` refcount bumps) instead of `event.clone()` (which deep-clones `workspace: HashMap<String, OwnedValue>`).
- DLQ record construction on the failure path becomes `event: snapshot` directly — no `OutputEvent::from_owned(&snapshot)` conversion at record-emission time because the snapshot is already `OutputEvent`-shaped.
- The unknown-output branch (`output_senders.get(...)` miss) gets the same treatment for consistency.

### Semantics preserved verbatim

- `ErroredEventContext::Output::event` was already `OutputEvent`; the previous code built it from the `OwnedEvent` snapshot at record-emission time. Workspace was being discarded at that step anyway. This change moves the moment of workspace discard from record-emission to enqueue-prep — earlier, with the same observable result.
- `QueueSender::send`'s per-output `events_failed` bump still fires from inside the send; the pipeline-level termination override to `PipelineTermination::Errored` still fires from the outer `!failed_outputs.is_empty()` gate. Only the type of the intermediate buffer moved.
- `inject output` replay behaviour is unchanged — the DLQ file schema is the same (`OutputEvent`).

## Test plan

- [x] `cargo test -p limpid` (default features, macOS): 851 passed / 0 failed / 1 ignored (baseline unchanged; behaviour-preserving).
- [x] `cargo clippy -p limpid --all-targets -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.
- [ ] Playground aarch64 D-shape throughput (with A applied, B' unmerged): expected `~72k → ~90k eps` (Codex bisect estimate). Combined with the follow-up Part B' commit against the same shape, expected `~150k → ~220k eps`.
