### PR TITLE
release: 0.7.12 — daemon SIGPIPE hotfix + packaged unit Restart=always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime shape converge. After 1.0, changes will follow semver strictly.
 
+## [0.7.12] - 2026-07-11
+
+0.7.12 is a hotfix for a daemon-fatal SIGPIPE path: a saturated stderr / systemd-journald pipe under a tracing burst (typically a downed OTLP output driving its retry loop's WARN spam) would take the whole daemon with it, and systemd would not restart it because the exit looked clean. The daemon now keeps Rust's `SIG_IGN` default for `SIGPIPE`, and the shipped `limpid.service` unit restarts on any exit reason as defence-in-depth against future variants.
+
+### Fixed — daemon no longer dies on a broken tracing pipe
+
+`crates/limpid/src/main.rs` previously restored `SIGPIPE = SIG_DFL` at process entry unconditionally, before CLI parsing. The intent was to make CLI-style modes (`--check`, `--test-pipeline`, `--graph`) terminate cleanly when their stdout was piped through `head` / `less`; the effect was to also arm the daemon to die on any broken pipe. Under a downed OTLP endpoint, the retry loop's per-attempt `tracing::warn!` messages saturated the stderr-to-journald forwarding pipe; when the pipe closed, the next write raised `SIGPIPE` and the process exited (systemd log: `Deactivated successfully. … signal=PIPE`). Restart was suppressed because the exit was clean from systemd's perspective.
+
+The fix moves the `SIG_DFL` install after `Cli::parse()` and gates it on the CLI-mode flags. Daemon mode now keeps Rust's `SIG_IGN` default, so a broken pipe on the stderr side surfaces as an ordinary `EPIPE` write error the tracing subscriber drops rather than a fatal signal. The CLI-mode behaviour is unchanged: `--check | head` still terminates cleanly on downstream close.
+
+### Changed — packaged systemd unit uses `Restart=always` and disables `StartLimitIntervalSec`
+
+`packaging/limpid.service` moves from `Restart=on-failure` to `Restart=always` so a signal-killed exit that systemd classifies as clean (SIGPIPE being the load-bearing case) still triggers a restart. `systemctl stop` continues to stop the unit cleanly because systemd remembers operator-initiated transitions and does not restart across them. `StartLimitIntervalSec=0` disables the start-rate ceiling so a sustained-crash regression cannot wedge the unit into `failed` state; `RestartSec=5` still paces individual restart attempts. Together the two settings turn systemd into a real defence-in-depth layer around whatever the daemon itself missed to catch.
+
 ## [0.7.11] - 2026-07-11
 
 0.7.11 formalises the snippet library's contracts. The library has grown from a handful of parsers into 39 files across four kinds (parsers / composers / filters / functions), and the ad-hoc header conventions and namespace naming had started to obscure rather than help — vendor documentation blocks and shared-intermediate blurbs were repeating themselves out of sync, the intermediate namespace's `workspace.limpid` name conflated the schema shape with the daemon crate, and the composer contract left it up to each snippet to write `egress` directly with no invariant an operator could rely on. 0.7.11 renames the intermediate to LSIS (Limpid Snippet Intermediate Schema, `workspace.lsis.*`), extracts the header schema into an xtask-enforced per-kind contract with an auto-generated inventory in the packaging README, splits composers into a schema layer that writes an LSIS slot and an envelope layer that wraps a payload, and introduces a `compose_otlp` envelope composer alongside a single-writer invariant on `egress`. Five cloud parsers (AWS GuardDuty, VPC Flow, Azure Activity, Kubernetes audit, Okta System Log) join the tracked set. The daemon runtime is unchanged in shape and throughput — the behaviour differences are confined to what shipped snippets produce, and the two user-visible breaking changes for out-of-tree configs are the namespace rename and the composer-contract split (both described in their own sections below).
@@ -1909,6 +1923,7 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
 [Unreleased]: https://github.com/naoto256/limpid/compare/v0.7.9...HEAD
+[0.7.12]: https://github.com/naoto256/limpid/compare/v0.7.11...v0.7.12
 [0.7.11]: https://github.com/naoto256/limpid/compare/v0.7.10...v0.7.11
 [0.7.9]: https://github.com/naoto256/limpid/compare/v0.7.8...v0.7.9
 [0.7.8]: https://github.com/naoto256/limpid/compare/v0.7.7...v0.7.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpid/src/main.rs
+++ b/crates/limpid/src/main.rs
@@ -81,18 +81,36 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
-    // Restore the default SIGPIPE disposition for the CLI-style modes
-    // (`--check`, `--test-pipeline`) which write to stdout and may be
-    // piped through `head`/`less`. Daemon mode doesn't write structured
-    // stdout, so this is a no-op there. Without this, the Rust default
-    // (`SIG_IGN`) turns a closed downstream pipe into an `EPIPE` that
-    // the println! infrastructure escalates into a panic.
-    #[cfg(unix)]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
-
     let cli = Cli::parse();
+
+    // Restore the default SIGPIPE disposition (`SIG_DFL`) ONLY for
+    // CLI-style modes (`--check`, `--graph`, `--test-pipeline`) that
+    // write structured stdout and may be piped through `head` / `less`.
+    // In those modes a downstream pipe close should cleanly terminate
+    // limpid; without `SIG_DFL` the Rust default (`SIG_IGN`) turns the
+    // closed pipe into an `EPIPE` that `println!` escalates into a panic.
+    //
+    // Daemon mode keeps the Rust default (`SIG_IGN`) so a broken pipe
+    // on the stderr side (systemd-journald backing off under a retry-
+    // loop tracing burst, or the journald being restarted) surfaces as
+    // an ordinary `EPIPE` write error the tracing subscriber can drop,
+    // rather than killing the whole daemon. The earlier unconditional
+    // `SIG_DFL` at main entry allowed a saturated stderr / journald
+    // pipe under a tracing burst to raise SIGPIPE on the next write and
+    // take the daemon down; systemd can classify a SIGPIPE exit as
+    // clean (`Deactivated successfully. … signal=PIPE`), so daemon
+    // mode must not restore `SIG_DFL`.
+    let is_cli_mode = cli.check
+        || cli.strict_warnings
+        || cli.ultra_strict
+        || cli.graph.is_some()
+        || cli.test_pipeline.is_some();
+    #[cfg(unix)]
+    if is_cli_mode {
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        }
+    }
 
     // Initialize tracing
     if cli.debug {

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1008,7 +1008,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.11"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.12"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -10,13 +10,14 @@ Description=limpid log pipeline daemon
 Documentation=https://github.com/naoto256/limpid
 After=network.target
 Conflicts=rsyslog.service syslog-ng.service syslog.socket
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/limpid --config /etc/limpid/limpid.conf
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=15
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 User=syslog

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -24,7 +24,7 @@ read that and explains the OTLP-specific reading on top.
 
 ## 1. Scope
 
-| Aspect | Current (0.7.11) |
+| Aspect | Current (0.7.12) |
 |---|---|
 | Signal | **logs** only — no traces, no metrics, no profiles |
 | Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` introduced in 0.7.6; in 0.7.8 plaintext `http://` with `tls { ... }` is now rejected at parse time — see CHANGELOG 0.7.8) |

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -9,8 +9,17 @@ Type=simple
 ExecStart=/usr/bin/limpid --config /etc/limpid/limpid.conf
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=15
-Restart=on-failure
+# `Restart=always` (not `on-failure`) catches signal-killed exits that
+# systemd otherwise treats as clean — notably SIGPIPE from a saturated
+# stderr / journald pipe under a tracing burst. `systemctl stop` still
+# stops the unit cleanly because systemd remembers the operator-initiated
+# transition and does not restart. `StartLimitIntervalSec=0` disables
+# the start-rate ceiling so a sustained-crash regression cannot wedge
+# the unit into `failed` state; each attempt is still paced by
+# `RestartSec=5`.
+Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 # Run as dedicated user
 User=syslog

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -3,23 +3,28 @@ Description=limpid log pipeline daemon
 Documentation=https://github.com/naoto256/limpid
 After=network.target
 Conflicts=rsyslog.service syslog-ng.service syslog.socket
+# StartLimitIntervalSec lives in [Unit] (modern systemd rejects it
+# in [Service] with "Unknown lvalue"). Setting to 0 disables the
+# start-rate ceiling so a sustained-crash regression cannot wedge
+# the unit into `failed` state; individual attempts are still paced
+# by `RestartSec` in [Service]. Paired with `Restart=always` below.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/limpid --config /etc/limpid/limpid.conf
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=15
-# `Restart=always` (not `on-failure`) catches signal-killed exits that
-# systemd otherwise treats as clean — notably SIGPIPE from a saturated
-# stderr / journald pipe under a tracing burst. `systemctl stop` still
-# stops the unit cleanly because systemd remembers the operator-initiated
-# transition and does not restart. `StartLimitIntervalSec=0` disables
-# the start-rate ceiling so a sustained-crash regression cannot wedge
-# the unit into `failed` state; each attempt is still paced by
-# `RestartSec=5`.
+# `Restart=always` (not `on-failure`) catches signal-killed exits
+# that systemd otherwise treats as clean — notably SIGPIPE from a
+# saturated stderr / journald pipe under a tracing burst.
+# `systemctl stop` still stops the unit cleanly because systemd
+# remembers operator-initiated transitions and does not restart
+# across them. Paired with `StartLimitIntervalSec=0` in [Unit] so a
+# persistent crash loop keeps retrying instead of being rate-limited
+# into `failed` state.
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=0
 
 # Run as dedicated user
 User=syslog


### PR DESCRIPTION
Merges \`release/0.7.12\` into \`main\` for the v0.7.12 release. Static analysis gates (CodeQL + CodeRabbit) run on this PR; any findings are fixed on the \`release/0.7.12\` branch and pulled forward before merge. The \`v0.7.12\` tag is applied on \`main\` after merge.

## Release theme

Hotfix for a daemon-fatal SIGPIPE path. A saturated stderr / systemd-journald pipe under a tracing burst — typically a downed OTLP output driving its retry loop's WARN spam — would take the whole daemon with it, and systemd would not restart it because the exit looked clean. The daemon now keeps Rust's \`SIG_IGN\` default for SIGPIPE, and the shipped \`limpid.service\` unit restarts on any exit reason as defence-in-depth against future variants.

## Commits in this release

One commit is integrated:

| SHA | Subject |
|---|---|
| \`7f46445\` | fix(daemon,packaging): keep SIGPIPE ignored in daemon mode, and switch the packaged systemd unit to Restart=always with StartLimitIntervalSec=0 |

The commit went through commit-gate confidentiality (re-anchored after two rounds of prose tightening) and push-gate 9 scope audit (7 audit PASS + 2 owner-confirmed standing baselines) before landing on \`release/0.7.12\`; no new source diff is introduced by this PR itself.

## Highlights

- **Daemon no longer dies on a broken tracing pipe.** \`crates/limpid/src/main.rs\` previously restored \`SIGPIPE = SIG_DFL\` at process entry unconditionally, before CLI parsing. The intent was to make CLI-style modes (\`--check\`, \`--test-pipeline\`, \`--graph\`) terminate cleanly when their stdout was piped through \`head\` / \`less\`; the effect was to also arm the daemon to die on any broken pipe. The \`SIG_DFL\` install is now gated on the CLI-mode flags; daemon mode keeps Rust's \`SIG_IGN\` default, so a broken pipe on the stderr side surfaces as an ordinary \`EPIPE\` write error the tracing subscriber drops.
- **Packaged systemd unit uses \`Restart=always\` and disables \`StartLimitIntervalSec\`.** \`packaging/limpid.service\` moves from \`Restart=on-failure\` to \`Restart=always\` so a signal-killed exit that systemd classifies as clean still triggers restart (SIGPIPE being the load-bearing case). \`systemctl stop\` continues to stop the unit cleanly because systemd remembers operator-initiated transitions. \`StartLimitIntervalSec=0\` disables the start-rate ceiling so a sustained-crash regression cannot wedge the unit into \`failed\` state; \`RestartSec=5\` still paces individual restart attempts.

Full detail in \`CHANGELOG.md\` \`[0.7.12]\` entry.

## Test plan

- [ ] CI green on all check / check-kafka / supply-chain jobs
- [ ] CodeRabbit review clean (or findings triaged on release/0.7.12)
- [ ] Local \`cargo build --workspace\` produces binaries reporting \`0.7.12\`
- [ ] After merge + deb build + install on the log-forwarder host: \`systemctl show limpid --property=Restart --property=StartLimitIntervalUSec\` prints \`Restart=always\` and \`StartLimitIntervalUSec=infinity\` (\`0\` normalised); a SIGPIPE reproducer (e.g. filling the journald forwarding pipe on a downed OTLP output) leaves the daemon running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented daemon shutdowns and errors when tracing output pipes close unexpectedly.
  - Preserved expected behavior for command-line output modes.

- **Service Reliability**
  - Services now restart automatically regardless of exit reason.
  - Removed systemd start-rate limits that could prevent recovery after repeated restarts.

- **Documentation**
  - Updated version references and examples to reflect release 0.7.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->