### PR TITLE
docs(README): refresh single-core perf numbers to the v0.7.10 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,18 @@ Full reference: [Built-in Functions](docs/src/functions/expression-functions.md)
 
 ## Performance
 
-A single core handles **~168k events/sec** on the heaviest realistic DSL workload — full OCSF Authentication compose with `to_json` serialization, single-pipeline single-input, channel-direct injection. Lighter shapes scale up from there:
+A single core handles **~221k events/sec** on the heaviest realistic DSL workload — full OCSF Authentication compose with `to_json` serialization, single-pipeline single-input, channel-direct injection. Lighter shapes scale up from there:
 
 | Pipeline shape | events/sec/core |
 | --- | ---: |
-| passthrough | 312k |
-| `syslog.parse(ingress)` | 305k |
-| parse + 2× regex + if/else | 115k |
-| **OCSF compose + to_json (heaviest)** | **168k** |
+| passthrough | 378k |
+| `syslog.parse(ingress)` | 380k |
+| parse + 2× regex + if/else | 146k |
+| **OCSF compose + to_json (heaviest)** | **221k** |
 
 Multi-pipeline configurations scale across cores via Tokio's multi-thread runtime: 4 independent pipelines (each its own input, process chain, and output) reach ~459k events/sec aggregate on the OCSF compose workload — 2.7× the single-pipeline number on a 16-core host with no application-level work-stealing or pinning.
 
-The numbers come from the v0.6.0 perf milestone (per-event bump arena, direct `serde::Serialize` for the runtime `Value` tree, static-literal hash-key interning, and a boundary refactor that eliminated the hot-path `BorrowedEvent::to_owned()` at every output sink) and the v0.6.1 follow-up (per-worker bump-arena recycling, lifting the macOS `xzm` zone-lock contention that capped multi-pipeline scaling). Real I/O (`__sendto`) and tokio scheduling are now the dominant categories on the flame graph; allocation collapsed from 43% at v0.5.7 to 15% on the single-pipeline path. See the [CHANGELOG](CHANGELOG.md) for the cumulative breakdown.
+The numbers come from the v0.6.0 perf milestone (per-event bump arena, direct `serde::Serialize` for the runtime `Value` tree, static-literal hash-key interning, and a boundary refactor that eliminated the hot-path `BorrowedEvent::to_owned()` at every output sink), the v0.6.1 follow-up (per-worker bump-arena recycling, lifting the macOS `xzm` zone-lock contention that capped multi-pipeline scaling), and the v0.7.10 queue-consumer wake mitigation (batch-drain via `recv_many` plus an adaptive spin-before-park controller) that closed a wake-amplification tail on populated-workspace workloads. Real I/O (`__sendto`) and tokio scheduling are now the dominant categories on the flame graph; allocation collapsed from 43% at v0.5.7 to 15% on the single-pipeline path. See the [CHANGELOG](CHANGELOG.md) for the cumulative breakdown.
 
 ## Compared to rsyslog / fluentd / Vector
 


### PR DESCRIPTION
Prose-only README update — 4 numbers in the Performance table and the lede sentence, plus a v0.7.10 entry appended to the history paragraph next to v0.6.0 / v0.6.1.

- **Numbers refreshed** (single-core, single-pipeline, channel-direct injection):
  - passthrough: 312k → **378k** events/sec/core
  - `syslog.parse(ingress)`: 305k → **380k**
  - parse + 2× regex + if/else: 115k → **146k**
  - OCSF compose + to_json (heaviest realistic): 168k → **221k**
- **History paragraph** gains a third milestone alongside v0.6.0 (per-event bump arena) and v0.6.1 (per-worker bump-arena recycling): the v0.7.10 queue-consumer wake mitigation (`recv_many` batch drain + adaptive spin-before-park controller) that closed the wake-amplification tail on populated-workspace workloads.
- **Untouched**: multi-pipeline aggregate figure (~459k, not re-measured at v0.7.10), dominant-category flame-graph sentence, workload identity / labelling, table structure, everything outside `## Performance`.
- **Push-gate**: 8/8 scopes green via uchgs-audit (7 auditor-confirmed, `rust` standing-baseline owner-confirmed for pre-existing `cargo-deny` duplicate-crate warnings unchanged by this diff — same baseline confirmed on the T1 / syslog-A / R / S push-gates in this release cycle).