### PR TITLE
chore(release): bump crates to 0.7.13 and refresh the two version-mentioning docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1008,7 +1008,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.12"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.13"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -24,7 +24,7 @@ read that and explains the OTLP-specific reading on top.
 
 ## 1. Scope
 
-| Aspect | Current (0.7.12) |
+| Aspect | Current (0.7.13) |
 |---|---|
 | Signal | **logs** only — no traces, no metrics, no profiles |
 | Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` introduced in 0.7.6; in 0.7.8 plaintext `http://` with `tls { ... }` is now rejected at parse time — see CHANGELOG 0.7.8) |


### PR DESCRIPTION
## Summary

Companion to the 0.7.13 CHANGELOG entry that landed in the LSIS strata PR (#162). This bumps the three published crates to 0.7.13 so `cargo publish` picks up the release, and refreshes the two docs pages that quote the running daemon version so a fresh checkout at the tag matches what an operator sees at runtime.

- `crates/limpid`, `crates/limpidctl`, `crates/limpid-prometheus`: `version = "0.7.13"`; `Cargo.lock` re-locked (no dependency drift).
- `docs/src/otlp.md`: table header text `Current (0.7.12)` → `Current (0.7.13)`.
- `docs/src/functions/expression-functions.md`: `version()` example string `"0.7.12"` → `"0.7.13"`.

No CHANGELOG touch (already present at 2ee2145 / f30b5a1 line on release/0.7.13). No behavior change; runtime is identical to `release/0.7.13` at `f8c10f9`.

## Test plan

- [x] `cargo test --workspace` (all suites pass)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo build --workspace` clean
- [x] `cargo xtask lint-snippet-headers` (39 files, 0 err / 0 warn)
- [x] `cargo xtask gen-snippet-inventory --check` in sync
- [x] `mdbook build` clean
- [x] `cargo deny check` clean (5 duplicate warnings unchanged from 0.7.12)
- [x] `cargo audit` 0 vulns / 0 warns
- [x] 9-scope uchgs push-gate at 8addbd8: `uchgs verify push` pass=9 / fail=0

## uchgs push-gate receipts

`.uchgs/push/2026-07-11T111554.430479Z-8addbd83/` — inherited from the 0.7.13-feature session (2026-07-11T093529.764248Z-bbdb12a0). All 9 scopes chain-extended with `--head=8addbd8 --no-impact` (pure version bump, no invariant weakening).