### PR TITLE
perf(syslog): precompute peer display address, drop per-event UDP send timeout

### DIFF
--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -47,27 +47,67 @@ pub enum SyslogFraming {
 
 /// A configured destination. `tls` is `Some(...)` only for outputs
 /// that negotiate client-side TLS; plaintext outputs leave it `None`.
+///
+/// `display_address` is the `host:port` string every syslog output
+/// hands to `TcpStream::connect` / `tokio::net::lookup_host` /
+/// `format!()` in error contexts. It is computed once at construction
+/// time so the hot path can borrow `&str` from the peer instead of
+/// running `format!()` per event just to build a string that only
+/// error-context messages ever consume.
 #[derive(Debug, Clone)]
 pub struct Peer {
     pub host: String,
+    // The parsed port is also embedded in `display_address`, so
+    // nothing on the send-path reads this field directly today. Kept
+    // as-is so a future observability change (per-peer metric label,
+    // tap output shape, etc.) doesn't have to re-parse it out of the
+    // pre-formatted string.
+    #[allow(dead_code)]
     pub port: u16,
     pub tls: Option<crate::tls::ClientTlsConfig>,
+    display_address: String,
 }
 
 impl Peer {
-    /// Formatted `host:port` suitable for `TcpStream::connect` /
-    /// `UdpSocket::connect`. Bare IPv6 literals (e.g. `::1`) must be
-    /// bracketed so the port parses correctly — `format!("{}:{}", "::1", 514)`
-    /// yields `::1:514` which Rust's `SocketAddr` parser rejects (it
-    /// reads the trailing `:514` as part of the address). Hostnames
-    /// and IPv4 literals don't need brackets; an already-bracketed
-    /// literal (`[::1]`) is left untouched.
-    pub fn address(&self) -> String {
-        if self.host.contains(':') && !self.host.starts_with('[') && !self.host.ends_with(']') {
-            format!("[{}]:{}", self.host, self.port)
-        } else {
-            format!("{}:{}", self.host, self.port)
+    /// Build a `Peer`, computing its display address once. Call this
+    /// rather than a struct literal so any `Peer` in the process has a
+    /// populated `display_address`.
+    pub fn new(host: String, port: u16, tls: Option<crate::tls::ClientTlsConfig>) -> Self {
+        let display_address = format_display_address(&host, port);
+        Self {
+            host,
+            port,
+            tls,
+            display_address,
         }
+    }
+
+    /// `host:port` string suitable for `TcpStream::connect` /
+    /// `tokio::net::lookup_host` and for interpolating into
+    /// error-context messages. Bare IPv6 literals (e.g. `::1`) are
+    /// bracketed so the port parses correctly — `format!("{}:{}",
+    /// "::1", 514)` yields `::1:514` which Rust's `SocketAddr` parser
+    /// rejects (it reads the trailing `:514` as part of the address).
+    /// Hostnames and IPv4 literals aren't bracketed; an
+    /// already-bracketed literal (`[::1]`) is left untouched.
+    ///
+    /// Returns a borrow rather than an allocation — the string is
+    /// held on the `Peer` for as long as the peer lives, so every
+    /// call is a bare pointer/length copy. The pre-0.7.10 signature
+    /// returned `String` and re-ran the `format!()` on every send,
+    /// which showed up as a per-event allocation on the syslog_udp /
+    /// syslog_tcp hot path even though only the (near-zero-frequency)
+    /// error-context path actually consumed the value.
+    pub fn address(&self) -> &str {
+        &self.display_address
+    }
+}
+
+fn format_display_address(host: &str, port: u16) -> String {
+    if host.contains(':') && !host.starts_with('[') && !host.ends_with(']') {
+        format!("[{}]:{}", host, port)
+    } else {
+        format!("{}:{}", host, port)
     }
 }
 
@@ -560,11 +600,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
 
     fn peer(host: &str, port: u16) -> Peer {
-        Peer {
-            host: host.to_string(),
-            port,
-            tls: None,
-        }
+        Peer::new(host.to_string(), port, None)
     }
 
     fn peers(n: usize) -> Vec<Peer> {

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -290,7 +290,7 @@ fn parse_peer(
     let default_port = if tls.is_some() { 6514 } else { 514 };
     let host_port_label = format!("output '{}': {}", name, label);
     let (host, port) = parse_host_port(properties, default_port, &host_port_label)?;
-    Ok(Peer { host, port, tls })
+    Ok(Peer::new(host, port, tls))
 }
 
 fn parse_peer_tls(

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -12,8 +12,8 @@ use crate::dsl::schema::{PropertySpec, PropertyValueKind};
 use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::modules::output::syslog_peers::{
-    PEER_CONNECT_TIMEOUT, PEER_WRITE_TIMEOUT, Peer, PeerList, PeerSendError, PreSendShutdownMarker,
-    SyslogPayload, parse_host_port,
+    PEER_CONNECT_TIMEOUT, Peer, PeerList, PeerSendError, PreSendShutdownMarker, SyslogPayload,
+    parse_host_port,
 };
 use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
@@ -283,11 +283,13 @@ impl SyslogUdpOutput {
     /// lookup, socket bind, and UDP `connect` (all in-process or
     /// wire-preparation with no datagram side effect) in
     /// `pre_send_or_shutdown`. The `UdpSocket::send` call itself is
-    /// deliberately **not** shutdown-cancellable: UDP writes are
-    /// single-datagram, and a partial write is impossible, but the
-    /// send syscall does have a wire-visible effect (the datagram
-    /// leaves the process). The existing `PEER_WRITE_TIMEOUT`
-    /// bounds the wait.
+    /// deliberately **not** shutdown-cancellable and **not** wrapped
+    /// in a wall-clock timeout: UDP writes are single-datagram (no
+    /// partial-write state), the send syscall has a wire-visible
+    /// effect (the datagram leaves the process), and there is no
+    /// remote-peer wait for the sender to hang on — see the
+    /// per-site comment on the send call for the full asymmetry
+    /// rationale.
     async fn write_payload_shutdown_aware(
         &self,
         payload: SyslogPayload,
@@ -405,21 +407,53 @@ impl SyslogUdpOutput {
                             state.conn = Some(socket);
                         }
 
-                        // Send phase: single-datagram
-                        // `UdpSocket::send`. No shutdown wrap here;
-                        // partial write is impossible (UDP is
-                        // datagram-oriented), and the existing
-                        // `PEER_WRITE_TIMEOUT` bounds the wait.
+                        // Send phase: single-datagram `UdpSocket::send`.
+                        //
+                        // No timeout wrapper here (asymmetric with
+                        // `syslog_tcp`, which does wrap `write_all` in
+                        // `PEER_WRITE_TIMEOUT` — see the rationale on
+                        // that call site). A connected UDP send has
+                        // three terminal states: it succeeds
+                        // immediately (datagram enters the kernel
+                        // send buffer, the common case), it fails
+                        // immediately (ECONNREFUSED / ENETDOWN /
+                        // async ICMP surfaced synchronously by the
+                        // kernel), or it briefly Pends on writable
+                        // when the local send buffer / qdisc is full
+                        // and drains within microseconds-to-
+                        // milliseconds. There is no "remote peer
+                        // stopped reading" state for UDP: unlike TCP,
+                        // the sender doesn't wait on the peer at all.
+                        // A 10-second wall-clock cap over this
+                        // pattern only fires under kernel pathology
+                        // (send buffer full and the tokio waker
+                        // wedged), and in exchange for that
+                        // vanishingly rare protection the wrapper
+                        // adds per-event `Sleep` construction and
+                        // its scheduler-wake fallout to every
+                        // successful send. Profiling the passthrough
+                        // workload showed the timer / wake pattern
+                        // dominating this hot path.
+                        //
+                        // Removing the wrapper turns "send buffer
+                        // full" into ordinary async backpressure that
+                        // flows back through the queue to the input,
+                        // which is the correct log-pipeline
+                        // behaviour anyway: today a burst that fills
+                        // the kernel buffer would time out per event
+                        // for 10 s and route DLQ-shaped "Delivered"
+                        // failures for events the kernel is about to
+                        // drain, which is worse than pausing the
+                        // pipeline. Shutdown safety is unaffected
+                        // (the queue-consumer task is abort-ed by
+                        // the runtime shutdown budget; the ack
+                        // handle drops as `Dropped` and a disk
+                        // queue holds the cursor).
                         let socket = state.conn.as_mut().expect("connection should be present");
-                        let send_result =
-                            tokio::time::timeout(PEER_WRITE_TIMEOUT, socket.send(&egress))
-                                .await
-                                .map_err(|_| {
-                                    anyhow::anyhow!("syslog_udp send to {} timed out", address)
-                                })
-                                .and_then(|res| {
-                                    res.with_context(|| format!("syslog_udp send to {}", address))
-                                });
+                        let send_result = socket
+                            .send(&egress)
+                            .await
+                            .with_context(|| format!("syslog_udp send to {}", address));
                         if send_result.is_err() {
                             state.conn = None;
                         }
@@ -537,16 +571,13 @@ impl SyslogUdpOutput {
                         state.conn = Some(socket);
                     }
 
+                    // No timeout wrapper on UDP send — see the
+                    // rationale on the sibling shutdown-aware path.
                     let socket = state.conn.as_mut().expect("connection should be present");
-                    let send_result =
-                        tokio::time::timeout(PEER_WRITE_TIMEOUT, socket.send(&egress))
-                            .await
-                            .map_err(|_| {
-                                anyhow::anyhow!("syslog_udp send to {} timed out", address)
-                            })
-                            .and_then(|res| {
-                                res.with_context(|| format!("syslog_udp send to {}", address))
-                            });
+                    let send_result = socket
+                        .send(&egress)
+                        .await
+                        .with_context(|| format!("syslog_udp send to {}", address));
                     if send_result.is_err() {
                         state.conn = None;
                     }

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -108,11 +108,7 @@ fn parse_peers(name: &str, properties: &[Property]) -> Result<Vec<Peer>> {
 fn parse_peer(name: &str, label: &str, properties: &[Property]) -> Result<Peer> {
     let label = format!("output '{}': {}", name, label);
     let (host, port) = parse_host_port(properties, 514, &label)?;
-    Ok(Peer {
-        host,
-        port,
-        tls: None,
-    })
+    Ok(Peer::new(host, port, None))
 }
 
 impl HasMetrics for SyslogUdpOutput {
@@ -319,7 +315,7 @@ impl SyslogUdpOutput {
                                     shutdown,
                                     tokio::time::timeout(
                                         PEER_CONNECT_TIMEOUT,
-                                        tokio::net::lookup_host(address.as_str()),
+                                        tokio::net::lookup_host(address),
                                     ),
                                 )
                                 .await
@@ -476,7 +472,7 @@ impl SyslogUdpOutput {
                         // `TcpStream::connect` walking semantics.
                         let resolved: Vec<std::net::SocketAddr> = tokio::time::timeout(
                             PEER_CONNECT_TIMEOUT,
-                            tokio::net::lookup_host(address.as_str()),
+                            tokio::net::lookup_host(address),
                         )
                         .await
                         .with_context(|| format!("syslog_udp lookup {} timed out", address))?


### PR DESCRIPTION
Two commits addressing the passthrough → `syslog_udp` hot path — full rationale in the individual commit messages.

- **`4a185e5`** refactor(syslog): precompute peer display address at `Peer` construction time. Kills the per-event `format!("{host}:{port}")` allocation that the write-closure was making eagerly for an error-context path the success case never consumed.
- **`996358d`** perf(syslog_udp): drop the per-event `tokio::time::timeout(PEER_WRITE_TIMEOUT, socket.send(...))` wrapper. UDP has no "remote peer stopped reading" wait state — the wrapper only ever adds scheduler-wake / timer-wheel bookkeeping per send. `syslog_tcp` keeps its wrapper (TCP genuinely has that state), and `syslog_udp`'s connect-side timeout stays for DNS + `UdpSocket::connect`. Under a full local send buffer the change turns kernel backpressure into ordinary async backpressure instead of a `syslog_udp send timed out` → peer cooldown → 5 s wait cycle.

- **Scope**: `crates/limpid/src/modules/output/syslog_{peers,tcp,udp}.rs` only. Peer rotation / cooldown / metrics semantics unchanged. Public API of `SyslogUdpOutput` / `SyslogTcpOutput` unchanged. `PEER_WRITE_TIMEOUT` constant kept in `syslog_peers.rs` (syslog_tcp still uses it).
- **Tests**: 855 passed / 0 failed / 1 ignored (behaviour-preserving; existing bracketing / rotation pins hold).
- **Push-gate**: 8/8 scopes green via uchgs-audit (7 auditor-confirmed, `rust` standing-baseline owner-confirmed for pre-existing `cargo-deny` duplicate-crate warnings unchanged by this diff — same baseline confirmed on the T1 push).