### PR TITLE
LSIS strata: parsed / shed / composed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,84 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime shape converge. After 1.0, changes will follow semver strictly.
 
+## [0.7.13] - 2026-07-11
+
+0.7.13 splits the `workspace.lsis.*` LSIS namespace into three explicit layers and reshapes the two envelope composers around the new contract. The trigger was AMP (Azure Monitor Pipeline) integration surfacing that `compose_otlp` had no way to accept caller-supplied target-vocabulary attributes (CommonSecurityLog columns) without every downstream reimplementing the OTLP encoding locally. Rather than expose a shed slot per attribute as an ad-hoc extension hatch, the LSIS namespace itself now has three sub-layers with distinct kinds of contract — a facts layer parsers write, a plumbing layer glue blocks write for the next composer, and a products layer composers write. The runtime is unchanged in behaviour; the surface differences are confined to snippet pack contents, docs prose, and the header lint that keeps the pack self-consistent. All out-of-tree configs that touched `workspace.lsis.*` will need to move to the layered names — the mapping is mechanical and the CHANGELOG's `Changed` section below lists it explicitly.
+
+### Added — LSIS namespace stratified into `parsed` / `shed` / `composed`
+
+The flat `workspace.lsis.*` namespace forced facts, hand-off plumbing, and finished wire-form products to share the same face, and that flatness is what produced the recurring "OCSF-shaped" confusion in the field (readers looking for a schema with required fields on `workspace.lsis.*` and not finding one, because there wasn't one — it was a dictionary, and the values were graceful-absence).
+
+Three layers, each with a distinct kind of contract, now live under the same reserved root:
+
+- **`workspace.lsis.parsed.*`** — facts a parser established about the event. A vocabulary contract, dictionary semantics, every field optional; the vocabulary leans OCSF but is an open set. Writers: parsers. Readers: everyone.
+- **`workspace.lsis.shed.*`** — hand-off values a glue block wrote for the next composer. A per-consumer plumbing contract, no globally reserved vocabulary — names borrow the consumer's own vocabulary (`shed.otlp.log_record.body`, `shed.rfc5424.msg`), and each consuming composer's header enumerates the slots it eats and the defaults it applies. Values are scoped to one hand-off; nothing under `shed.` is a fact about the event.
+- **`workspace.lsis.composed.*`** — finished wire forms, one slot per composer (`composed.ocsf`, `composed.otlp`, `composed.rfc5424`, `composed.replayable`). A registry contract, single-writer invariant. Egress terminators read from here (`egress = workspace.lsis.composed.otlp` is the whole story of shipping an event).
+
+The pack README's LSIS section carries the canonical explanation of the three layers and the slot registries; docs/src references now link there rather than paraphrasing in place.
+
+### Changed — `compose_otlp` reads shed slots + parsed graceful reads (instead of the old `otlp_body` per-envelope slot)
+
+The 0.7.11 envelope composer's "envelope neutrality" doctrine — read only a declared `otlp_body` and produce a minimal envelope — is retired. Real OTLP targets need a way to feed target-specific attributes (AMP CommonSecurityLog columns, `service.name` for a specific backend, etc.) that the pack cannot know about, and forcing every downstream to reimplement compose_otlp locally is not a shape the pack should ship.
+
+`compose_otlp` now reads four `shed` slots plus two `parsed` graceful reads, with a uniform `coalesce(shed value, default)` replacement semantics for every shed slot (no merge):
+
+```
+workspace.lsis.shed.otlp.resource.attributes    (optional Array of KeyValue)
+workspace.lsis.shed.otlp.scope.attributes       (optional Array of KeyValue)
+workspace.lsis.shed.otlp.log_record.body        (required String)
+workspace.lsis.shed.otlp.log_record.attributes  (optional Array of KeyValue)
+
+workspace.lsis.parsed.time         → time_unix_nano  (falls back to received_at)
+workspace.lsis.parsed.severity_id  → severity_number (omitted when 0/absent —
+                                                       OCSF Unknown = 0)
+```
+
+Callers that supply `resource.attributes` REPLACE the default `[host.name]` array (if they still want host.name they include it in the array they pass); callers that supply nothing get the pre-0.7.13 behaviour byte-for-byte modulo the time / severity graceful reads that were previously hard-coded to `received_at` / omitted. The AMP attribute case is demonstrated in the composer's header.
+
+Pipelines that used the 0.7.11 shape (`{ workspace.lsis.otlp_body = workspace.lsis.ocsf } | compose_otlp | otlp_to_egress`) migrate mechanically to `{ workspace.lsis.shed.otlp.log_record.body = workspace.lsis.composed.ocsf } | compose_otlp | otlp_to_egress`.
+
+### Changed — `compose_rfc5424` split into a generic composer + `journald_to_rfc5424` bridge
+
+The 0.7.11 `compose_rfc5424` read `workspace.journald.*` directly, which was the same shape as the CEF-direct-read carve-out that the 0.7.11 design pass explicitly rejected for pack composers. It also had two latent DSL bugs (three zero-arg `def function`s without `()`, and function bodies reading `workspace.journald.*` in violation of the analyzer's purity contract) — neither the pack's CI nor any downstream test happened to exercise the file end-to-end, so both had been shipping quietly. 0.7.13 fixes the contract violation and the shipping bugs together.
+
+`compose_rfc5424.limpid` now contains three cooperating processes plus one pure helper:
+
+- **`def process compose_rfc5424`** (generic body composer) — reads eight `shed.rfc5424.*` slots (`pri` / `timestamp` / `hostname` / `app_name` / `procid` / `msgid` / `sd` / `msg`, with `msg` the only intended-required slot) and writes `workspace.lsis.composed.rfc5424`. Same `coalesce(shed value, default)` replacement semantics as compose_otlp.
+- **`def process journald_to_rfc5424`** (bridge) — reads `workspace.journald.*` (produced by `parse_journald`) and populates the `shed.rfc5424.*` slots. Unset slots fall back to compose_rfc5424's defaults, so the wire output is byte-identical to the old direct-read composer.
+- **`def function rfc5424_pri_from(facility_str, severity_str)`** — the PRI arithmetic (facility × 8 + severity) as a pure helper the bridge calls with journald's byte-string fields.
+- **`def process rfc5424_to_egress`** — unchanged.
+
+Pipelines that used `parse_journald | compose_rfc5424 | rfc5424_to_egress` migrate to `parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress` (one extra pipe stage). Non-journald upstreams that want to emit RFC 5424 records now set `shed.rfc5424.*` from an anonymous glue block or a bespoke bridge — see the composer's header for the two supported shapes.
+
+### Changed — namespace rename `workspace.lsis.<field>` → `workspace.lsis.<layer>.<field>` (mechanical)
+
+Every snippet body and every docs example is updated. The mechanical mapping for out-of-tree configs that touched `workspace.lsis.*` directly:
+
+| Old flat name | New layered name |
+|---|---|
+| `workspace.lsis.<any fact field>` (e.g. `.severity_id`, `.time`, `.src_endpoint.ip`) | `workspace.lsis.parsed.<same field>` |
+| `workspace.lsis.otlp_body` | `workspace.lsis.shed.otlp.log_record.body` |
+| `workspace.lsis.ocsf` | `workspace.lsis.composed.ocsf` |
+| `workspace.lsis.rfc5424` | `workspace.lsis.composed.rfc5424` |
+| `workspace.lsis.replayable` | `workspace.lsis.composed.replayable` |
+| `workspace.lsis.otlp` | `workspace.lsis.composed.otlp` |
+| bare `workspace.lsis = { … }` (whole-hash assign in a parser) | `workspace.lsis.parsed = { … }` |
+
+Transport-namespace parsers (`parse_syslog` → `workspace.syslog.*`, `parse_journald` → `workspace.journald.*`) are unaffected — those namespaces live outside LSIS by design, and the pack composers no longer read them directly (bridges now do that job on the consumer side).
+
+### Changed — xtask header lint accepts multi-segment paths
+
+`cargo xtask lint-snippet-headers` teaches its `Reads:` grammar to accept dot-separated ascii-ident paths — both in the workspace namespace at the first line (`workspace.lsis.shed.otlp.*` is a valid intake declaration) and in the intake dot-line's `<name>` field (`.log_record.attributes (optional, Array)` describes an intake slot with a structured name). The 7-element `INTAKE_TYPES` whitelist is unchanged; type refinements like "of KeyValue" go in trailing prose after the closing `)` rather than in the type marker. A new unit test locks in the relaxed grammar so it does not silently drift back.
+
+### Fixed — pack composer inventory table renders new slot names
+
+`cargo xtask gen-snippet-inventory` refreshes the composer table in `packaging/snippets/README.md`. The Writes column now points at the new `workspace.lsis.composed.<slot>` outputs, and the Summary column reflects the rewritten compose_otlp / compose_rfc5424 headers.
+
+### Changed — docs/src collapses LSIS mechanics to a single pointer
+
+Every docs page under `docs/src/` that previously carried its own paraphrase of the LSIS contract now links into `packaging/snippets/README.md`'s LSIS section — the canonical description lives there and only there. Docs prose stays snippet-pack-facing; the language reference does not gain LSIS material. Pipeline examples that showed old slot names are updated to the layered names.
+
 ## [0.7.12] - 2026-07-11
 
 0.7.12 is a hotfix for a daemon-fatal SIGPIPE path: a saturated stderr / systemd-journald pipe under a tracing burst (typically a downed OTLP output driving its retry loop's WARN spam) would take the whole daemon with it, and systemd would not restart it because the exit looked clean. The daemon now keeps Rust's `SIG_IGN` default for `SIGPIPE`, and the shipped `limpid.service` unit restarts on any exit reason as defence-in-depth against future variants.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ def pipeline fortigate_to_security_lake {
 }
 ```
 
-The flow is right there in the config. Bytes arrive on `fortigate_syslog`; `parse_fortigate_cef` extracts structured fields into the canonical `workspace.lsis.*` intermediate; `compose_ocsf` dispatches on `workspace.lsis.class_uid` and emits the matching OCSF JSON; the result leaves through `security_lake`. No hidden behavior. No plugin to install. No separate "transform" config.
+The flow is right there in the config. Bytes arrive on `fortigate_syslog`; `parse_fortigate_cef` extracts structured fields into `workspace.lsis.parsed.*` (the LSIS facts layer); `compose_ocsf` dispatches on `workspace.lsis.parsed.class_uid` and emits the matching OCSF JSON to `workspace.lsis.composed.ocsf`; the companion `ocsf_to_egress` hands that slot off to `egress` and the result leaves through `security_lake`. No hidden behavior. No plugin to install. No separate "transform" config.
 
 In limpid, anything you want to do to a log on its way from input to output is achieved by freely combining `process`es.
 
@@ -36,20 +36,20 @@ A reusable chunk of pipeline logic — small, named, drop-in. You write them you
 
 ```limpid
 def process compose_ocsf_detection_finding {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    2004,                     // Detection Finding
         category_uid: 2,                        // Findings
         activity_id:  activity,
         type_uid:     2004 * 100 + activity,
-        time:         coalesce(workspace.lsis.time, received_at),
-        severity_id:  workspace.lsis.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        severity_id:  workspace.lsis.parsed.severity_id,
         // ...
     }))
 }
 // Companion one-line process `ocsf_to_egress` (in the same file)
-// moves the LSIS slot to `egress` — the egress single-writer
-// invariant. See packaging/snippets/README.md § Slot registry.
+// moves the composed slot to `egress` — the egress single-writer
+// invariant. See packaging/snippets/README.md § Slot registry — composed layer.
 ```
 
 Each `def process` is one small responsibility — parse one vendor, shape one schema, drop one class of events. A pipeline is a chain of them, separated by `|`, written in the same DSL whether you authored the piece yourself or pulled it from the library.
@@ -73,7 +73,7 @@ And here is the half that should make you grin — daily operations the alternat
 - **You can watch the pipeline work, live.** `limpidctl tap output security_lake --json` streams events as they leave for the destination (source, ingress, egress bytes). `limpidctl tap process compose_ocsf --json` shows the workspace state at that pipeline hop. No pause, no traffic duplication, no second tool. Every pipeline is its own debugger.
 
   ```text
-  $ limpidctl tap process compose_ocsf --json | jq -c '{src: .source, sev: .workspace.lsis.severity_id, class: .workspace.lsis.class_uid}'
+  $ limpidctl tap process compose_ocsf --json | jq -c '{src: .source, sev: .workspace.lsis.parsed.severity_id, class: .workspace.lsis.parsed.class_uid}'
   {"src":{"ip":"10.0.0.21","port":51234},"sev":3,"class":200401}
   {"src":{"ip":"10.0.0.21","port":51234},"sev":7,"class":200401}
   {"src":{"ip":"10.0.0.22","port":42100},"sev":2,"class":200401}
