### PR TITLE
fix(packaging,docs): move StartLimitIntervalSec to [Unit] and refresh systemd docs example

### DIFF
--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -10,13 +10,14 @@ Description=limpid log pipeline daemon
 Documentation=https://github.com/naoto256/limpid
 After=network.target
 Conflicts=rsyslog.service syslog-ng.service syslog.socket
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/limpid --config /etc/limpid/limpid.conf
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=15
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 User=syslog

--- a/packaging/limpid.service
+++ b/packaging/limpid.service
@@ -3,23 +3,28 @@ Description=limpid log pipeline daemon
 Documentation=https://github.com/naoto256/limpid
 After=network.target
 Conflicts=rsyslog.service syslog-ng.service syslog.socket
+# StartLimitIntervalSec lives in [Unit] (modern systemd rejects it
+# in [Service] with "Unknown lvalue"). Setting to 0 disables the
+# start-rate ceiling so a sustained-crash regression cannot wedge
+# the unit into `failed` state; individual attempts are still paced
+# by `RestartSec` in [Service]. Paired with `Restart=always` below.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/limpid --config /etc/limpid/limpid.conf
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=15
-# `Restart=always` (not `on-failure`) catches signal-killed exits that
-# systemd otherwise treats as clean — notably SIGPIPE from a saturated
-# stderr / journald pipe under a tracing burst. `systemctl stop` still
-# stops the unit cleanly because systemd remembers the operator-initiated
-# transition and does not restart. `StartLimitIntervalSec=0` disables
-# the start-rate ceiling so a sustained-crash regression cannot wedge
-# the unit into `failed` state; each attempt is still paced by
-# `RestartSec=5`.
+# `Restart=always` (not `on-failure`) catches signal-killed exits
+# that systemd otherwise treats as clean — notably SIGPIPE from a
+# saturated stderr / journald pipe under a tracing burst.
+# `systemctl stop` still stops the unit cleanly because systemd
+# remembers operator-initiated transitions and does not restart
+# across them. Paired with `StartLimitIntervalSec=0` in [Unit] so a
+# persistent crash loop keeps retrying instead of being rate-limited
+# into `failed` state.
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=0
 
 # Run as dedicated user
 User=syslog


### PR DESCRIPTION
Two CodeRabbit findings on PR #160 (release/0.7.12 → main):

**Finding 1 — spec bug (Minor, Quick win)**: \`StartLimitIntervalSec=\` must live in the \`[Unit]\` section. Modern systemd rejects it in \`[Service]\` with \"Unknown lvalue\"; the 0.7.12 hotfix placed it under \`[Service]\` alongside \`Restart=\` because they are conceptually a pair, but systemd's section rules override the readability preference.

**Finding 2 — docs drift (Minor, Quick win)**: \`docs/src/operations/systemd.md\` still displayed the pre-hotfix \`Restart=on-failure\` example and had no \`StartLimitIntervalSec\` line at all, so an operator copy-pasting from the docs would have gotten neither the SIGPIPE recovery nor the start-rate override.

## Fix

- \`packaging/limpid.service\`: move \`StartLimitIntervalSec=0\` from \`[Service]\` to \`[Unit]\`. Thread the paired \`Restart=always\` explanation across the two sections so a reader of either half sees why the other setting exists.
- \`docs/src/operations/systemd.md\`: refresh the worked-example block to match the shipped unit (Restart=always in \`[Service]\`, StartLimitIntervalSec=0 in \`[Unit]\`).

Runtime semantics unchanged — systemd applies \`StartLimitIntervalSec\` the same way regardless of which section a legacy version accepted it from; the move only stops modern systemd from rejecting the directive.

## Verification

- \`cargo build --workspace\` — green
- \`cargo test --workspace\` — 946 passed / 1 ignored / 0 failed
- \`cargo xtask lint-snippet-headers\` — 39 files, 0 errors, 0 warnings
- \`cargo fmt --all -- --check\` — clean

## Test plan

- [ ] CI green on all check / check-kafka / supply-chain jobs
- [ ] \`systemd-analyze verify /path/to/limpid.service\` prints no \"Unknown lvalue\" warning against the packaged unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)