### PR TITLE
Prepare release 0.7.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+## [0.7.14] - 2026-07-16
+
 ### Changed — snippet severity is canonical OpenTelemetry severity
 
 Bundled semantic parsers now write normalized OTel `SeverityNumber` values to
@@ -2068,9 +2070,12 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.7.9...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.7.14...HEAD
+[0.7.14]: https://github.com/naoto256/limpid/compare/v0.7.13...v0.7.14
+[0.7.13]: https://github.com/naoto256/limpid/compare/v0.7.12...v0.7.13
 [0.7.12]: https://github.com/naoto256/limpid/compare/v0.7.11...v0.7.12
 [0.7.11]: https://github.com/naoto256/limpid/compare/v0.7.10...v0.7.11
+[0.7.10]: https://github.com/naoto256/limpid/compare/v0.7.9...v0.7.10
 [0.7.9]: https://github.com/naoto256/limpid/compare/v0.7.8...v0.7.9
 [0.7.8]: https://github.com/naoto256/limpid/compare/v0.7.7...v0.7.8
 [0.7.7]: https://github.com/naoto256/limpid/compare/v0.7.6...v0.7.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.13"
+version = "0.7.14"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.13"
+version = "0.7.14"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.13"
+version = "0.7.14"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1016,7 +1016,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.13"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.14"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -24,7 +24,7 @@ read that and explains the OTLP-specific reading on top.
 
 ## 1. Scope
 
-| Aspect | Current (0.7.13) |
+| Aspect | Current (0.7.14) |
 |---|---|
 | Signal | **logs** only — no traces, no metrics, no profiles |
 | Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` introduced in 0.7.6; in 0.7.8 plaintext `http://` with `tls { ... }` is now rejected at parse time — see CHANGELOG 0.7.8) |


### PR DESCRIPTION
## Summary

- finalize the 0.7.14 changelog entry and comparison links
- bump limpid, limpidctl, and limpid-prometheus to 0.7.14
- refresh Cargo.lock and versioned documentation examples

## Validation

- `cargo metadata --no-deps`
- `cargo fmt --all -- --check`
- `cargo test --workspace` (966 passed, 1 ignored)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo xtask lint-snippet-headers`
- `cargo xtask gen-snippet-inventory --check`
- `git diff --check`

No runtime behavior or dependency changes are included.