@@ -159,10 +159,10 @@ Curated parser / composer / filter library, installed under `/usr/share/limpid/s
 
 - **Transport parsers (2, v0.7.1)** — `parse_syslog` (RFC 3164 / 5424 syslog wire) · `parse_journald` (systemd journald JSON). These populate `workspace.<transport>.*` and feed any vocabulary parser downstream via an inline bridge.
 - **Vendor parsers (29)** — security devices / cloud audit: `parse_fortigate_cef` · `parse_fortigate_syslog` · `parse_paloalto_cef` · `parse_paloalto_syslog` · `parse_asa` · `parse_cloudtrail` · `parse_juniper_srx_sd_syslog` (Junos structured-data) · `parse_juniper_srx_syslog` (Junos unstructured RT_IDP) · `parse_checkpoint_leef` (LEEF 2.0 / QRadar) · `parse_checkpoint_syslog` (Check Point Syslog Exporter, real-corpus verified) · `parse_nsp` (Trellix Network Security Platform, real-traffic verified). OSS NDR: `parse_suricata` (EVE JSON) · `parse_zeek_default` / `parse_zeek_soc` / `parse_zeek_full` (Zeek 8 / 20 / 43 protocol scripts, nested-superset scopes, with `_native` / `_flat` convenience variants for raw Zeek vs Filebeat-flat upstream). Cloud (audit / data-plane / findings / identity / orchestration): `parse_aws_guardduty` · `parse_aws_vpc_flow` · `parse_azure_activity` · `parse_k8s_audit` · `parse_okta_system`. Server / host vocabulary: `parse_openssh` · `parse_sudo` · `parse_combined_log` (Apache / Nginx) · `parse_postfix` · `parse_winevent_json` · `parse_sysmon` · `parse_bind` · `parse_auditd` (7 LSIS classes, real-corpus verified). Vendor-neutral: `parse_ocsf`.
-- **Composers (4)** — `compose_ocsf` (OCSF 1.3.0 priority set, 27 classes, dispatched by `workspace.lsis.class_uid`) · `compose_rfc5424` (journald → RFC 5424 wire, v0.7.1) · `compose_replayable` (replay-shape capture) · `compose_otlp` (envelope composer wrapping a schema slot into OTLP 1.0.0 ResourceLogs bytes). Schema composers write to `workspace.lsis.<schema>` slots; a companion `<schema>_to_egress` one-line process (shipped alongside each composer) moves the slot to `egress` under the egress single-writer invariant.
+- **Composers (4)** — `compose_ocsf` (OCSF 1.3.0 priority set, 27 classes, dispatched by `workspace.lsis.parsed.class_uid`) · `compose_rfc5424` (generic RFC 5424 record composer with a `journald_to_rfc5424` bridge for edge → syslog-relay use, v0.7.1) · `compose_replayable` (replay-shape capture) · `compose_otlp` (assembles OTLP 1.0.0 `ResourceLogs` proto bytes from per-field shed slots + parsed-layer graceful reads). Composers write to `workspace.lsis.composed.<slot>`; a companion `<slot>_to_egress` one-line process (shipped alongside each composer) moves the slot to `egress` under the egress single-writer invariant.
 - **Filters (1)** — `filter_openssh_journal` (drops PAM session double-count noise from journald sshd streams).
 
-Each parser writes to the canonical `workspace.lsis.*` intermediate (the Limpid Snippet Intermediate Schema — see [LSIS](packaging/snippets/README.md#lsis--the-parser--composer-intermediate)); `compose_ocsf` reads from it and emits OCSF JSON to the LSIS slot `workspace.lsis.ocsf`, and the companion `ocsf_to_egress` hands the slot off to `egress`. Two `include` lines + a two-stage pipeline gets vendor logs into a SIEM / data lake in OCSF form. Full reference: [Snippet Library](packaging/snippets/README.md).
+Each parser writes facts to `workspace.lsis.parsed.*` (the LSIS facts layer — the Limpid Snippet Intermediate Schema, a three-layer gentleman's agreement documented in the [pack snippet README](packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema)); `compose_ocsf` reads from it and emits OCSF JSON to `workspace.lsis.composed.ocsf`, and the companion `ocsf_to_egress` hands the slot off to `egress`. Two `include` lines + a two-stage pipeline gets vendor logs into a SIEM / data lake in OCSF form. Full reference: [Snippet Library](packaging/snippets/README.md).
 
 ### Functions
 

--- a/crates/limpid/src/functions/primitives/coalesce.rs
+++ b/crates/limpid/src/functions/primitives/coalesce.rs
@@ -4,12 +4,12 @@
 //! `Value::Null`. If every argument is null, returns `Null`.
 //!
 //! Designed for the OCSF / replay-shape composers, where a populated
-//! field on `workspace.lsis` should win over an environmental
+//! field on `workspace.lsis.parsed` should win over an environmental
 //! fallback (`received_at`, `hostname()`, an explicit literal). The
 //! pre-coalesce idiom was a per-leaf `switch true { x != null { x }
 //! default { y } }`, which is correct but verbose at 27 OCSF leaves.
-//! `coalesce(workspace.lsis.time, received_at)` is the same
-//! semantically, ten characters wide, and reads top-to-bottom.
+//! `coalesce(workspace.lsis.parsed.time, received_at)` is the same
+//! semantically, and reads top-to-bottom.
 //!
 //! Semantics:
 //! - **Eager**: every argument is evaluated before `coalesce` runs (DSL

--- a/crates/xtask/src/header.rs
+++ b/crates/xtask/src/header.rs
@@ -554,10 +554,16 @@ fn classify_reads_first_line(first_line: &str) -> ReadsShape {
     if first_token == "ingress" {
         return ReadsShape::Ingress;
     }
-    // workspace.<ident>.*
+    // workspace.<ident>[.<ident>]*.*  — a dot-separated path of ascii
+    // idents ending in `.*`. Multi-segment paths surface the LSIS
+    // strata (`workspace.lsis.parsed.*`, `workspace.lsis.shed.otlp.*`)
+    // and any future nested transport namespace; single-segment paths
+    // (`workspace.journald.*`, `workspace.cef.*`) still classify the
+    // same way.
     if let Some(after_workspace) = first_token.strip_prefix("workspace.")
-        && let Some(dot_star) = after_workspace.strip_suffix(".*")
-        && is_ascii_ident(dot_star)
+        && let Some(path) = after_workspace.strip_suffix(".*")
+        && !path.is_empty()
+        && path.split('.').all(is_ascii_ident)
     {
         return ReadsShape::WorkspaceNamespace;
     }
@@ -568,19 +574,23 @@ fn classify_reads_first_line(first_line: &str) -> ReadsShape {
 /// [`DotLineDecl`]. Returns None if the line doesn't match. Trailing
 /// prose (e.g. `— sshd application body`) is permitted after the
 /// closing paren.
+///
+/// `<name>` may be a single ident (`.body`) or a dot-separated path
+/// (`.log_record.attributes`) that mirrors the structure of the
+/// intake slot. Every segment must be an ascii ident.
 fn parse_dot_line(line: &str) -> Option<DotLineDecl> {
     let s = line.strip_prefix('.')?;
-    // Consume identifier.
+    // Consume dot-separated identifier path: `<ident>(.<ident>)*`.
     let ident_end = s
         .char_indices()
-        .find(|(_, c)| !c.is_ascii_alphanumeric() && *c != '_')
+        .find(|(_, c)| !c.is_ascii_alphanumeric() && *c != '_' && *c != '.')
         .map(|(i, _)| i)
         .unwrap_or(s.len());
     if ident_end == 0 {
         return None;
     }
     let name = &s[..ident_end];
-    if !is_ascii_ident(name) {
+    if !name.split('.').all(is_ascii_ident) {
         return None;
     }
     // Consume required whitespace.
@@ -1009,6 +1019,24 @@ def function proto_num(name) {}
         let d = parse_dot_line(".body (required, String)  — sshd body").unwrap();
         assert_eq!(d.name, "body");
         assert!(d.required);
+    }
+
+    #[test]
+    fn reads_multi_segment_workspace_namespace_accepted() {
+        // LSIS strata surface as multi-segment paths:
+        // workspace.lsis.parsed.*, workspace.lsis.shed.otlp.*, etc.
+        // Also dot-line intake names may be dotted (log_record.body).
+        let h = composer(
+            "\
+// Summary:     Composer reading a multi-segment shed sub-tree
+// Reads:       workspace.lsis.shed.otlp.* — per-slot intake
+//                .log_record.body       (required, String) — body
+//                .log_record.attributes (optional, Array)  — attrs
+// Writes:      workspace.lsis.composed.otlp — proto bytes
+// Test corpus: spec-only (OTLP proto shape)
+",
+        );
+        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
     }
 
     #[test]

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -520,10 +520,10 @@ throughout composers and parsers.
 
 ```limpid
 // Composer: prefer parsed event time, fall back to received_at
-let event_time = coalesce(workspace.lsis.time, received_at)
+let event_time = coalesce(workspace.lsis.parsed.time, received_at)
 
 // Parser: pick first source IP that is populated
-workspace.lsis.src_endpoint.ip = coalesce(
+workspace.lsis.parsed.src_endpoint.ip = coalesce(
     workspace.cef.src,
     workspace.cef.sourceTranslatedAddress,
     workspace.syslog.hostname
@@ -582,9 +582,9 @@ egress = to_json(null_omit(workspace.payload))
 | `42` | `42` (scalar pass-through) |
 
 Designed for the schema-composer pattern (build a HashLit from
-parser-populated `workspace.lsis.*` fields, then `to_json` into the
-LSIS slot `workspace.lsis.<schema>`; the companion
-`<schema>_to_egress` process moves the slot to `egress`).
+`workspace.lsis.parsed.*` fields, then `to_json` into the composed
+slot `workspace.lsis.composed.<slot>`; the companion
+`<slot>_to_egress` process moves it to `egress`).
 Without `null_omit`, every absent field renders as `"key": null` in
 the output — not strictly invalid, but consumers that strictly
 validate against OCSF schema (Microsoft Sentinel, Splunk DM) often
@@ -679,7 +679,7 @@ Text-only primitives (`upper`, `regex_*`, `format`, `to_int`,
 Coerces a value to a 64-bit signed integer. Returns `null` on unparseable input, matching the partial-data policy of `regex_extract` and `table_lookup`.
 
 ```limpid
-workspace.lsis.src_endpoint.port = to_int(workspace.cef.spt)  // CEF ext: "54321" → 54321
+workspace.lsis.parsed.src_endpoint.port = to_int(workspace.cef.spt)  // CEF ext: "54321" → 54321
 ```
 
 | Input | Result |
@@ -817,7 +817,7 @@ let leaf = path(workspace.geo, dynamic_key, "name")
 Return a new array with `value` added at the back (`append`) or the front (`prepend`). The input array is not mutated — callers re-bind:
 
 ```limpid
-workspace.lsis.observables = append(workspace.lsis.observables, new_obs)
+workspace.lsis.parsed.observables = append(workspace.lsis.parsed.observables, new_obs)
 workspace.high_prio_tags = prepend(workspace.high_prio_tags, "urgent")
 ```
 
@@ -844,7 +844,7 @@ Cardinality primitive — works for every container-like type:
 | Scalars (`Int` / `Float` / `Bool`) | `Null` |
 
 ```limpid
-workspace.n_observables = len(workspace.lsis.observables)
+workspace.n_observables = len(workspace.lsis.parsed.observables)
 workspace.msg_len = len(workspace.syslog.msg)
 ```
 

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -17,7 +17,7 @@ Use one anywhere an expression goes:
 
 ```
 def process parse_fortigate_cef_traffic {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         connection_info: {
             protocol_num:  workspace.cef.proto,
             protocol_name: normalize_proto(workspace.cef.proto)
@@ -35,8 +35,8 @@ The name must be a bare identifier. `def function normalize_proto() { ... }` is 
 
 Anywhere an expression is evaluated — there's no callsite restriction on the function dispatch itself:
 
-- **Process bodies**: `workspace.lsis.severity_id = normalize_severity(workspace.cef.severity)`.
-- **Pipeline-level conditions**: `if is_critical(workspace.lsis.severity_id) { output urgent }`.
+- **Process bodies**: `workspace.lsis.parsed.severity_id = normalize_severity(workspace.cef.severity)`.
+- **Pipeline-level conditions**: `if is_critical(workspace.lsis.parsed.severity_id) { output urgent }`.
 - **`output` templates over event-intrinsic args**: `path "/var/log/limpid/${normalize_proto(source.port)}/events.log"` — the function call itself is fine; what *its arguments* may reference is restricted by the surrounding surface (output config rejects `workspace`, `egress`, `error`; see [DSL Syntax → String interpolation](../dsl-syntax.md#string-interpolation)). To route on a pipeline-mutable value, branch in the pipeline body and select between outputs whose own templates only reference event-intrinsic fields:
   ```limpid
   def output proto_tcp { type file path "/var/log/limpid/tcp/events.log" }
@@ -50,7 +50,7 @@ Anywhere an expression is evaluated — there's no callsite restriction on the f
       }
   }
   ```
-- **HashLit values**: `workspace.lsis = { severity_id: normalize_severity(...), ... }`.
+- **HashLit values**: `workspace.lsis.parsed = { severity_id: normalize_severity(...), ... }`.
 - **Function arguments**: `lower(normalize_proto(workspace.cef.proto))`.
 - **Binary operands**: `if double_score(s) > threshold { ... }`.
 
@@ -220,7 +220,7 @@ def function normalize_proto(num) {
 
 // parsers/parse_fortigate_cef.limpid
 def process parse_fortigate_cef_traffic {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid: 4001,
         severity_id: normalize_severity(workspace.cef.severity),
         connection_info: {

--- a/docs/src/inputs/journal.md
+++ b/docs/src/inputs/journal.md
@@ -95,17 +95,20 @@ def output relay {
 
 def pipeline ssh_to_relay {
     input ssh_journal
-    process parse_journald | compose_rfc5424 | rfc5424_to_egress
+    process parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress
     output relay
 }
 ```
 
 `parse_journald` populates `workspace.journald.*` with everything in the
-ingress JSON. `compose_rfc5424` reads those fields and writes a single-line
-RFC 5424 record to `workspace.lsis.rfc5424`; the companion `rfc5424_to_egress`
-step at the end of the pipeline hands that slot to `egress`. Swap
-`compose_rfc5424 | rfc5424_to_egress` for `parse_openssh | compose_ocsf |
-ocsf_to_egress` to ship OCSF Authentication events instead.
+ingress JSON. `journald_to_rfc5424` (a bridge shipped in the same file as
+`compose_rfc5424`) reads those fields and writes the per-RFC-5424-field shed
+slots; `compose_rfc5424` assembles the record and writes it to
+`workspace.lsis.composed.rfc5424`; the companion `rfc5424_to_egress` step at
+the end of the pipeline hands that slot to `egress`. Swap
+`journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress` for
+`parse_openssh | compose_ocsf | ocsf_to_egress` to ship OCSF Authentication
+events instead.
 
 ## Notes
 

--- a/docs/src/operations/schema-validation.md
+++ b/docs/src/operations/schema-validation.md
@@ -74,10 +74,10 @@ When a new downstream appears with a schema nobody has seen before, the integrat
 
 ## Recipes
 
-All recipes stream a JSONL Event via `limpidctl tap <kind> <name> --json` — the same Event JSON described in [Debug Tap](./tap.md), one event per line, with `received_at`, `source`, `ingress`, and `egress` top-level keys always present. Which tap point you pick — and whether the payload the schema lives on is `.egress` or `.workspace.lsis.<schema>` — depends on where the check lives:
+All recipes stream a JSONL Event via `limpidctl tap <kind> <name> --json` — the same Event JSON described in [Debug Tap](./tap.md), one event per line, with `received_at`, `source`, `ingress`, and `egress` top-level keys always present. Which tap point you pick — and whether the payload the schema lives on is `.egress` or `.workspace.lsis.composed.<slot>` — depends on where the check lives:
 
 - **Wire-level validation** (schema over the bytes the sink will actually ship) uses `tap output <name> --json` and reads `.egress`. This is the shape a receiver sees. `tap output --json` never carries `workspace` — the projection is unconditional in v0.7.10 regardless of queue backend.
-- **Pre-serialization / composed-object validation** (schema over the tree the pipeline built before rendering) uses `tap process <compose_process> --json` and reads `.workspace.lsis.<schema>` — the process tap emits at process exit with the full workspace state visible, which is where the composed structured payload lives before the sink renders it into `egress`. Picking the named `compose` process one hop back keeps the recipe reading the same LSIS slot the schema composer wrote, just from the pipeline point that actually holds it (see [LSIS slot registry](../../../packaging/snippets/README.md#slot-registry) for the full list).
+- **Pre-serialization / composed-object validation** (schema over the tree the pipeline built before rendering) uses `tap process <compose_process> --json` and reads `.workspace.lsis.composed.<slot>` — the process tap emits at process exit with the full workspace state visible, which is where the composed structured payload lives before the sink renders it into `egress`. Picking the named `compose` process one hop back keeps the recipe reading the same LSIS slot the schema composer wrote, just from the pipeline point that actually holds it (see [LSIS slot registry](../../../packaging/snippets/README.md#slot-registry) for the full list).
 
 ### OCSF (JSON Schema)
 
@@ -85,11 +85,11 @@ Use any JSON Schema validator. `ajv-cli` is convenient because it streams:
 
 ```bash
 limpidctl tap process compose_ocsf --json \
-  | jq -c '.workspace.lsis.ocsf' \
+  | jq -c '.workspace.lsis.composed.ocsf' \
   | ajv validate -s ocsf-schemas/network_activity.json --all-errors -
 ```
 
-`jq -c '.workspace.lsis.ocsf'` extracts the structured payload the pipeline built under a workspace key; substitute your own compose process name and the workspace path it writes to.
+`jq -c '.workspace.lsis.composed.ocsf'` extracts the structured payload the pipeline built under a workspace key; substitute your own compose process name and the workspace path it writes to.
 
 ### ECS (Elastic)
 
@@ -97,7 +97,7 @@ ECS ships YAML; convert to JSON Schema once with Elastic's generator and feed it
 
 ```bash
 limpidctl tap process compose_ecs --json \
-  | jq -c '.workspace.lsis.ecs' \
+  | jq -c '.workspace.lsis.composed.ecs' \
   | jsonschema -i /dev/stdin ecs.schema.json
 ```
 
@@ -146,7 +146,7 @@ sudo limpidctl inject input edge_syslog --json < tests/fixtures/edge.jsonl
 sleep 1   # drain
 kill $TAP_PID
 
-jq -c '.workspace.lsis.ocsf' tap.jsonl \
+jq -c '.workspace.lsis.composed.ocsf' tap.jsonl \
   | ajv validate -s schemas/ocsf/network_activity.json --all-errors -
 ```
 
@@ -162,7 +162,7 @@ Run the validator alongside the daemon as a separate service. The systemd patter
 # /etc/systemd/system/limpid-ocsf-monitor.service
 [Service]
 ExecStart=/bin/sh -c 'limpidctl tap process compose_ocsf --json \
-  | jq -c ".workspace.lsis.ocsf" \
+  | jq -c ".workspace.lsis.composed.ocsf" \
   | ajv validate -s /etc/limpid/schemas/ocsf_network_activity.json - \
   | logger -t limpid-ocsf-monitor'
 Restart=always

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -458,11 +458,24 @@ kvlist. limpid's snippet author chooses, per pipeline:
   understands the OTLP attribute model (the OTel-native path)
 
 A common pattern for cloud-bound pipelines is to run `compose_ocsf`
-so the OCSF JSON lands in the LSIS slot `workspace.lsis.ocsf`, then
-ship it as `body: { string_value: workspace.lsis.ocsf }` (the slot
-holds the already-serialised string, so no per-event `to_json`). This
-matches what most cloud backends expect, lets the OCSF schema do the
-structuring work, and avoids fighting the OTLP attribute namespace.
+so the OCSF JSON lands in `workspace.lsis.composed.ocsf`, then hand
+it into `compose_otlp` via the shed slot in a glue block:
+
+```
+process parse_x
+      | compose_ocsf
+      | {
+          workspace.lsis.shed.otlp.log_record.body =
+              workspace.lsis.composed.ocsf
+        }
+      | compose_otlp
+      | otlp_to_egress
+```
+
+The composed slot holds the already-serialised string, so no
+per-event `to_json`. This matches what most cloud backends expect,
+lets the OCSF schema do the structuring work, and avoids fighting the
+OTLP attribute namespace.
 
 ---
 

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -91,7 +91,7 @@ def process compose_otlp_from_ocsf {
 
     workspace.otlp = {
         resource: { attributes: [
-            { key: "service.name", value: { string_value: workspace.lsis.metadata.product.name } }
+            { key: "service.name", value: { string_value: workspace.lsis.parsed.metadata.product.name } }
         ]},
         scope_logs: [{
             scope: { name: "limpid", version: "0.5.0" },
@@ -99,7 +99,7 @@ def process compose_otlp_from_ocsf {
                 time_unix_nano: workspace.event_time_ns,
                 severity_number: 9,
                 severity_text: "INFO",
-                body: { string_value: workspace.lsis.ocsf }
+                body: { string_value: workspace.lsis.composed.ocsf }
             }]
         }]
     }

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -70,27 +70,27 @@ Put tags in the first block of comments inside the process body. One tag per lin
 
 ```
 def process compose_ocsf_authentication {
-    // @requires: workspace.lsis.severity_id          (required)
-    // @requires: workspace.lsis.src_endpoint.ip      (recommended)
-    // @requires: workspace.lsis.actor.user.name      (recommended)
-    // @produces: workspace.lsis.ocsf  (OCSF Authentication Activity, JSON string)
+    // @requires: workspace.lsis.parsed.severity_id          (required)
+    // @requires: workspace.lsis.parsed.src_endpoint.ip      (recommended)
+    // @requires: workspace.lsis.parsed.actor.user.name      (recommended)
+    // @produces: workspace.lsis.composed.ocsf  (OCSF Authentication Activity, JSON string)
     //
     // Expects: the calling pipeline has run a vendor parser that
-    // already mapped its raw fields into `workspace.lsis.*` canonical
-    // LSIS form. This composer is vendor-unaware — it does not read
-    // `workspace.cef.*` / `workspace.syslog.*` directly.
+    // already mapped its raw fields into `workspace.lsis.parsed.*`
+    // (the LSIS facts layer). This composer is vendor-unaware — it
+    // does not read `workspace.cef.*` / `workspace.syslog.*` directly.
     //
-    // Contract note: schema composers write to their LSIS slot
-    // (`workspace.lsis.ocsf` here) — never to `egress` directly. A
-    // companion one-line process `ocsf_to_egress` (defined next to
-    // the composer in the same file) moves the slot to `egress`
-    // when the pipeline emits OCSF as its wire form. This is the
-    // egress single-writer invariant — see
-    // [Slot registry](../../../packaging/snippets/README.md#slot-registry).
+    // Contract note: composers write their finished wire form to
+    // `workspace.lsis.composed.<slot>` — never to `egress` directly.
+    // A companion one-line process `ocsf_to_egress` (defined next to
+    // the composer in the same file) moves the slot to `egress` when
+    // the pipeline emits OCSF as its wire form. This is the egress
+    // single-writer invariant — see the [pack
+    // README](../../../packaging/snippets/README.md#slot-registry--composed-layer).
 
-    workspace.lsis.class_uid   = 3002
-    workspace.lsis.activity_id = 1
-    workspace.lsis.ocsf        = to_json(workspace.lsis)
+    workspace.lsis.parsed.class_uid   = 3002
+    workspace.lsis.parsed.activity_id = 1
+    workspace.lsis.composed.ocsf      = to_json(workspace.lsis.parsed)
 }
 ```
 
@@ -183,7 +183,7 @@ The question "function or process?" has a clean answer:
 | Recursive | A `def process` (`def function` rejects recursion at `--check` time) |
 | Operator-specific policy (facility rewrite, vendor filter, site-specific routing) | Always a `def process`, defined close to the pipeline that uses it |
 
-A snippet library (the `functions/*.limpid` + `parsers/parse_*.limpid` + `composers/compose_*.limpid` collection that ships under `/usr/share/limpid/snippets/`) mixes the three: `def function` files under `functions/` for vendor-agnostic mappings (severity, proto, action), `def process` files under `parsers/parse_*` for vendor parsers and under `composers/compose_*` for the per-class composer bodies that consume Event state and write to `workspace.lsis`, and built-in primitives (`syslog.parse`, `cef.parse`, `to_json`, `regex_*`) as the building blocks underneath.
+A snippet library (the `functions/*.limpid` + `parsers/parse_*.limpid` + `composers/compose_*.limpid` collection that ships under `/usr/share/limpid/snippets/`) mixes the three: `def function` files under `functions/` for vendor-agnostic mappings (severity, proto, action), `def process` files under `parsers/parse_*` for vendor parsers and under `composers/compose_*` for the per-class composer bodies that consume Event state and write to `workspace.lsis.parsed` / `workspace.lsis.composed.<slot>`, and built-in primitives (`syslog.parse`, `cef.parse`, `to_json`, `regex_*`) as the building blocks underneath.
 
 ## Writing for a snippet library
 
@@ -193,7 +193,7 @@ If your process is intended to ship in a library (vendor parsers, OCSF composers
 
 The library's organising axis is the **schema** a snippet implements. For vendor parsers, a schema is a *(vendor, format)* pair — `parsers/parse_fortigate_cef.limpid` is one schema (FortiGate's CEF field model), `parsers/parse_fortigate_syslog.limpid` is another (FortiGate's KV-over-syslog field model). The two share a vendor name but their field shapes, dispatchers, and subtype handling are different enough that the FortiGate documentation itself splits them into separate references; the snippet library follows.
 
-For OCSF composers, the schema is the class. The library ships a single dispatcher per emit format (`composers/compose_ocsf.limpid`) that branches on the OCSF class id (`workspace.lsis.class_uid`) to assemble the right shape per event, so vendors that feed multiple OCSF classes can share one composer entry point.
+For OCSF composers, the schema is the class. The library ships a single dispatcher per emit format (`composers/compose_ocsf.limpid`) that branches on the OCSF class id (`workspace.lsis.parsed.class_uid`) to assemble the right shape per event, so vendors that feed multiple OCSF classes can share one composer entry point.
 
 The contents of one file:
 
@@ -207,7 +207,7 @@ Do not pack multiple unrelated schemas into a single file.
 
 ### Use `workspace.lsis` as the canonical intermediate
 
-Pick one canonical intermediate shape and have every parser write into it; have every composer read from it. limpid's library uses the namespace `workspace.lsis` for this — the Limpid Snippet Intermediate Schema (LSIS), whose vocabulary is borrowed from OCSF 1.3.0 but which is not itself an OCSF conformance claim; see [LSIS](../../../packaging/snippets/README.md#lsis--the-parser--composer-intermediate) for the canonical definition and slot registry. The chain has three responsibility layers:
+Pick one canonical intermediate shape and have every parser write into it; have every composer read from it. limpid's library uses the namespace `workspace.lsis` for this — the Limpid Snippet Intermediate Schema (LSIS), stratified into `parsed` / `shed` / `composed` layers. See the [pack README](../../../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the layer contracts and slot registries; the summary that matters for this guide is the flow:
 
 ```
 ingress
@@ -223,15 +223,15 @@ ingress
    ▼
 ┌──────────────────────┐
 │  vendor parsers      │
-│  parse_fortigate_cef,│ ─► workspace.lsis.*    — canonical LSIS shape
-│  parse_paloalto_cef, │                            (OCSF-vocabulary, not
-│  parse_cloudtrail, … │                             OCSF-bound)
+│  parse_fortigate_cef,│ ─► workspace.lsis.parsed.*    — facts layer
+│  parse_paloalto_cef, │                                  (OCSF-vocabulary,
+│  parse_cloudtrail, … │                                   not OCSF-bound)
 └──────────────────────┘
    │
    ▼
 ┌────────────────────────────────┐
 │  schema composers              │
-│  compose_ocsf,                 │ ─► workspace.lsis.<slot>
+│  compose_ocsf,                 │ ─► workspace.lsis.composed.<slot>
 │  compose_rfc5424,              │       (target wire form: OCSF JSON,
 │  compose_replayable, …         │        RFC 5424 record, JSONL, …)
 └────────────────────────────────┘
@@ -246,24 +246,24 @@ ingress
 ```
 
 - **Format primitives** (`syslog.parse`, `cef.parse`, `parse_kv`, `parse_json`, `csv_parse`) capture raw bytes into a format-specific namespace (`workspace.syslog`, `workspace.cef`, …). They know nothing about vendors or downstream schemas.
-- **Vendor parsers** (`parse_fortigate_cef`, `parse_paloalto_cef`, `parse_cloudtrail`, `parse_ocsf`, …) read the format namespace and write canonical fields under `workspace.lsis.*`. This is the only layer that knows both the vendor's quirks and the canonical shape. (The shipped set grows on the 0.7.x cadence — see [Snippet Library](../snippets/README.md) for the current inventory.)
-- **Composers** (`compose_ocsf_network_activity`, `compose_ocsf_detection_finding`, `compose_ecs_network`, …) read `workspace.lsis.*` and serialise to the LSIS slot named after the target wire schema (`workspace.lsis.ocsf`, `workspace.lsis.rfc5424`, …). A companion one-line process, `<schema>_to_egress`, moves the slot to `egress` when the pipeline emits that schema as its wire form; envelope composers (e.g. `compose_otlp`) read the schema slot directly instead. Composers are vendor-unaware on purpose: they pluck `workspace.lsis.src_endpoint.ip` regardless of whether it came from a FortiGate or a Palo Alto event.
+- **Vendor parsers** (`parse_fortigate_cef`, `parse_paloalto_cef`, `parse_cloudtrail`, `parse_ocsf`, …) read the format namespace and write facts under `workspace.lsis.parsed.*`. This is the only layer that knows both the vendor's quirks and the canonical shape. (The shipped set grows on the 0.7.x cadence — see [Snippet Library](../snippets/README.md) for the current inventory.)
+- **Composers** read `workspace.lsis.parsed.*` (facts) and, when their target has structural room the facts layer cannot express, optionally `workspace.lsis.shed.<consumer>.*` (caller-supplied hand-off values). They serialise to `workspace.lsis.composed.<slot>` (OCSF JSON, RFC 5424 record, OTLP proto bytes, …). A companion one-line process, `<slot>_to_egress`, moves the slot to `egress` when the pipeline emits that shape as its wire form. Composers are vendor-unaware on purpose: they pluck `workspace.lsis.parsed.src_endpoint.ip` regardless of whether it came from a FortiGate or a Palo Alto event.
 
 The payoffs:
 
 - **Adding a new vendor** is a new parser; no composer change.
 - **Bumping a target wire schema** (OCSF v3 → v4, ECS minor bump) is a composer change; no parser change.
-- **Multiple vendors → one target** falls out for free — every parser drops its output into the same canonical workspace shape.
-- **Multiple targets from the same canonical** (one OCSF composer + one ECS composer reading the same `workspace.lsis.*`) is what makes the matrix manageable. The N-vendor × M-target multiplication never happens at the parser level.
+- **Multiple vendors → one target** falls out for free — every parser drops its output into the same facts layer.
+- **Multiple targets from the same facts** (one OCSF composer + one ECS composer reading the same `workspace.lsis.parsed.*`) is what makes the matrix manageable. The N-vendor × M-target multiplication never happens at the parser level.
 
 #### The parser / composer contract
 
-The two-sided rule of thumb for `workspace.lsis.*`:
+The two-sided rule of thumb for `workspace.lsis.parsed.*`:
 
-- **Parsers fill `workspace.lsis` in canonical LSIS shape — OCSF-vocabulary, not OCSF-bound.** Whenever a vendor field has a clean OCSF home, use the OCSF field name (`src_endpoint.ip`, `actor.user.name`). When it doesn't, carry it on `workspace.lsis` under a vendor-meaningful name; do not throw the data away just because OCSF has no slot.
-- **Composers may assume `workspace.lsis` follows canonical LSIS shape — but they must not assume strict OCSF compliance.** A composer reads the fields it needs and tolerates extras / absences. An OCSF composer renders `workspace.lsis.*` to OCSF JSON in the `workspace.lsis.ocsf` slot; an ECS composer would translate the same `workspace.lsis.*` into an ECS JSON slot, taking advantage of the OCSF-vocabulary overlap without depending on it.
+- **Parsers fill `workspace.lsis.parsed` in canonical LSIS shape — OCSF-vocabulary, not OCSF-bound.** Whenever a vendor field has a clean OCSF home, use the OCSF field name (`src_endpoint.ip`, `actor.user.name`). When it doesn't, carry it on `workspace.lsis.parsed` under a vendor-meaningful name; do not throw the data away just because OCSF has no slot.
+- **Composers may assume `workspace.lsis.parsed` follows canonical LSIS shape — but they must not assume strict OCSF compliance.** A composer reads the fields it needs and tolerates extras / absences. An OCSF composer renders `workspace.lsis.parsed.*` to OCSF JSON in the `workspace.lsis.composed.ocsf` slot; an ECS composer would translate the same facts into an ECS JSON slot, taking advantage of the OCSF-vocabulary overlap without depending on it.
 
-A parser must not write vendor-specific format names that bleed into the composer (`workspace.cef.src`, `workspace.fgt_session_id` left at top level); a composer must not read vendor-specific format names directly (`workspace.cef.src`). The contract between them is `workspace.lsis.*`, full stop. Each rename or pass-through layer beyond that is a drift risk.
+A parser must not write vendor-specific format names into the facts layer (`workspace.cef.src`, `workspace.fgt_session_id` left at top level); a composer must not read vendor-specific format names directly (`workspace.cef.src`). The contract between them is `workspace.lsis.parsed.*`, full stop. Each rename or pass-through layer beyond that is a drift risk.
 
 ### Keep composers pure
 
@@ -291,7 +291,7 @@ state it explicitly in a header block at the top of the file:
 //             pid   ← coalesce(workspace.journald._PID,
 //                              workspace.journald.SYSLOG_PID)
 //           (no upstream — falls back to parse_syslog inline on `ingress`)
-// Output:   workspace.lsis.* (OCSF Authentication, class_uid 3002)
+// Output:   workspace.lsis.parsed.* (OCSF Authentication, class_uid 3002)
 ```
 
 Stacks not listed are out of scope. If your wire is `openssh` over

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -35,7 +35,7 @@ A `let` binding can hold any value type — scalar, Object, or Array. When the b
 ```limpid
 def process parse_xxx {
     let f = regex_parse(workspace.body, "(?P<user>\\S+) (?P<host>\\S+)")
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         user: f.user,                    // read from the let-bound Object
         host: f.host
     }

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -59,23 +59,36 @@ SIGHUP).
 ### Composers
 
 - `composers/compose_ocsf.limpid` — dispatches by
-  `workspace.lsis.class_uid` to per-class leaves. Covers the OCSF
-  1.3.0 priority set (27 classes spanning System Activity / Findings
-  / Identity & Access Management / Network Activity / Application
-  Activity). Each leaf strips `null` keys via `null_omit` and writes
-  OCSF JSON to the LSIS slot `workspace.lsis.ocsf`; the companion
-  `ocsf_to_egress` process moves the slot to `egress` (the egress
-  single-writer invariant — see
-  [Slot registry](../../../packaging/snippets/README.md#slot-registry)).
-- `composers/compose_rfc5424.limpid` — `workspace.journald.*` →
-  RFC 5424 syslog wire. Used at edge boxes to re-frame journald
-  entries for syslog relay (e.g. edge → relay → AMA).
+  `workspace.lsis.parsed.class_uid` to per-class leaves. Covers the
+  OCSF 1.3.0 priority set (27 classes spanning System Activity /
+  Findings / Identity & Access Management / Network Activity /
+  Application Activity). Each leaf strips `null` keys via
+  `null_omit` and writes OCSF JSON to
+  `workspace.lsis.composed.ocsf`; the companion `ocsf_to_egress`
+  process moves the slot to `egress`.
+- `composers/compose_otlp.limpid` — assembles an OTLP-1.0.0
+  `ResourceLogs` proto envelope. The log body, target-specific
+  attributes, resource attributes, and scope attributes come from
+  `workspace.lsis.shed.otlp.*` slots that the caller sets in a glue
+  block. Common wrapping shape:
+  `{ workspace.lsis.shed.otlp.log_record.body =
+  workspace.lsis.composed.ocsf } | compose_otlp | otlp_to_egress`.
+- `composers/compose_rfc5424.limpid` — generic RFC 5424 wire
+  composer reading `workspace.lsis.shed.rfc5424.*` (pri / timestamp
+  / hostname / app_name / procid / msgid / sd / msg). A named
+  `journald_to_rfc5424` bridge lives in the same file for the
+  common journald → syslog-relay path (edge → relay → AMA).
 - `composers/compose_replayable.limpid` — minimal `{received_at,
   source, ingress}` JSON shape that round-trips through `inject
   --json` for parser regression / replay capture. Use it on a
   fan-out branch to record the raw wire while a parallel branch
   parses, so a parser bug discovered later can be fixed and the
   saved JSONL replayed offline.
+
+See the [pack
+README](../../../packaging/snippets/README.md#slot-registry--composed-layer)
+for the full composed / shed slot registries and the LSIS layer
+contracts.
 
 ### Filters
 
@@ -131,12 +144,12 @@ def pipeline fw_to_security_lake {
 }
 ```
 
-`parse_fortigate_cef` writes the parsed event to `workspace.lsis.*`
-in canonical LSIS shape; `compose_ocsf` reads from there and writes
-the OCSF JSON record to the LSIS slot `workspace.lsis.ocsf`; the
-one-line `ocsf_to_egress` companion at the tail of the pipeline
-moves the slot to `egress`. Swap the parser for any of the others;
-swap `compose_ocsf | ocsf_to_egress` for
+`parse_fortigate_cef` writes facts to `workspace.lsis.parsed.*`;
+`compose_ocsf` reads from there and writes the OCSF JSON record to
+`workspace.lsis.composed.ocsf`; the one-line `ocsf_to_egress`
+companion at the tail of the pipeline moves the slot to `egress`.
+Swap the parser for any of the others; swap
+`compose_ocsf | ocsf_to_egress` for
 `compose_replayable | replayable_to_egress` to capture replay-shape;
 chain a filter ahead of the parser to drop noise.
 
@@ -158,32 +171,14 @@ def pipeline mixed_in {
 
 ## Design contracts
 
-Two contracts run through the library — the parser ↔ composer
-canonical intermediate, and the loud-fail-fast policy on
-unsupported vocabulary.
+The LSIS namespace convention (three layers: parsed / shed /
+composed) that ties parsers and composers together is documented in
+the [pack
+README](../../../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema).
+Snippets and pipelines below follow the same three-layer contract.
 
-### `workspace.lsis` is the canonical intermediate
-
-`workspace.lsis.*` is the **LSIS** — the Limpid Snippet Intermediate
-Schema. LSIS's vocabulary is borrowed from OCSF 1.3.0 (so
-`compose_ocsf` renders LSIS to conformant OCSF JSON without
-translation) but LSIS is not itself an OCSF conformance claim —
-canonical definition and slot registry at
-[packaging/snippets/README.md § LSIS](../../../packaging/snippets/README.md#lsis--the-parser--composer-intermediate).
-
-Parsers populate `workspace.lsis.*` only with LSIS-vocabulary
-fields. Vendor / transport intermediates (`workspace.cef`,
-`workspace.syslog`, `workspace.pf`, `workspace.ct`,
-`workspace.winevent`, etc.) are parser-private scratch — no composer
-reads them. This keeps schema composers LSIS-aware without their
-being vendor-aware (they never see CEF quirks, FortiGate dialect,
-or PAN-OS positional CSV columns).
-
-The parser / composer chain is documented in [Process Design Guide →
-Use `workspace.lsis` as the canonical
-intermediate](../processing/design-guide.md#use-workspacelsis-as-the-canonical-intermediate). New
-parsers follow it; out-of-tree vendor parsers should follow it too
-so they compose cleanly with `compose_ocsf`.
+The other contract worth calling out here is the loud-fail-fast
+policy on unsupported vocabulary.
 
 ### Loud-fail-fast on unsupported vocabulary
 
@@ -272,8 +267,8 @@ conventions are:
 - **Two-tier dispatch**: the top-level `def process parse_<vendor>`
   strips the wrapper and routes by header field (`switch
   workspace.<vendor>.<key>`); per-leaf `def process` re-parses the
-  body against its subtype-specific shape and writes the OCSF
-  record to `workspace.lsis.*`.
+  body against its subtype-specific shape and writes the parsed
+  fact record to `workspace.lsis.parsed.*`.
 - **Loud-fail-fast** on unsupported vocabulary via `default { error
   "<operator-readable msg>" }`.
 - **Helpers** (`def function ...`) carry per-vendor mapping tables

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -67,7 +67,7 @@ After editing the config, reload the daemon to pick up the change — either `su
 
 FortiGate `traffic` events are too noisy to forward to AMA, but you still want them in the on-disk archive for after-the-fact investigation. So: archive everything, then drop FortiGate traffic, then forward what's left.
 
-To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The FortiGate CEF parser is provided as `parsers/parse_fortigate_cef.limpid` and exposes a `parse_fortigate_cef` process that fills `workspace.lsis.*` (limpid's canonical LSIS intermediate — see [LSIS](../packaging/snippets/README.md#lsis--the-parser--composer-intermediate) and [Process Design Guide](./processing/design-guide.md#use-workspacelsis-as-the-canonical-intermediate)) from a FortiGate CEF event. Before it builds the canonical intermediate, the parser also leaves the raw CEF header / extensions in `workspace.cef.*`; in particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
+To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The FortiGate CEF parser is provided as `parsers/parse_fortigate_cef.limpid` and exposes a `parse_fortigate_cef` process that fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract) — from a FortiGate CEF event. Before it builds the canonical intermediate, the parser also leaves the raw CEF header / extensions in `workspace.cef.*`; in particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
 
 ```limpid
 // /etc/limpid/limpid.conf  — add at the top
@@ -92,7 +92,7 @@ def output ama {
 def pipeline main {
     input fw_tcp
     output archive                                            // everything goes to disk
-    process parse_fortigate_cef                               // populate workspace.cef.* + workspace.lsis.*
+    process parse_fortigate_cef                               // populate workspace.cef.* + workspace.lsis.parsed.*
     if workspace.cef.cat == "traffic:forward" { drop }        // drop the noise
     output ama                                                // only the survivors reach AMA
 }
@@ -104,7 +104,7 @@ The first is the magic from Step 2. Even though the `process` and `if drop` afte
 
 The second is what the pipeline body actually contains: an `input`, two `output`s, a `process`, and an `if/drop`. There is no separate "filter" or "router" abstraction — routing decisions live in the pipeline as ordinary statements, in the order they execute. That mirrors how you'd describe the pipeline in words: "archive everything, parse it as FortiGate, drop traffic events, forward the rest to AMA."
 
-Worth one more note: `parse_fortigate_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) on its way to building `workspace.lsis.*`, and the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
+Worth one more note: `parse_fortigate_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) on its way to building `workspace.lsis.parsed.*`, and the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
 
 ## Step 4 — Confirm the drop is actually happening
 
@@ -225,7 +225,7 @@ The requirement changes: AMA *does* want visibility into FortiGate traffic event
 
 Dropping is no longer the right operation. Instead, dedup: forward the first event for each `(src, dst)` pair, suppress the rest until the entry expires.
 
-`parse_fortigate_cef` already populated `workspace.lsis.src_endpoint.ip` and `workspace.lsis.dst_endpoint.ip` (the snippet maps the FortiGate CEF event into limpid's canonical LSIS shape — see [Process Design Guide → canonical intermediate](./processing/design-guide.md#use-workspacelsis-as-the-canonical-intermediate)). We need somewhere to remember which pairs we have seen recently — that's what limpid's in-memory tables are for. Declare a table in `limpid.conf` (the `table` block must live in the main config), then write the process that consults and updates it.
+`parse_fortigate_cef` already populated `workspace.lsis.parsed.src_endpoint.ip` and `workspace.lsis.parsed.dst_endpoint.ip` (the snippet maps the FortiGate CEF event into the pack's LSIS facts layer — see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema)). We need somewhere to remember which pairs we have seen recently — that's what limpid's in-memory tables are for. Declare a table in `limpid.conf` (the `table` block must live in the main config), then write the process that consults and updates it.
 
 ```limpid
 // /etc/limpid/limpid.conf  — add the table block
@@ -241,7 +241,7 @@ table {
 // /etc/limpid/processes/dedup_fortigate_traffic.limpid
 def process dedup_fortigate_traffic {
     if workspace.cef.cat == "traffic:forward" {
-        let key = workspace.lsis.src_endpoint.ip + "|" + workspace.lsis.dst_endpoint.ip
+        let key = workspace.lsis.parsed.src_endpoint.ip + "|" + workspace.lsis.parsed.dst_endpoint.ip
         if table_lookup("traffic_seen", key) != null {
             drop
         }
@@ -263,7 +263,7 @@ def pipeline main {
 A few things to read:
 
 - `process A | B` chains processes left to right — the event flows through `parse_fortigate_cef` first, then `dedup_fortigate_traffic`. Equivalent to writing them on two `process` lines; the `|` form just reads more naturally when several processes line up.
-- `workspace.lsis.src_endpoint.ip` and `workspace.lsis.dst_endpoint.ip` exist because `parse_fortigate_cef` ran first. Pipeline order is real order — what comes earlier has populated the canonical intermediate by the time later steps run.
+- `workspace.lsis.parsed.src_endpoint.ip` and `workspace.lsis.parsed.dst_endpoint.ip` exist because `parse_fortigate_cef` ran first. Pipeline order is real order — what comes earlier has populated the canonical intermediate by the time later steps run.
 - `let key = ...` is a process-local scratch variable — scoped to this process invocation, gone when the event leaves. The binding can hold any value type (scalar, Object, or Array); for an Object, `key.x` reads through the binding the same way `workspace.x.y` does. The binding *name* itself is a single identifier (`let foo.bar = ...` is a parse error — the `let` LHS is a single identifier in the grammar; write into `workspace.*` if you need a path target).
 - `table_upsert` resets the TTL on every call, so a flow that keeps appearing keeps being suppressed; the dedup window only opens up once a flow has been quiet for five minutes (`ttl 300` on the table).
 - The table is in-memory and lost on daemon restart. That's usually fine for dedup — at worst, the first batch after restart is forwarded normally instead of being suppressed. See [table functions](./functions/expression-functions.md#table-functions) for the full surface (`table_lookup` / `table_upsert` / `table_delete`).

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -10,15 +10,14 @@ prefix.
 
 ```
 /usr/share/limpid/snippets/
-├─ parsers/      per-vendor / per-format parsers writing to
-│                workspace.lsis.* (the parser ↔ composer
-│                canonical intermediate — see LSIS below)
-├─ composers/    two-layer target rendering:
-│                • schema composers (compose_ocsf, compose_rfc5424,
-│                  compose_replayable) read workspace.lsis.* and
-│                  write workspace.lsis.<schema>
-│                • envelope composers (compose_otlp) read a declared
-│                  per-envelope input slot and write encoded bytes
+├─ parsers/      per-vendor / per-format parsers, populating
+│                workspace.lsis.parsed.* (the LSIS facts layer —
+│                see LSIS below)
+├─ composers/    target-shape rendering. Each composer reads
+│                workspace.lsis.parsed.* (facts) and/or
+│                workspace.lsis.shed.<consumer>.* (caller-supplied
+│                hand-off slots) and writes its finished wire form
+│                to workspace.lsis.composed.<slot>
 ├─ filters/      pre-parser noise filters (drop / pass-through by
 │                content predicate)
 └─ functions/    shared pure functions (RFC 3164 timestamp parsing,
@@ -30,38 +29,105 @@ The directory name is the snippet kind. `cargo xtask
 lint-snippet-headers` dispatches header validation on it — the file
 layout is the schema.
 
-## LSIS — the parser ↔ composer intermediate
+## LSIS — the Limpid Snippet Intermediate Schema
 
-**LSIS** (Limpid Snippet Intermediate Schema) is the canonical data
-shape parsers write and schema composers read. It lives in the
-`workspace.lsis.*` scratch namespace on every event.
+LSIS is the gentleman's agreement that lets independent snippets
+compose: a reserved workspace namespace (`workspace.lsis.*`) whose
+names carry meaning by convention. It binds the snippets in this
+pack — and nothing else. Your own config may read and write whatever
+it likes; the daemon neither knows nor enforces LSIS. Keep your own
+state outside `workspace.lsis.*` and the two worlds never collide.
+The only enforcement anywhere is this pack's own CI keeping the pack
+internally consistent.
 
-LSIS's vocabulary — field names, numeric class IDs (`class_uid
-3002`, `4001`, …), activity / status enumerations — is borrowed
-from OCSF 1.3.0 so that `compose_ocsf` can render LSIS to conformant
-OCSF JSON without translation. LSIS is **not** an OCSF conformance
-claim: fields outside a class's OCSF definition are permitted (they
-land in `unmapped` when rendered), and future LSIS revisions can
-diverge from OCSF where wire realities demand it.
+The namespace is stratified into three layers, and the layers differ
+not in strictness but in the *kind* of contract each one makes.
 
-### Slot registry
+### `workspace.lsis.parsed.*` — facts (a vocabulary contract)
 
-Schema and envelope composers write their rendered output to a
-dedicated LSIS slot. Each slot has a single writer (see the "egress
-single-writer invariant" below).
+What parsers established about the event: `parsed.severity_id`,
+`parsed.time`, `parsed.device.hostname`, and friends. The contract is
+a dictionary: *if* a field is present under this name, it means this
+— nothing more. The vocabulary leans OCSF but is an open set
+(syslog, CEF, OCSF-shaped, but not limited to), and every field is
+optional; readers handle absence gracefully. Do not look for a schema
+with required fields here. There isn't one, by design. Writers:
+parsers. Readers: everyone.
+
+### `workspace.lsis.shed.*` — plumbing (a hand-off contract)
+
+Tentative values written by glue blocks for the *next* stage: a
+payload to wrap, target-specific attributes to attach. This layer has
+no vocabulary of its own. Names borrow the consumer's vocabulary
+(`shed.otlp.log_record.body` mirrors the OTLP proto), and each
+consuming snippet's header defines the slots it eats. Meaning comes
+from *who writes for whom*, not from the name globally. Values are
+scoped to one hand-off; nothing under `shed.` is a fact about the
+event.
+
+### `workspace.lsis.composed.*` — products (a registry contract)
+
+Finished wire forms, one slot per composer: `composed.ocsf`,
+`composed.otlp`, `composed.rfc5424`. The slot name announces what got
+produced, and the producing composer is its only writer. Egress
+terminators read from here — `egress = workspace.lsis.composed.otlp`
+is the whole story of shipping an event.
+
+### Why three layers
+
+A flat namespace forced facts, plumbing, and products to wear the
+same face, and every reader had to guess which was which — that
+guessing is where the old "OCSF-shaped" confusion came from. The
+strata make the data's role part of its name. If you catch yourself
+asking "where are the required fields?", you are in `parsed.*`
+expecting a schema — it is a dictionary. If you are asking "what does
+this `shed.` slot mean?", ask instead "which composer consumes it?"
+— that composer's header is the contract.
+
+### `parsed.*` vocabulary — OCSF alignment note
+
+The `parsed.*` field names, numeric class IDs (`class_uid 3002`,
+`4001`, …), and activity / status enumerations are borrowed from OCSF
+1.3.0 so that `compose_ocsf` can render `parsed` to conformant OCSF
+JSON without translation. This is not an OCSF conformance claim: fields
+outside a class's OCSF definition are permitted (they land in
+`unmapped` when rendered), and future LSIS revisions can diverge from
+OCSF where wire realities demand it.
+
+### Slot registry — composed layer
+
+Each composer owns exactly one `composed.<slot>` output. This is the
+single-writer invariant that keeps `<slot>_to_egress` terminators
+unambiguous.
 
 | Slot | Type | Writer | Purpose |
 |---|---|---|---|
-| `workspace.lsis.*` | Object | vocabulary parsers | canonical intermediate (parser ↔ schema composer contract) |
-| `workspace.lsis.ocsf` | String | `compose_ocsf` | OCSF 1.3.0 JSON, one object per event |
-| `workspace.lsis.rfc5424` | String | `compose_rfc5424` | single-line RFC 5424 syslog record |
-| `workspace.lsis.replayable` | String | `compose_replayable` | replay-shape JSONL (`{received_at, source, ingress}`) |
-| `workspace.lsis.otlp_body` | String | (caller assigns) | envelope input — payload the envelope composer wraps |
-| `workspace.lsis.otlp` | Bytes | `compose_otlp` | OTLP-1.0.0 `ResourceLogs` proto bytes |
+| `workspace.lsis.composed.ocsf` | String | `compose_ocsf` | OCSF 1.3.0 JSON, one object per event |
+| `workspace.lsis.composed.rfc5424` | String | `compose_rfc5424` | single-line RFC 5424 syslog record |
+| `workspace.lsis.composed.replayable` | String | `compose_replayable` | replay-shape JSONL (`{received_at, source, ingress}`) |
+| `workspace.lsis.composed.otlp` | Bytes | `compose_otlp` | OTLP-1.0.0 `ResourceLogs` proto bytes |
 
-Companion one-line processes `<schema>_to_egress` (defined in the
-same file as each schema/envelope composer) move the slot to
-`egress` when the pipeline emits that shape as its wire form.
+Companion one-line processes `<slot>_to_egress` (defined in the same
+file as each composer) move the slot to `egress` when the pipeline
+emits that shape as its wire form.
+
+### Shed slots — declared per consumer
+
+The `shed.*` layer has no globally reserved sub-namespace. Each
+consuming composer's header enumerates the slots it eats and the
+default that applies when the caller omits the slot. Current
+consumers:
+
+| Consumer | Shed sub-tree | See header |
+|---|---|---|
+| `compose_otlp` | `workspace.lsis.shed.otlp.*` (resource / scope / log_record attributes + body) | `composers/compose_otlp.limpid` |
+| `compose_rfc5424` | `workspace.lsis.shed.rfc5424.*` (pri / timestamp / hostname / app_name / procid / msgid / sd / msg) | `composers/compose_rfc5424.limpid` |
+
+`compose_ocsf` and `compose_replayable` do not read shed slots; they
+read `parsed.*` directly. A composer adds a shed sub-tree when its
+target has structural room the LSIS facts layer cannot express (OTLP
+target-specific attributes, RFC 5424 fields that the pack cannot
+synthesise on the caller's behalf).
 
 ## What's included
 
@@ -217,26 +283,26 @@ def pipeline fw_to_ocsf {
 }
 ```
 
-That's it. The parser writes to `workspace.lsis.*` (the LSIS
-canonical intermediate); `compose_ocsf` reads from `workspace.lsis.*`
-and writes OCSF JSON to `workspace.lsis.ocsf`; the one-line
-`ocsf_to_egress` step at the tail of the pipeline hands that slot
-off to `egress`. Add `output` to your SIEM / data-lake destination
-(Sentinel, Splunk, Security Lake, OTLP, …) and you're shipping
-OCSF.
+That's it. The parser writes facts to `workspace.lsis.parsed.*`;
+`compose_ocsf` reads `workspace.lsis.parsed.*` and writes OCSF JSON
+to `workspace.lsis.composed.ocsf`; the one-line `ocsf_to_egress`
+step at the tail of the pipeline hands that slot off to `egress`.
+Add `output` to your SIEM / data-lake destination (Sentinel, Splunk,
+Security Lake, OTLP, …) and you're shipping OCSF.
 
 ## Design principles
 
-The library follows four contracts, documented at length in
-`docs/src/processing/user-defined.md`:
+The library follows four contracts:
 
-1. **`workspace.lsis` is the parser ↔ schema-composer canonical
-   intermediate (LSIS).** Parsers populate `workspace.lsis.*` only
-   with LSIS-vocabulary fields. Vendor / transport intermediates
-   (`workspace.cef`, `workspace.syslog`, `workspace.pf`,
-   `workspace.journald`, …) are parser-private and no composer
-   reads them. This keeps the schema composer LSIS-aware without
-   its being vendor-aware.
+1. **LSIS strata (`parsed` / `shed` / `composed`).** Parsers populate
+   `workspace.lsis.parsed.*` with facts about the event; composers
+   read `parsed.*` (facts) and optionally `shed.*` (caller-supplied
+   hand-off slots) and write finished wire forms to
+   `workspace.lsis.composed.<slot>`. See the LSIS section above for
+   the layer contracts and the shed / composed slot registries.
+   Transport-namespace intermediates (`workspace.cef`,
+   `workspace.syslog`, `workspace.journald`, …) live outside LSIS
+   by design; pack composers do not read them directly.
 
 2. **Loud-fail-fast on unsupported vocabulary.** Each parser's
    dispatcher routes events with shapes / subtypes / message IDs
@@ -247,21 +313,20 @@ The library follows four contracts, documented at length in
    extend the snippet or update the upstream allow-list.
 
 3. **egress single-writer invariant.** A composer never assigns
-   `egress` directly. Schema composers write `workspace.lsis.<slot>`;
-   the companion `<slot>_to_egress` one-line process (or an
-   envelope composer downstream) is the sole writer of `egress`
-   per pipeline. `grep 'egress = ' packaging/snippets/` names the
-   writer for every terminal.
+   `egress` directly. Composers write to `workspace.lsis.composed.
+   <slot>`; the companion `<slot>_to_egress` one-line process is the
+   sole writer of `egress` per pipeline. `grep 'egress = '
+   packaging/snippets/` names the writer for every terminal.
 
-4. **Two-layer composer contract.** A schema composer takes LSIS
-   to a wire schema slot (e.g. `compose_ocsf` → `workspace.lsis.ocsf`).
-   An envelope composer takes a declared per-envelope input slot
-   to encoded envelope bytes (e.g. `compose_otlp` reads
-   `workspace.lsis.otlp_body`, writes `workspace.lsis.otlp`).
-   Feeding a schema slot into an envelope's input is an explicit
-   inline block in the pipeline (`{ workspace.lsis.otlp_body =
-   workspace.lsis.ocsf }`) — not a proliferation of `<schema>_to_<envelope_body>`
-   bridging snippets.
+4. **Bridges belong to the consumer.** When a composer reads
+   something other than its plain shed vocabulary — a transport
+   namespace, another composer's `composed` product, an ad-hoc
+   caller value — the reader that decided to reach outside pays the
+   cost. Named bridges (e.g. `journald_to_rfc5424`) live in the
+   consuming composer's file, not in a shared bridges/ directory;
+   ad-hoc glue blocks in the pipeline (`{ workspace.lsis.shed.otlp.
+   log_record.body = workspace.lsis.composed.ocsf }`) do the same
+   job when the mapping is one line.
 
 ## Pipeline shapes
 
@@ -271,20 +336,28 @@ Schema wire form:
 process <vendor_parser> | compose_ocsf | ocsf_to_egress
 ```
 
-Envelope-wrapped schema:
+Envelope-wrapped schema (OTLP wrapping the OCSF JSON as the log
+body):
 
 ```
 process <vendor_parser>
       | compose_ocsf
-      | { workspace.lsis.otlp_body = workspace.lsis.ocsf }
+      | {
+          workspace.lsis.shed.otlp.log_record.body =
+              workspace.lsis.composed.ocsf
+        }
       | compose_otlp
       | otlp_to_egress
 ```
 
+Target-specific attributes (e.g. Azure Monitor Pipeline's
+CommonSecurityLog columns) go in the same glue block via
+`workspace.lsis.shed.otlp.log_record.attributes = [ ... ]`; see the
+`compose_otlp` header for the full example.
+
 For mixed-vendor / mixed-format inputs, dispatch upstream of the
 parser with a `switch contains(ingress, "...")` block, calling the
-appropriate parser per branch. (See the test scaffolding under
-`_check_*.limpid` in the repo root for working examples.)
+appropriate parser per branch.
 
 ## Authoring conventions
 

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -120,7 +120,7 @@ consumers:
 
 | Consumer | Shed sub-tree | See header |
 |---|---|---|
-| `compose_otlp` | `workspace.lsis.shed.otlp.*` (resource / scope / log_record attributes + body) | `composers/compose_otlp.limpid` |
+| `compose_otlp` | `workspace.lsis.shed.otlp.*` (resource attributes; scope name/version/attributes; log_record body/attributes/severity_text/observed_time_unix_nano) | `composers/compose_otlp.limpid` |
 | `compose_rfc5424` | `workspace.lsis.shed.rfc5424.*` (pri / timestamp / hostname / app_name / procid / msgid / sd / msg) | `composers/compose_rfc5424.limpid` |
 
 `compose_ocsf` and `compose_replayable` do not read shed slots; they

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -417,9 +417,10 @@ passed through unchanged, `hostname()`) is not declared in `Reads:`
 ### `Writes:` — LSIS-slot contract
 
 `Writes:` names the LSIS slot(s) the snippet produces. Parsers
-usually write to `workspace.lsis.*` and enumerate the OCSF class(es)
-their dispatcher emits; composers write a single named slot from
-the slot registry above.
+write facts to `workspace.lsis.parsed.*` and enumerate the OCSF
+class(es) their dispatcher emits; composers write a single
+`workspace.lsis.composed.<slot>` from the composed-layer registry
+above.
 
 ### `Category:` — parser-only, closed vocabulary
 

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -201,10 +201,10 @@ regions.
 
 | File | Summary | Writes |
 |---|---|---|
-| `composers/compose_ocsf.limpid` | Renders the LSIS intermediate to OCSF 1.3.0 JSON (27-class priority set), dispatched by class_uid. | `workspace.lsis.ocsf` |
-| `composers/compose_otlp.limpid` | Wraps an already-serialised payload string in a minimal OTLP-1.0.0 ResourceLogs proto envelope (envelope composer — agnostic to what the payload encodes). | `workspace.lsis.otlp` |
-| `composers/compose_replayable.limpid` | Serialises the event into the minimal replay-record shape `{ received_at, source, ingress }` — the same three fields the error_log (DLQ) preserves and `inject --json` consumes. | `workspace.lsis.replayable` |
-| `composers/compose_rfc5424.limpid` | journald entry → single-line RFC 5424 syslog record (https://datatracker.ietf.org/doc/html/rfc5424). | `workspace.lsis.rfc5424` |
+| `composers/compose_ocsf.limpid` | Renders the LSIS intermediate to OCSF 1.3.0 JSON (27-class priority set), dispatched by class_uid. | `workspace.lsis.composed.ocsf` |
+| `composers/compose_otlp.limpid` | Assembles an OTLP-1.0.0 ResourceLogs proto envelope from per-field shed slots + parsed-layer graceful reads. Emits a single LogRecord per event, encoded as protobuf bytes for both otlp_http and otlp_grpc. | `workspace.lsis.composed.otlp` |
+| `composers/compose_replayable.limpid` | Serialises the event into the minimal replay-record shape `{ received_at, source, ingress }` — the same three fields the error_log (DLQ) preserves and `inject --json` consumes. | `workspace.lsis.composed.replayable` |
+| `composers/compose_rfc5424.limpid` | Assembles a single-line RFC 5424 syslog record from per-field shed slots (https://datatracker.ietf.org/doc/html/rfc5424). | `workspace.lsis.composed.rfc5424` |
 <!-- END: inventory:composers -->
 
 ### Filters

--- a/packaging/snippets/composers/compose_ocsf.limpid
+++ b/packaging/snippets/composers/compose_ocsf.limpid
@@ -1,13 +1,13 @@
 // Summary:     Renders the LSIS intermediate to OCSF 1.3.0 JSON
 //              (27-class priority set), dispatched by class_uid.
-// Reads:       workspace.lsis.* (the canonical intermediate produced
+// Reads:       workspace.lsis.parsed.* (the canonical intermediate produced
 //              by vocabulary parsers)
 //                .class_uid (required, Int) — dispatch discriminator;
 //                            unknown values route to error_log
 //              Remaining fields are read per class by the
 //              `compose_ocsf_<class>` leaves (see class coverage
 //              below); `time` falls back to `received_at`.
-// Writes:      workspace.lsis.ocsf — OCSF 1.3.0 JSON, one object per
+// Writes:      workspace.lsis.composed.ocsf — OCSF 1.3.0 JSON, one object per
 //              event (String). Pipe `| ocsf_to_egress` (defined at
 //              the foot of this file) to emit it as the wire form;
 //              envelope composers (e.g. compose_otlp) read the slot
@@ -15,11 +15,11 @@
 // Test corpus: spec-only (OCSF 1.3.0 schema; per-class leaf shapes
 //              cross-checked against schema.ocsf.io class definitions)
 //
-// Contract — workspace.lsis is the parser ↔ composer canonical intermediate (LSIS):
-//   * parsers populate `workspace.lsis.*` only with LSIS-vocabulary
+// Contract — workspace.lsis.parsed is the parser ↔ composer canonical intermediate (LSIS):
+//   * parsers populate `workspace.lsis.parsed.*` only with LSIS-vocabulary
 //     fields. Vendor intermediates (`workspace.cef`, `workspace.syslog`)
 //     are NOT read by the composer.
-//   * composer reads `workspace.lsis.*` only.
+//   * composer reads `workspace.lsis.parsed.*` only.
 //   * unknown `class_uid` is routed to the error_log via `error` —
 //     leaving the slot unwritten would let `ocsf_to_egress` fire a
 //     null egress, which silently disappears into the output stage's
@@ -27,7 +27,7 @@
 //
 // OCSF version — targeting **1.3.0**. The composer emits
 // `metadata.version = "1.3.0"` so receivers can dispatch by schema
-// version. Parsers populate `workspace.lsis.metadata` with at least
+// version. Parsers populate `workspace.lsis.parsed.metadata` with at least
 // `{ product: { vendor_name, name, version }, version: "1.3.0" }`.
 //
 // Class coverage (OCSF 1.3.0 priority classes):
@@ -71,13 +71,13 @@
 //
 // Each leaf assumes the dispatcher has already verified `class_uid` and
 // reads only the fields its OCSF class defines, plucking from
-// `workspace.lsis.*`. Common envelope fields (`class_uid`,
+// `workspace.lsis.parsed.*`. Common envelope fields (`class_uid`,
 // `category_uid`, `activity_id`, `type_uid`, `severity_id`, `time`,
 // `metadata`) are emitted uniformly.
 //
 // `time` policy:
-//   `coalesce(workspace.lsis.time, received_at)` — prefer the parser's
-//   `workspace.lsis.time` (the actual event timestamp parsed off the
+//   `coalesce(workspace.lsis.parsed.time, received_at)` — prefer the parser's
+//   `workspace.lsis.parsed.time` (the actual event timestamp parsed off the
 //   wire) when populated, fall back to `received_at` (the moment the
 //   ingress hit limpid) otherwise. This is what makes
 //   `parse_ocsf | compose_ocsf` round-trip preserve `time`, while
@@ -88,7 +88,7 @@
 // ---------------------------------------------------------------------------
 
 def process compose_ocsf {
-    switch workspace.lsis.class_uid {
+    switch workspace.lsis.parsed.class_uid {
         // System Activity (category 1)
         1001 { process compose_ocsf_file_system_activity }
         1007 { process compose_ocsf_process_activity }
@@ -121,7 +121,7 @@ def process compose_ocsf {
         6004 { process compose_ocsf_web_resource_access }
         6005 { process compose_ocsf_datastore_activity }
         6007 { process compose_ocsf_scan_activity }
-        default { error "compose_ocsf: unsupported class_uid ${workspace.lsis.class_uid}" }
+        default { error "compose_ocsf: unsupported class_uid ${workspace.lsis.parsed.class_uid}" }
     }
 }
 
@@ -136,26 +136,26 @@ def process compose_ocsf {
 // File create / read / update / delete / rename / etc. — typically from
 // EDR / file-integrity-monitoring sources (Sysmon FileCreate, Falco fs
 // rules, Defender ATP, Windows Security 4663). Parsers populate
-// `workspace.lsis.file` (the affected file), `workspace.lsis.actor`
-// (the process that performed the action), and `workspace.lsis.user`
+// `workspace.lsis.parsed.file` (the affected file), `workspace.lsis.parsed.actor`
+// (the process that performed the action), and `workspace.lsis.parsed.user`
 // for the executing user.
 def process compose_ocsf_file_system_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    1001,
         category_uid: 1,
         activity_id:  activity,
         type_uid:     1001 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        status_id:    workspace.lsis.status_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        file:         workspace.lsis.file,
-        actor:        workspace.lsis.actor,
-        device:       workspace.lsis.device,
-        user:         workspace.lsis.user,
-        message:      workspace.lsis.message,
-        unmapped:     workspace.lsis.unmapped,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        status_id:    workspace.lsis.parsed.status_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        file:         workspace.lsis.parsed.file,
+        actor:        workspace.lsis.parsed.actor,
+        device:       workspace.lsis.parsed.device,
+        user:         workspace.lsis.parsed.user,
+        message:      workspace.lsis.parsed.message,
+        unmapped:     workspace.lsis.parsed.unmapped,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -165,25 +165,25 @@ def process compose_ocsf_file_system_activity {
 //
 // Process launch / terminate / inject / set-uid — Sysmon ProcessCreate
 // (event id 1), Linux audit execve, EDR process events. Parsers populate
-// `workspace.lsis.process` (the process being acted on),
-// `workspace.lsis.actor.process` (the parent / initiator), and
-// `workspace.lsis.actor.user`.
+// `workspace.lsis.parsed.process` (the process being acted on),
+// `workspace.lsis.parsed.actor.process` (the parent / initiator), and
+// `workspace.lsis.parsed.actor.user`.
 def process compose_ocsf_process_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    1007,
         category_uid: 1,
         activity_id:  activity,
         type_uid:     1007 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        status_id:    workspace.lsis.status_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        process:      workspace.lsis.process,
-        actor:        workspace.lsis.actor,
-        device:       workspace.lsis.device,
-        message:      workspace.lsis.message,
-        unmapped:     workspace.lsis.unmapped,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        status_id:    workspace.lsis.parsed.status_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        process:      workspace.lsis.parsed.process,
+        actor:        workspace.lsis.parsed.actor,
+        device:       workspace.lsis.parsed.device,
+        message:      workspace.lsis.parsed.message,
+        unmapped:     workspace.lsis.parsed.unmapped,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -192,22 +192,22 @@ def process compose_ocsf_process_activity {
 // ---------------------------------------------------------------------------
 //
 // Windows registry key create / delete / rename. Parsers populate
-// `workspace.lsis.reg_key` (path) and `workspace.lsis.actor.process`
+// `workspace.lsis.parsed.reg_key` (path) and `workspace.lsis.parsed.actor.process`
 // (the process that touched it).
 def process compose_ocsf_registry_key_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    1008,
         category_uid: 1,
         activity_id:  activity,
         type_uid:     1008 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        reg_key:      workspace.lsis.reg_key,
-        actor:        workspace.lsis.actor,
-        device:       workspace.lsis.device,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        reg_key:      workspace.lsis.parsed.reg_key,
+        actor:        workspace.lsis.parsed.actor,
+        device:       workspace.lsis.parsed.device,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -216,22 +216,22 @@ def process compose_ocsf_registry_key_activity {
 // ---------------------------------------------------------------------------
 //
 // Windows registry value set / delete / modify. Parsers populate
-// `workspace.lsis.reg_value` (path + data) and
-// `workspace.lsis.actor.process`.
+// `workspace.lsis.parsed.reg_value` (path + data) and
+// `workspace.lsis.parsed.actor.process`.
 def process compose_ocsf_registry_value_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    1009,
         category_uid: 1,
         activity_id:  activity,
         type_uid:     1009 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        reg_value:    workspace.lsis.reg_value,
-        actor:        workspace.lsis.actor,
-        device:       workspace.lsis.device,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        reg_value:    workspace.lsis.parsed.reg_value,
+        actor:        workspace.lsis.parsed.actor,
+        device:       workspace.lsis.parsed.device,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -244,24 +244,24 @@ def process compose_ocsf_registry_value_activity {
 // ---------------------------------------------------------------------------
 //
 // Vulnerability scanner output (Tenable, Qualys, OpenVAS). Parsers
-// populate `workspace.lsis.finding_info`,
-// `workspace.lsis.vulnerabilities` (array of CVE / CVSS / etc.),
-// `workspace.lsis.affected_packages`, and `workspace.lsis.resources`.
+// populate `workspace.lsis.parsed.finding_info`,
+// `workspace.lsis.parsed.vulnerabilities` (array of CVE / CVSS / etc.),
+// `workspace.lsis.parsed.affected_packages`, and `workspace.lsis.parsed.resources`.
 def process compose_ocsf_vulnerability_finding {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:         2002,
         category_uid:      2,
         activity_id:       activity,
         type_uid:          2002 * 100 + activity,
-        severity_id:       workspace.lsis.severity_id,
-        time:              coalesce(workspace.lsis.time, received_at),
-        finding_info:      workspace.lsis.finding_info,
-        vulnerabilities:   workspace.lsis.vulnerabilities,
-        affected_packages: workspace.lsis.affected_packages,
-        resources:         workspace.lsis.resources,
-        message:           workspace.lsis.message,
-        metadata:          workspace.lsis.metadata
+        severity_id:       workspace.lsis.parsed.severity_id,
+        time:              coalesce(workspace.lsis.parsed.time, received_at),
+        finding_info:      workspace.lsis.parsed.finding_info,
+        vulnerabilities:   workspace.lsis.parsed.vulnerabilities,
+        affected_packages: workspace.lsis.parsed.affected_packages,
+        resources:         workspace.lsis.parsed.resources,
+        message:           workspace.lsis.parsed.message,
+        metadata:          workspace.lsis.parsed.metadata
     }))
 }
 
@@ -270,23 +270,23 @@ def process compose_ocsf_vulnerability_finding {
 // ---------------------------------------------------------------------------
 //
 // Configuration / posture compliance violation (CIS, AWS Config rules,
-// SOC 2 control failures). Parsers populate `workspace.lsis.compliance`
-// (control / standards) and `workspace.lsis.resource`.
+// SOC 2 control failures). Parsers populate `workspace.lsis.parsed.compliance`
+// (control / standards) and `workspace.lsis.parsed.resource`.
 def process compose_ocsf_compliance_finding {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    2003,
         category_uid: 2,
         activity_id:  activity,
         type_uid:     2003 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        finding_info: workspace.lsis.finding_info,
-        compliance:   workspace.lsis.compliance,
-        resource:     workspace.lsis.resource,
-        remediation:  workspace.lsis.remediation,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        finding_info: workspace.lsis.parsed.finding_info,
+        compliance:   workspace.lsis.parsed.compliance,
+        resource:     workspace.lsis.parsed.resource,
+        remediation:  workspace.lsis.parsed.remediation,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -295,34 +295,34 @@ def process compose_ocsf_compliance_finding {
 // ---------------------------------------------------------------------------
 //
 // Used by IDS/IPS, antivirus, web filter, DLP, and other detection-type
-// events. Parsers populate `workspace.lsis.finding_info` (title /
-// types / uid), `workspace.lsis.disposition_id` (Allowed / Blocked /
+// events. Parsers populate `workspace.lsis.parsed.finding_info` (title /
+// types / uid), `workspace.lsis.parsed.disposition_id` (Allowed / Blocked /
 // Detected / Quarantined / etc.), and optionally `attack` / `malware` /
 // `evidences` objects with engine-specific detail.
 def process compose_ocsf_detection_finding {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:       2004,
         category_uid:    2,
         activity_id:     activity,
         type_uid:        2004 * 100 + activity,
-        severity_id:     workspace.lsis.severity_id,
-        status_id:       workspace.lsis.status_id,
-        time:            coalesce(workspace.lsis.time, received_at),
-        finding_info:    workspace.lsis.finding_info,
-        disposition_id:  workspace.lsis.disposition_id,
-        src_endpoint:    workspace.lsis.src_endpoint,
-        dst_endpoint:    workspace.lsis.dst_endpoint,
-        connection_info: workspace.lsis.connection_info,
-        device:          workspace.lsis.device,
-        actor:           workspace.lsis.actor,
-        attacks:         workspace.lsis.attacks,
-        attack:          workspace.lsis.attack,
-        malware:         workspace.lsis.malware,
-        evidences:       workspace.lsis.evidences,
-        message:         workspace.lsis.message,
-        unmapped:        workspace.lsis.unmapped,
-        metadata:        workspace.lsis.metadata
+        severity_id:     workspace.lsis.parsed.severity_id,
+        status_id:       workspace.lsis.parsed.status_id,
+        time:            coalesce(workspace.lsis.parsed.time, received_at),
+        finding_info:    workspace.lsis.parsed.finding_info,
+        disposition_id:  workspace.lsis.parsed.disposition_id,
+        src_endpoint:    workspace.lsis.parsed.src_endpoint,
+        dst_endpoint:    workspace.lsis.parsed.dst_endpoint,
+        connection_info: workspace.lsis.parsed.connection_info,
+        device:          workspace.lsis.parsed.device,
+        actor:           workspace.lsis.parsed.actor,
+        attacks:         workspace.lsis.parsed.attacks,
+        attack:          workspace.lsis.parsed.attack,
+        malware:         workspace.lsis.parsed.malware,
+        evidences:       workspace.lsis.parsed.evidences,
+        message:         workspace.lsis.parsed.message,
+        unmapped:        workspace.lsis.parsed.unmapped,
+        metadata:        workspace.lsis.parsed.metadata
     }))
 }
 
@@ -334,21 +334,21 @@ def process compose_ocsf_detection_finding {
 // engines. Carries finding metadata plus assignment / status_id and
 // optional links to underlying findings.
 def process compose_ocsf_incident_finding {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    2005,
         category_uid: 2,
         activity_id:  activity,
         type_uid:     2005 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        status_id:    workspace.lsis.status_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        finding_info: workspace.lsis.finding_info,
-        assignee:     workspace.lsis.assignee,
-        priority:     workspace.lsis.priority,
-        impact_id:    workspace.lsis.impact_id,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        status_id:    workspace.lsis.parsed.status_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        finding_info: workspace.lsis.parsed.finding_info,
+        assignee:     workspace.lsis.parsed.assignee,
+        priority:     workspace.lsis.parsed.priority,
+        impact_id:    workspace.lsis.parsed.impact_id,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -361,22 +361,22 @@ def process compose_ocsf_incident_finding {
 // ---------------------------------------------------------------------------
 //
 // Account create / delete / disable / enable / password-change. Parsers
-// populate `workspace.lsis.user` (the account being changed) and
-// `workspace.lsis.actor.user` (the actor performing the change).
+// populate `workspace.lsis.parsed.user` (the account being changed) and
+// `workspace.lsis.parsed.actor.user` (the actor performing the change).
 def process compose_ocsf_account_change {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    3001,
         category_uid: 3,
         activity_id:  activity,
         type_uid:     3001 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        user:         workspace.lsis.user,
-        actor:        workspace.lsis.actor,
-        src_endpoint: workspace.lsis.src_endpoint,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        user:         workspace.lsis.parsed.user,
+        actor:        workspace.lsis.parsed.actor,
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -385,30 +385,30 @@ def process compose_ocsf_account_change {
 // ---------------------------------------------------------------------------
 //
 // Login / logout / failed-auth events. Parsers populate
-// `workspace.lsis.user`, `workspace.lsis.src_endpoint`, and
-// `workspace.lsis.status_id` (1 Success / 2 Failure).
+// `workspace.lsis.parsed.user`, `workspace.lsis.parsed.src_endpoint`, and
+// `workspace.lsis.parsed.status_id` (1 Success / 2 Failure).
 def process compose_ocsf_authentication {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    3002,
         category_uid: 3,
         activity_id:  activity,
         type_uid:     3002 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        status_id:    workspace.lsis.status_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        user:         workspace.lsis.user,
-        actor:        workspace.lsis.actor,
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        device:       workspace.lsis.device,
-        auth_protocol:    workspace.lsis.auth_protocol,
-        auth_protocol_id: workspace.lsis.auth_protocol_id,
-        service:      workspace.lsis.service,
-        session:      workspace.lsis.session,
-        logon_type_id: workspace.lsis.logon_type_id,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        status_id:    workspace.lsis.parsed.status_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        user:         workspace.lsis.parsed.user,
+        actor:        workspace.lsis.parsed.actor,
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        device:       workspace.lsis.parsed.device,
+        auth_protocol:    workspace.lsis.parsed.auth_protocol,
+        auth_protocol_id: workspace.lsis.parsed.auth_protocol_id,
+        service:      workspace.lsis.parsed.service,
+        session:      workspace.lsis.parsed.session,
+        logon_type_id: workspace.lsis.parsed.logon_type_id,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -417,26 +417,26 @@ def process compose_ocsf_authentication {
 // ---------------------------------------------------------------------------
 //
 // Session authorization (sudo, su, RBAC role-elevation). Parsers populate
-// `workspace.lsis.user`, `workspace.lsis.session`, and
-// `workspace.lsis.privileges`.
+// `workspace.lsis.parsed.user`, `workspace.lsis.parsed.session`, and
+// `workspace.lsis.parsed.privileges`.
 def process compose_ocsf_authorize_session {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    3003,
         category_uid: 3,
         activity_id:  activity,
         type_uid:     3003 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        status_id:    workspace.lsis.status_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        user:         workspace.lsis.user,
-        actor:        workspace.lsis.actor,
-        session:      workspace.lsis.session,
-        src_endpoint: workspace.lsis.src_endpoint,
-        device:       workspace.lsis.device,
-        privileges:   workspace.lsis.privileges,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        status_id:    workspace.lsis.parsed.status_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        user:         workspace.lsis.parsed.user,
+        actor:        workspace.lsis.parsed.actor,
+        session:      workspace.lsis.parsed.session,
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        device:       workspace.lsis.parsed.device,
+        privileges:   workspace.lsis.parsed.privileges,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -446,20 +446,20 @@ def process compose_ocsf_authorize_session {
 //
 // Privilege grant / revoke / role-assignment operations.
 def process compose_ocsf_user_access_management {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    3005,
         category_uid: 3,
         activity_id:  activity,
         type_uid:     3005 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        user:         workspace.lsis.user,
-        actor:        workspace.lsis.actor,
-        privileges:   workspace.lsis.privileges,
-        resource:     workspace.lsis.resource,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        user:         workspace.lsis.parsed.user,
+        actor:        workspace.lsis.parsed.actor,
+        privileges:   workspace.lsis.parsed.privileges,
+        resource:     workspace.lsis.parsed.resource,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -469,19 +469,19 @@ def process compose_ocsf_user_access_management {
 //
 // Group create / delete / membership change.
 def process compose_ocsf_group_management {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    3006,
         category_uid: 3,
         activity_id:  activity,
         type_uid:     3006 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        group:        workspace.lsis.group,
-        user:         workspace.lsis.user,
-        actor:        workspace.lsis.actor,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        group:        workspace.lsis.parsed.group,
+        user:         workspace.lsis.parsed.user,
+        actor:        workspace.lsis.parsed.actor,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -494,29 +494,29 @@ def process compose_ocsf_group_management {
 // ---------------------------------------------------------------------------
 //
 // Generic network connection (firewall traffic logs, NetFlow, packet
-// captures). Parsers populate `workspace.lsis.src_endpoint`,
-// `workspace.lsis.dst_endpoint`, `workspace.lsis.connection_info`,
-// and optionally `workspace.lsis.traffic` (bytes_in/out).
+// captures). Parsers populate `workspace.lsis.parsed.src_endpoint`,
+// `workspace.lsis.parsed.dst_endpoint`, `workspace.lsis.parsed.connection_info`,
+// and optionally `workspace.lsis.parsed.traffic` (bytes_in/out).
 def process compose_ocsf_network_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:       4001,
         category_uid:    4,
         activity_id:     activity,
         type_uid:        4001 * 100 + activity,
-        severity_id:     workspace.lsis.severity_id,
-        status_id:       workspace.lsis.status_id,
-        time:            coalesce(workspace.lsis.time, received_at),
-        src_endpoint:    workspace.lsis.src_endpoint,
-        dst_endpoint:    workspace.lsis.dst_endpoint,
-        connection_info: workspace.lsis.connection_info,
-        traffic:         workspace.lsis.traffic,
-        app_name:        workspace.lsis.app_name,
-        device:          workspace.lsis.device,
-        actor:           workspace.lsis.actor,
-        message:         workspace.lsis.message,
-        unmapped:        workspace.lsis.unmapped,
-        metadata:        workspace.lsis.metadata
+        severity_id:     workspace.lsis.parsed.severity_id,
+        status_id:       workspace.lsis.parsed.status_id,
+        time:            coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint:    workspace.lsis.parsed.src_endpoint,
+        dst_endpoint:    workspace.lsis.parsed.dst_endpoint,
+        connection_info: workspace.lsis.parsed.connection_info,
+        traffic:         workspace.lsis.parsed.traffic,
+        app_name:        workspace.lsis.parsed.app_name,
+        device:          workspace.lsis.parsed.device,
+        actor:           workspace.lsis.parsed.actor,
+        message:         workspace.lsis.parsed.message,
+        unmapped:        workspace.lsis.parsed.unmapped,
+        metadata:        workspace.lsis.parsed.metadata
     }))
 }
 
@@ -525,28 +525,28 @@ def process compose_ocsf_network_activity {
 // ---------------------------------------------------------------------------
 //
 // HTTP request/response cycle (web servers, reverse proxies, WAFs).
-// Parsers populate `workspace.lsis.http_request` (method / url /
-// headers / body_length) and `workspace.lsis.http_response` (status /
+// Parsers populate `workspace.lsis.parsed.http_request` (method / url /
+// headers / body_length) and `workspace.lsis.parsed.http_response` (status /
 // headers / body_length).
 def process compose_ocsf_http_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:     4002,
         category_uid:  4,
         activity_id:   activity,
         type_uid:      4002 * 100 + activity,
-        severity_id:   workspace.lsis.severity_id,
-        status_id:     workspace.lsis.status_id,
-        time:          coalesce(workspace.lsis.time, received_at),
-        src_endpoint:  workspace.lsis.src_endpoint,
-        dst_endpoint:  workspace.lsis.dst_endpoint,
-        device:        workspace.lsis.device,
-        actor:         workspace.lsis.actor,
-        http_request:  workspace.lsis.http_request,
-        http_response: workspace.lsis.http_response,
-        traffic:       workspace.lsis.traffic,
-        message:       workspace.lsis.message,
-        metadata:      workspace.lsis.metadata
+        severity_id:   workspace.lsis.parsed.severity_id,
+        status_id:     workspace.lsis.parsed.status_id,
+        time:          coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint:  workspace.lsis.parsed.src_endpoint,
+        dst_endpoint:  workspace.lsis.parsed.dst_endpoint,
+        device:        workspace.lsis.parsed.device,
+        actor:         workspace.lsis.parsed.actor,
+        http_request:  workspace.lsis.parsed.http_request,
+        http_response: workspace.lsis.parsed.http_response,
+        traffic:       workspace.lsis.parsed.traffic,
+        message:       workspace.lsis.parsed.message,
+        metadata:      workspace.lsis.parsed.metadata
     }))
 }
 
@@ -555,26 +555,26 @@ def process compose_ocsf_http_activity {
 // ---------------------------------------------------------------------------
 //
 // DNS query / response (BIND, Unbound, Windows DNS, passive DNS taps).
-// Parsers populate `workspace.lsis.query` (question name + type) and
-// `workspace.lsis.answers` (resolved records).
+// Parsers populate `workspace.lsis.parsed.query` (question name + type) and
+// `workspace.lsis.parsed.answers` (resolved records).
 def process compose_ocsf_dns_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4003,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4003 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        rcode_id:     workspace.lsis.rcode_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        device:       workspace.lsis.device,
-        actor:        workspace.lsis.actor,
-        query:        workspace.lsis.query,
-        answers:      workspace.lsis.answers,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        rcode_id:     workspace.lsis.parsed.rcode_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        device:       workspace.lsis.parsed.device,
+        actor:        workspace.lsis.parsed.actor,
+        query:        workspace.lsis.parsed.query,
+        answers:      workspace.lsis.parsed.answers,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -584,20 +584,20 @@ def process compose_ocsf_dns_activity {
 //
 // DHCP lease lifecycle (discover / offer / request / ack / release).
 def process compose_ocsf_dhcp_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4004,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4004 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        is_renewal:   workspace.lsis.is_renewal,
-        lease_dur:    workspace.lsis.lease_dur,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        is_renewal:   workspace.lsis.parsed.is_renewal,
+        lease_dur:    workspace.lsis.parsed.lease_dur,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -605,22 +605,22 @@ def process compose_ocsf_dhcp_activity {
 // RDP Activity (class_uid 4005)
 // ---------------------------------------------------------------------------
 def process compose_ocsf_rdp_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4005,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4005 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        protocol_ver: workspace.lsis.protocol_ver,
-        capabilities: workspace.lsis.capabilities,
-        device:       workspace.lsis.device,
-        user:         workspace.lsis.user,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        protocol_ver: workspace.lsis.parsed.protocol_ver,
+        capabilities: workspace.lsis.parsed.capabilities,
+        device:       workspace.lsis.parsed.device,
+        user:         workspace.lsis.parsed.user,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -628,22 +628,22 @@ def process compose_ocsf_rdp_activity {
 // SMB Activity (class_uid 4006)
 // ---------------------------------------------------------------------------
 def process compose_ocsf_smb_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4006,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4006 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        share:        workspace.lsis.share,
-        share_type_id: workspace.lsis.share_type_id,
-        file:         workspace.lsis.file,
-        command:      workspace.lsis.command,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        share:        workspace.lsis.parsed.share,
+        share_type_id: workspace.lsis.parsed.share_type_id,
+        file:         workspace.lsis.parsed.file,
+        command:      workspace.lsis.parsed.command,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -651,23 +651,23 @@ def process compose_ocsf_smb_activity {
 // SSH Activity (class_uid 4007)
 // ---------------------------------------------------------------------------
 def process compose_ocsf_ssh_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4007,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4007 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        protocol_ver: workspace.lsis.protocol_ver,
-        client_hassh: workspace.lsis.client_hassh,
-        server_hassh: workspace.lsis.server_hassh,
-        auth_type:    workspace.lsis.auth_type,
-        user:         workspace.lsis.user,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        protocol_ver: workspace.lsis.parsed.protocol_ver,
+        client_hassh: workspace.lsis.parsed.client_hassh,
+        server_hassh: workspace.lsis.parsed.server_hassh,
+        auth_type:    workspace.lsis.parsed.auth_type,
+        user:         workspace.lsis.parsed.user,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -675,22 +675,22 @@ def process compose_ocsf_ssh_activity {
 // FTP Activity (class_uid 4008)
 // ---------------------------------------------------------------------------
 def process compose_ocsf_ftp_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4008,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4008 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        command:      workspace.lsis.command,
-        codes:        workspace.lsis.codes,
-        port:         workspace.lsis.port,
-        file:         workspace.lsis.file,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        command:      workspace.lsis.parsed.command,
+        codes:        workspace.lsis.parsed.codes,
+        port:         workspace.lsis.parsed.port,
+        file:         workspace.lsis.parsed.file,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -698,23 +698,23 @@ def process compose_ocsf_ftp_activity {
 // Email Activity (class_uid 4009)
 // ---------------------------------------------------------------------------
 def process compose_ocsf_email_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4009,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4009 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        direction_id: workspace.lsis.direction_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        device:       workspace.lsis.device,
-        actor:        workspace.lsis.actor,
-        email:        workspace.lsis.email,
-        smtp_hello:   workspace.lsis.smtp_hello,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        direction_id: workspace.lsis.parsed.direction_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        device:       workspace.lsis.parsed.device,
+        actor:        workspace.lsis.parsed.actor,
+        email:        workspace.lsis.parsed.email,
+        smtp_hello:   workspace.lsis.parsed.smtp_hello,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -724,21 +724,21 @@ def process compose_ocsf_email_activity {
 //
 // Cross-host file access over network protocols (NFS, SMB-as-FS, etc.).
 def process compose_ocsf_network_file_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    4010,
         category_uid: 4,
         activity_id:  activity,
         type_uid:     4010 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        file:         workspace.lsis.file,
-        share:        workspace.lsis.share,
-        actor:        workspace.lsis.actor,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        file:         workspace.lsis.parsed.file,
+        share:        workspace.lsis.parsed.share,
+        actor:        workspace.lsis.parsed.actor,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -751,28 +751,28 @@ def process compose_ocsf_network_file_activity {
 // ---------------------------------------------------------------------------
 //
 // API call records (CloudTrail, k8s audit log, internal API gateway).
-// Parsers populate `workspace.lsis.api` (operation / version / service)
-// and `workspace.lsis.actor` (the calling principal).
+// Parsers populate `workspace.lsis.parsed.api` (operation / version / service)
+// and `workspace.lsis.parsed.actor` (the calling principal).
 def process compose_ocsf_api_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    6003,
         category_uid: 6,
         activity_id:  activity,
         type_uid:     6003 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        status_id:    workspace.lsis.status_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        api:          workspace.lsis.api,
-        actor:        workspace.lsis.actor,
-        src_endpoint: workspace.lsis.src_endpoint,
-        dst_endpoint: workspace.lsis.dst_endpoint,
-        http_request: workspace.lsis.http_request,
-        cloud:        workspace.lsis.cloud,
-        resources:    workspace.lsis.resources,
-        message:      workspace.lsis.message,
-        unmapped:     workspace.lsis.unmapped,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        status_id:    workspace.lsis.parsed.status_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        api:          workspace.lsis.parsed.api,
+        actor:        workspace.lsis.parsed.actor,
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        http_request: workspace.lsis.parsed.http_request,
+        cloud:        workspace.lsis.parsed.cloud,
+        resources:    workspace.lsis.parsed.resources,
+        message:      workspace.lsis.parsed.message,
+        unmapped:     workspace.lsis.parsed.unmapped,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -781,26 +781,26 @@ def process compose_ocsf_api_activity {
 // ---------------------------------------------------------------------------
 //
 // Used by web-filter and similar URL-allow/deny events. Parsers
-// populate `workspace.lsis.http_request` (url + method),
-// `workspace.lsis.web_resources` (categorisation), and
-// `workspace.lsis.actor.user` for the requesting user.
+// populate `workspace.lsis.parsed.http_request` (url + method),
+// `workspace.lsis.parsed.web_resources` (categorisation), and
+// `workspace.lsis.parsed.actor.user` for the requesting user.
 def process compose_ocsf_web_resource_access {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:     6004,
         category_uid:  6,
         activity_id:   activity,
         type_uid:      6004 * 100 + activity,
-        severity_id:   workspace.lsis.severity_id,
-        time:          coalesce(workspace.lsis.time, received_at),
-        src_endpoint:  workspace.lsis.src_endpoint,
-        dst_endpoint:  workspace.lsis.dst_endpoint,
-        http_request:  workspace.lsis.http_request,
-        http_response: workspace.lsis.http_response,
-        web_resources: workspace.lsis.web_resources,
-        actor:         workspace.lsis.actor,
-        message:       workspace.lsis.message,
-        metadata:      workspace.lsis.metadata
+        severity_id:   workspace.lsis.parsed.severity_id,
+        time:          coalesce(workspace.lsis.parsed.time, received_at),
+        src_endpoint:  workspace.lsis.parsed.src_endpoint,
+        dst_endpoint:  workspace.lsis.parsed.dst_endpoint,
+        http_request:  workspace.lsis.parsed.http_request,
+        http_response: workspace.lsis.parsed.http_response,
+        web_resources: workspace.lsis.parsed.web_resources,
+        actor:         workspace.lsis.parsed.actor,
+        message:       workspace.lsis.parsed.message,
+        metadata:      workspace.lsis.parsed.metadata
     }))
 }
 
@@ -810,22 +810,22 @@ def process compose_ocsf_web_resource_access {
 //
 // Database / S3 / object-store access events.
 def process compose_ocsf_datastore_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    6005,
         category_uid: 6,
         activity_id:  activity,
         type_uid:     6005 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        actor:        workspace.lsis.actor,
-        src_endpoint: workspace.lsis.src_endpoint,
-        database:     workspace.lsis.database,
-        databucket:   workspace.lsis.databucket,
-        table:        workspace.lsis.table,
-        query_info:   workspace.lsis.query_info,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        actor:        workspace.lsis.parsed.actor,
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        database:     workspace.lsis.parsed.database,
+        databucket:   workspace.lsis.parsed.databucket,
+        table:        workspace.lsis.parsed.table,
+        query_info:   workspace.lsis.parsed.query_info,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -836,20 +836,20 @@ def process compose_ocsf_datastore_activity {
 // Vulnerability / asset / config scan job records (the orchestration
 // layer; individual findings are class 2002 / 2003).
 def process compose_ocsf_scan_activity {
-    let activity = workspace.lsis.activity_id
-    workspace.lsis.ocsf = to_json(null_omit({
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
         class_uid:    6007,
         category_uid: 6,
         activity_id:  activity,
         type_uid:     6007 * 100 + activity,
-        severity_id:  workspace.lsis.severity_id,
-        time:         coalesce(workspace.lsis.time, received_at),
-        scan:         workspace.lsis.scan,
-        actor:        workspace.lsis.actor,
-        devices:      workspace.lsis.devices,
-        policy:       workspace.lsis.policy,
-        message:      workspace.lsis.message,
-        metadata:     workspace.lsis.metadata
+        severity_id:  workspace.lsis.parsed.severity_id,
+        time:         coalesce(workspace.lsis.parsed.time, received_at),
+        scan:         workspace.lsis.parsed.scan,
+        actor:        workspace.lsis.parsed.actor,
+        devices:      workspace.lsis.parsed.devices,
+        policy:       workspace.lsis.parsed.policy,
+        message:      workspace.lsis.parsed.message,
+        metadata:     workspace.lsis.parsed.metadata
     }))
 }
 
@@ -857,11 +857,11 @@ def process compose_ocsf_scan_activity {
 // Egress terminator
 // ---------------------------------------------------------------------------
 //
-// Moves the OCSF JSON string from `workspace.lsis.ocsf` to `egress`.
+// Moves the OCSF JSON string from `workspace.lsis.composed.ocsf` to `egress`.
 // Pipelines that emit OCSF as the wire form pipe
 // `compose_ocsf | ocsf_to_egress`. When wrapping into another
 // envelope (e.g. OTLP), skip this step and feed the slot directly
 // into the envelope's input.
 def process ocsf_to_egress {
-    egress = workspace.lsis.ocsf
+    egress = workspace.lsis.composed.ocsf
 }

--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -2,10 +2,10 @@
 //              minimal OTLP-1.0.0 ResourceLogs proto envelope
 //              (envelope composer — agnostic to what the payload
 //              encodes).
-// Reads:       workspace.lsis.* (per-envelope declared input)
+// Reads:       workspace.lsis.parsed.* (per-envelope declared input)
 //                .otlp_body (required, String) — payload wrapped as
 //                            body.string_value on the log record
-// Writes:      workspace.lsis.otlp — ResourceLogs proto bytes
+// Writes:      workspace.lsis.composed.otlp — ResourceLogs proto bytes
 //              (Bytes). Pipe `| otlp_to_egress` (foot of file) to
 //              emit for `output otlp_http` / `otlp_grpc`.
 // Test corpus: spec-only (OTLP/1.0.0 proto shape;
@@ -14,11 +14,11 @@
 //
 // Two-layer contract —
 //   schema composer (compose_ocsf, compose_rfc5424, …) — reads
-//     `workspace.lsis.*`, writes `workspace.lsis.<schema>` slot with
+//     `workspace.lsis.parsed.*`, writes `workspace.lsis.parsed.<schema>` slot with
 //     the schema-shape wire form (String).
 //   envelope composer (compose_otlp) — reads the declared per-envelope
-//     input slot `workspace.lsis.otlp_body` (the payload to wrap),
-//     writes `workspace.lsis.otlp` with the encoded envelope bytes.
+//     input slot `workspace.lsis.shed.otlp.log_record.body` (the payload to wrap),
+//     writes `workspace.lsis.composed.otlp` with the encoded envelope bytes.
 //
 // Because each slot has a single writer, feeding a schema composer's
 // output into the envelope composer's input is done in the pipeline
@@ -26,7 +26,7 @@
 //
 //   process parse_x
 //         | compose_ocsf
-//         | { workspace.lsis.otlp_body = workspace.lsis.ocsf }
+//         | { workspace.lsis.shed.otlp.log_record.body = workspace.lsis.composed.ocsf }
 //         | compose_otlp
 //         | otlp_to_egress
 //
@@ -44,13 +44,13 @@
 // Time — `received_at` is used as `time_unix_nano`. Callers that
 // carry a source-claimed timestamp (parsed off the wire) can
 // override in an inline block before compose_otlp:
-//   `{ workspace.event_time_ns = coalesce(workspace.lsis.time, received_at) }`
+//   `{ workspace.event_time_ns = coalesce(workspace.lsis.parsed.time, received_at) }`
 // then swap the log-record timestamp read in a wrapper composer.
 // See `docs/src/outputs/otlp_http.md` for the full-fidelity
 // timestamp pattern.
 
 def process compose_otlp {
-    workspace.lsis.otlp = otlp.encode_resourcelog_protobuf({
+    workspace.lsis.composed.otlp = otlp.encode_resourcelog_protobuf({
         resource: {
             attributes: [
                 { key: "host.name", value: { string_value: hostname() } }
@@ -60,7 +60,7 @@ def process compose_otlp {
             scope: { name: "limpid" },
             log_records: [{
                 time_unix_nano: received_at,
-                body: { string_value: workspace.lsis.otlp_body }
+                body: { string_value: workspace.lsis.shed.otlp.log_record.body }
             }]
         }]
     })
@@ -70,9 +70,9 @@ def process compose_otlp {
 // Egress terminator
 // ---------------------------------------------------------------------------
 //
-// Moves the OTLP ResourceLogs proto bytes from `workspace.lsis.otlp`
+// Moves the OTLP ResourceLogs proto bytes from `workspace.lsis.composed.otlp`
 // to `egress`. Pipelines that emit OTLP as the wire form pipe
 // `compose_otlp | otlp_to_egress`.
 def process otlp_to_egress {
-    egress = workspace.lsis.otlp
+    egress = workspace.lsis.composed.otlp
 }

--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -4,15 +4,15 @@
 //              protobuf bytes for both otlp_http and otlp_grpc.
 // Reads:       workspace.lsis.shed.otlp.* — per-slot intake
 //              (OTLP proto vocabulary):
-//                .resource.attributes    (optional, Array of KeyValue) —
-//                             default: [{ key: "host.name", value:
+//                .resource.attributes    (optional, Array) — of KeyValue.
+//                             default — [{ key: "host.name", value:
 //                             { string_value: hostname() } }]. Specifying
 //                             this slot REPLACES the default (no merge):
 //                             callers who still want host.name in their
 //                             resource attributes must include it in the
 //                             array they pass.
-//                .scope.attributes       (optional, Array of KeyValue) —
-//                             default: empty. `scope.name` is fixed at
+//                .scope.attributes       (optional, Array) — of KeyValue.
+//                             default — empty. `scope.name` is fixed at
 //                             "limpid".
 //                .log_record.body        (required, String) — placed on
 //                             the LogRecord as `body.string_value`. Absent
@@ -20,8 +20,8 @@
 //                             deliberate wrapper (schema composer output,
 //                             raw ingress, etc.) is the caller's job to
 //                             assign in a glue block.
-//                .log_record.attributes  (optional, Array of KeyValue) —
-//                             default: empty. Replacement semantics as
+//                .log_record.attributes  (optional, Array) — of KeyValue.
+//                             default — empty. Replacement semantics as
 //                             above.
 //              workspace.lsis.parsed.* — graceful reads from the fact
 //              layer, no shed intake for these:

--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -1,66 +1,108 @@
-// Summary:     Wraps an already-serialised payload string in a
-//              minimal OTLP-1.0.0 ResourceLogs proto envelope
-//              (envelope composer — agnostic to what the payload
-//              encodes).
-// Reads:       workspace.lsis.parsed.* (per-envelope declared input)
-//                .otlp_body (required, String) — payload wrapped as
-//                            body.string_value on the log record
+// Summary:     Assembles an OTLP-1.0.0 ResourceLogs proto envelope
+//              from per-field shed slots + parsed-layer graceful reads.
+//              Emits a single LogRecord per event, encoded as
+//              protobuf bytes for both otlp_http and otlp_grpc.
+// Reads:       workspace.lsis.shed.otlp.* — per-slot intake
+//              (OTLP proto vocabulary):
+//                .resource.attributes    (optional, Array of KeyValue) —
+//                             default: [{ key: "host.name", value:
+//                             { string_value: hostname() } }]. Specifying
+//                             this slot REPLACES the default (no merge):
+//                             callers who still want host.name in their
+//                             resource attributes must include it in the
+//                             array they pass.
+//                .scope.attributes       (optional, Array of KeyValue) —
+//                             default: empty. `scope.name` is fixed at
+//                             "limpid".
+//                .log_record.body        (required, String) — placed on
+//                             the LogRecord as `body.string_value`. Absent
+//                             body yields an empty body string; a
+//                             deliberate wrapper (schema composer output,
+//                             raw ingress, etc.) is the caller's job to
+//                             assign in a glue block.
+//                .log_record.attributes  (optional, Array of KeyValue) —
+//                             default: empty. Replacement semantics as
+//                             above.
+//              workspace.lsis.parsed.* — graceful reads from the fact
+//              layer, no shed intake for these:
+//                .time         (optional, Int) — used as `time_unix_nano`
+//                             when populated; falls back to `received_at`
+//                             otherwise. Time is a fact about the event,
+//                             so it lives in `parsed`, not `shed`.
+//                .severity_id  (optional, Int) — used as `severity_number`
+//                             when populated. Absent (or 0 = OCSF Unknown)
+//                             means the field is omitted from the wire.
 // Writes:      workspace.lsis.composed.otlp — ResourceLogs proto bytes
-//              (Bytes). Pipe `| otlp_to_egress` (foot of file) to
-//              emit for `output otlp_http` / `otlp_grpc`.
+//              (Bytes). Pipe `| otlp_to_egress` (foot of file) to emit
+//              for `output otlp_http` / `output otlp_grpc`.
 // Test corpus: spec-only (OTLP/1.0.0 proto shape;
 //              otlp.encode_resourcelog_protobuf reference in
 //              docs/src/functions/expression-functions.md)
 //
-// Two-layer contract —
-//   schema composer (compose_ocsf, compose_rfc5424, …) — reads
-//     `workspace.lsis.parsed.*`, writes `workspace.lsis.parsed.<schema>` slot with
-//     the schema-shape wire form (String).
-//   envelope composer (compose_otlp) — reads the declared per-envelope
-//     input slot `workspace.lsis.shed.otlp.log_record.body` (the payload to wrap),
-//     writes `workspace.lsis.composed.otlp` with the encoded envelope bytes.
+// Sourcing the shed slots — a glue block in the pipeline hands the
+// upstream composer's product (or ad-hoc caller-supplied values) into
+// this composer's intake. Two common shapes:
 //
-// Because each slot has a single writer, feeding a schema composer's
-// output into the envelope composer's input is done in the pipeline
-// with an inline block:
+//   1. Wrap an OCSF JSON produced by compose_ocsf as the log body:
 //
-//   process parse_x
-//         | compose_ocsf
-//         | { workspace.lsis.shed.otlp.log_record.body = workspace.lsis.composed.ocsf }
-//         | compose_otlp
-//         | otlp_to_egress
+//        process parse_x
+//              | compose_ocsf
+//              | { workspace.lsis.shed.otlp.log_record.body =
+//                    workspace.lsis.composed.ocsf }
+//              | compose_otlp
+//              | otlp_to_egress
 //
-// The same pattern works for any other schema slot (RFC 5424 record,
-// replayable JSONL line, etc.) — the envelope is agnostic to what the
-// body string encodes.
+//   2. Ship a target-specific attribute vocabulary (e.g. Azure Monitor
+//      Pipeline's CommonSecurityLog columns) via log_record.attributes,
+//      alongside a body of the caller's choosing:
 //
-// Envelope neutrality — this composer deliberately does NOT read LSIS
-// fields other than the declared `otlp_body`. Resource attributes are
-// minimal (`host.name` only) and the scope carries a fixed
-// `{ name: "limpid" }` marker; richer attributes are the caller's
-// concern — override with a downstream process, or write a
-// project-specific `compose_otlp_<flavour>` that reads more of LSIS.
+//        process parse_fortigate_cef
+//              | {
+//                  workspace.lsis.shed.otlp.log_record.body =
+//                      workspace.syslog.msg
+//                  workspace.lsis.shed.otlp.log_record.attributes = [
+//                      { key: "DeviceVendor",  value: { string_value:
+//                          workspace.cef.device_vendor } },
+//                      { key: "DeviceProduct", value: { string_value:
+//                          workspace.cef.device_product } },
+//                      { key: "SourceIP",      value: { string_value:
+//                          workspace.cef.src } }
+//                  ]
+//                }
+//              | compose_otlp
+//              | otlp_to_egress
 //
-// Time — `received_at` is used as `time_unix_nano`. Callers that
-// carry a source-claimed timestamp (parsed off the wire) can
-// override in an inline block before compose_otlp:
-//   `{ workspace.event_time_ns = coalesce(workspace.lsis.parsed.time, received_at) }`
-// then swap the log-record timestamp read in a wrapper composer.
-// See `docs/src/outputs/otlp_http.md` for the full-fidelity
-// timestamp pattern.
+// Bridges live *with the composer that consumes them* (this file is
+// their home). A named `<upstream>_to_otlp` bridge is worth introducing
+// when the caller's mapping is non-trivial and reusable across
+// pipelines; ad-hoc glue blocks like the two above are the norm.
 
 def process compose_otlp {
     workspace.lsis.composed.otlp = otlp.encode_resourcelog_protobuf({
         resource: {
-            attributes: [
-                { key: "host.name", value: { string_value: hostname() } }
-            ]
+            attributes: coalesce(
+                workspace.lsis.shed.otlp.resource.attributes,
+                [ { key: "host.name", value: { string_value: hostname() } } ]
+            )
         },
         scope_logs: [{
-            scope: { name: "limpid" },
+            scope: {
+                name: "limpid",
+                attributes: coalesce(
+                    workspace.lsis.shed.otlp.scope.attributes,
+                    []
+                )
+            },
             log_records: [{
-                time_unix_nano: received_at,
-                body: { string_value: workspace.lsis.shed.otlp.log_record.body }
+                time_unix_nano:  coalesce(workspace.lsis.parsed.time, received_at),
+                severity_number: workspace.lsis.parsed.severity_id,
+                body: { string_value: coalesce(
+                    workspace.lsis.shed.otlp.log_record.body, ""
+                ) },
+                attributes: coalesce(
+                    workspace.lsis.shed.otlp.log_record.attributes,
+                    []
+                )
             }]
         }]
     })

--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -11,9 +11,16 @@
 //                             callers who still want host.name in their
 //                             resource attributes must include it in the
 //                             array they pass.
+//                .scope.name             (optional, String) — instrumentation
+//                             scope name. default — "limpid". Callers
+//                             segmenting by pipeline family override this
+//                             (e.g. "limpid.amp.cef", "limpid.amp.syslog").
+//                .scope.version          (optional, String) — instrumentation
+//                             scope version. default — omitted from the
+//                             wire (proto3 default). Set when the caller
+//                             is versioning the shape it emits.
 //                .scope.attributes       (optional, Array) — of KeyValue.
-//                             default — empty. `scope.name` is fixed at
-//                             "limpid".
+//                             default — empty.
 //                .log_record.body        (required, String) — placed on
 //                             the LogRecord as `body.string_value`. Absent
 //                             body yields an empty body string; a
@@ -23,6 +30,18 @@
 //                .log_record.attributes  (optional, Array) — of KeyValue.
 //                             default — empty. Replacement semantics as
 //                             above.
+//                .log_record.severity_text          (optional, String) —
+//                             free-form severity label. default — omitted
+//                             from the wire (proto3 default). Common
+//                             pairing with a caller-classified severity is
+//                             `"INFO"`/`"WARN"`/`"ERROR"`.
+//                .log_record.observed_time_unix_nano (optional, Int) —
+//                             time the current process observed the event
+//                             (LogRecord field 11). default — omitted from
+//                             the wire (proto3 default). Set when the
+//                             caller wants both event time (parsed) and
+//                             observed time (usually `to_int(received_at)`)
+//                             on the wire.
 //              workspace.lsis.parsed.* — graceful reads from the fact
 //              layer, no shed intake for these:
 //                .time         (optional, Int) — used as `time_unix_nano`
@@ -32,6 +51,13 @@
 //                .severity_id  (optional, Int) — used as `severity_number`
 //                             when populated. Absent (or 0 = OCSF Unknown)
 //                             means the field is omitted from the wire.
+//
+// Slots deliberately NOT exposed today — `log_record.trace_id`,
+// `log_record.span_id`, `log_record.event_name`, and the
+// `dropped_attributes_count` / `flags` housekeeping fields. These have
+// no implementation-driving caller in the pack today; they are added
+// on the same coalesce-with-default pattern above when a real caller
+// needs them.
 // Writes:      workspace.lsis.composed.otlp — ResourceLogs proto bytes
 //              (Bytes). Pipe `| otlp_to_egress` (foot of file) to emit
 //              for `output otlp_http` / `output otlp_grpc`.
@@ -87,15 +113,18 @@ def process compose_otlp {
         },
         scope_logs: [{
             scope: {
-                name: "limpid",
+                name:       coalesce(workspace.lsis.shed.otlp.scope.name, "limpid"),
+                version:    workspace.lsis.shed.otlp.scope.version,
                 attributes: coalesce(
                     workspace.lsis.shed.otlp.scope.attributes,
                     []
                 )
             },
             log_records: [{
-                time_unix_nano:  coalesce(workspace.lsis.parsed.time, received_at),
-                severity_number: workspace.lsis.parsed.severity_id,
+                time_unix_nano:          coalesce(workspace.lsis.parsed.time, received_at),
+                observed_time_unix_nano: workspace.lsis.shed.otlp.log_record.observed_time_unix_nano,
+                severity_number:         workspace.lsis.parsed.severity_id,
+                severity_text:           workspace.lsis.shed.otlp.log_record.severity_text,
                 body: { string_value: coalesce(
                     workspace.lsis.shed.otlp.log_record.body, ""
                 ) },

--- a/packaging/snippets/composers/compose_replayable.limpid
+++ b/packaging/snippets/composers/compose_replayable.limpid
@@ -5,7 +5,7 @@
 // Reads:       ingress (passed through verbatim) — plus the ambient
 //              event metadata `received_at` / `source`, which every
 //              process can read unconditionally.
-// Writes:      workspace.lsis.replayable — replay record JSONL line
+// Writes:      workspace.lsis.composed.replayable — replay record JSONL line
 //              (String). Pipe `| replayable_to_egress` (foot of
 //              file) to emit it as the capture stream.
 // Test corpus: spec-only (mirrors the error_log DLQ record shape;
@@ -47,7 +47,7 @@ def process compose_replayable {
     // `{ip, port}` object — same shape `inject --json` expects — so
     // the composer can pass it straight through with no string
     // assembly and no port-placeholder fidelity loss.
-    workspace.lsis.replayable = to_json({
+    workspace.lsis.composed.replayable = to_json({
         received_at: received_at,
         source:      source,
         ingress:     ingress
@@ -58,9 +58,9 @@ def process compose_replayable {
 // Egress terminator
 // ---------------------------------------------------------------------------
 //
-// Moves the replay record from `workspace.lsis.replayable` to
+// Moves the replay record from `workspace.lsis.composed.replayable` to
 // `egress`. Pipelines that emit the capture stream as the wire form
 // pipe `compose_replayable | replayable_to_egress`.
 def process replayable_to_egress {
-    egress = workspace.lsis.replayable
+    egress = workspace.lsis.composed.replayable
 }

--- a/packaging/snippets/composers/compose_rfc5424.limpid
+++ b/packaging/snippets/composers/compose_rfc5424.limpid
@@ -13,10 +13,13 @@
 //                .procid     (optional, String) — default "-"
 //                .msgid      (optional, String) — default "-"
 //                .sd         (optional, String) — default "-"
-//                .msg        (String)           — treated as required. If
-//                             the slot is absent the record still assembles
-//                             with an empty MSG, which is spec-compliant
-//                             (RFC 5424 § 6 grammar makes MSG optional).
+//                .msg        (required, String) — the log body. If the slot
+//                             is absent the record still assembles with an
+//                             empty MSG, which is spec-compliant (RFC 5424
+//                             § 6 grammar makes MSG optional); required is
+//                             the intended contract from the composer's
+//                             point of view, and absence is a caller bug
+//                             to flag.
 // Writes:      workspace.lsis.composed.rfc5424 — single-line RFC 5424
 //              record (String). Pipe `| rfc5424_to_egress` (foot of file)
 //              to emit it as the wire form.

--- a/packaging/snippets/composers/compose_rfc5424.limpid
+++ b/packaging/snippets/composers/compose_rfc5424.limpid
@@ -1,95 +1,175 @@
-// Summary:     journald entry → single-line RFC 5424 syslog record
+// Summary:     Assembles a single-line RFC 5424 syslog record from
+//              per-field shed slots
 //              (https://datatracker.ietf.org/doc/html/rfc5424).
-// Reads:       workspace.journald.* (from parse_journald)
-//                .PRIORITY           (optional, String) — severity 0-7
-//                .SYSLOG_FACILITY    (optional, String) — facility number
-//                .SYSLOG_IDENTIFIER  (optional, String) — APP-NAME source
-//                ._COMM              (optional, String) — APP-NAME fallback
-//                ._PID               (optional, String) — PROCID source
-//                .SYSLOG_PID         (optional, String) — PROCID fallback
-//                ._HOSTNAME          (optional, String) — originating host
-//                .MESSAGE            (optional, String) — MSG (verbatim)
-//              Other upstreams (e.g. workspace.syslog.* or
-//              workspace.cef.*) are out of scope — write your own
-//              composer if you need to re-wrap from a different
-//              intermediate.
-// Writes:      workspace.lsis.composed.rfc5424 — single-line RFC 5424 record
-//              (String). Pipe `| rfc5424_to_egress` (foot of file)
+// Reads:       workspace.lsis.shed.rfc5424.* — per-field intake
+//              (RFC 5424 ABNF vocabulary):
+//                .pri        (optional, Int)    — default 14 (user.info)
+//                .timestamp  (optional, String) — default is `received_at`
+//                             formatted as RFC 3339 with microsecond UTC
+//                             precision. Callers supplying their own value
+//                             MUST also supply the RFC 5424 wire form.
+//                .hostname   (optional, String) — default hostname()
+//                .app_name   (optional, String) — default "-"
+//                .procid     (optional, String) — default "-"
+//                .msgid      (optional, String) — default "-"
+//                .sd         (optional, String) — default "-"
+//                .msg        (String)           — treated as required. If
+//                             the slot is absent the record still assembles
+//                             with an empty MSG, which is spec-compliant
+//                             (RFC 5424 § 6 grammar makes MSG optional).
+// Writes:      workspace.lsis.composed.rfc5424 — single-line RFC 5424
+//              record (String). Pipe `| rfc5424_to_egress` (foot of file)
 //              to emit it as the wire form.
-// Test corpus: spec-only (RFC 5424 frame shape; field decisions
+// Test corpus: spec-only (RFC 5424 § 6 frame shape; field decisions
 //              documented below)
-//
-// Generic journald → RFC 5424 wire composer. Replaces the hand-rolled
-// `wrap_<program>` patterns that used to live per-host (one per
-// service: sshd / sudo / etc.) and that re-extracted PID and identifier
-// from a synthesised string.
 //
 // Wire shape —
 //   <PRI>1 TIMESTAMP HOSTNAME APP-NAME PROCID MSGID STRUCTURED-DATA MSG
 //
-// Field decisions —
-//   PRI             coalesce(SYSLOG_FACILITY, "1")*8 + coalesce(PRIORITY, "6")
-//                   Default 14 (user.info) when journald did not record one.
-//                   Edge does NOT preserve __REALTIME_TIMESTAMP-derived PRI;
-//                   PRIORITY+SYSLOG_FACILITY in the entry are what we use.
+// Contract — this composer is generic. It knows only the RFC 5424 wire
+// format; it does not read any transport / vocabulary namespace directly.
+// Callers feed it through `workspace.lsis.shed.rfc5424.*` (per-slot,
+// replacement semantics: `coalesce(shed value, default)` — no merge).
+//
+// Sourcing the shed slots — two supported shapes:
+//
+//   1. Named bridge (see `journald_to_rfc5424` below) for well-known
+//      upstreams that ship with this pack:
+//
+//        process parse_journald
+//              | journald_to_rfc5424
+//              | compose_rfc5424
+//              | rfc5424_to_egress
+//
+//   2. Anonymous glue block in the pipeline, when the caller is
+//      wrapping an ad-hoc payload (e.g. an OCSF JSON produced by
+//      compose_ocsf, or a message the caller already has in hand):
+//
+//        process parse_x
+//              | compose_ocsf
+//              | { workspace.lsis.shed.rfc5424.msg =
+//                    workspace.lsis.composed.ocsf }
+//              | compose_rfc5424
+//              | rfc5424_to_egress
+//
+// Bridges live *with the composer that consumes them* (one file =
+// one composer's full consumption story: helpers / bridge / body /
+// egress terminator). Additional bridges belong here, not in a
+// separate directory — the bridge is the consumer's cost of eating
+// something other than the plain shed vocabulary, and belongs to the
+// composer.
+//
+// Field decisions (defaults applied when the corresponding shed slot
+// is absent) —
+//   PRI             14 (facility=1 user, severity=6 informational)
 //   VERSION         1 (literal)
-//   TIMESTAMP       received_at, not __REALTIME_TIMESTAMP. Edge stays
-//                   neutral — downstream relay decides whether to
-//                   substitute the original wall-clock for replay.
-//                   Format — RFC 3339 with microsecond precision, UTC.
-//   HOSTNAME        Original `_HOSTNAME` from the journald entry,
-//                   falling back to `hostname()` (this host) if the
-//                   field is absent. This preserves the originating
-//                   host across a relay hop — the relay is forwarding
-//                   someone else's record, not generating its own, so
-//                   stamping the relay's hostname here would erase
-//                   "where did the sshd event actually happen" from
-//                   the RFC 5424 frame.
-//   APP-NAME        SYSLOG_IDENTIFIER, falling back to _COMM, then "-"
-//   PROCID          _PID, falling back to SYSLOG_PID, then "-"
-//   MSGID           "-" (journald has no equivalent concept at this layer)
-//   STRUCTURED-DATA "-" (not synthesised at the edge; downstream
-//                   composers can wrap if they need SD-ELEMENT)
-//   MSG             MESSAGE (verbatim, including any embedded newlines)
+//   TIMESTAMP       `received_at` formatted RFC 3339 with microsecond
+//                   precision, UTC. Callers holding a source-claimed
+//                   timestamp can pre-format and place it in
+//                   `shed.rfc5424.timestamp`.
+//   HOSTNAME        `hostname()` (this box) when the slot is absent.
+//                   Bridges preserving the originating host across a
+//                   relay hop supply the slot themselves — see
+//                   `journald_to_rfc5424` below.
+//   APP-NAME        "-"
+//   PROCID          "-"
+//   MSGID           "-"
+//   STRUCTURED-DATA "-"
+//   MSG             "" when absent (a valid but empty RFC 5424 MSG).
+
+// ---------------------------------------------------------------------------
+// Helper: PRI arithmetic (facility * 8 + severity). Bridges pass in the
+// two byte-string fields from their upstream; the function is pure. Both
+// arguments may be null — the coalesce fallbacks apply per RFC 5424 § 6.2.1
+// convention (unknown facility → 1 user, unknown severity → 6 informational).
+// ---------------------------------------------------------------------------
+
+def function rfc5424_pri_from(facility_str, severity_str) {
+    let facility = to_int(coalesce(facility_str, "1"))
+    let severity = to_int(coalesce(severity_str, "6"))
+    facility * 8 + severity
+}
+
+// ---------------------------------------------------------------------------
+// Generic RFC 5424 body composer — reads shed.rfc5424.*, writes composed.
+// ---------------------------------------------------------------------------
+
+def process compose_rfc5424 {
+    let pri       = coalesce(workspace.lsis.shed.rfc5424.pri, 14)
+    let ts        = coalesce(
+                      workspace.lsis.shed.rfc5424.timestamp,
+                      strftime(received_at, "%Y-%m-%dT%H:%M:%S%.6fZ", "UTC")
+                    )
+    let host      = coalesce(workspace.lsis.shed.rfc5424.hostname, hostname())
+    let app       = coalesce(workspace.lsis.shed.rfc5424.app_name, "-")
+    let procid    = coalesce(workspace.lsis.shed.rfc5424.procid, "-")
+    let msgid     = coalesce(workspace.lsis.shed.rfc5424.msgid, "-")
+    let sd        = coalesce(workspace.lsis.shed.rfc5424.sd, "-")
+    let msg       = coalesce(workspace.lsis.shed.rfc5424.msg, "")
+
+    workspace.lsis.composed.rfc5424 = "<${pri}>1 ${ts} ${host} ${app} ${procid} ${msgid} ${sd} ${msg}"
+}
+
+// ---------------------------------------------------------------------------
+// Bridge: journald entry → shed.rfc5424.*
+// ---------------------------------------------------------------------------
+//
+// Reads workspace.journald.* (produced by `parse_journald`) and populates
+// the RFC 5424 shed slots. Replaces the hand-rolled `wrap_<program>`
+// patterns that used to live per-host (one per service: sshd / sudo / etc.)
+// and that re-extracted PID and identifier from a synthesised string.
+//
+// Field decisions specific to journald sourcing —
+//   PRI       SYSLOG_FACILITY * 8 + PRIORITY (both are strings on the
+//             journalctl -o json wire; parsed via `to_int`). Missing
+//             SYSLOG_FACILITY defaults to facility=1 (user), missing
+//             PRIORITY to severity=6 (informational). Edge does NOT
+//             preserve __REALTIME_TIMESTAMP-derived PRI; the fields in
+//             the entry are what we use.
+//   TIMESTAMP not populated by the bridge — `compose_rfc5424` falls back
+//             to `received_at`. Edge stays neutral; downstream relay
+//             decides whether to substitute the original wall-clock for
+//             replay.
+//   HOSTNAME  `_HOSTNAME` from the journald entry, only when present.
+//             When absent, `compose_rfc5424` falls back to `hostname()`.
+//             This preserves the originating host across a relay hop —
+//             the relay is forwarding someone else's record, not
+//             generating its own, so stamping the relay's hostname
+//             here would erase "where did the sshd event actually
+//             happen" from the RFC 5424 frame.
+//   APP-NAME  SYSLOG_IDENTIFIER, falling back to _COMM.
+//   PROCID    _PID, falling back to SYSLOG_PID.
+//   MSGID     not populated (journald has no equivalent concept at
+//             this layer).
+//   SD        not populated (not synthesised at the edge; downstream
+//             composers can wrap if they need SD-ELEMENT).
+//   MSG       MESSAGE (verbatim, including any embedded newlines).
 //
 // Typical pipeline (edge box forwarding journald to a syslog relay):
 //   def pipeline ssh_to_relay {
 //       input ssh_journal
-//       process parse_journald | compose_rfc5424 | rfc5424_to_egress
+//       process parse_journald
+//             | journald_to_rfc5424
+//             | compose_rfc5424
+//             | rfc5424_to_egress
 //       output relay
 //   }
 
-def function rfc5424_pri {
-    let facility = to_int(coalesce(workspace.journald.SYSLOG_FACILITY, "1"))
-    let severity = to_int(coalesce(workspace.journald.PRIORITY, "6"))
-    facility * 8 + severity
-}
-
-def function rfc5424_appname {
-    coalesce(
-        workspace.journald.SYSLOG_IDENTIFIER,
-        workspace.journald._COMM,
-        "-"
-    )
-}
-
-def function rfc5424_procid {
-    coalesce(
-        workspace.journald._PID,
-        workspace.journald.SYSLOG_PID,
-        "-"
-    )
-}
-
-def process compose_rfc5424 {
-    let pri      = rfc5424_pri()
-    let ts       = strftime(received_at, "%Y-%m-%dT%H:%M:%S%.6fZ", "UTC")
-    let host     = coalesce(workspace.journald._HOSTNAME, hostname())
-    let app      = rfc5424_appname()
-    let procid   = rfc5424_procid()
-    let msg      = coalesce(workspace.journald.MESSAGE, "")
-
-    workspace.lsis.composed.rfc5424 = "<${pri}>1 ${ts} ${host} ${app} ${procid} - - ${msg}"
+def process journald_to_rfc5424 {
+    workspace.lsis.shed.rfc5424.pri      = rfc5424_pri_from(
+                                              workspace.journald.SYSLOG_FACILITY,
+                                              workspace.journald.PRIORITY
+                                            )
+    workspace.lsis.shed.rfc5424.hostname = workspace.journald._HOSTNAME
+    workspace.lsis.shed.rfc5424.app_name = coalesce(
+                                              workspace.journald.SYSLOG_IDENTIFIER,
+                                              workspace.journald._COMM
+                                            )
+    workspace.lsis.shed.rfc5424.procid   = coalesce(
+                                              workspace.journald._PID,
+                                              workspace.journald.SYSLOG_PID
+                                            )
+    workspace.lsis.shed.rfc5424.msg      = workspace.journald.MESSAGE
 }
 
 // ---------------------------------------------------------------------------
@@ -98,7 +178,8 @@ def process compose_rfc5424 {
 //
 // Moves the RFC 5424 record from `workspace.lsis.composed.rfc5424` to
 // `egress`. Pipelines that emit RFC 5424 as the wire form pipe
-// `compose_rfc5424 | rfc5424_to_egress`.
+// `compose_rfc5424 | rfc5424_to_egress` (usually preceded by a bridge
+// or glue block that populates the shed slots).
 def process rfc5424_to_egress {
     egress = workspace.lsis.composed.rfc5424
 }

--- a/packaging/snippets/composers/compose_rfc5424.limpid
+++ b/packaging/snippets/composers/compose_rfc5424.limpid
@@ -13,7 +13,7 @@
 //              workspace.cef.*) are out of scope — write your own
 //              composer if you need to re-wrap from a different
 //              intermediate.
-// Writes:      workspace.lsis.rfc5424 — single-line RFC 5424 record
+// Writes:      workspace.lsis.composed.rfc5424 — single-line RFC 5424 record
 //              (String). Pipe `| rfc5424_to_egress` (foot of file)
 //              to emit it as the wire form.
 // Test corpus: spec-only (RFC 5424 frame shape; field decisions
@@ -89,16 +89,16 @@ def process compose_rfc5424 {
     let procid   = rfc5424_procid()
     let msg      = coalesce(workspace.journald.MESSAGE, "")
 
-    workspace.lsis.rfc5424 = "<${pri}>1 ${ts} ${host} ${app} ${procid} - - ${msg}"
+    workspace.lsis.composed.rfc5424 = "<${pri}>1 ${ts} ${host} ${app} ${procid} - - ${msg}"
 }
 
 // ---------------------------------------------------------------------------
 // Egress terminator
 // ---------------------------------------------------------------------------
 //
-// Moves the RFC 5424 record from `workspace.lsis.rfc5424` to
+// Moves the RFC 5424 record from `workspace.lsis.composed.rfc5424` to
 // `egress`. Pipelines that emit RFC 5424 as the wire form pipe
 // `compose_rfc5424 | rfc5424_to_egress`.
 def process rfc5424_to_egress {
-    egress = workspace.lsis.rfc5424
+    egress = workspace.lsis.composed.rfc5424
 }

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -1,7 +1,7 @@
 // Summary:     Cisco ASA / FTD (ASA-syslog-compatibility) %ASA syslog
 //              messages → LSIS Authentication + Network Activity.
 // Reads:       ingress (raw wire) — syslog-wrapped %ASA-<level>-<msg_id> messages
-// Writes:      workspace.lsis.* — 3002 (Authentication) and 4001 (Network
+// Writes:      workspace.lsis.parsed.* — 3002 (Authentication) and 4001 (Network
 //              Activity), dispatched by message ID; unmapped IDs route to
 //              error_log. Per-ID table below.
 // Category:    Network firewall / IPS
@@ -122,7 +122,7 @@ def process parse_asa {
     // nested form was historically broken (sub-process `error` was
     // swallowed at the ProcessCall boundary, so unsupported message
     // IDs would silently flow into compose_ocsf with an empty
-    // workspace.lsis); the v0.7.0 propagation fix
+    // workspace.lsis.parsed); the v0.7.0 propagation fix
     // (`fix/process-call-error-propagation`) made the nested form
     // work as written.
     switch true {
@@ -214,7 +214,7 @@ def process parse_asa_605005_login_permitted {
         workspace.asa.body,
         "^Login permitted from (?P<src_ip>\\S+?)/(?P<src_port>\\d+) to (?P<iface>[^:]+):(?P<dst_ip>\\S+?)/(?P<service>\\S+) for user (?P<user>\\S+)$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 1, asa_severity_id(to_int(workspace.asa.level)),
         f.user, f.src_ip,
         "ASA admin login permitted (service=${f.service})"
@@ -231,7 +231,7 @@ def process parse_asa_605004_login_denied {
         workspace.asa.body,
         "^Login denied from (?P<src_ip>\\S+?)/(?P<src_port>\\d+) to (?P<iface>[^:]+):(?P<dst_ip>\\S+?)/(?P<service>\\S+) for user (?P<user>\\S+)$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 2, 3,
         f.user, f.src_ip,
         "ASA admin login denied (service=${f.service})"
@@ -249,7 +249,7 @@ def process parse_asa_611101_vpn_auth_succeeded {
         workspace.asa.body,
         "^User authentication succeeded: IP, (?P<src_ip>\\S+) : Uname: (?P<user>\\S+)$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 1, asa_severity_id(to_int(workspace.asa.level)),
         f.user, f.src_ip,
         "ASA VPN user auth succeeded"
@@ -269,7 +269,7 @@ def process parse_asa_611102_vpn_auth_failed {
         workspace.asa.body,
         "^User authentication failed: IP, (?P<src_ip>\\S+) : Uname: (?P<user>\\S+)$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 2, 3,
         f.user, f.src_ip,
         "ASA VPN user auth failed"
@@ -287,7 +287,7 @@ def process parse_asa_611103_vpn_logout {
         workspace.asa.body,
         "^User logged out: Uname: (?P<user>\\S+)$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         2, 1, asa_severity_id(to_int(workspace.asa.level)),
         f.user, null,
         "ASA VPN user logged out"
@@ -307,7 +307,7 @@ def process parse_asa_109001_aaa_auth_start {
         workspace.asa.body,
         "^Auth start for user (?P<user>\\S+) from (?P<src_ip>\\S+?)/(?P<src_port>\\d+) to (?P<dst_ip>\\S+?)/(?P<dst_port>\\d+)$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 1, asa_severity_id(to_int(workspace.asa.level)),
         f.user, f.src_ip,
         "ASA AAA auth start"
@@ -325,7 +325,7 @@ def process parse_asa_109005_aaa_auth_succeeded {
         workspace.asa.body,
         "^Authentication succeeded for user (?P<user>\\S+) from (?P<src_ip>\\S+?)/(?P<src_port>\\d+) to (?P<dst_ip>\\S+?)/(?P<dst_port>\\d+) on interface (?P<iface>\\S+)\\.?$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 1, asa_severity_id(to_int(workspace.asa.level)),
         f.user, f.src_ip,
         "ASA AAA auth succeeded (iface=${f.iface})"
@@ -341,7 +341,7 @@ def process parse_asa_109005_aaa_auth_succeeded {
 
 def process parse_asa_109017_aaa_insufficient_resources {
     let f = regex_parse(workspace.asa.body, "user (?P<user>\\S+)")
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 99, 3,
         coalesce(f.user, null),
         null,
@@ -362,7 +362,7 @@ def process parse_asa_113012_aaa_user_accept {
         workspace.asa.body,
         "^AAA user authentication Successful : server = (?P<server>\\S+) : user = (?P<user>\\S+)$"
     )
-    workspace.lsis = asa_authentication_record(
+    workspace.lsis.parsed = asa_authentication_record(
         1, 1, asa_severity_id(to_int(workspace.asa.level)),
         f.user, null,
         "ASA AAA user accept (server=${f.server})"
@@ -385,7 +385,7 @@ def process parse_asa_302013_tcp_built {
         workspace.asa.body,
         "^Built (?P<direction>\\S+) TCP connection (?P<conn_id>\\d+) for (?P<src_iface>[^:]+):(?P<src_ip>\\S+?)/(?P<src_port>\\d+) .* to (?P<dst_iface>[^:]+):(?P<dst_ip>\\S+?)/(?P<dst_port>\\d+)"
     )
-    workspace.lsis = asa_network_activity_record(
+    workspace.lsis.parsed = asa_network_activity_record(
         1, asa_severity_id(to_int(workspace.asa.level)),
         f.src_ip, to_int(f.src_port),
         f.dst_ip, to_int(f.dst_port),
@@ -406,7 +406,7 @@ def process parse_asa_302014_tcp_teardown {
         workspace.asa.body,
         "^Teardown TCP connection (?P<conn_id>\\d+) for (?P<src_iface>[^:]+):(?P<src_ip>\\S+?)/(?P<src_port>\\d+) to (?P<dst_iface>[^:]+):(?P<dst_ip>\\S+?)/(?P<dst_port>\\d+)"
     )
-    workspace.lsis = asa_network_activity_record(
+    workspace.lsis.parsed = asa_network_activity_record(
         2, asa_severity_id(to_int(workspace.asa.level)),
         f.src_ip, to_int(f.src_port),
         f.dst_ip, to_int(f.dst_port),
@@ -427,7 +427,7 @@ def process parse_asa_302015_udp_built {
         workspace.asa.body,
         "^Built (?P<direction>\\S+) UDP connection (?P<conn_id>\\d+) for (?P<src_iface>[^:]+):(?P<src_ip>\\S+?)/(?P<src_port>\\d+) .* to (?P<dst_iface>[^:]+):(?P<dst_ip>\\S+?)/(?P<dst_port>\\d+)"
     )
-    workspace.lsis = asa_network_activity_record(
+    workspace.lsis.parsed = asa_network_activity_record(
         1, asa_severity_id(to_int(workspace.asa.level)),
         f.src_ip, to_int(f.src_port),
         f.dst_ip, to_int(f.dst_port),
@@ -448,7 +448,7 @@ def process parse_asa_302016_udp_teardown {
         workspace.asa.body,
         "^Teardown UDP connection (?P<conn_id>\\d+) for (?P<src_iface>[^:]+):(?P<src_ip>\\S+?)/(?P<src_port>\\d+) to (?P<dst_iface>[^:]+):(?P<dst_ip>\\S+?)/(?P<dst_port>\\d+)"
     )
-    workspace.lsis = asa_network_activity_record(
+    workspace.lsis.parsed = asa_network_activity_record(
         2, asa_severity_id(to_int(workspace.asa.level)),
         f.src_ip, to_int(f.src_port),
         f.dst_ip, to_int(f.dst_port),
@@ -471,7 +471,7 @@ def process parse_asa_106023_acl_deny {
         workspace.asa.body,
         "^Deny (?P<proto>\\S+) src (?P<src_iface>[^:]+):(?P<src_ip>\\S+?)/(?P<src_port>\\d+) dst (?P<dst_iface>[^:]+):(?P<dst_ip>\\S+?)/(?P<dst_port>\\d+) by access-group \"(?P<acl>[^\"]+)\""
     )
-    workspace.lsis = asa_network_activity_record(
+    workspace.lsis.parsed = asa_network_activity_record(
         5, 3,
         f.src_ip, to_int(f.src_port),
         f.dst_ip, to_int(f.dst_port),

--- a/packaging/snippets/parsers/parse_auditd.limpid
+++ b/packaging/snippets/parsers/parse_auditd.limpid
@@ -4,7 +4,7 @@
 //                .body (required, String) — the auditd record
 //                .hostname (optional, String) — host where audit ran
 //                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.* — 3002 (Authentication), 3001 (Account Change),
+// Writes:      workspace.lsis.parsed.* — 3002 (Authentication), 3001 (Account Change),
 //              1007 (Process Activity), 1001 (File System Activity), 2004
 //              (Detection Finding), dispatched by record type; unmapped types
 //              route to error_log. Per-type table below.
@@ -471,7 +471,7 @@ def process parse_auditd_auth_dispatch {
         2       { 3 }          // Medium for auth failure
         default { 1 }
     }
-    workspace.lsis = auditd_auth_record(
+    workspace.lsis.parsed = auditd_auth_record(
         activity, status, severity,
         user, addr, terminal, pid, exe,
         workspace.auditd.hostname,
@@ -511,7 +511,7 @@ def process parse_auditd_account_dispatch {
         "role_change" { 2 }
         default       { 99 }
     }
-    workspace.lsis = auditd_account_change_record(
+    workspace.lsis.parsed = auditd_account_change_record(
         activity,
         auditd_status_id(res),
         switch true { is_group { null } default { target_user } },
@@ -550,7 +550,7 @@ def process parse_auditd_process_dispatch {
         "no"   { 2 }
         default { 99 }
     }
-    workspace.lsis = auditd_process_record(
+    workspace.lsis.parsed = auditd_process_record(
         activity, status,
         comm, exe, pid, ppid, uid,
         workspace.auditd.hostname,
@@ -576,7 +576,7 @@ def process parse_auditd_file_dispatch {
     let body = workspace.auditd.body
     let path_name = parse_auditd_outer_kv_quoted(body, "name")
     let cwd = parse_auditd_outer_kv_quoted(body, "cwd")
-    workspace.lsis = auditd_file_record(
+    workspace.lsis.parsed = auditd_file_record(
         99,                          // Other (open / access / etc. unknown without SYSCALL pair)
         1,
         coalesce(path_name, cwd),
@@ -660,7 +660,7 @@ def process parse_auditd_lifecycle_dispatch {
         "SOFTWARE_UPDATE" { 2 }     // Update
         default           { 99 }    // Other
     }
-    workspace.lsis = auditd_lifecycle_record(
+    workspace.lsis.parsed = auditd_lifecycle_record(
         activity, auditd_status_id(res),
         comm, exe, pid,
         workspace.auditd.hostname,
@@ -711,7 +711,7 @@ def process parse_auditd_network_dispatch {
     let src = parse_auditd_outer_kv(body, "src")
     let dst = parse_auditd_outer_kv(body, "dst")
     let res = parse_auditd_outer_kv(body, "res")
-    workspace.lsis = auditd_network_event_record(
+    workspace.lsis.parsed = auditd_network_event_record(
         99,                                     // Other (kernel netfilter / IPsec event)
         auditd_status_id(res),
         src, dst,
@@ -800,7 +800,7 @@ def process parse_auditd_config_dispatch {
         "CONFIG_CHANGE" { 2 }
         default         { 1 }
     }
-    workspace.lsis = auditd_config_record(
+    workspace.lsis.parsed = auditd_config_record(
         title, severity,
         comm, exe, pid,
         workspace.auditd.hostname,
@@ -831,7 +831,7 @@ def process parse_auditd_finding_dispatch {
         "anom_abend" { 3 }
         default      { 2 }
     }
-    workspace.lsis = auditd_finding_record(
+    workspace.lsis.parsed = auditd_finding_record(
         severity, title, 99,
         workspace.auditd.hostname,
         workspace.auditd.time,

--- a/packaging/snippets/parsers/parse_aws_guardduty.limpid
+++ b/packaging/snippets/parsers/parse_aws_guardduty.limpid
@@ -3,7 +3,7 @@
 // Summary:     AWS GuardDuty findings JSON → LSIS Detection Finding.
 // Reads:       ingress (raw wire) — one GuardDuty finding object per ingress
 //              (identical across EventBridge / SNS / S3 delivery)
-// Writes:      workspace.lsis.* — 2004 (Detection Finding), one finding → one
+// Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding), one finding → one
 //              record; unknown ThreatPurpose values route to error_log.
 // Category:    Cloud security findings
 // Test corpus: spec-only (AWS documentation per-finding-type sample bodies;
@@ -314,25 +314,25 @@ def process parse_aws_guardduty {
 def process parse_aws_guardduty_dispatch {
     switch workspace.gd_type.category {
         "Recon" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Reconnaissance")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Reconnaissance")
         }
         "Discovery" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Discovery")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Discovery")
         }
         "InitialAccess" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Initial Access")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Initial Access")
         }
         "Execution" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Execution")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Execution")
         }
         "Persistence" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Persistence")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Persistence")
         }
         "PrivilegeEscalation" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Privilege Escalation")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Privilege Escalation")
         }
         "DefenseEvasion" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Defense Evasion")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Defense Evasion")
         }
         "Stealth" {
             // AWS-specific bucket: covers log-tampering / audit-
@@ -340,48 +340,48 @@ def process parse_aws_guardduty_dispatch {
             // public-access-block disabled, etc.). Closest ATT&CK
             // tactic is Defense Evasion; pass the AWS label through
             // verbatim so the consumer can disambiguate.
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Stealth")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Stealth")
         }
         "Exfiltration" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Exfiltration")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Exfiltration")
         }
         "Impact" {
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Impact")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Impact")
         }
         "UnauthorizedAccess" {
             // AWS-specific: anomalous auth / API-call patterns
             // (ConsoleLoginSuccess.B, MaliciousIPCaller.Custom,
             // TorIPCaller, etc.). Spans ATT&CK Initial Access and
             // Credential Access; pass the AWS label through.
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "UnauthorizedAccess")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "UnauthorizedAccess")
         }
         "Backdoor" {
             // AWS-specific: EC2 instance behaving as part of a C2
             // channel (DNS C2, persistent outbound to known C2 IP).
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Backdoor")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Backdoor")
         }
         "Trojan" {
             // AWS-specific: EC2 instance exhibiting trojan-family
             // network behaviour (DGA domain queries, dropper
             // beacons).
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Trojan")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Trojan")
         }
         "CryptoCurrency" {
             // AWS-specific: connections to known mining pools /
             // crypto-jacking activity on EC2 / EKS / ECS.
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "CryptoCurrency")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "CryptoCurrency")
         }
         "Policy" {
             // AWS-specific: account / org hygiene posture findings
             // (root user activity, password policy weak, S3 block-
             // public-access disabled). Operational, not adversary-
             // driven — pass the AWS label through.
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Policy")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "Policy")
         }
         "PenTest" {
             // AWS-specific: known pen-test tooling user-agents
             // (Kali, ParrotLinux, Pentoo) hitting the API.
-            workspace.lsis = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "PenTest")
+            workspace.lsis.parsed = aws_guardduty_finding_record(workspace.gd, workspace.gd_type, "PenTest")
         }
         default {
             error "parse_aws_guardduty: unknown ThreatPurpose category `${workspace.gd_type.category}` (full type `${workspace.gd.type}`); GuardDuty closed taxonomy was extended — extend the dispatcher"

--- a/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
+++ b/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
@@ -4,7 +4,7 @@
 //              formats) → LSIS Network Activity.
 // Reads:       ingress (raw wire) — one space-separated flow-log record per
 //              line; dispatch by the leading version token
-// Writes:      workspace.lsis.* — 4001 (Network Activity); unknown version
+// Writes:      workspace.lsis.parsed.* — 4001 (Network Activity); unknown version
 //              tokens route to error_log.
 // Category:    Cloud network (data plane)
 // Test corpus: spec-only (AWS VPC Flow Logs documentation column layouts;
@@ -211,7 +211,7 @@ def process parse_aws_vpc_flow_v2_record {
     let proto_num = aws_vpc_flow_int_or_null(f.protocol)
     let action    = f.action
     let activity  = aws_vpc_flow_activity_id(action)
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  activity,
@@ -289,7 +289,7 @@ def process parse_aws_vpc_flow_v5_record {
     let proto_num = aws_vpc_flow_int_or_null(f.protocol)
     let action    = f.action
     let activity  = aws_vpc_flow_activity_id(action)
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  activity,

--- a/packaging/snippets/parsers/parse_azure_activity.limpid
+++ b/packaging/snippets/parsers/parse_azure_activity.limpid
@@ -3,7 +3,7 @@
 // Summary:     Azure Activity Log events JSON → LSIS API Activity.
 // Reads:       ingress (raw wire) — one Activity Log event per ingress (flat
 //              per-record form; unwrap Event Hub batches upstream)
-// Writes:      workspace.lsis.* — 6003 (API Activity), dispatched over the
+// Writes:      workspace.lsis.parsed.* — 6003 (API Activity), dispatched over the
 //              8 documented categories; unknown categories route to
 //              error_log.
 // Category:    Cloud audit (API control plane)
@@ -146,7 +146,7 @@ def process parse_azure_activity_record {
     let rp       = azure_resource_provider(workspace.az.resourceId)
     let rtype    = azure_resource_type(workspace.az.resourceId)
 
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    6003,
         category_uid: 6,
         activity_id:  activity,

--- a/packaging/snippets/parsers/parse_bind.limpid
+++ b/packaging/snippets/parsers/parse_bind.limpid
@@ -4,7 +4,7 @@
 //                .pid (optional, String) — named pid
 //                .hostname (optional, String) — DNS server hostname
 //                .time (optional, Int) — epoch nanoseconds of arrival
-// Writes:      workspace.lsis.* — 4003 (DNS Activity). Only the queries
+// Writes:      workspace.lsis.parsed.* — 4003 (DNS Activity). Only the queries
 //              channel; other BIND log categories route to error_log.
 // Category:    DNS server
 // Test corpus: synthetic (sample querylog lines in this header)
@@ -145,7 +145,7 @@ def process parse_bind {
 }
 
 def process parse_bind_query_record {
-    workspace.lsis = bind_dns_record(
+    workspace.lsis.parsed = bind_dns_record(
         workspace.bind_query.client_ip,
         workspace.bind_query.client_port,
         workspace.bind_query.qname,

--- a/packaging/snippets/parsers/parse_checkpoint_leef.limpid
+++ b/packaging/snippets/parsers/parse_checkpoint_leef.limpid
@@ -4,7 +4,7 @@
 //                .body (required, String) — full syslog wire
 //                .hostname (optional, String) — collector-side hostname override
 //                .time (optional, Int) — epoch nanoseconds of arrival
-// Writes:      workspace.lsis.* — 4001 (Network Activity) for traffic EventIDs
+// Writes:      workspace.lsis.parsed.* — 4001 (Network Activity) for traffic EventIDs
 //              (Accept / Drop / Reject / Block); other LEEF events route to
 //              error_log.
 // Category:    Network firewall / IPS
@@ -124,7 +124,7 @@ def process parse_checkpoint_leef_record {
             let proto = parse_checkpoint_leef_kv(ext, "proto")
             let src_port = parse_checkpoint_leef_kv(ext, "srcPort")
             let dst_port = parse_checkpoint_leef_kv(ext, "dstPort")
-            workspace.lsis = {
+            workspace.lsis.parsed = {
                 class_uid:    4001,
                 category_uid: 4,
                 activity_id:  activity,

--- a/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
+++ b/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
@@ -4,7 +4,7 @@
 //                .body (required, String) — the full RFC 5424 wire
 //                .hostname (optional, String) — collector-side hostname override
 //                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.* — firewall actions → 4001, threat actions →
+// Writes:      workspace.lsis.parsed.* — firewall actions → 4001, threat actions →
 //              2004, auth actions → 3002; unknown actions land in 4001 with
 //              the action preserved in unmapped.
 // Category:    Network firewall / IPS
@@ -390,7 +390,7 @@ def process parse_checkpoint_syslog_dispatch {
 
 def process parse_checkpoint_syslog_network_record_proc {
     let sd = workspace.cp_syslog_class.sd
-    workspace.lsis = checkpoint_syslog_network_record(
+    workspace.lsis.parsed = checkpoint_syslog_network_record(
         sd,
         parse_checkpoint_syslog_kv(sd, "action"),
         parse_checkpoint_syslog_kv(sd, "src"),
@@ -409,7 +409,7 @@ def process parse_checkpoint_syslog_network_record_proc {
 
 def process parse_checkpoint_syslog_finding_record_proc {
     let sd = workspace.cp_syslog_class.sd
-    workspace.lsis = checkpoint_syslog_finding_record(
+    workspace.lsis.parsed = checkpoint_syslog_finding_record(
         sd,
         parse_checkpoint_syslog_kv(sd, "action"),
         parse_checkpoint_syslog_kv(sd, "src"),
@@ -424,7 +424,7 @@ def process parse_checkpoint_syslog_finding_record_proc {
 
 def process parse_checkpoint_syslog_auth_record {
     let sd = workspace.cp_syslog_class.sd
-    workspace.lsis = checkpoint_syslog_auth_record(
+    workspace.lsis.parsed = checkpoint_syslog_auth_record(
         sd,
         parse_checkpoint_syslog_kv(sd, "action"),
         coalesce(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname),

--- a/packaging/snippets/parsers/parse_cloudtrail.limpid
+++ b/packaging/snippets/parsers/parse_cloudtrail.limpid
@@ -1,7 +1,7 @@
 // Summary:     AWS CloudTrail JSON events → LSIS API Activity.
 // Reads:       ingress (raw wire) — one CloudTrail event JSON object per
 //              ingress (unwrap {"Records":[...]} at the transport layer)
-// Writes:      workspace.lsis.* — 6003 (API Activity).
+// Writes:      workspace.lsis.parsed.* — 6003 (API Activity).
 // Category:    Cloud audit (API control plane)
 // Test corpus: public (FLAWS CloudTrail dataset, 1M events)
 //
@@ -130,7 +130,7 @@ def function cloudtrail_activity_id(name) {
 // ---------------------------------------------------------------------------
 //
 // One process: parse the JSON, then translate top-level CloudTrail
-// fields into OCSF API Activity (6003) on workspace.lsis.
+// fields into OCSF API Activity (6003) on workspace.lsis.parsed.
 
 def process parse_cloudtrail {
     workspace.ct = parse_json(ingress)
@@ -141,7 +141,7 @@ def process parse_cloudtrail {
         default                        { 1 }
     }
 
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    6003,
         category_uid: 6,
         activity_id:  activity,

--- a/packaging/snippets/parsers/parse_combined_log.limpid
+++ b/packaging/snippets/parsers/parse_combined_log.limpid
@@ -2,7 +2,7 @@
 // Reads:       workspace.combined_log.* (bridge — see Bridges below)
 //                .body (required, String) — the CLF line
 //                .hostname (optional, String) — web server hostname
-// Writes:      workspace.lsis.* — 4002 (HTTP Activity).
+// Writes:      workspace.lsis.parsed.* — 4002 (HTTP Activity).
 // Category:    Web / proxy access
 // Test corpus: synthetic (sample CLF lines in this header)
 //
@@ -131,7 +131,7 @@ def process parse_combined_log_record {
         default { workspace.web.referer }
     }
 
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4002,
         category_uid: 4,
         activity_id:  activity,

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -1,7 +1,7 @@
 // Summary:     Fortinet FortiGate CEF (FortiOS set format cef) → LSIS,
 //              dispatched by CEF cat subtype.
 // Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Fortinet|Fortigate|...)
-// Writes:      workspace.lsis.* — class per subtype (traffic → 4001,
+// Writes:      workspace.lsis.parsed.* — class per subtype (traffic → 4001,
 //              IPS / virus → 2004, …); see the subtype leaves below.
 // Category:    Network firewall / IPS
 // Test corpus: real (anonymised FortiGate captures — the dialect-quirks
@@ -169,7 +169,7 @@ def process parse_fortigate_cef {
 //   src / spt / dst / dpt / proto / act / app / in / out / msg
 def process parse_fortigate_cef_traffic {
     let proto_num = to_int(workspace.cef.proto)
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  fortigate_cef_action_to_activity_id(workspace.cef.act),
@@ -209,7 +209,7 @@ def process parse_fortigate_cef_traffic {
 //   FTNTFGTref       — reference URL (vendor ext)
 //   src / spt / dst / dpt / proto / act / msg — standard CEF
 def process parse_fortigate_cef_utm_ips {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -262,7 +262,7 @@ def process parse_fortigate_cef_utm_webfilter {
         "monitor"     { 1 }
         default       { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    6004,
         category_uid: 6,
         activity_id:  activity,
@@ -307,7 +307,7 @@ def process parse_fortigate_cef_utm_webfilter {
 //   FTNTFGTfilename — infected filename
 //   FTNTFGTfilehash — file hash
 def process parse_fortigate_cef_utm_antivirus {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -359,7 +359,7 @@ def process parse_fortigate_cef_utm_antivirus {
 // Subtype leaf: utm:dlp → OCSF Detection Finding (2004)
 // ---------------------------------------------------------------------------
 def process parse_fortigate_cef_utm_dlp {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -404,7 +404,7 @@ def process parse_fortigate_cef_utm_dlp {
 //
 // Application control: app name + risk level + user.
 def process parse_fortigate_cef_utm_appctrl {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -459,7 +459,7 @@ def process parse_fortigate_cef_utm_dns {
         "REFUSED"  { 5 }
         default    { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4003,
         category_uid: 4,
         activity_id:  activity,
@@ -492,7 +492,7 @@ def process parse_fortigate_cef_utm_emailfilter {
         "passthrough" { 6 }
         default       { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4009,
         category_uid: 4,
         activity_id:  activity,
@@ -521,7 +521,7 @@ def process parse_fortigate_cef_utm_emailfilter {
 //
 // FortiGate Web Application Firewall — signature + matched URL.
 def process parse_fortigate_cef_utm_waf {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -580,7 +580,7 @@ def process parse_fortigate_cef_utm_waf {
 //   src / spt / dst / dpt / proto / msg — standard CEF
 //   act                  — engine verdict (`info` / `block`)
 def process parse_fortigate_cef_utm_ssl {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -638,7 +638,7 @@ def process parse_fortigate_cef_utm_voip {
         "end"    { 2 }
         default  { 6 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  activity,
@@ -687,7 +687,7 @@ def process parse_fortigate_cef_event_user {
         "login-failed"    { 2 }
         default           { 1 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  activity,
@@ -724,7 +724,7 @@ def process parse_fortigate_cef_event_vpn {
         "ssl-login-fail"  { 2 }
         default           { 1 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  activity,
@@ -754,7 +754,7 @@ def process parse_fortigate_cef_event_vpn {
 // because they're posture / configuration signals, with `act` carrying
 // the specific event name and `FTNTFGTlogdesc` the human description.
 def process parse_fortigate_cef_event_system {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2003,
         category_uid: 2,
         activity_id:  1,
@@ -787,7 +787,7 @@ def process parse_fortigate_cef_event_wireless {
         "client-roam"       { 6 }
         default             { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  activity,
@@ -828,7 +828,7 @@ def process parse_fortigate_cef_event_wireless {
 //   FTNTFGTlowcount       — number of low findings
 //   FTNTFGTpassedcount    — number of passed checks
 def process parse_fortigate_cef_event_security_rating {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2003,
         category_uid: 2,
         activity_id:  1,

--- a/packaging/snippets/parsers/parse_fortigate_syslog.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_syslog.limpid
@@ -2,7 +2,7 @@
 //              "default" format) → same LSIS shape as parse_fortigate_cef.
 // Reads:       ingress (raw wire) — syslog priority + KV body
 //              (date=... time=... type=...)
-// Writes:      workspace.lsis.* — same classes as parse_fortigate_cef
+// Writes:      workspace.lsis.parsed.* — same classes as parse_fortigate_cef
 //              (the LSIS contract is format-agnostic).
 // Category:    Network firewall / IPS
 // Test corpus: synthetic (FortiOS "default"-format sample wires in this header)
@@ -177,7 +177,7 @@ def function fortigate_syslog_metadata(version_hint) {
 //   inline `parse_kv(...)` upstream of this process.
 def process parse_fortigate_syslog_traffic {
     let proto_num = to_int(workspace.kv.proto)
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  fortigate_syslog_action_to_activity_id(workspace.kv.action),
@@ -214,7 +214,7 @@ def process parse_fortigate_syslog_traffic {
 //   severity    — severity label (informational/low/medium/high/critical)
 //   msg         — human-readable
 def process parse_fortigate_syslog_utm_ips {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -254,7 +254,7 @@ def process parse_fortigate_syslog_utm_webfilter {
         "monitor"     { 1 }
         default       { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    6004,
         category_uid: 6,
         activity_id:  activity,
@@ -296,7 +296,7 @@ def process parse_fortigate_syslog_utm_webfilter {
 //   virus    — malware family / signature
 //   virusid  — numeric signature id
 def process parse_fortigate_syslog_utm_antivirus {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -344,7 +344,7 @@ def process parse_fortigate_syslog_utm_antivirus {
 // Subtype leaf: utm:dlp → OCSF Detection Finding (2004)
 // ---------------------------------------------------------------------------
 def process parse_fortigate_syslog_utm_dlp {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -383,7 +383,7 @@ def process parse_fortigate_syslog_utm_dlp {
 // Subtype leaf: utm:app-ctrl → OCSF Detection Finding (2004)
 // ---------------------------------------------------------------------------
 def process parse_fortigate_syslog_utm_appctrl {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -432,7 +432,7 @@ def process parse_fortigate_syslog_utm_dns {
         "REFUSED"  { 5 }
         default    { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4003,
         category_uid: 4,
         activity_id:  activity,
@@ -459,7 +459,7 @@ def process parse_fortigate_syslog_utm_emailfilter {
         "passthrough" { 6 }
         default       { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4009,
         category_uid: 4,
         activity_id:  activity,
@@ -482,7 +482,7 @@ def process parse_fortigate_syslog_utm_emailfilter {
 // Subtype leaf: utm:waf → OCSF Detection Finding (2004)
 // ---------------------------------------------------------------------------
 def process parse_fortigate_syslog_utm_waf {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -534,7 +534,7 @@ def process parse_fortigate_syslog_utm_waf {
 //   hostname      — server hostname (CN or expected SNI)
 //   action        — engine verdict (`info` / `block`)
 def process parse_fortigate_syslog_utm_ssl {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -584,7 +584,7 @@ def process parse_fortigate_syslog_utm_voip {
         default  { 6 }
     }
     let proto_num = to_int(workspace.kv.proto)
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  activity,
@@ -629,7 +629,7 @@ def process parse_fortigate_syslog_event_user {
         "login-failed"    { 2 }
         default           { 1 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  activity,
@@ -658,7 +658,7 @@ def process parse_fortigate_syslog_event_vpn {
         "ssl-login-fail"  { 2 }
         default           { 1 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  activity,
@@ -675,7 +675,7 @@ def process parse_fortigate_syslog_event_vpn {
 // Subtype leaf: event:system → OCSF Compliance Finding (2003)
 // ---------------------------------------------------------------------------
 def process parse_fortigate_syslog_event_system {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2003,
         category_uid: 2,
         activity_id:  1,
@@ -704,7 +704,7 @@ def process parse_fortigate_syslog_event_wireless {
         "client-roam"       { 6 }
         default             { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  activity,
@@ -737,7 +737,7 @@ def process parse_fortigate_syslog_event_wireless {
 //   auditreporttype  — "CoverageReport" / "OptimizationReport" / ...
 //   criticalcount, highcount, mediumcount, lowcount, passedcount
 def process parse_fortigate_syslog_event_security_rating {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2003,
         category_uid: 2,
         activity_id:  1,

--- a/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
@@ -4,7 +4,7 @@
 //                .body (required, String) — the full RFC 5424 wire INCLUDING the leading `<PRI>1`
 //                .hostname (optional, String) — collector-side override (parser prefers the wire's HOSTNAME field via classify)
 //                .time (optional, Int) — epoch nanoseconds of arrival
-// Writes:      workspace.lsis.* — RT_FLOW / APPTRACK → 4001, RT_IDP / RT_IDS /
+// Writes:      workspace.lsis.parsed.* — RT_FLOW / APPTRACK → 4001, RT_IDP / RT_IDS /
 //              RT_UTM (AV, antispam, content-filter) / RT_AAMW / RT_SECINTEL →
 //              2004, RT_UTM WEBFILTER_URL_* → 4002. Per-daemon table below.
 // Category:    Network firewall / IPS
@@ -392,7 +392,7 @@ def function parse_juniper_srx_sd_syslog_flow_fields(sd) {
 
 def process parse_juniper_srx_sd_syslog_flow_create {
     workspace.srx_sd_fields = parse_juniper_srx_sd_syslog_flow_fields(workspace.srx_sd_class.sd)
-    workspace.lsis = juniper_srx_sd_syslog_network_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_network_record(
         1, 1, 1,
         workspace.srx_sd_fields.src, workspace.srx_sd_fields.src_port,
         workspace.srx_sd_fields.dst, workspace.srx_sd_fields.dst_port,
@@ -410,7 +410,7 @@ def process parse_juniper_srx_sd_syslog_flow_create {
 
 def process parse_juniper_srx_sd_syslog_flow_close {
     workspace.srx_sd_fields = parse_juniper_srx_sd_syslog_flow_fields(workspace.srx_sd_class.sd)
-    workspace.lsis = juniper_srx_sd_syslog_network_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_network_record(
         2, 1, 1,
         workspace.srx_sd_fields.src, workspace.srx_sd_fields.src_port,
         workspace.srx_sd_fields.dst, workspace.srx_sd_fields.dst_port,
@@ -429,7 +429,7 @@ def process parse_juniper_srx_sd_syslog_flow_close {
 
 def process parse_juniper_srx_sd_syslog_flow_deny {
     workspace.srx_sd_fields = parse_juniper_srx_sd_syslog_flow_fields(workspace.srx_sd_class.sd)
-    workspace.lsis = juniper_srx_sd_syslog_network_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_network_record(
         6, 2, 3,
         workspace.srx_sd_fields.src, workspace.srx_sd_fields.src_port,
         workspace.srx_sd_fields.dst, workspace.srx_sd_fields.dst_port,
@@ -447,7 +447,7 @@ def process parse_juniper_srx_sd_syslog_flow_deny {
 
 def process parse_juniper_srx_sd_syslog_apptrack_create {
     workspace.srx_sd_fields = parse_juniper_srx_sd_syslog_flow_fields(workspace.srx_sd_class.sd)
-    workspace.lsis = juniper_srx_sd_syslog_network_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_network_record(
         1, 1, 1,
         workspace.srx_sd_fields.src, workspace.srx_sd_fields.src_port,
         workspace.srx_sd_fields.dst, workspace.srx_sd_fields.dst_port,
@@ -465,7 +465,7 @@ def process parse_juniper_srx_sd_syslog_apptrack_create {
 
 def process parse_juniper_srx_sd_syslog_apptrack_close {
     workspace.srx_sd_fields = parse_juniper_srx_sd_syslog_flow_fields(workspace.srx_sd_class.sd)
-    workspace.lsis = juniper_srx_sd_syslog_network_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_network_record(
         2, 1, 1,
         workspace.srx_sd_fields.src, workspace.srx_sd_fields.src_port,
         workspace.srx_sd_fields.dst, workspace.srx_sd_fields.dst_port,
@@ -484,7 +484,7 @@ def process parse_juniper_srx_sd_syslog_apptrack_close {
 
 def process parse_juniper_srx_sd_syslog_apptrack_volume {
     workspace.srx_sd_fields = parse_juniper_srx_sd_syslog_flow_fields(workspace.srx_sd_class.sd)
-    workspace.lsis = juniper_srx_sd_syslog_network_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_network_record(
         99, 1, 1,
         workspace.srx_sd_fields.src, workspace.srx_sd_fields.src_port,
         workspace.srx_sd_fields.dst, workspace.srx_sd_fields.dst_port,
@@ -520,7 +520,7 @@ def process parse_juniper_srx_sd_syslog_idp_dispatch {
 def process parse_juniper_srx_sd_syslog_idp_attack {
     let sd = workspace.srx_sd_class.sd
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         juniper_srx_sd_syslog_severity_id(parse_juniper_srx_sd_syslog_kv(sd, "threat-severity")),
         juniper_srx_sd_syslog_status_id(action),
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -552,7 +552,7 @@ def process parse_juniper_srx_sd_syslog_idp_appddos {
     let sd = workspace.srx_sd_class.sd
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
     let title = coalesce(parse_juniper_srx_sd_syslog_kv(sd, "application-name"), "IDP AppDDoS")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         4,
         juniper_srx_sd_syslog_status_id(action),
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -583,7 +583,7 @@ def process parse_juniper_srx_sd_syslog_screen_record {
     let sd = workspace.srx_sd_class.sd
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
     let attack = parse_juniper_srx_sd_syslog_kv(sd, "attack-name")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         3,
         juniper_srx_sd_syslog_status_id(action),
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -631,7 +631,7 @@ def process parse_juniper_srx_sd_syslog_utm_dispatch {
 def process parse_juniper_srx_sd_syslog_utm_webfilter {
     let sd = workspace.srx_sd_class.sd
     let permitted = workspace.srx_sd_class.msgid == "WEBFILTER_URL_PERMITTED"
-    workspace.lsis = juniper_srx_sd_syslog_http_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_http_record(
         switch true { permitted { 1 } default { 2 } },
         switch true { permitted { 1 } default { 3 } },
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -653,7 +653,7 @@ def process parse_juniper_srx_sd_syslog_utm_antivirus {
     let sd = workspace.srx_sd_class.sd
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
     let virus = coalesce(parse_juniper_srx_sd_syslog_kv(sd, "virus-name"), workspace.srx_sd_class.msgid)
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         4,
         juniper_srx_sd_syslog_status_id(action),
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -681,7 +681,7 @@ def process parse_juniper_srx_sd_syslog_utm_antivirus {
 def process parse_juniper_srx_sd_syslog_utm_antispam {
     let sd = workspace.srx_sd_class.sd
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         3,
         juniper_srx_sd_syslog_status_id(action),
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -709,7 +709,7 @@ def process parse_juniper_srx_sd_syslog_utm_antispam {
 def process parse_juniper_srx_sd_syslog_utm_content {
     let sd = workspace.srx_sd_class.sd
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         3,
         juniper_srx_sd_syslog_status_id(action),
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -755,7 +755,7 @@ def process parse_juniper_srx_sd_syslog_aamw_action {
     let sd = workspace.srx_sd_class.sd
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
     let mal = coalesce(parse_juniper_srx_sd_syslog_kv_or_null(sd, "malware-info"), "AAMW action")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         4,
         juniper_srx_sd_syslog_status_id(action),
         parse_juniper_srx_sd_syslog_kv(sd, "source-address"),
@@ -788,7 +788,7 @@ def process parse_juniper_srx_sd_syslog_aamw_action {
 def process parse_juniper_srx_sd_syslog_aamw_malware {
     let sd = workspace.srx_sd_class.sd
     let mal = coalesce(parse_juniper_srx_sd_syslog_kv_or_null(sd, "malware-info"), "AAMW malware")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         4,
         2,
         parse_juniper_srx_sd_syslog_kv(sd, "client-ip"),
@@ -813,7 +813,7 @@ def process parse_juniper_srx_sd_syslog_aamw_malware {
 
 def process parse_juniper_srx_sd_syslog_aamw_host {
     let sd = workspace.srx_sd_class.sd
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         5,
         2,
         parse_juniper_srx_sd_syslog_kv(sd, "client-ip"),
@@ -850,7 +850,7 @@ def process parse_juniper_srx_sd_syslog_secintel_record {
     let action = parse_juniper_srx_sd_syslog_kv(sd, "action")
     let sev_str = parse_juniper_srx_sd_syslog_kv(sd, "threat-severity")
     let title = coalesce(parse_juniper_srx_sd_syslog_kv_or_null(sd, "feed-name"), "SecIntel")
-    workspace.lsis = juniper_srx_sd_syslog_finding_record(
+    workspace.lsis.parsed = juniper_srx_sd_syslog_finding_record(
         switch true {
             sev_str == "0"  { 1 }
             sev_str == null { 1 }

--- a/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
@@ -4,7 +4,7 @@
 //                .body (required, String) — the syslog wire
 //                .hostname (optional, String) — collector-side hostname
 //                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.* — RT_IDP IDP_ATTACK_LOG_EVENT → 2004 (Detection
+// Writes:      workspace.lsis.parsed.* — RT_IDP IDP_ATTACK_LOG_EVENT → 2004 (Detection
 //              Finding); other daemons / subtypes route to error_log until
 //              their shapes are added.
 // Category:    Network firewall / IPS
@@ -224,7 +224,7 @@ def process parse_juniper_srx_syslog_idp_attack_record {
             error "parse_juniper_srx_syslog_idp_attack_record: body did not match expected shape: ${workspace.juniper_srx_syslog.body}"
         }
         default {
-            workspace.lsis = juniper_srx_syslog_idp_finding_record(
+            workspace.lsis.parsed = juniper_srx_syslog_idp_finding_record(
                 workspace.srx_idp_fields.src,
                 workspace.srx_idp_fields.src_port,
                 workspace.srx_idp_fields.dst,

--- a/packaging/snippets/parsers/parse_k8s_audit.limpid
+++ b/packaging/snippets/parsers/parse_k8s_audit.limpid
@@ -4,7 +4,7 @@
 //              Activity + Authentication.
 // Reads:       ingress (raw wire) — one audit Event object per ingress
 //              (no {"items":[...]} envelope)
-// Writes:      workspace.lsis.* — 6003 (API Activity) for resource requests,
+// Writes:      workspace.lsis.parsed.* — 6003 (API Activity) for resource requests,
 //              3002 (Authentication) for authentication.k8s.io objectRefs;
 //              unknown kinds route to error_log.
 // Category:    Container / orchestration
@@ -190,7 +190,7 @@ def process parse_k8s_audit_api {
         default         { "${api_group}/${api_version}/${workspace.k8s.objectRef.resource}" }
     }
 
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    6003,
         category_uid: 6,
         activity_id:  activity,
@@ -259,7 +259,7 @@ def process parse_k8s_audit_authn {
     let groups = k8s_audit_build_groups(workspace.k8s.user.groups)
     let src_ip = k8s_audit_pick_src_ip(workspace.k8s.sourceIPs)
 
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  1,            // Logon — TokenReview/TokenRequest validates a credential

--- a/packaging/snippets/parsers/parse_nsp.limpid
+++ b/packaging/snippets/parsers/parse_nsp.limpid
@@ -4,7 +4,7 @@
 //                .body (required, String) — the KV body
 //                .hostname (optional, String) — collector-side hostname
 //                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.* — 2004 (Detection Finding).
+// Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding).
 // Category:    Network firewall / IPS
 // Test corpus: real (Trellix NSP Manager capture — 56/56 alerts across HTTP /
 //              SSH / SSL / NETBIOS-SS / TELNET / NTP / BACKDOOR signature
@@ -298,7 +298,7 @@ def process parse_nsp {
             error "parse_nsp: not a Trellix NSP standard-template body: ${workspace.nsp.body}"
         }
         default {
-            workspace.lsis = nsp_finding_record(
+            workspace.lsis.parsed = nsp_finding_record(
                 workspace.nsp_kv,
                 workspace.nsp.hostname,
                 workspace.nsp.time

--- a/packaging/snippets/parsers/parse_ocsf.limpid
+++ b/packaging/snippets/parsers/parse_ocsf.limpid
@@ -2,7 +2,7 @@
 //              unchanged, ready for compose_ocsf round-trip.
 // Reads:       ingress (raw wire) — one OCSF class instance JSON object
 //              per ingress (class_uid at the root)
-// Writes:      workspace.lsis.* — same class as the input (passthrough).
+// Writes:      workspace.lsis.parsed.* — same class as the input (passthrough).
 // Category:    Vendor-neutral
 // Test corpus: spec-only (OCSF 1.3.0 class instances; round-trips with
 //              compose_ocsf)
@@ -30,13 +30,13 @@
 //     re-parses it for further processing (enrichment, filtering,
 //     class-specific routing) without re-implementing 27 class shapes.
 //
-// Contract (per the workspace.lsis canonical intermediate):
-//   * top-level JSON object becomes `workspace.lsis` directly
+// Contract (per the workspace.lsis.parsed canonical intermediate):
+//   * top-level JSON object becomes `workspace.lsis.parsed` directly
 //   * unknown / missing `class_uid` is left to downstream
 //     (compose_ocsf already routes unknown class_uid to error_log)
 //   * non-object JSON or malformed JSON fails inside parse_json
 //     (process error → DLQ per pipeline error policy)
 
 def process parse_ocsf {
-    workspace.lsis = parse_json(ingress)
+    workspace.lsis.parsed = parse_json(ingress)
 }

--- a/packaging/snippets/parsers/parse_okta_system.limpid
+++ b/packaging/snippets/parsers/parse_okta_system.limpid
@@ -4,7 +4,7 @@
 //              identity classes, dispatched by eventType.
 // Reads:       ingress (raw wire) — one LogEvent object per ingress (unwrap
 //              Event Hooks data.events[] upstream)
-// Writes:      workspace.lsis.* — user.session/user.authentication → 3002,
+// Writes:      workspace.lsis.parsed.* — user.session/user.authentication → 3002,
 //              user.lifecycle → 3001, user.account → 3005, group.* → 3006;
 //              other eventTypes route to error_log.
 // Category:    Identity / IdP
@@ -300,7 +300,7 @@ def process parse_okta_user_authentication {
         subject_target != null { okta_user(subject_target) }
         default                { okta_user(ev.actor) }
     }
-    workspace.lsis = okta_authentication_record(
+    workspace.lsis.parsed = okta_authentication_record(
         activity_id,
         okta_status_id(ev.outcome.result),
         okta_severity_id(ev.outcome.result),
@@ -371,7 +371,7 @@ def process parse_okta_user_lifecycle {
         default                                    { 99 }
     }
     let subject_target = okta_first_target(ev.target, "User")
-    workspace.lsis = okta_account_change_record(
+    workspace.lsis.parsed = okta_account_change_record(
         activity_id,
         okta_status_id(ev.outcome.result),
         okta_severity_id(ev.outcome.result),
@@ -456,7 +456,7 @@ def process parse_okta_user_account {
             error "parse_okta_system: ${et} carries no User target (expected for 3005 User Management)"
         }
         default {
-            workspace.lsis = okta_user_management_record(
+            workspace.lsis.parsed = okta_user_management_record(
                 activity_id,
                 okta_status_id(ev.outcome.result),
                 okta_severity_id(ev.outcome.result),
@@ -531,7 +531,7 @@ def process parse_okta_group_membership {
             error "parse_okta_system: ${et} carries no UserGroup target (expected for 3006 Group Management)"
         }
         default {
-            workspace.lsis = okta_group_management_record(
+            workspace.lsis.parsed = okta_group_management_record(
                 activity_id,
                 okta_status_id(ev.outcome.result),
                 okta_severity_id(ev.outcome.result),
@@ -562,7 +562,7 @@ def process parse_okta_group_lifecycle {
             error "parse_okta_system: ${et} carries no UserGroup target (expected for 3006 Group Management)"
         }
         default {
-            workspace.lsis = okta_group_management_record(
+            workspace.lsis.parsed = okta_group_management_record(
                 activity_id,
                 okta_status_id(ev.outcome.result),
                 okta_severity_id(ev.outcome.result),
@@ -596,7 +596,7 @@ def process parse_okta_group_privilege {
             error "parse_okta_system: ${et} carries no UserGroup target (expected for 3006 Group Management)"
         }
         default {
-            workspace.lsis = okta_group_management_record(
+            workspace.lsis.parsed = okta_group_management_record(
                 activity_id,
                 okta_status_id(ev.outcome.result),
                 okta_severity_id(ev.outcome.result),

--- a/packaging/snippets/parsers/parse_openssh.limpid
+++ b/packaging/snippets/parsers/parse_openssh.limpid
@@ -5,7 +5,7 @@
 //                .pid (optional, String) — process id as string
 //                .hostname (optional, String) — SSH server hostname
 //                .time (optional, Int) — epoch nanoseconds of the event
-// Writes:      workspace.lsis.* — 3002 (Authentication).
+// Writes:      workspace.lsis.parsed.* — 3002 (Authentication).
 // Category:    Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sshd bodies in this header)
 //
@@ -68,7 +68,7 @@
 //   Disconnected from authenticating user alice 192.0.2.10 port 54321 [preauth]
 //   Connection closed by 192.0.2.10 port 54321 [preauth]
 //
-// Each pattern populates workspace.lsis as an OCSF Authentication
+// Each pattern populates workspace.lsis.parsed as an OCSF Authentication
 // (3002) record. Login attempts (success / failure) → activity_id=1;
 // session teardown → activity_id=2.
 //
@@ -340,7 +340,7 @@ def function parse_openssh_message(msg) {
 // ---------------------------------------------------------------------------
 
 def process parse_openssh_accepted {
-    workspace.lsis = openssh_auth_record(
+    workspace.lsis.parsed = openssh_auth_record(
         1,                              // activity_id: Logon
         1,                              // status_id:   Success
         1,                              // severity_id: Informational
@@ -370,7 +370,7 @@ def process parse_openssh_failed {
         invalid != null { 3 }   // Medium — invalid-user attempt
         default         { 2 }   // Low — failed auth on a known account
     }
-    workspace.lsis = openssh_auth_record(
+    workspace.lsis.parsed = openssh_auth_record(
         1,                              // activity_id: Logon
         2,                              // status_id:   Failure
         severity,
@@ -389,7 +389,7 @@ def process parse_openssh_failed {
 // ---------------------------------------------------------------------------
 
 def process parse_openssh_invalid_user {
-    workspace.lsis = openssh_auth_record(
+    workspace.lsis.parsed = openssh_auth_record(
         1,                              // activity_id: Logon
         2,                              // status_id:   Failure
         3,                              // severity_id: Medium (probe)
@@ -415,7 +415,7 @@ def process parse_openssh_invalid_user {
 // ---------------------------------------------------------------------------
 
 def process parse_openssh_disconnected {
-    workspace.lsis = openssh_auth_record(
+    workspace.lsis.parsed = openssh_auth_record(
         2,                              // activity_id: Logoff
         1,                              // status_id:   Success
         1,                              // severity_id: Informational
@@ -437,7 +437,7 @@ def process parse_openssh_disconnected {
 // ---------------------------------------------------------------------------
 
 def process parse_openssh_no_ident {
-    workspace.lsis = openssh_auth_record(
+    workspace.lsis.parsed = openssh_auth_record(
         99,                             // activity_id: Other
         2,                              // status_id:   Failure
         2,                              // severity_id: Low

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -1,7 +1,7 @@
 // Summary:     Palo Alto Networks PAN-OS CEF → LSIS, dispatched by CEF
 //              name (TRAFFIC / THREAT / URL / …).
 // Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Palo Alto Networks|PAN-OS|...)
-// Writes:      workspace.lsis.* — TRAFFIC → 4001, THREAT / WILDFIRE → 2004,
+// Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT / WILDFIRE → 2004,
 //              URL → 6004, GLOBALPROTECT / AUTHENTICATION → 3002; see the
 //              subtype leaves below.
 // Category:    Network firewall / IPS
@@ -139,7 +139,7 @@ def process parse_paloalto_cef {
 //   workspace.cef populated by `parse_paloalto_cef` dispatcher or an
 //   inline `cef.parse(...)` upstream of this process.
 def process parse_paloalto_cef_traffic {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  paloalto_cef_traffic_action_to_activity_id(workspace.cef.act),
@@ -198,7 +198,7 @@ def process parse_paloalto_cef_traffic {
 //   suser            — source user
 //   app              — application
 def process parse_paloalto_cef_threat {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -262,7 +262,7 @@ def process parse_paloalto_cef_url {
         "override"  { 1 }
         default     { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    6004,
         category_uid: 6,
         activity_id:  activity,
@@ -323,7 +323,7 @@ def process parse_paloalto_cef_wildfire {
         "benign"    { 1 }
         default     { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -385,7 +385,7 @@ def process parse_paloalto_cef_globalprotect {
         "failed" { 2 }
         default  { 1 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  activity,
@@ -422,7 +422,7 @@ def process parse_paloalto_cef_authentication {
         "failure" { 2 }
         default   { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  1,

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -2,7 +2,7 @@
 //              dispatched by the positional Type field.
 // Reads:       ingress (raw wire) — syslog-wrapped positional CSV
 //              (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
-// Writes:      workspace.lsis.* — TRAFFIC → 4001, THREAT → 2004
+// Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT → 2004
 //              (url → 6004, wildfire → 2004), GLOBALPROTECT /
 //              AUTHENTICATION → 3002; see the subtype leaves below.
 // Category:    Network firewall / IPS
@@ -30,7 +30,7 @@
 //      `Type` (and `Subtype` for THREAT routing) — keeps the dispatcher
 //      cheap, single-row parse skips most of the field array.
 //   2. The matched leaf re-runs csv_parse with the type-specific full
-//      schema and maps to canonical workspace.lsis.
+//      schema and maps to canonical workspace.lsis.parsed.
 //
 // Sample input (RFC 3164 syslog wrapper around CSV, TRAFFIC):
 //   <134>Apr 27 10:00:00 fw-pan01 1,2026-04-27 10:00:00,012345678,TRAFFIC,end,2049,2026-04-27 10:00:00,192.0.2.10,198.51.100.5,...
@@ -180,7 +180,7 @@ def process parse_paloalto_syslog_traffic {
         "VirtualSystemName", // 52
         "DeviceName"         // 53
     ])
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  paloalto_syslog_traffic_action_to_activity_id(workspace.pan.Action),
@@ -337,7 +337,7 @@ def process parse_paloalto_syslog_threat_url {
         "override"     { 1 }
         default        { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    6004,
         category_uid: 6,
         activity_id:  activity,
@@ -378,7 +378,7 @@ def process parse_paloalto_syslog_threat_url {
 // Subtype leaf: THREAT/wildfire → OCSF Detection Finding (2004) Malware
 // ---------------------------------------------------------------------------
 def process parse_paloalto_syslog_threat_wildfire {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -426,7 +426,7 @@ def process parse_paloalto_syslog_threat_wildfire {
 // Subtype leaf: THREAT/virus → OCSF Detection Finding (2004) Malware
 // ---------------------------------------------------------------------------
 def process parse_paloalto_syslog_threat_virus {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -474,7 +474,7 @@ def process parse_paloalto_syslog_threat_virus {
 //             → OCSF Detection Finding (2004) generic
 // ---------------------------------------------------------------------------
 def process parse_paloalto_syslog_threat_generic {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    2004,
         category_uid: 2,
         activity_id:    1,
@@ -558,7 +558,7 @@ def process parse_paloalto_syslog_globalprotect {
         "tunnel-establish-failed"  { 2 }
         default                    { 1 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  activity,
@@ -632,7 +632,7 @@ def process parse_paloalto_syslog_authentication {
         "failure" { 2 }
         default   { 0 }
     }
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    3002,
         category_uid: 3,
         activity_id:  1,

--- a/packaging/snippets/parsers/parse_postfix.limpid
+++ b/packaging/snippets/parsers/parse_postfix.limpid
@@ -4,7 +4,7 @@
 //                .body (required, String) — the postfix-tagged body
 //                .hostname (optional, String) — host where the MTA ran
 //                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.* — 4009 (Email Activity) for mail-flow programs
+// Writes:      workspace.lsis.parsed.* — 4009 (Email Activity) for mail-flow programs
 //              (smtp / smtpd / qmgr / bounce); daemon-control noise routes to
 //              error_log.
 // Category:    Mail (MTA)
@@ -181,7 +181,7 @@ def process parse_postfix_smtp {
 }
 
 def process parse_postfix_smtp_record {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4009,
         category_uid: 4,
         activity_id:  1,
@@ -232,7 +232,7 @@ def process parse_postfix_smtpd {
 }
 
 def process parse_postfix_smtpd_connect_record {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4009,
         category_uid: 4,
         activity_id:  2,
@@ -261,7 +261,7 @@ def process parse_postfix_smtpd_connect_record {
 }
 
 def process parse_postfix_smtpd_reject_record {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4009,
         category_uid: 4,
         activity_id:  2,
@@ -310,7 +310,7 @@ def process parse_postfix_qmgr {
 }
 
 def process parse_postfix_qmgr_record {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4009,
         category_uid: 4,
         activity_id:  1,
@@ -356,7 +356,7 @@ def process parse_postfix_bounce {
 }
 
 def process parse_postfix_bounce_record {
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4009,
         category_uid: 4,
         activity_id:  1,

--- a/packaging/snippets/parsers/parse_sudo.limpid
+++ b/packaging/snippets/parsers/parse_sudo.limpid
@@ -5,7 +5,7 @@
 //                .pid (optional, String) — process id as string
 //                .hostname (optional, String) — host where sudo ran
 //                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.* — 3003 (Authorize Session).
+// Writes:      workspace.lsis.parsed.* — 3003 (Authorize Session).
 // Category:    Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sudo bodies in this header)
 //
@@ -63,7 +63,7 @@
 //   PAM session closed (privilege deactivation marker):
 //   pam_unix(sudo:session): session closed for user root
 //
-// Each pattern populates `workspace.lsis` as an OCSF Authorize
+// Each pattern populates `workspace.lsis.parsed` as an OCSF Authorize
 // Session (3003) record. Invocation lines map to activity_id=1
 // "Assign Privileges" (status=Success on a clean invocation,
 // status=Failure on auth or authorization denial). PAM session
@@ -280,7 +280,7 @@ def process parse_sudo {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_invocation {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,  // activity_id: Assign Privileges
         1,  // status_id:   Success
         1,  // severity_id: Informational
@@ -300,7 +300,7 @@ def process parse_sudo_invocation {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_auth_failed {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,  // activity_id: Assign Privileges (denied)
         2,  // status_id:   Failure
         3,  // severity_id: Medium
@@ -320,7 +320,7 @@ def process parse_sudo_auth_failed {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_denied_sudoers {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,  // activity_id: Assign Privileges (denied)
         2,  // status_id:   Failure
         3,  // severity_id: Medium — non-sudoer attempting privilege
@@ -341,7 +341,7 @@ def process parse_sudo_denied_sudoers {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_denied_command {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,  // activity_id: Assign Privileges (denied)
         2,  // status_id:   Failure
         2,  // severity_id: Low
@@ -371,7 +371,7 @@ def process parse_sudo_denied_command {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_password_required {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,  // activity_id: Assign Privileges (denied)
         2,  // status_id:   Failure
         3,  // severity_id: Medium
@@ -385,7 +385,7 @@ def process parse_sudo_password_required {
 }
 
 def process parse_sudo_pam_session_open {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         2,  // activity_id: Activate Privileges
         1,  // status_id:   Success
         1,  // severity_id: Informational
@@ -407,7 +407,7 @@ def process parse_sudo_pam_session_open {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_pam_session_close {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         2,  // activity_id: Activate Privileges (closing edge)
         1,  // status_id:   Success
         1,  // severity_id: Informational
@@ -436,7 +436,7 @@ def process parse_sudo_pam_session_close {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_pam_auth_failure_classic {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,    // activity_id: Assign Privileges (denied)
         2,    // status_id:   Failure
         3,    // severity_id: Medium
@@ -459,7 +459,7 @@ def process parse_sudo_pam_auth_failure_classic {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_pam_auth_lookup_failed {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,    // activity_id: Assign Privileges (denied)
         2,    // status_id:   Failure
         3,    // severity_id: Medium
@@ -483,7 +483,7 @@ def process parse_sudo_pam_auth_lookup_failed {
 // ---------------------------------------------------------------------------
 
 def process parse_sudo_pam_auth_conversation_failed {
-    workspace.lsis = sudo_authorize_session_record(
+    workspace.lsis.parsed = sudo_authorize_session_record(
         1,    // activity_id: Assign Privileges (denied)
         2,    // status_id:   Failure
         2,    // severity_id: Low — usually benign abort

--- a/packaging/snippets/parsers/parse_suricata.limpid
+++ b/packaging/snippets/parsers/parse_suricata.limpid
@@ -5,7 +5,7 @@
 //   .body (required, Object) — parsed EVE event (caller does `parse_json(ingress)`)
 //   .hostname (optional, String) — collector override
 //   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.* — alert → 2004, dns → 4003, http → 4002,
+// Writes:      workspace.lsis.parsed.* — alert → 2004, dns → 4003, http → 4002,
 //              tls / flow / fileinfo → 4001; stats dropped; other
 //              event_types route to error_log.
 // Category:    OSS NDR
@@ -413,7 +413,7 @@ def process parse_suricata {
 }
 
 def process parse_suricata_alert {
-    workspace.lsis = suricata_alert_record(
+    workspace.lsis.parsed = suricata_alert_record(
         workspace.suricata.body,
         workspace.suricata.hostname,
         suricata_time_ns(workspace.suricata.body, workspace.suricata.time)
@@ -421,7 +421,7 @@ def process parse_suricata_alert {
 }
 
 def process parse_suricata_dns {
-    workspace.lsis = suricata_dns_record(
+    workspace.lsis.parsed = suricata_dns_record(
         workspace.suricata.body,
         workspace.suricata.hostname,
         suricata_time_ns(workspace.suricata.body, workspace.suricata.time)
@@ -429,7 +429,7 @@ def process parse_suricata_dns {
 }
 
 def process parse_suricata_http {
-    workspace.lsis = suricata_http_record(
+    workspace.lsis.parsed = suricata_http_record(
         workspace.suricata.body,
         workspace.suricata.hostname,
         suricata_time_ns(workspace.suricata.body, workspace.suricata.time)
@@ -437,7 +437,7 @@ def process parse_suricata_http {
 }
 
 def process parse_suricata_flow {
-    workspace.lsis = suricata_flow_record(
+    workspace.lsis.parsed = suricata_flow_record(
         workspace.suricata.body,
         workspace.suricata.hostname,
         suricata_time_ns(workspace.suricata.body, workspace.suricata.time)
@@ -445,7 +445,7 @@ def process parse_suricata_flow {
 }
 
 def process parse_suricata_tls {
-    workspace.lsis = suricata_tls_record(
+    workspace.lsis.parsed = suricata_tls_record(
         workspace.suricata.body,
         workspace.suricata.hostname,
         suricata_time_ns(workspace.suricata.body, workspace.suricata.time)
@@ -453,7 +453,7 @@ def process parse_suricata_tls {
 }
 
 def process parse_suricata_fileinfo {
-    workspace.lsis = suricata_fileinfo_record(
+    workspace.lsis.parsed = suricata_fileinfo_record(
         workspace.suricata.body,
         workspace.suricata.hostname,
         suricata_time_ns(workspace.suricata.body, workspace.suricata.time)

--- a/packaging/snippets/parsers/parse_sysmon.limpid
+++ b/packaging/snippets/parsers/parse_sysmon.limpid
@@ -6,7 +6,7 @@
 //   .body (required, Object) — parsed Sysmon event (caller does `parse_json(ingress)`)
 //   .hostname (optional, String) — collector override
 //   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.* — EventID 1 (ProcessCreate) → 1007,
+// Writes:      workspace.lsis.parsed.* — EventID 1 (ProcessCreate) → 1007,
 //              3 (NetworkConnect) → 4001, 11 (FileCreate) → 1001;
 //              unknown EventIDs route to error_log.
 // Category:    EDR
@@ -99,7 +99,7 @@ def process parse_sysmon {
 
 def process parse_sysmon_process_create {
     let ed = workspace.sysmon.body.EventData
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    1007,
         category_uid: 1,
         activity_id:  1,                                // Launch
@@ -169,7 +169,7 @@ def process parse_sysmon_process_create {
 
 def process parse_sysmon_network_connect {
     let ed = workspace.sysmon.body.EventData
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
         activity_id:  1,                                // Open
@@ -230,7 +230,7 @@ def process parse_sysmon_network_connect {
 
 def process parse_sysmon_file_create {
     let ed = workspace.sysmon.body.EventData
-    workspace.lsis = {
+    workspace.lsis.parsed = {
         class_uid:    1001,
         category_uid: 1,
         activity_id:  1,                                // Create

--- a/packaging/snippets/parsers/parse_winevent_json.limpid
+++ b/packaging/snippets/parsers/parse_winevent_json.limpid
@@ -2,7 +2,7 @@
 //              Security channel) → LSIS, dispatched by EventID.
 // Reads:       ingress (raw wire) — one Windows event record JSON object
 //              per ingress
-// Writes:      workspace.lsis.* — 3002 (logon/logoff), 1007 (process),
+// Writes:      workspace.lsis.parsed.* — 3002 (logon/logoff), 1007 (process),
 //              3001 (account change), 3006 (group management), dispatched
 //              by EventID; unmapped IDs route to error_log. Per-ID table
 //              below.
@@ -251,7 +251,7 @@ def function winevent_group_management_record(activity_id, severity_id, time, gr
 
 def process parse_winevent_4624_logon_success {
     let we = workspace.winevent
-    workspace.lsis = winevent_authentication_record(
+    workspace.lsis.parsed = winevent_authentication_record(
         1, 1, 1,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -266,7 +266,7 @@ def process parse_winevent_4624_logon_success {
 
 def process parse_winevent_4625_logon_failure {
     let we = workspace.winevent
-    workspace.lsis = winevent_authentication_record(
+    workspace.lsis.parsed = winevent_authentication_record(
         1, 2, 3,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -281,7 +281,7 @@ def process parse_winevent_4625_logon_failure {
 
 def process parse_winevent_4634_logoff {
     let we = workspace.winevent
-    workspace.lsis = winevent_authentication_record(
+    workspace.lsis.parsed = winevent_authentication_record(
         2, 1, 1,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -300,7 +300,7 @@ def process parse_winevent_4634_logoff {
 
 def process parse_winevent_4688_process_create {
     let we = workspace.winevent
-    workspace.lsis = winevent_process_activity_record(
+    workspace.lsis.parsed = winevent_process_activity_record(
         1, 1,
         winevent_time(we.EventTime),
         we.NewProcessName,
@@ -314,7 +314,7 @@ def process parse_winevent_4688_process_create {
 
 def process parse_winevent_4689_process_terminate {
     let we = workspace.winevent
-    workspace.lsis = winevent_process_activity_record(
+    workspace.lsis.parsed = winevent_process_activity_record(
         4, 1,
         winevent_time(we.EventTime),
         we.ProcessName,
@@ -332,7 +332,7 @@ def process parse_winevent_4689_process_terminate {
 
 def process parse_winevent_4720_account_create {
     let we = workspace.winevent
-    workspace.lsis = winevent_account_change_record(
+    workspace.lsis.parsed = winevent_account_change_record(
         1, 2,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -344,7 +344,7 @@ def process parse_winevent_4720_account_create {
 
 def process parse_winevent_account_enable {
     let we = workspace.winevent
-    workspace.lsis = winevent_account_change_record(
+    workspace.lsis.parsed = winevent_account_change_record(
         2, 2,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -356,7 +356,7 @@ def process parse_winevent_account_enable {
 
 def process parse_winevent_account_disable {
     let we = workspace.winevent
-    workspace.lsis = winevent_account_change_record(
+    workspace.lsis.parsed = winevent_account_change_record(
         3, 2,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -368,7 +368,7 @@ def process parse_winevent_account_disable {
 
 def process parse_winevent_account_modify {
     let we = workspace.winevent
-    workspace.lsis = winevent_account_change_record(
+    workspace.lsis.parsed = winevent_account_change_record(
         99, 2,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -380,7 +380,7 @@ def process parse_winevent_account_modify {
 
 def process parse_winevent_account_delete {
     let we = workspace.winevent
-    workspace.lsis = winevent_account_change_record(
+    workspace.lsis.parsed = winevent_account_change_record(
         4, 2,
         winevent_time(we.EventTime),
         winevent_actor_user(we.TargetUserName, we.TargetDomainName),
@@ -396,7 +396,7 @@ def process parse_winevent_account_delete {
 
 def process parse_winevent_group_member_add {
     let we = workspace.winevent
-    workspace.lsis = winevent_group_management_record(
+    workspace.lsis.parsed = winevent_group_management_record(
         1, 2,
         winevent_time(we.EventTime),
         we.TargetUserName,
@@ -409,7 +409,7 @@ def process parse_winevent_group_member_add {
 
 def process parse_winevent_group_member_remove {
     let we = workspace.winevent
-    workspace.lsis = winevent_group_management_record(
+    workspace.lsis.parsed = winevent_group_management_record(
         2, 2,
         winevent_time(we.EventTime),
         we.TargetUserName,

--- a/packaging/snippets/parsers/parse_zeek_default.limpid
+++ b/packaging/snippets/parsers/parse_zeek_default.limpid
@@ -6,7 +6,7 @@
 //   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
 //   .hostname (optional, String) — collector override
 //   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.* — conn / ssl / files / x509 → 4001,
+// Writes:      workspace.lsis.parsed.* — conn / ssl / files / x509 → 4001,
 //              dns → 4003, http → 4002, weird / notice → 2004; other
 //              _paths route to error_log.
 // Category:    OSS NDR
@@ -530,7 +530,7 @@ def process parse_zeek_default {
 }
 
 def process parse_zeek_default_conn {
-    workspace.lsis = zeek_conn_record(
+    workspace.lsis.parsed = zeek_conn_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)
@@ -538,7 +538,7 @@ def process parse_zeek_default_conn {
 }
 
 def process parse_zeek_default_dns {
-    workspace.lsis = zeek_dns_record(
+    workspace.lsis.parsed = zeek_dns_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)
@@ -546,7 +546,7 @@ def process parse_zeek_default_dns {
 }
 
 def process parse_zeek_default_http {
-    workspace.lsis = zeek_http_record(
+    workspace.lsis.parsed = zeek_http_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)
@@ -554,7 +554,7 @@ def process parse_zeek_default_http {
 }
 
 def process parse_zeek_default_ssl {
-    workspace.lsis = zeek_ssl_record(
+    workspace.lsis.parsed = zeek_ssl_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)
@@ -562,7 +562,7 @@ def process parse_zeek_default_ssl {
 }
 
 def process parse_zeek_default_files {
-    workspace.lsis = zeek_files_record(
+    workspace.lsis.parsed = zeek_files_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)
@@ -570,7 +570,7 @@ def process parse_zeek_default_files {
 }
 
 def process parse_zeek_default_x509 {
-    workspace.lsis = zeek_x509_record(
+    workspace.lsis.parsed = zeek_x509_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)
@@ -578,7 +578,7 @@ def process parse_zeek_default_x509 {
 }
 
 def process parse_zeek_default_weird {
-    workspace.lsis = zeek_weird_record(
+    workspace.lsis.parsed = zeek_weird_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)
@@ -586,7 +586,7 @@ def process parse_zeek_default_weird {
 }
 
 def process parse_zeek_default_notice {
-    workspace.lsis = zeek_notice_record(
+    workspace.lsis.parsed = zeek_notice_record(
         workspace.zeek.body,
         workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time)

--- a/packaging/snippets/parsers/parse_zeek_full.limpid
+++ b/packaging/snippets/parsers/parse_zeek_full.limpid
@@ -7,7 +7,7 @@
 //   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
 //   .hostname (optional, String) — collector override
 //   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.* — 14 protocol streams → 4001 (generic);
+// Writes:      workspace.lsis.parsed.* — 14 protocol streams → 4001 (generic);
 //              stats / capture_loss / known_* / software dropped; catch-all
 //              wraps any other _path into 4001 with the raw body under
 //              unmapped.
@@ -311,97 +311,97 @@ def process parse_zeek_full {
 }
 
 def process parse_zeek_full_signature {
-    workspace.lsis = zeek_signature_record(
+    workspace.lsis.parsed = zeek_signature_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_full_intel {
-    workspace.lsis = zeek_intel_record(
+    workspace.lsis.parsed = zeek_intel_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_full_traceroute {
-    workspace.lsis = zeek_traceroute_record(
+    workspace.lsis.parsed = zeek_traceroute_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_full_rfb {
-    workspace.lsis = zeek_rfb_record(
+    workspace.lsis.parsed = zeek_rfb_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_full_tunnel {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "tunnel")
 }
 
 def process parse_zeek_full_mysql {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "mysql")
 }
 
 def process parse_zeek_full_irc {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "irc")
 }
 
 def process parse_zeek_full_sip {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "sip")
 }
 
 def process parse_zeek_full_dnp3 {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "dnp3")
 }
 
 def process parse_zeek_full_modbus {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "modbus")
 }
 
 def process parse_zeek_full_socks {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "socks")
 }
 
 def process parse_zeek_full_syslog_over_wire {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "syslog")
 }
 
 def process parse_zeek_full_ntp {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "ntp")
 }
 
 def process parse_zeek_full_ocsp {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "ocsp")
 }
 
 def process parse_zeek_full_pe {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "pe")
 }
 
 def process parse_zeek_full_dpd {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time), "dpd")
 }
@@ -409,7 +409,7 @@ def process parse_zeek_full_dpd {
 // Catch-all: any _path that even parse_zeek_soc rejects. Wraps the
 // entire body into a 4001 Network Activity record's `unmapped`.
 def process parse_zeek_full_catchall {
-    workspace.lsis = zeek_generic_4001_record(
+    workspace.lsis.parsed = zeek_generic_4001_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time),
         coalesce(workspace.zeek.body._path, "unknown"))

--- a/packaging/snippets/parsers/parse_zeek_soc.limpid
+++ b/packaging/snippets/parsers/parse_zeek_soc.limpid
@@ -7,7 +7,7 @@
 //   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
 //   .hostname (optional, String) — collector override
 //   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.* — ssh → 4007, smtp → 4009, ftp → 4008,
+// Writes:      workspace.lsis.parsed.* — ssh → 4007, smtp → 4009, ftp → 4008,
 //              dhcp → 4004, kerberos / ntlm / radius → 3002,
 //              smb_mapping / smb_cmd / smb_files → 4006,
 //              dce_rpc / snmp → 4001, rdp → 4005; stock streams fall
@@ -572,79 +572,79 @@ def process parse_zeek_soc {
 }
 
 def process parse_zeek_soc_ssh {
-    workspace.lsis = zeek_ssh_record(
+    workspace.lsis.parsed = zeek_ssh_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_smtp {
-    workspace.lsis = zeek_smtp_record(
+    workspace.lsis.parsed = zeek_smtp_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_ftp {
-    workspace.lsis = zeek_ftp_record(
+    workspace.lsis.parsed = zeek_ftp_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_dhcp {
-    workspace.lsis = zeek_dhcp_record(
+    workspace.lsis.parsed = zeek_dhcp_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_kerberos {
-    workspace.lsis = zeek_kerberos_record(
+    workspace.lsis.parsed = zeek_kerberos_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_ntlm {
-    workspace.lsis = zeek_ntlm_record(
+    workspace.lsis.parsed = zeek_ntlm_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_radius {
-    workspace.lsis = zeek_radius_record(
+    workspace.lsis.parsed = zeek_radius_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_smb_mapping {
-    workspace.lsis = zeek_smb_mapping_record(
+    workspace.lsis.parsed = zeek_smb_mapping_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_smb_cmd {
-    workspace.lsis = zeek_smb_cmd_record(
+    workspace.lsis.parsed = zeek_smb_cmd_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_smb_files {
-    workspace.lsis = zeek_smb_files_record(
+    workspace.lsis.parsed = zeek_smb_files_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_dce_rpc {
-    workspace.lsis = zeek_dce_rpc_record(
+    workspace.lsis.parsed = zeek_dce_rpc_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_snmp {
-    workspace.lsis = zeek_snmp_record(
+    workspace.lsis.parsed = zeek_snmp_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
 def process parse_zeek_soc_rdp {
-    workspace.lsis = zeek_rdp_record(
+    workspace.lsis.parsed = zeek_rdp_record(
         workspace.zeek.body, workspace.zeek.hostname,
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }


### PR DESCRIPTION
## Summary

Split the `workspace.lsis.*` namespace into three explicit layers so the pack can name the three contract kinds that already existed but were being conflated:

- `workspace.lsis.parsed.*` — vocabulary contract (facts a parser publishes; graceful reads on the consumer side).
- `workspace.lsis.shed.*` — hand-off contract (per-field intake slots a composer honors via `coalesce(shed, default)`).
- `workspace.lsis.composed.*` — registry contract (named output slots a schema composer owns).

`compose_otlp` is rewritten shed-driven with `time` / `severity_id` as parsed graceful reads, then extended with four more shed slots (`scope.name`, `scope.version`, `log_record.severity_text`, `log_record.observed_time_unix_nano`) driven by an AMP CommonSecurityLog integration that needed each of them. Trace/span/event fields are deliberately left off — no implementation driver yet.

`compose_rfc5424` is split into a generic composer + `journald_to_rfc5424` bridge (bridges belong to the consumer, not a shared directory), with `rfc5424_pri_from` as a pure helper.

Docs — the pack README, docs/src, root README, and CHANGELOG are all realigned to the strata; xtask's header lint learns multi-segment `Reads:` paths.

## Test plan

- [x] `cargo test --workspace` (873 + 27 + 4 + 14 + 29 pass, 1 ignored)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo deny check` clean (5 duplicate warnings unchanged from 0.7.12)
- [x] `cargo audit` 0 vulns / 0 warns
- [x] `xtask lint-snippet-headers` (39 files, 0 err / 0 warn)
- [x] `xtask gen-snippet-inventory --check` in sync
- [x] `mdbook build` clean
- [x] AMP CommonSecurityLog end-to-end: LogRecord byte-equal to hand-written baseline modulo `time_unix_nano` / `observed_time_unix_nano` low-4-byte drift
- [x] RFC 5424 wire form matches documented shape via both `journald_to_rfc5424` and the generic path
- [x] 9-scope uchgs push-gate audit confirmed at HEAD ec6289a

## uchgs push-gate receipts

`.uchgs/push/2026-07-11T093529.764248Z-bbdb12a0/` — all 9 scopes confirmed=true at HEAD ec6289a (abstraction / boundary-contract / ci-precheck / cicd-pipeline / confidentiality / perf / readme-current / rust / security).