### PR TITLE
chore(release): bump crate versions to 0.7.10 and update the two docs pages that pin the running crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.9"
+version = "0.7.10"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.9"
+version = "0.7.10"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.9"
+version = "0.7.10"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1006,7 +1006,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.8"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.10"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -24,7 +24,7 @@ read that and explains the OTLP-specific reading on top.
 
 ## 1. Scope
 
-| Aspect | Current (0.7.9) |
+| Aspect | Current (0.7.10) |
 |---|---|
 | Signal | **logs** only — no traces, no metrics, no profiles |
 | Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` introduced in 0.7.6; in 0.7.8 plaintext `http://` with `tls { ... }` is now rejected at parse time — see CHANGELOG 0.7.8) |


### PR DESCRIPTION
Final piece of the 0.7.10 release cycle before tagging — bumps the three published crate versions and syncs the two docs pages that quote them, so a fresh checkout at the `v0.7.10` tag matches what `version()` will return at runtime.

- **Versions**: `crates/limpid/Cargo.toml`, `crates/limpidctl/Cargo.toml`, `crates/limpid-prometheus/Cargo.toml` — `0.7.9` → `0.7.10`. `Cargo.lock` picks up the three workspace `[[package]]` blocks only; no transitive dependency movement.
- **Docs**: `docs/src/otlp.md` line 27 header cell `Current (0.7.9)` → `Current (0.7.10)`; `docs/src/functions/expression-functions.md` line 1009 `version()` example advances to `"0.7.10"`. The pre-bump literal on that expression-functions line was `"0.7.8"` — the same line was skipped by the 0.7.8 → 0.7.9 bump, so this commit catches up two release cycles' worth of docs drift there while it is here (the drift was found by the drift audit that produced #151).
- **Deliberately untouched**: transitive dependency versions (this is a release-cadence bump, not a supply-chain refresh); historical release references in prose or CHANGELOG (`introduced in 0.7.6`, `pre-0.7.7`, `0.7.8 splits the module`, and so on) — those are timeline anchors; anything under `crates/limpid/src/`.
- **Validation**: `cargo test -p limpid` 870 passed / 0 failed / 1 ignored on the tip; `cargo update -p limpid -p limpidctl -p limpid-prometheus` locks the three published crates only; the Cargo.lock diff confirms no transitive movement.
- **Push-gate**: 8/8 scopes green via uchgs-audit (6 auditor-confirmed, `rust` + `cicd-pipeline` standing-baseline owner-confirmed — same baselines confirmed across the 0.7.10 release cycle).

After this merges, `release/0.7.10` is ready for the `v0.7.10` tag.