### PR TITLE
fix(snippets/compose_otlp): default observed_time_unix_nano to received_at

### DIFF
--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -213,8 +213,12 @@ limpid's snippet convention is:
   received_at)` defensively: an absent key encodes as `timeUnixNano: 0`
   on the wire (proto3 default), and the encoder does not warn on
   absent keys — only on present-but-uncoercible values.
-- `observed_time_unix_nano = received_at` only when the snippet
-  explicitly chooses to populate it; not auto-set
+- `observed_time_unix_nano = received_at` by default — the logs.proto
+  comment requires the field to be set once the event is observed, so
+  the packaged `compose_otlp` snippet coalesces its shed slot with
+  `to_int(received_at)`. A snippet overrides the slot only to carry an
+  earlier observation point (e.g. a timestamp stamped by an upstream
+  collector).
 
 The spec is comfortable with this split; the practice in the wild is
 not consistent.

--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -37,11 +37,13 @@
 //                             `"INFO"`/`"WARN"`/`"ERROR"`.
 //                .log_record.observed_time_unix_nano (optional, Int) —
 //                             time the current process observed the event
-//                             (LogRecord field 11). default — omitted from
-//                             the wire (proto3 default). Set when the
-//                             caller wants both event time (parsed) and
-//                             observed time (usually `to_int(received_at)`)
-//                             on the wire.
+//                             (LogRecord field 11). default —
+//                             `to_int(received_at)`: the logs.proto
+//                             comment says this field MUST be set once
+//                             the event is observed, so the receive time
+//                             always goes on the wire. Set the slot to
+//                             carry an earlier observation point (e.g. a
+//                             timestamp stamped by an upstream collector).
 //              workspace.lsis.parsed.* — graceful reads from the fact
 //              layer, no shed intake for these:
 //                .time         (optional, Int) — used as `time_unix_nano`
@@ -167,7 +169,10 @@ def process compose_otlp {
             },
             log_records: [{
                 time_unix_nano:          coalesce(workspace.lsis.parsed.time, received_at),
-                observed_time_unix_nano: workspace.lsis.shed.otlp.log_record.observed_time_unix_nano,
+                observed_time_unix_nano: coalesce(
+                    workspace.lsis.shed.otlp.log_record.observed_time_unix_nano,
+                    to_int(received_at)
+                ),
                 severity_number:         otlp_severity_number(workspace.lsis.parsed.severity_id),
                 severity_text:           workspace.lsis.shed.otlp.log_record.severity_text,
                 body: { string_value: coalesce(


### PR DESCRIPTION
## Summary
- Coalesce `observed_time_unix_nano` with `to_int(received_at)` in the packaged `compose_otlp` composer so the field is always populated on the wire.
- Update the header comment (default description) and `docs/src/otlp.md` §4.3 to match.

## Why
opentelemetry-proto v1.0.0 `logs.proto` says:

> This field MUST be set once the event is observed by OpenTelemetry.

limpid, as the receiver, is the OpenTelemetry component that observes the event, so the packaged composer must satisfy the MUST. The shed slot (`workspace.lsis.shed.otlp.log_record.observed_time_unix_nano`) is preserved as the override for callers that carry an earlier observation point (e.g. a timestamp stamped by an upstream collector).

## Test plan
- [x] `cargo xtask lint-snippet-headers` — 39 files / 0 errors / 0 warnings
- [x] `limpid --check` on a config that pipes `compose_otlp | otlp_to_egress` — the composer parses cleanly
- [x] uchgs push-gate verify — 9/9 scopes pass, `would_push_succeed: true`