### PR TITLE
fix(snippets/compose_otlp): translate OCSF severity_id to OTLP severity_number

### DIFF
--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -48,16 +48,46 @@
 //                             when populated; falls back to `received_at`
 //                             otherwise. Time is a fact about the event,
 //                             so it lives in `parsed`, not `shed`.
-//                .severity_id  (optional, Int) — used as `severity_number`
-//                             when populated. Absent (or 0 = OCSF Unknown)
-//                             means the field is omitted from the wire.
+//                .severity_id  (optional, Int) — translated to
+//                             `severity_number` via the OCSF-to-OTel
+//                             severity scale mapping below. Absent (or
+//                             0 = OCSF Unknown, 99 = OCSF Other) means
+//                             the field is omitted from the wire.
 //
-// Slots deliberately NOT exposed today — `log_record.trace_id`,
-// `log_record.span_id`, `log_record.event_name`, and the
-// `dropped_attributes_count` / `flags` housekeeping fields. These have
-// no implementation-driving caller in the pack today; they are added
-// on the same coalesce-with-default pattern above when a real caller
-// needs them.
+//              OCSF `severity_id` (LSIS parsed scale, 0-6 + 99) and OTLP
+//              `severity_number` (1-24, with 9=INFO / 13=WARN / 17=ERROR
+//              / 21=FATAL and finer-grained sub-levels between) are NOT
+//              the same scale — passing the OCSF value straight to the
+//              wire silently misclassifies severity (OCSF 4 = High would
+//              land in the OTel DEBUG band). This composer bridges them:
+//
+//                LSIS severity_id → OTLP severity_number
+//                  0  Unknown       → omitted
+//                  1  Informational → 9   INFO
+//                  2  Low           → 10  INFO2
+//                  3  Medium        → 13  WARN
+//                  4  High          → 17  ERROR
+//                  5  Critical      → 20  ERROR4
+//                  6  Fatal         → 21  FATAL
+//                  99 Other         → omitted (no numeric semantics;
+//                                     supply a label via .severity_text)
+//                  other            → omitted (unknown values are not
+//                                     invented on the wire)
+//
+//              The table is a judgement call — no spec pins it — but the
+//              rung positions preserve ordering, keep INFO/WARN/ERROR
+//              aligned with syslog-derived parsers (see parse_asa
+//              helper), and reserve OTel FATAL for OCSF Fatal (which
+//              matches OTel's "unrecoverable" definition). Callers who
+//              disagree layer the target-specific value themselves via
+//              `.severity_text` or a bespoke composer.
+//
+// Slots deliberately NOT exposed today — `log_record.severity_number`
+// override, `log_record.trace_id`, `log_record.span_id`,
+// `log_record.event_name`, and the `dropped_attributes_count` / `flags`
+// housekeeping fields. These have no implementation-driving caller in
+// the pack today; they are added on the same coalesce-with-default
+// pattern above when a real caller needs them.
 // Writes:      workspace.lsis.composed.otlp — ResourceLogs proto bytes
 //              (Bytes). Pipe `| otlp_to_egress` (foot of file) to emit
 //              for `output otlp_http` / `output otlp_grpc`.
@@ -103,6 +133,21 @@
 // when the caller's mapping is non-trivial and reusable across
 // pipelines; ad-hoc glue blocks like the two above are the norm.
 
+// OCSF severity_id (LSIS parsed scale) → OTLP severity_number. The
+// mapping table and its rationale live in the header above. Unknown /
+// Other / unmapped values return null so the encoder omits the field.
+def function otlp_severity_number(severity_id) {
+    switch severity_id {
+        1       { 9 }
+        2       { 10 }
+        3       { 13 }
+        4       { 17 }
+        5       { 20 }
+        6       { 21 }
+        default { null }
+    }
+}
+
 def process compose_otlp {
     workspace.lsis.composed.otlp = otlp.encode_resourcelog_protobuf({
         resource: {
@@ -123,7 +168,7 @@ def process compose_otlp {
             log_records: [{
                 time_unix_nano:          coalesce(workspace.lsis.parsed.time, received_at),
                 observed_time_unix_nano: workspace.lsis.shed.otlp.log_record.observed_time_unix_nano,
-                severity_number:         workspace.lsis.parsed.severity_id,
+                severity_number:         otlp_severity_number(workspace.lsis.parsed.severity_id),
                 severity_text:           workspace.lsis.shed.otlp.log_record.severity_text,
                 body: { string_value: coalesce(
                     workspace.lsis.shed.otlp.log_record.body, ""


### PR DESCRIPTION
## Summary

`compose_otlp` was passing the parsed layer's `severity_id` (OCSF scale, 0-6 + 99 = Other) straight into the OTLP `severity_number` field, which expects the OTel scale (1-24, with 9 = INFO / 13 = WARN / 17 = ERROR / 21 = FATAL). Because the two scales overlap numerically but disagree semantically, real severity was silently misclassified on the wire — an OCSF `4 High` event landed in the OTel DEBUG band (1-8).

This PR bridges the scales inside the composer:

- Adds an `otlp_severity_number` helper mapping OCSF → OTel:
  `1 → 9`, `2 → 10`, `3 → 13`, `4 → 17`, `5 → 20`, `6 → 21`; `0` (Unknown), `99` (Other), and any unmapped value fall through to `null` so the encoder omits the field (proto3 default).
- Updates the header to document the mapping table and its rationale — no spec pins it, so the table is a judgement call; the rung positions preserve ordering and keep INFO/WARN/ERROR aligned with the syslog-derived parsers in the pack. Callers that disagree layer their own severity via `.severity_text` or a bespoke composer.
- Swaps the `severity_number:` slot in `compose_otlp` from a raw read of `workspace.lsis.parsed.severity_id` to `otlp_severity_number(workspace.lsis.parsed.severity_id)`.

Only `packaging/snippets/composers/compose_otlp.limpid` is touched (+55 / -10).

## Test plan

- [x] `cargo xtask lint-snippet-headers` — 39 files, 0 errors, 0 warnings
- [x] `cargo xtask gen-snippet-inventory --check` — README in sync
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 947 passed / 1 ignored / 0 failed
- [x] `cargo-audit` — 0 vulnerabilities
- [x] uchgs push-gate: 9/9 scopes PASS on ade021c