### PR TITLE
fix(release-0.7.10): review pass — gate spin phase to memory backend, tighten schema-validation intro, add EntityRef round-trip test

### DIFF
--- a/crates/limpid/src/functions/otlp/encode.rs
+++ b/crates/limpid/src/functions/otlp/encode.rs
@@ -734,4 +734,84 @@ mod tests {
             other => panic!("expected StringValueStrindex(42), got {:?}", other),
         }
     }
+
+    /// OTLP 0.32 promoted `Resource.entity_refs` (`EntityRef`) to a
+    /// first-class wire surface. The DSL primitive must preserve
+    /// every named field on that surface across a decode/encode
+    /// cycle — schema_url, type, id_keys, description_keys — or a
+    /// caller that constructs an EntityRef through the DSL will
+    /// silently lose the field on the wire.
+    #[test]
+    fn entity_ref_round_trips_all_fields_through_hashlit_form() {
+        // Construct a full-shape EntityRef DSL object.
+        let id_keys: &[Value<'_>] = &[Value::String("host.id"), Value::String("host.name")];
+        let description_keys: &[Value<'_>] = &[Value::String("host.type")];
+        let entity_entries: &[(&str, Value<'_>)] = &[
+            (
+                "schema_url",
+                Value::String("https://opentelemetry.io/schemas/1.32.0"),
+            ),
+            ("type", Value::String("host")),
+            ("id_keys", Value::Array(id_keys)),
+            ("description_keys", Value::Array(description_keys)),
+        ];
+
+        // DSL → proto: every named field must land on the wire.
+        let er = hashlit_to_entity_ref(&Value::Object(entity_entries)).unwrap();
+        assert_eq!(er.schema_url, "https://opentelemetry.io/schemas/1.32.0");
+        assert_eq!(er.r#type, "host");
+        assert_eq!(
+            er.id_keys,
+            vec!["host.id".to_string(), "host.name".to_string()]
+        );
+        assert_eq!(er.description_keys, vec!["host.type".to_string()]);
+
+        // proto → DSL: the same fields must come back through the
+        // arena-side encoder in the object shape the DSL side reads.
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let out = entity_ref_to_hashlit(&arena, &er);
+        let out_entries = match out {
+            Value::Object(entries) => entries,
+            other => panic!("entity_ref_to_hashlit must return Object, got {:?}", other),
+        };
+        let get = |k: &str| -> Value<'_> {
+            out_entries
+                .iter()
+                .find(|(key, _)| *key == k)
+                .map(|(_, v)| *v)
+                .unwrap_or_else(|| panic!("EntityRef roundtrip: missing field `{}`", k))
+        };
+        assert!(matches!(
+            get("schema_url"),
+            Value::String("https://opentelemetry.io/schemas/1.32.0")
+        ));
+        assert!(matches!(get("type"), Value::String("host")));
+        match get("id_keys") {
+            Value::Array(xs) => {
+                let strs: Vec<&str> = xs
+                    .iter()
+                    .map(|v| match v {
+                        Value::String(s) => *s,
+                        other => panic!("id_keys element must be String, got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(strs, vec!["host.id", "host.name"]);
+            }
+            other => panic!("id_keys must be Array, got {:?}", other),
+        }
+        match get("description_keys") {
+            Value::Array(xs) => {
+                let strs: Vec<&str> = xs
+                    .iter()
+                    .map(|v| match v {
+                        Value::String(s) => *s,
+                        other => panic!("description_keys element must be String, got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(strs, vec!["host.type"]);
+            }
+            other => panic!("description_keys must be Array, got {:?}", other),
+        }
+    }
 }

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -592,6 +592,27 @@ impl QueueReceiver {
         }
     }
 
+    /// Return the current spin budget only when the spin phase is
+    /// worth running on this receiver's backend.
+    ///
+    /// The `SpinController` state machine is per-receiver and applies
+    /// uniformly, but the *cost model* of the spin phase's `try_recv`
+    /// calls does not: memory `try_recv` is nanoseconds (one atomic
+    /// mpsc peek), disk `try_recv` opens a segment file and seeks per
+    /// call (multiple microseconds). The spin phase is meant to
+    /// convert a park/wake round trip (a few microseconds) into a
+    /// handful of quick `try_recv` calls, and only earns its keep on
+    /// the memory backend where each poll is cheap. On the disk
+    /// backend the same 128-iteration budget would cost more than
+    /// the park it is meant to skip. Gating the phase here is the
+    /// smallest change that respects both sides of the balance.
+    fn spin_budget_for_backend(&self) -> Option<u32> {
+        match &self.inner {
+            ReceiverInner::Memory(_) => self.spin_ctrl.should_spin(),
+            ReceiverInner::Disk(_) => None,
+        }
+    }
+
     /// Wait for at least one event, then greedily drain up to `max`
     /// events total from the queue into `buf`. Returns the number of
     /// events appended (0 only when the queue is closed and empty).
@@ -608,12 +629,14 @@ impl QueueReceiver {
     /// Flow:
     /// 1. **Fast-path drain**: pop already-queued events synchronously.
     ///    On a healthy backlog regime this is the only step that runs.
-    /// 2. **Adaptive spin** (`SpinController::should_spin`): if the
-    ///    controller has a non-zero budget, spin `try_recv` /
-    ///    `spin_loop` up to that budget. On a hit inside the spin
-    ///    window we skip the park entirely and record the arrival
-    ///    depth via `record_hit`; on budget exhaustion we call
-    ///    `record_spin_miss` right before parking.
+    /// 2. **Adaptive spin** (`SpinController::should_spin`, gated to
+    ///    the memory backend via [`Self::spin_budget_for_backend`]): if
+    ///    the controller has a non-zero budget and the receiver's
+    ///    backend is memory, spin `try_recv` / `spin_loop` up to that
+    ///    budget. On a hit inside the spin window we skip the park
+    ///    entirely and record the arrival depth via `record_hit`; on
+    ///    budget exhaustion we call `record_spin_miss` right before
+    ///    parking.
     /// 3. **Timed park**: `Instant::now()` before `recv().await`,
     ///    `elapsed()` after — the duration is fed to `record_park`
     ///    so the controller can grow the budget when it sees a park
@@ -638,10 +661,21 @@ impl QueueReceiver {
             return buf.len() - start;
         }
 
-        // (2) Adaptive spin phase. When budget is 0 (cold start /
-        // decayed at idle) `should_spin` returns None and we go
-        // straight to park — that is the "idle byte-identical" path.
-        if let Some(budget) = self.spin_ctrl.should_spin() {
+        // (2) Adaptive spin phase. Gated to the memory backend: on
+        // the disk backend every `try_recv` performs a fresh segment
+        // file open + seek (multi-microseconds), so a spin budget of
+        // up to `SPIN_CAP = 128` iterations against an empty
+        // disk-backed queue would cost hundreds of microseconds per
+        // idle poll — comparable to or worse than the single park
+        // round trip the spin phase is meant to save. The controller
+        // still records park durations on the disk backend below
+        // (the state is cheap and preserves R4's pseudo-hit escape
+        // shape) but the spin phase itself is a memory-only path.
+        // When the budget is 0 (cold start / decayed at idle) or
+        // the backend is disk, `spin_budget_for_backend` returns
+        // `None` and we go straight to park — that is the
+        // "idle byte-identical" path.
+        if let Some(budget) = self.spin_budget_for_backend() {
             let mut iterations: u32 = 0;
             while iterations < budget {
                 iterations = iterations.saturating_add(1);
@@ -2741,8 +2775,9 @@ mod consumer_lifecycle_tests {
         let body = &body_tail[..slice_end];
 
         assert!(
-            body.contains("self.spin_ctrl.should_spin()"),
-            "recv_many must consult SpinController via should_spin"
+            body.contains("self.spin_budget_for_backend()"),
+            "recv_many must gate the spin phase through spin_budget_for_backend \
+             (which composes SpinController::should_spin with the backend check)"
         );
         assert!(
             body.contains("self.spin_ctrl.record_hit("),
@@ -2763,6 +2798,69 @@ mod consumer_lifecycle_tests {
         assert!(
             body.contains("std::hint::spin_loop()"),
             "recv_many must use std::hint::spin_loop between spin iterations"
+        );
+    }
+
+    /// Backend-aware spin gating: on the memory backend the helper
+    /// forwards the controller's current budget (nanosecond-scale
+    /// `try_recv` per iteration is worth spinning); on the disk
+    /// backend the helper returns `None` regardless of controller
+    /// state (multi-microsecond `try_recv` per iteration would cost
+    /// more than the park round trip the spin phase is meant to
+    /// skip). Prevents a mechanical simplification from lifting the
+    /// spin phase back onto the disk backend, which no unit test
+    /// timing check would catch on its own.
+    #[tokio::test]
+    async fn spin_budget_for_backend_returns_none_on_disk_backend() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_sender, mut receiver) = create_queue(
+            "spin_budget_disk".into(),
+            QueueConfig {
+                queue_type: QueueType::Disk {
+                    path: tmp.path().display().to_string(),
+                    max_size: 4 * 1024 * 1024,
+                },
+                capacity: 16,
+            },
+        )
+        .unwrap();
+
+        // Warm the receiver's own controller — a copy would only pin
+        // the SpinController state machine, not the backend gate the
+        // helper on the receiver is supposed to apply on top of it.
+        receiver.spin_ctrl.record_hit(SPIN_CAP);
+        assert!(
+            receiver.spin_ctrl.should_spin().is_some(),
+            "sanity: receiver's controller is warm — the assertion below is checking the gate, not the controller"
+        );
+
+        // With the receiver's own controller genuinely warm, the
+        // helper must still return None because the backend is disk.
+        assert!(
+            receiver.spin_budget_for_backend().is_none(),
+            "disk backend must never enter the spin phase, even when the receiver's controller is warm"
+        );
+    }
+
+    #[tokio::test]
+    async fn spin_budget_for_backend_forwards_controller_on_memory_backend() {
+        let (_sender, mut receiver) = create_queue(
+            "spin_budget_memory".into(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 16,
+            },
+        )
+        .unwrap();
+
+        // Cold controller: helper returns None (matches R5).
+        assert!(receiver.spin_budget_for_backend().is_none());
+
+        // Warm the controller and confirm the helper now forwards it.
+        receiver.spin_ctrl.record_hit(4);
+        assert!(
+            receiver.spin_budget_for_backend().is_some(),
+            "memory backend with a warm controller must return Some(budget)"
         );
     }
 

--- a/docs/src/operations/schema-validation.md
+++ b/docs/src/operations/schema-validation.md
@@ -74,10 +74,10 @@ When a new downstream appears with a schema nobody has seen before, the integrat
 
 ## Recipes
 
-All recipes assume `limpidctl tap <kind> <name> --json` is producing the pipeline's final serialized output — the same Event JSON described in [Debug Tap](./tap.md). Each event is one line, with `received_at`, `source`, `ingress`, and `egress` top-level keys. Which tap point exposes the structured payload depends on where the check lives:
+All recipes stream a JSONL Event via `limpidctl tap <kind> <name> --json` — the same Event JSON described in [Debug Tap](./tap.md), one event per line, with `received_at`, `source`, `ingress`, and `egress` top-level keys always present. Which tap point you pick — and whether the payload the schema lives on is `.egress` or `.workspace.<schema>` — depends on where the check lives:
 
-- **Wire-level validation** (schema over the bytes the sink will actually ship) uses `tap output <name> --json` and reads `.egress`. This is the shape a receiver sees.
-- **Pre-serialization / composed-object validation** (schema over the tree the pipeline built before rendering) uses `tap process <compose_process> --json` and reads `.workspace.<schema>` — the process tap is where workspace state is observable. `tap output --json` does not expose `workspace`; picking the named `compose` process one hop back keeps the recipe reading the same fields it always has, just from the pipeline point that actually holds them.
+- **Wire-level validation** (schema over the bytes the sink will actually ship) uses `tap output <name> --json` and reads `.egress`. This is the shape a receiver sees. `tap output --json` never carries `workspace` — the projection is unconditional in v0.7.10 regardless of queue backend.
+- **Pre-serialization / composed-object validation** (schema over the tree the pipeline built before rendering) uses `tap process <compose_process> --json` and reads `.workspace.<schema>` — the process tap emits at process exit with the full workspace state visible, which is where the composed structured payload lives before the sink renders it into `egress`. Picking the named `compose` process one hop back keeps the recipe reading the same fields it always has, just from the pipeline point that actually holds them.
 
 ### OCSF (JSON Schema)
 


### PR DESCRIPTION
Follow-up on the release/0.7.10 → main PR (#154) review pass. Three findings addressed in the smallest scope that fixes each underlying problem.

- **Adaptive spin phase, memory-only gate** (`queue/mod.rs`): the spin phase in `recv_many` previously gated on `SpinController::should_spin` alone, which does not know that the disk backend's `try_recv` opens a segment file and seeks per call (multi-µs), where the memory backend's `try_recv` is nanoseconds. On an empty disk-backed queue with a warm controller, the spin phase would burn `SPIN_CAP = 128` iterations of file-open + seek before parking — hundreds of µs per idle poll, comparable to or worse than the single park round trip the spin phase exists to save. A new private `spin_budget_for_backend` helper composes the existing controller decision with a backend-kind check (memory forwards the controller's budget, disk returns `None`), so the spin phase becomes a memory-only path. Two new tests pin the gate on both backends; the structural pin on `recv_many` updates its marker to point at the new helper.
- **Schema-validation recipe intro** (`docs/src/operations/schema-validation.md`): the intro previously blanketed both tap points as `producing the pipeline's final serialized output`, but the pre-serialization bullet directly below points readers at `tap process <compose_process> --json`, whose shape is precisely not the pipeline's final serialized output. The intro is rewritten so the JSONL envelope invariants (four top-level keys always present, one event per line) are separated from the tap-point-dependent bit (which field, `.egress` or `.workspace.<schema>`, the schema lives on), and the two bullets are tightened to name both the v0.7.10 workspace-projection behaviour on `tap output` and the workspace visibility on `tap process` explicitly.
- **OTLP EntityRef round-trip test** (`functions/otlp/encode.rs`): OTLP 0.32 added `Resource.entity_refs` (`EntityRef` with `schema_url` / `type` / `id_keys` / `description_keys`) and the DSL primitive gained both directions of the mapping when the stack was lifted. The sibling new-wire-surface fields `key_strindex` and `string_value_strindex` got dedicated tests when they landed; `EntityRef` did not. A new `entity_ref_round_trips_all_fields_through_hashlit_form` walks a full-shape EntityRef DSL object through decode and encode and asserts every field survives.
- **Validation**: `cargo test -p limpid` 873 passed / 0 failed / 1 ignored (base 870 + 3 new tests). `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`, `cargo-deny`, `cargo-audit`: clean.
- **Push-gate**: 8/8 scopes green via uchgs-audit (6 auditor-confirmed, `rust` + `cicd-pipeline` standing-baseline owner-confirmed — same baselines confirmed across the 0.7.10 release cycle).

After this merges, the release/0.7.10 → main PR (#154) picks it up automatically.