### PR TITLE
fix(otlp): align adapter fields with parser contracts

### DIFF
--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -2563,6 +2563,664 @@ def pipeline zeek_full_otlp {
         }
     }
 
+    fn collect_expr_parsed_reads(expr: &Expr, reads: &mut std::collections::BTreeSet<String>) {
+        if let ExprKind::Ident(parts) = &expr.kind
+            && parts.starts_with(&["workspace".into(), "lsis".into(), "parsed".into()])
+            && parts.len() > 3
+        {
+            reads.insert(parts[3..].join("."));
+        }
+        crate::dsl::ast::walk_children(expr, |child| collect_expr_parsed_reads(child, reads));
+    }
+
+    fn collect_statement_parsed_reads(
+        statements: &[ProcessStatement],
+        reads: &mut std::collections::BTreeSet<String>,
+    ) {
+        for statement in statements {
+            match statement {
+                ProcessStatement::Assign(_, expr)
+                | ProcessStatement::LetBinding(_, expr)
+                | ProcessStatement::ExprStmt(expr) => collect_expr_parsed_reads(expr, reads),
+                ProcessStatement::Error(Some(expr)) => collect_expr_parsed_reads(expr, reads),
+                ProcessStatement::If(chain) => {
+                    for (condition, body) in &chain.branches {
+                        collect_expr_parsed_reads(condition, reads);
+                        for branch in body {
+                            if let BranchBody::Process(statement) = branch {
+                                collect_statement_parsed_reads(
+                                    std::slice::from_ref(statement),
+                                    reads,
+                                );
+                            }
+                        }
+                    }
+                    if let Some(body) = &chain.else_body {
+                        for branch in body {
+                            if let BranchBody::Process(statement) = branch {
+                                collect_statement_parsed_reads(
+                                    std::slice::from_ref(statement),
+                                    reads,
+                                );
+                            }
+                        }
+                    }
+                }
+                ProcessStatement::Switch(scrutinee, arms) => {
+                    collect_expr_parsed_reads(scrutinee, reads);
+                    for arm in arms {
+                        if let Some(pattern) = &arm.pattern {
+                            collect_expr_parsed_reads(pattern, reads);
+                        }
+                        for branch in &arm.body {
+                            if let BranchBody::Process(statement) = branch {
+                                collect_statement_parsed_reads(
+                                    std::slice::from_ref(statement),
+                                    reads,
+                                );
+                            }
+                        }
+                    }
+                }
+                ProcessStatement::TryCatch(try_body, catch_body) => {
+                    collect_statement_parsed_reads(try_body, reads);
+                    collect_statement_parsed_reads(catch_body, reads);
+                }
+                ProcessStatement::ProcessCall(_)
+                | ProcessStatement::Drop
+                | ProcessStatement::Error(None) => {}
+            }
+        }
+    }
+
+    fn collect_written_shape(
+        expr: &Expr,
+        prefix: &str,
+        config: &CompiledConfig,
+        writes: &mut std::collections::BTreeSet<String>,
+        active_functions: &mut std::collections::HashSet<String>,
+    ) {
+        match &expr.kind {
+            ExprKind::HashLit(fields) => {
+                for (key, value) in fields {
+                    let path = if prefix.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{prefix}.{key}")
+                    };
+                    collect_written_shape(value, &path, config, writes, active_functions);
+                }
+            }
+            ExprKind::SwitchExpr { arms, .. } => {
+                for arm in arms {
+                    collect_written_shape(&arm.body, prefix, config, writes, active_functions);
+                }
+            }
+            ExprKind::FuncCall { name, .. } if config.functions.contains_key(name) => {
+                if !active_functions.insert(name.clone()) {
+                    return;
+                }
+                let function = &config.functions[name];
+                let return_expr = match &function.body.ret.kind {
+                    ExprKind::Ident(parts) if parts.len() == 1 => function
+                        .body
+                        .lets
+                        .iter()
+                        .rev()
+                        .find(|binding| binding.name == parts[0])
+                        .map(|binding| &binding.value)
+                        .unwrap_or(&function.body.ret),
+                    _ => &function.body.ret,
+                };
+                collect_written_shape(return_expr, prefix, config, writes, active_functions);
+                active_functions.remove(name);
+            }
+            ExprKind::Ident(parts) if parts.len() == 1 => {
+                writes.insert(format!("{prefix}.*"));
+            }
+            _ if !prefix.is_empty() => {
+                writes.insert(prefix.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_reachable_parsed_writes(
+        process_name: &str,
+        config: &CompiledConfig,
+        visited_processes: &mut std::collections::HashSet<String>,
+        writes: &mut std::collections::BTreeSet<String>,
+    ) {
+        if !visited_processes.insert(process_name.to_string()) {
+            return;
+        }
+        let process = config
+            .processes
+            .get(process_name)
+            .unwrap_or_else(|| panic!("missing packaged process {process_name}"));
+
+        fn walk(
+            statements: &[ProcessStatement],
+            config: &CompiledConfig,
+            visited_processes: &mut std::collections::HashSet<String>,
+            writes: &mut std::collections::BTreeSet<String>,
+        ) {
+            for statement in statements {
+                match statement {
+                    ProcessStatement::Assign(AssignTarget::Workspace(path), expr)
+                        if path.starts_with(&["lsis".into(), "parsed".into()]) =>
+                    {
+                        let prefix = path[2..].join(".");
+                        collect_written_shape(
+                            expr,
+                            &prefix,
+                            config,
+                            writes,
+                            &mut std::collections::HashSet::new(),
+                        );
+                    }
+                    ProcessStatement::ProcessCall(name) => {
+                        collect_reachable_parsed_writes(name, config, visited_processes, writes)
+                    }
+                    ProcessStatement::If(chain) => {
+                        for (_, body) in &chain.branches {
+                            for branch in body {
+                                if let BranchBody::Process(statement) = branch {
+                                    walk(
+                                        std::slice::from_ref(statement),
+                                        config,
+                                        visited_processes,
+                                        writes,
+                                    );
+                                }
+                            }
+                        }
+                        if let Some(body) = &chain.else_body {
+                            for branch in body {
+                                if let BranchBody::Process(statement) = branch {
+                                    walk(
+                                        std::slice::from_ref(statement),
+                                        config,
+                                        visited_processes,
+                                        writes,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    ProcessStatement::Switch(_, arms) => {
+                        for arm in arms {
+                            for branch in &arm.body {
+                                if let BranchBody::Process(statement) = branch {
+                                    walk(
+                                        std::slice::from_ref(statement),
+                                        config,
+                                        visited_processes,
+                                        writes,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    ProcessStatement::TryCatch(try_body, catch_body) => {
+                        walk(try_body, config, visited_processes, writes);
+                        walk(catch_body, config, visited_processes, writes);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        walk(&process.body, config, visited_processes, writes);
+    }
+
+    #[test]
+    fn packaged_otlp_adapter_parsed_reads_are_written_by_source_parsers() {
+        let config = compile_packaged_otlp_composers().unwrap();
+        let mut adapters = config
+            .processes
+            .keys()
+            .filter(|name| name.ends_with("_to_otlp"))
+            .cloned()
+            .collect::<Vec<_>>();
+        adapters.sort();
+        assert_eq!(
+            adapters.len(),
+            30,
+            "packaged source adapter inventory drift"
+        );
+
+        let mut mismatches = Vec::new();
+        for adapter_name in adapters {
+            let source_name = adapter_name.trim_end_matches("_to_otlp");
+            let parser_name = format!("parse_{source_name}");
+            let mut reads = std::collections::BTreeSet::new();
+            collect_statement_parsed_reads(&config.processes[&adapter_name].body, &mut reads);
+
+            let mut writes = std::collections::BTreeSet::new();
+            collect_reachable_parsed_writes(
+                &parser_name,
+                &config,
+                &mut std::collections::HashSet::new(),
+                &mut writes,
+            );
+
+            for read in reads {
+                let matched = writes.iter().any(|write| {
+                    write == &read
+                        || write.strip_suffix(".*").is_some_and(|prefix| {
+                            read == prefix || read.starts_with(&format!("{prefix}."))
+                        })
+                });
+                if !matched {
+                    mismatches.push(format!(
+                        "{adapter_name} reads parsed.{read}, but {parser_name} never writes it"
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            mismatches.is_empty(),
+            "packaged OTLP adapter/parser path mismatches:\n{}",
+            mismatches.join("\n")
+        );
+    }
+
+    #[test]
+    fn packaged_ocsf_severity_unknown_and_other_normalize_without_canonical_zero() {
+        let unknown = run_packaged_parser_json(
+            "parse_ocsf",
+            None,
+            "parse_ocsf",
+            br#"{"class_uid":4001,"severity_id":0}"#,
+        );
+        assert!(unknown["severity_id"].is_null());
+        assert!(unknown["severity_number"].is_null());
+
+        let other = run_packaged_parser_json(
+            "parse_ocsf",
+            None,
+            "parse_ocsf",
+            br#"{"class_uid":4001,"severity_id":99}"#,
+        );
+        assert_eq!(other["severity_id"], 99);
+        assert!(other["severity_number"].is_null());
+
+        let error = run_packaged_parser_json(
+            "parse_ocsf",
+            None,
+            "parse_ocsf",
+            br#"{"class_uid":4001,"severity_id":3}"#,
+        );
+        assert!(error["severity_id"].is_null());
+        assert_eq!(error["severity_number"], 17);
+    }
+
+    #[test]
+    fn packaged_changed_otlp_routes_preserve_classification_and_fact_paths() {
+        use crate::functions::{FunctionRegistry, register_builtins, register_user_functions};
+        use serde_json::json;
+
+        let cfg = compile_packaged_otlp_composers().unwrap();
+        let mut funcs = FunctionRegistry::new();
+        register_builtins(&mut funcs, crate::runtime::init_tables(&cfg).unwrap());
+        register_user_functions(&mut funcs, &cfg);
+        let received_at = chrono::DateTime::from_timestamp(1_784_073_600, 123_456_789)
+            .expect("valid receive timestamp");
+
+        for (wire, expected_kind, expected_category, expected_type) in [
+            (
+                b"type=USER_END msg=audit(1710000000.123:43): pid=100 uid=0 auid=1000 ses=1 msg='op=PAM:session_close acct=alice exe=/usr/bin/sshd hostname=? addr=192.0.2.10 terminal=ssh res=success'".as_slice(),
+                "event",
+                "authentication",
+                "end",
+            ),
+            (
+                b"type=SERVICE_STOP msg=audit(1710000000.123:44): pid=1 uid=0 auid=0 ses=1 comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" unit=\"sshd.service\" res=success".as_slice(),
+                "event",
+                "process",
+                "end",
+            ),
+            (
+                b"type=CONFIG_CHANGE msg=audit(1710000000.123:45): pid=1 uid=0 auid=0 ses=1 op=updated_rules res=success".as_slice(),
+                "event",
+                "configuration",
+                "change",
+            ),
+            (
+                b"type=SOCKADDR msg=audit(1710000000.123:46): saddr=02000035C000020A0000000000000000 src=192.0.2.10 dst=198.51.100.5 res=success".as_slice(),
+                "event",
+                "network",
+                "info",
+            ),
+            (
+                b"type=AVC msg=audit(1710000000.123:47): avc: denied { read } for pid=42 comm=\"cat\" scontext=a tcontext=b tclass=file".as_slice(),
+                "alert",
+                "intrusion_detection",
+                "info",
+            ),
+        ] {
+            let resource_logs = run_packaged_otlp_resource_logs_at(
+                &cfg,
+                &funcs,
+                "auditd_otlp",
+                wire,
+                json!({"auditd": {"body": String::from_utf8_lossy(wire), "hostname": "host-1"}}),
+                received_at,
+            );
+            let attributes = &resource_logs.scope_logs[0].log_records[0].attributes;
+            assert_eq!(
+                otlp_string_attribute(attributes, "event.kind"),
+                Some(expected_kind)
+            );
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.category"),
+                Some(vec![expected_category])
+            );
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.type"),
+                Some(vec![expected_type])
+            );
+        }
+
+        for (category, expected_kind, expected_category, expected_type) in [
+            ("Security", "alert", Some("intrusion_detection"), "info"),
+            ("Alert", "alert", Some("intrusion_detection"), "info"),
+            ("Administrative", "event", Some("configuration"), "change"),
+            ("ServiceHealth", "event", None, "info"),
+            ("Recommendation", "event", None, "info"),
+        ] {
+            let body = json!({
+                "time": "2026-04-29T10:00:00Z",
+                "resourceId": "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+                "category": category,
+                "level": "Informational",
+                "operationName": "Example operation",
+                "resultType": "Success"
+            });
+            let wire = serde_json::to_vec(&body).unwrap();
+            let resource_logs = run_packaged_otlp_resource_logs_at(
+                &cfg,
+                &funcs,
+                "azure_activity_otlp",
+                &wire,
+                json!({}),
+                received_at,
+            );
+            let attributes = &resource_logs.scope_logs[0].log_records[0].attributes;
+            assert_eq!(
+                otlp_string_attribute(attributes, "event.kind"),
+                Some(expected_kind)
+            );
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.category"),
+                expected_category.map(|value| vec![value])
+            );
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.type"),
+                Some(vec![expected_type])
+            );
+        }
+
+        let checkpoint_wire = b"<134>1 2026-04-30T01:23:45Z - CheckPoint - - [action:\"Accept\"; product:\"VPN-1 & FireWall-1\"; src:\"192.0.2.10\"; dst:\"198.51.100.5\"; proto:\"tcp\"; severity:\"Informational\"; sys_message::\"Allowed connection\"]";
+        let checkpoint = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "checkpoint_syslog_otlp",
+            checkpoint_wire,
+            json!({"checkpoint_syslog": {"body": String::from_utf8_lossy(checkpoint_wire), "hostname": "fallback-fw"}}),
+            received_at,
+        );
+        assert_eq!(
+            otlp_string_attribute(
+                &checkpoint.resource.as_ref().expect("resource").attributes,
+                "host.name"
+            ),
+            Some("fallback-fw")
+        );
+        assert_eq!(
+            otlp_string_attribute(
+                &checkpoint.scope_logs[0].log_records[0].attributes,
+                "message"
+            ),
+            Some("Allowed connection")
+        );
+
+        let fortigate_dns_wire = b"<129>Apr 27 10:00:00 fw01 CEF:0|Fortinet|Fortigate|v7.4.11|dns|utm:dns|3|cat=utm:dns act=blocked src=192.0.2.10 dst=198.51.100.5 FTNTFGTqname=example.test FTNTFGTqtype=A FTNTFGTrcode=NXDOMAIN";
+        let fortigate_dns = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "fortigate_cef_otlp",
+            fortigate_dns_wire,
+            json!({"fortigate_cef": {"timezone": "UTC"}}),
+            received_at,
+        );
+        let fortigate_dns_attributes = &fortigate_dns.scope_logs[0].log_records[0].attributes;
+        assert_eq!(
+            otlp_string_attribute(fortigate_dns_attributes, "event.action"),
+            Some("blocked")
+        );
+        assert_eq!(
+            otlp_string_attribute(fortigate_dns_attributes, "dns.question.name"),
+            Some("example.test")
+        );
+        assert_eq!(
+            otlp_string_attribute(fortigate_dns_attributes, "dns.question.type"),
+            Some("A")
+        );
+
+        let openssh_wire = b"Disconnected from user alice 192.0.2.10 port 54321";
+        let openssh = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "openssh_otlp",
+            openssh_wire,
+            json!({"openssh": {"body": String::from_utf8_lossy(openssh_wire), "hostname": "host-1"}}),
+            received_at,
+        );
+        assert_eq!(
+            otlp_string_array_attribute(
+                &openssh.scope_logs[0].log_records[0].attributes,
+                "event.type"
+            ),
+            Some(vec!["end"])
+        );
+
+        let paloalto_cef_wire = b"<134>Apr 27 10:00:00 fw-pan01 CEF:0|Palo Alto Networks|PAN-OS|10.2.0|gp|GLOBALPROTECT|3|act=logout suser=alice src=192.0.2.10";
+        let paloalto_cef = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "paloalto_cef_otlp",
+            paloalto_cef_wire,
+            json!({"paloalto_cef": {"timezone": "UTC"}}),
+            received_at,
+        );
+        assert_eq!(
+            otlp_string_array_attribute(
+                &paloalto_cef.scope_logs[0].log_records[0].attributes,
+                "event.type"
+            ),
+            Some(vec!["end"])
+        );
+
+        let mut pan_fields = vec![""; 28];
+        pan_fields[1] = "2026/04/27 10:00:00";
+        pan_fields[2] = "012345678";
+        pan_fields[3] = "GLOBALPROTECT";
+        pan_fields[6] = "2026/04/27 10:00:01";
+        pan_fields[8] = "gateway-logout";
+        pan_fields[9] = "disconnected";
+        pan_fields[12] = "alice";
+        pan_fields[15] = "192.0.2.10";
+        pan_fields[27] = "Disconnected";
+        let paloalto_native_wire =
+            format!("<134>Apr 27 10:00:00 fw-pan01 {}", pan_fields.join(","));
+        let paloalto_native = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "paloalto_native_otlp",
+            paloalto_native_wire.as_bytes(),
+            json!({"paloalto_syslog": {"timezone": "UTC"}}),
+            received_at,
+        );
+        assert_eq!(
+            otlp_string_array_attribute(
+                &paloalto_native.scope_logs[0].log_records[0].attributes,
+                "event.type"
+            ),
+            Some(vec!["end"])
+        );
+
+        for (event_id, event_data, expected_name, expected_parent, expected_file) in [
+            (
+                1,
+                json!({"UtcTime":"2026-04-29 10:00:00.123","ProcessId":"42","Image":"C:\\Windows\\app.exe","CommandLine":"app.exe","User":"CORP\\alice","ParentProcessId":"7","ParentImage":"C:\\Windows\\parent.exe"}),
+                Some("app.exe"),
+                Some("parent.exe"),
+                None,
+            ),
+            (
+                3,
+                json!({"UtcTime":"2026-04-29 10:00:00.123","ProcessId":"43","Image":"C:\\Windows\\net.exe","User":"CORP\\alice","Protocol":"tcp","SourceIp":"192.0.2.10","SourcePort":"54321","DestinationIp":"198.51.100.5","DestinationPort":"443","Initiated":"true"}),
+                Some("net.exe"),
+                None,
+                None,
+            ),
+            (
+                11,
+                json!({"UtcTime":"2026-04-29 10:00:00.123","ProcessId":"44","Image":"C:\\Windows\\file.exe","User":"CORP\\alice","TargetFilename":"C:\\Temp\\created.txt"}),
+                Some("file.exe"),
+                None,
+                Some("created.txt"),
+            ),
+        ] {
+            let body = json!({
+                "EventID": event_id,
+                "Channel": "Microsoft-Windows-Sysmon/Operational",
+                "EventTime": "2026-04-29T10:00:00.123456Z",
+                "Computer": "WORKSTATION1",
+                "EventData": event_data
+            });
+            let wire = serde_json::to_vec(&body).unwrap();
+            let resource_logs = run_packaged_otlp_resource_logs_at(
+                &cfg,
+                &funcs,
+                "sysmon_otlp",
+                &wire,
+                json!({"sysmon": {"body": body}}),
+                received_at,
+            );
+            let attributes = &resource_logs.scope_logs[0].log_records[0].attributes;
+            assert_eq!(
+                otlp_string_attribute(attributes, "process.name"),
+                expected_name
+            );
+            assert_eq!(
+                otlp_string_attribute(attributes, "process.parent.name"),
+                expected_parent
+            );
+            assert_eq!(
+                otlp_string_attribute(attributes, "file.name"),
+                expected_file
+            );
+        }
+
+        let zeek_dns_body = json!({"_path":"dns","ts":1710000000.125,"uid":"D1","id":{"orig_h":"192.0.2.10","orig_p":54321,"resp_h":"198.51.100.53","resp_p":53},"query":"example.test","qtype_name":"A","qclass_name":"C_INTERNET","rcode_name":"NOERROR","answers":["198.51.100.5"]});
+        let zeek_dns_wire = serde_json::to_vec(&zeek_dns_body).unwrap();
+        let zeek_dns = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "zeek_default_otlp",
+            &zeek_dns_wire,
+            json!({"zeek": {"body": zeek_dns_body, "hostname": "sensor-1"}}),
+            received_at,
+        );
+        assert_eq!(
+            otlp_string_attribute(
+                &zeek_dns.scope_logs[0].log_records[0].attributes,
+                "dns.question.name"
+            ),
+            Some("example.test")
+        );
+
+        let zeek_http_body = json!({"_path":"http","ts":1710000000.25,"uid":"H1","id":{"orig_h":"192.0.2.10","orig_p":54321,"resp_h":"198.51.100.5","resp_p":80},"method":"GET","host":"example.test","uri":"/index.html","status_code":200});
+        let zeek_http_wire = serde_json::to_vec(&zeek_http_body).unwrap();
+        for pipeline in ["zeek_default_otlp", "zeek_soc_otlp", "zeek_full_otlp"] {
+            let resource_logs = run_packaged_otlp_resource_logs_at(
+                &cfg,
+                &funcs,
+                pipeline,
+                &zeek_http_wire,
+                json!({"zeek": {"body": zeek_http_body.clone(), "hostname": "sensor-1"}}),
+                received_at,
+            );
+            let attributes = &resource_logs.scope_logs[0].log_records[0].attributes;
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.category"),
+                Some(vec!["web"])
+            );
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.type"),
+                Some(vec!["access"])
+            );
+            assert_eq!(
+                otlp_string_attribute(attributes, "url.domain"),
+                Some("example.test")
+            );
+            assert_eq!(
+                otlp_string_attribute(attributes, "url.path"),
+                Some("/index.html")
+            );
+        }
+
+        let zeek_notice_body = json!({"_path":"notice","ts":1710000000.5,"uid":"N1","id":{"orig_h":"192.0.2.10","orig_p":1,"resp_h":"198.51.100.5","resp_p":2},"note":"Scan::Port_Scan","msg":"Example notice","sub":"scan","actions":["Notice::ACTION_LOG"]});
+        let zeek_notice_wire = serde_json::to_vec(&zeek_notice_body).unwrap();
+        for pipeline in ["zeek_default_otlp", "zeek_soc_otlp", "zeek_full_otlp"] {
+            let resource_logs = run_packaged_otlp_resource_logs_at(
+                &cfg,
+                &funcs,
+                pipeline,
+                &zeek_notice_wire,
+                json!({"zeek": {"body": zeek_notice_body.clone(), "hostname": "sensor-1"}}),
+                received_at,
+            );
+            let attributes = &resource_logs.scope_logs[0].log_records[0].attributes;
+            assert_eq!(
+                otlp_string_attribute(attributes, "event.kind"),
+                Some("alert")
+            );
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.category"),
+                Some(vec!["intrusion_detection"])
+            );
+            assert_eq!(
+                otlp_string_array_attribute(attributes, "event.type"),
+                Some(vec!["info"])
+            );
+        }
+
+        let zeek_smb_body = json!({"_path":"smb_files","ts":1710000000.75,"uid":"S1","id":{"orig_h":"192.0.2.10","orig_p":54321,"resp_h":"198.51.100.5","resp_p":445},"action":"SMB::FILE_OPEN","name":"report.txt","path":"\\\\share"});
+        let zeek_smb_wire = serde_json::to_vec(&zeek_smb_body).unwrap();
+        for pipeline in ["zeek_soc_otlp", "zeek_full_otlp"] {
+            let resource_logs = run_packaged_otlp_resource_logs_at(
+                &cfg,
+                &funcs,
+                pipeline,
+                &zeek_smb_wire,
+                json!({"zeek": {"body": zeek_smb_body.clone(), "hostname": "sensor-1"}}),
+                received_at,
+            );
+            assert_eq!(
+                otlp_string_attribute(
+                    &resource_logs.scope_logs[0].log_records[0].attributes,
+                    "file.name"
+                ),
+                Some("report.txt")
+            );
+        }
+    }
+
     #[test]
     fn packaged_compose_otlp_projects_canonical_severity() {
         use crate::functions::{FunctionRegistry, register_builtins, register_user_functions};
@@ -3051,6 +3709,10 @@ def pipeline zeek_full_otlp {
             otlp_int_attribute(&vpc_record.attributes, "event.end"),
             Some(1_714_000_060_000_000_000)
         );
+        assert_eq!(
+            otlp_string_attribute(&vpc_record.attributes, "network.direction"),
+            Some("outbound")
+        );
         assert_otlp_attribute_contract(&vpc_record.attributes);
 
         let azure_wire = br#"{"time":"2026-04-29T10:00:00.1234567Z","resourceId":"/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1","operationName":"MICROSOFT.COMPUTE/VIRTUALMACHINES/WRITE","category":"Administrative","level":"Informational","resultType":"Success","resultSignature":"Succeeded.","durationMs":1234,"callerIpAddress":"203.0.113.10","correlationId":"corr-1","tenantId":"tenant-1","subscriptionId":"sub-1","caller":"alice@example.com","identity":{"claims":{"oid":"user-1"}},"properties":{"statusCode":"Created"}}"#;
@@ -3257,6 +3919,10 @@ def pipeline zeek_full_otlp {
             otlp_string_attribute(&fortigate_cef_record.attributes, "rule.name"),
             Some("Example-Signature")
         );
+        assert_eq!(
+            otlp_string_attribute(&fortigate_cef_record.attributes, "event.action"),
+            Some("detected")
+        );
 
         let juniper_legacy_wire = b"<14>May 16 13:32:30 srx01 RT_IDP: IDP_ATTACK_LOG_EVENT: IDP: at 1778905950, SIG Attack log <198.51.100.10/63074->192.0.2.100/445> for TCP protocol and service SERVICE_IDP application SMB by rule Tap of rulebase IPS in policy Tap. attack: id=19519, repeat=0, action=DROP, threat-severity=HIGH, name=SMB:CVE-2017-0143-001";
         let juniper_legacy = run_packaged_otlp_resource_logs_at(
@@ -3289,6 +3955,26 @@ def pipeline zeek_full_otlp {
         assert_eq!(
             otlp_string_attribute(&juniper_sd_record.attributes, "juniper.session.id"),
             Some("123")
+        );
+
+        let juniper_secintel_wire = b"<134>1 2026-04-30T01:23:45Z srx01 RT_SECINTEL - SECINTEL_ACTION_LOG [junos@2636 source-address=\"192.0.2.10\" source-port=\"54321\" destination-address=\"198.51.100.5\" destination-port=\"443\" protocol-id=\"6\" action=\"BLOCK\" feed-name=\"Example feed\" threat-severity=\"7\"]";
+        let juniper_secintel = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "juniper_structured_otlp",
+            juniper_secintel_wire,
+            json!({"juniper_srx_sd_syslog": {"body": String::from_utf8_lossy(juniper_secintel_wire)}}),
+            received_at,
+        );
+        let juniper_secintel_record = &juniper_secintel.scope_logs[0].log_records[0];
+        assert_eq!(juniper_secintel_record.severity_number, 19);
+        assert_eq!(juniper_secintel_record.severity_text, "");
+        assert_eq!(
+            otlp_string_attribute(
+                &juniper_secintel_record.attributes,
+                "juniper.secintel.severity"
+            ),
+            Some("7")
         );
 
         let nsp_wire = b"admin_domain=Default alert_id=12345 alert_type=Signature app_protocol=HTTP confidence=Tentative attack_count=1 attack_id=0x40000123 attack_name=SQL-Injection severity=High alert_signature=HTTP-SQL-INJ-001 attack_time=\"2026-05-16 10:00:00\" category=Application dest_ip=192.0.2.10 dest_name=webserver01 dest_port=80 device_name=nsp-sensor-01 direction=Inbound confidence= file_name= file_hash= file_type= virus_name= action_status= error_status= protocol=TCP result=Blocked src_ip=198.51.100.5 src_name= src_port=54321";
@@ -3371,6 +4057,14 @@ def pipeline zeek_full_otlp {
             otlp_string_attribute(&paloalto_native_record.attributes, "palo_alto.session.id"),
             Some("98765")
         );
+        assert_eq!(
+            otlp_int_attribute(&paloalto_native_record.attributes, "source.bytes"),
+            Some(1024)
+        );
+        assert_eq!(
+            otlp_int_attribute(&paloalto_native_record.attributes, "destination.bytes"),
+            Some(2048)
+        );
 
         for resource_logs in [
             asa,
@@ -3379,6 +4073,7 @@ def pipeline zeek_full_otlp {
             fortigate_cef,
             juniper_legacy,
             juniper_structured,
+            juniper_secintel,
             nsp,
             paloalto_cef,
             paloalto_native,

--- a/packaging/snippets/functions/severity_converter.limpid
+++ b/packaging/snippets/functions/severity_converter.limpid
@@ -5,15 +5,16 @@
 // Test corpus: unit (OCSF 1.3.0 and OTel severity boundary tables)
 
 // These partial functions encode only the published standard-to-standard
-// boundary. Null stays null. OCSF Other (99) also maps to null because its
-// meaning lives in the sibling `severity` text, not in an OTel numeric band.
+// boundary. Null stays null. OCSF Unknown (0) maps to an unset canonical
+// SeverityNumber, and Other (99) also maps to null because its meaning lives
+// in the sibling `severity` text, not in an OTel numeric band.
 // Values outside either standard's domain return null; protocol-boundary
 // processes compare the source and result and raise an operator-readable
 // error for invalid non-null input.
 
 def function ocsf_severity_id_to_otel_severity_number(severity_id) {
     switch severity_id {
-        0       { 0 }
+        0       { null }
         1       { 9 }
         2       { 13 }
         3       { 17 }
@@ -27,7 +28,6 @@ def function ocsf_severity_id_to_otel_severity_number(severity_id) {
 
 def function otel_severity_number_to_ocsf_severity_id(severity_number) {
     switch severity_number {
-        0       { 0 }
         1       { 1 }
         2       { 1 }
         3       { 1 }

--- a/packaging/snippets/parsers/parse_auditd.limpid
+++ b/packaging/snippets/parsers/parse_auditd.limpid
@@ -871,20 +871,35 @@ def function auditd_otlp_event_category(class_uid) {
     switch class_uid {
         1001 { "file" }
         1007 { "process" }
+        2002 { "configuration" }
         2004 { "intrusion_detection" }
         3001 { "iam" }
         3002 { "authentication" }
+        4001 { "network" }
         default { "host" }
     }
 }
 
-def function auditd_otlp_event_type(class_uid) {
+def function auditd_otlp_event_type(class_uid, activity_id) {
     switch class_uid {
         1001 { "change" }
-        1007 { "start" }
-        2004 { "indicator" }
+        1007 {
+            switch activity_id {
+                2       { "change" }
+                4       { "end" }
+                default { "start" }
+            }
+        }
+        2002 { "change" }
+        2004 { "info" }
         3001 { "change" }
-        3002 { "start" }
+        3002 {
+            switch activity_id {
+                2       { "end" }
+                default { "start" }
+            }
+        }
+        4001 { "info" }
         default { "info" }
     }
 }
@@ -907,7 +922,7 @@ def process auditd_to_otlp {
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: auditd_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: auditd_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: auditd_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: auditd_otlp_event_type(workspace.lsis.parsed.class_uid, workspace.lsis.parsed.activity_id) }] } } }],
         switch workspace.auditd_class.type != null { true { [{ key: "event.code", value: { string_value: workspace.auditd_class.type } }] } default { [] } },
         switch auditd_otlp_event_outcome(workspace.lsis.parsed.status_id) != null { true { [{ key: "event.outcome", value: { string_value: auditd_otlp_event_outcome(workspace.lsis.parsed.status_id) } }] } default { [] } },
         switch coalesce(workspace.lsis.parsed.actor.user.name, workspace.lsis.parsed.user.name) != null { true { [{ key: "user.name", value: { string_value: coalesce(workspace.lsis.parsed.actor.user.name, workspace.lsis.parsed.user.name) } }] } default { [] } },
@@ -915,7 +930,6 @@ def process auditd_to_otlp {
         switch workspace.lsis.parsed.process.name != null { true { [{ key: "process.name", value: { string_value: workspace.lsis.parsed.process.name } }] } default { [] } },
         switch workspace.lsis.parsed.process.pid != null { true { [{ key: "process.pid", value: { int_value: workspace.lsis.parsed.process.pid } }] } default { [] } },
         switch workspace.lsis.parsed.file.name != null { true { [{ key: "file.name", value: { string_value: workspace.lsis.parsed.file.name } }] } default { [] } },
-        switch workspace.lsis.parsed.file.path != null { true { [{ key: "file.path", value: { string_value: workspace.lsis.parsed.file.path } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.ip != null { true { [{ key: "source.ip", value: { string_value: workspace.lsis.parsed.src_endpoint.ip } }] } default { [] } },
         switch workspace.lsis.parsed.dst_endpoint.ip != null { true { [{ key: "destination.ip", value: { string_value: workspace.lsis.parsed.dst_endpoint.ip } }] } default { [] } },
         switch workspace.lsis.parsed.finding_info.title != null { true { [{ key: "rule.name", value: { string_value: workspace.lsis.parsed.finding_info.title } }] } default { [] } }

--- a/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
+++ b/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
@@ -427,7 +427,7 @@ def process aws_vpc_flow_to_otlp {
             default { [] }
         },
         switch workspace.lsis.parsed.connection_info.direction != null {
-            true { [{ key: "network.direction", value: { string_value: workspace.lsis.parsed.connection_info.direction } }] }
+            true { [{ key: "network.direction", value: { string_value: lower(workspace.lsis.parsed.connection_info.direction) } }] }
             default { [] }
         },
         switch workspace.lsis.parsed.start_time != null {

--- a/packaging/snippets/parsers/parse_azure_activity.limpid
+++ b/packaging/snippets/parsers/parse_azure_activity.limpid
@@ -303,13 +303,31 @@ def process parse_azure_activity {
     }
 }
 
+def function azure_activity_otlp_event_kind(category) {
+    switch category {
+        "Security" { "alert" }
+        "Alert"    { "alert" }
+        default    { "event" }
+    }
+}
+
 def function azure_activity_otlp_event_category(category) {
     switch category {
         "Security"       { "intrusion_detection" }
         "Alert"          { "intrusion_detection" }
-        "ServiceHealth"  { "availability" }
-        "ResourceHealth" { "availability" }
-        default          { "configuration" }
+        "Administrative" { "configuration" }
+        "Autoscale"      { "configuration" }
+        "Policy"         { "configuration" }
+        default          { null }
+    }
+}
+
+def function azure_activity_otlp_event_type(category) {
+    switch category {
+        "Administrative" { "change" }
+        "Autoscale"      { "change" }
+        "Policy"         { "change" }
+        default          { "info" }
     }
 }
 
@@ -339,9 +357,12 @@ def process azure_activity_to_otlp {
 
     workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
-        [{ key: "event.kind", value: { string_value: "event" } }],
-        [{ key: "event.category", value: { array_value: { values: [{ string_value: azure_activity_otlp_event_category(workspace.az.category) }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: "change" }] } } }],
+        [{ key: "event.kind", value: { string_value: azure_activity_otlp_event_kind(workspace.az.category) } }],
+        switch azure_activity_otlp_event_category(workspace.az.category) != null {
+            true { [{ key: "event.category", value: { array_value: { values: [{ string_value: azure_activity_otlp_event_category(workspace.az.category) }] } } }] }
+            default { [] }
+        },
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: azure_activity_otlp_event_type(workspace.az.category) }] } } }],
         switch workspace.az.operationName != null {
             true { [{ key: "event.action", value: { string_value: workspace.az.operationName } }] }
             default { [] }

--- a/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
+++ b/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
@@ -188,6 +188,7 @@ def function checkpoint_syslog_network_record(sd, action, src, src_port, dst, ds
         severity:        severity,
         status_id:    checkpoint_syslog_status_id(action),
         time:         time_ns,
+        message:      parse_checkpoint_syslog_kv_or_null(sd, "sys_message"),
         src_endpoint: {
             ip:   src,
             port: checkpoint_syslog_int_opt(src_port)
@@ -243,6 +244,7 @@ def function checkpoint_syslog_finding_record(sd, action, src, src_port, dst, ds
         severity:        severity,
         status_id:    checkpoint_syslog_status_id(action),
         time:         time_ns,
+        message:      parse_checkpoint_syslog_kv_or_null(sd, "sys_message"),
         finding_info: {
             uid:   parse_checkpoint_syslog_kv(sd, "protection_id"),
             title: attack,
@@ -321,6 +323,7 @@ def function checkpoint_syslog_auth_record(sd, action, host, time_ns, severity_n
         severity:        severity,
         status_id:    status,
         time:         time_ns,
+        message:      parse_checkpoint_syslog_kv_or_null(sd, "sys_message"),
         user: { name: user },
         actor: { user: { name: user } },
         src_endpoint: { ip: src_ip },
@@ -368,6 +371,14 @@ def function parse_checkpoint_syslog_classify(body) {
                 "^<\\d+>1 (?P<timestamp>\\S+) (?P<host>\\S+) \\S+ - Log \\[Fields@\\S+ (?P<sd>.*)\\]\\s*$"
             )
         }
+    }
+}
+
+def function checkpoint_syslog_source_host(wire_host, fallback_host) {
+    switch wire_host {
+        "-"     { fallback_host }
+        null    { fallback_host }
+        default { wire_host }
     }
 }
 
@@ -431,7 +442,7 @@ def process parse_checkpoint_syslog_network_record_proc {
         parse_checkpoint_syslog_kv(sd, "rule_name"),
         parse_checkpoint_syslog_kv(sd, "rule_uid"),
         parse_checkpoint_syslog_kv(sd, "layer_name"),
-        coalesce(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname),
+        checkpoint_syslog_source_host(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname),
         checkpoint_syslog_time_ns(workspace.cp_syslog_class.timestamp),
         workspace.checkpoint_syslog_severity.number,
         workspace.checkpoint_syslog_severity.text
@@ -449,7 +460,7 @@ def process parse_checkpoint_syslog_finding_record_proc {
         parse_checkpoint_syslog_kv(sd, "dst"),
         parse_checkpoint_syslog_kv(sd, "service"),
         parse_checkpoint_syslog_kv(sd, "proto"),
-        coalesce(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname),
+        checkpoint_syslog_source_host(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname),
         checkpoint_syslog_time_ns(workspace.cp_syslog_class.timestamp),
         workspace.checkpoint_syslog_severity.number,
         workspace.checkpoint_syslog_severity.text
@@ -462,7 +473,7 @@ def process parse_checkpoint_syslog_auth_record {
     workspace.lsis.parsed = checkpoint_syslog_auth_record(
         sd,
         parse_checkpoint_syslog_kv(sd, "action"),
-        coalesce(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname),
+        checkpoint_syslog_source_host(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname),
         checkpoint_syslog_time_ns(workspace.cp_syslog_class.timestamp),
         workspace.checkpoint_syslog_severity.number,
         workspace.checkpoint_syslog_severity.text
@@ -503,6 +514,7 @@ def function checkpoint_syslog_otlp_event_outcome(status_id) {
 def process checkpoint_syslog_to_otlp {
     let sd = workspace.cp_syslog_class.sd
     let product = parse_checkpoint_syslog_kv_or_null(sd, "product")
+    let source_host = checkpoint_syslog_source_host(workspace.cp_syslog_class.host, workspace.checkpoint_syslog.hostname)
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Check Point Software Technologies" } }],
         switch product != null {
@@ -510,8 +522,8 @@ def process checkpoint_syslog_to_otlp {
             default { [] }
         },
         [{ key: "observer.type", value: { string_value: "firewall" } }],
-        switch workspace.cp_syslog_class.host != null {
-            true { [{ key: "host.name", value: { string_value: workspace.cp_syslog_class.host } }] }
+        switch source_host != null {
+            true { [{ key: "host.name", value: { string_value: source_host } }] }
             default { [] }
         },
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -981,8 +981,8 @@ def process fortigate_cef_to_otlp {
         [{ key: "event.kind", value: { string_value: fortigate_cef_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: fortigate_cef_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
         [{ key: "event.type", value: { array_value: { values: [{ string_value: fortigate_cef_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
-        switch workspace.cef.cat != null {
-            true { [{ key: "event.action", value: { string_value: workspace.cef.cat } }] }
+        switch workspace.cef.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
             default { [] }
         },
         switch fortigate_cef_otlp_event_outcome(workspace.lsis.parsed.status_id) != null {
@@ -1033,20 +1033,20 @@ def process fortigate_cef_to_otlp {
             true { [{ key: "destination.bytes", value: { int_value: workspace.lsis.parsed.traffic.bytes_out } }] }
             default { [] }
         },
-        switch coalesce(workspace.lsis.parsed.http_request.url.url_string, workspace.lsis.parsed.url.url_string) != null {
-            true { [{ key: "url.full", value: { string_value: coalesce(workspace.lsis.parsed.http_request.url.url_string, workspace.lsis.parsed.url.url_string) } }] }
+        switch workspace.lsis.parsed.http_request.url.url_string != null {
+            true { [{ key: "url.full", value: { string_value: workspace.lsis.parsed.http_request.url.url_string } }] }
             default { [] }
         },
         switch workspace.lsis.parsed.http_request.http_method != null {
             true { [{ key: "http.request.method", value: { string_value: workspace.lsis.parsed.http_request.http_method } }] }
             default { [] }
         },
-        switch workspace.lsis.parsed.dns_query.hostname != null {
-            true { [{ key: "dns.question.name", value: { string_value: workspace.lsis.parsed.dns_query.hostname } }] }
+        switch workspace.lsis.parsed.query.hostname != null {
+            true { [{ key: "dns.question.name", value: { string_value: workspace.lsis.parsed.query.hostname } }] }
             default { [] }
         },
-        switch workspace.lsis.parsed.dns_query.type != null {
-            true { [{ key: "dns.question.type", value: { string_value: workspace.lsis.parsed.dns_query.type } }] }
+        switch workspace.lsis.parsed.query.type != null {
+            true { [{ key: "dns.question.type", value: { string_value: workspace.lsis.parsed.query.type } }] }
             default { [] }
         },
         switch workspace.lsis.parsed.finding_info.title != null {

--- a/packaging/snippets/parsers/parse_ocsf.limpid
+++ b/packaging/snippets/parsers/parse_ocsf.limpid
@@ -4,7 +4,8 @@
 //              per ingress (class_uid at the root)
 // Writes:      workspace.lsis.parsed.* — same class and fields as the input,
 //              except root `.time` is normalized from ms to ns and
-//              `.severity_id` becomes canonical `.severity_number`.
+//              `.severity_id` becomes canonical `.severity_number`, except
+//              OCSF Other (99), which remains in the legacy compatibility slot.
 // Category:    Vendor-neutral
 // Test corpus: spec-only (OCSF 1.3.0 class instances; round-trips with
 //              compose_ocsf)
@@ -48,10 +49,13 @@ def process parse_ocsf {
 
     let source_severity_id = workspace.lsis.parsed.severity_id
     let severity_number = ocsf_severity_id_to_otel_severity_number(source_severity_id)
-    switch source_severity_id != null and source_severity_id != 99 and severity_number == null {
+    switch source_severity_id != null and source_severity_id != 0 and source_severity_id != 99 and severity_number == null {
         true { error "parse_ocsf: invalid OCSF severity_id ${source_severity_id}" }
     }
-    workspace.lsis.parsed.severity_id = null
+    workspace.lsis.parsed.severity_id = switch source_severity_id {
+        99      { 99 }
+        default { null }
+    }
     workspace.lsis.parsed.severity_number = severity_number
 
     switch workspace.lsis.parsed.time != null {

--- a/packaging/snippets/parsers/parse_openssh.limpid
+++ b/packaging/snippets/parsers/parse_openssh.limpid
@@ -445,6 +445,10 @@ def function openssh_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+def function openssh_otlp_event_type(activity_id) {
+    switch activity_id { 2 { "end" } default { "start" } }
+}
+
 def process openssh_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "OpenBSD" } }],
@@ -459,7 +463,7 @@ def process openssh_to_otlp {
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: "authentication" }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: "start" }] } } }],
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: openssh_otlp_event_type(workspace.lsis.parsed.activity_id) }] } } }],
         switch workspace.ssh.kind != null { true { [{ key: "event.action", value: { string_value: workspace.ssh.kind } }] } default { [] } },
         switch openssh_otlp_event_outcome(workspace.lsis.parsed.status_id) != null { true { [{ key: "event.outcome", value: { string_value: openssh_otlp_event_outcome(workspace.lsis.parsed.status_id) } }] } default { [] } },
         switch workspace.lsis.parsed.user.name != null { true { [{ key: "user.name", value: { string_value: workspace.lsis.parsed.user.name } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -519,10 +519,12 @@ def function paloalto_cef_otlp_event_category(class_uid) {
     }
 }
 
-def function paloalto_cef_otlp_event_type(class_uid) {
+def function paloalto_cef_otlp_event_type(class_uid, activity_id) {
     switch class_uid {
         2004    { "indicator" }
-        3002    { "start" }
+        3002 {
+            switch activity_id { 2 { "end" } default { "start" } }
+        }
         6004    { "access" }
         default { "connection" }
     }
@@ -558,7 +560,7 @@ def process paloalto_cef_to_otlp {
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: paloalto_cef_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: paloalto_cef_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: paloalto_cef_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: paloalto_cef_otlp_event_type(workspace.lsis.parsed.class_uid, workspace.lsis.parsed.activity_id) }] } } }],
         switch workspace.cef.name != null {
             true { [{ key: "event.code", value: { string_value: workspace.cef.name } }] }
             default { [] }
@@ -607,8 +609,8 @@ def process paloalto_cef_to_otlp {
             true { [{ key: "network.application", value: { string_value: workspace.lsis.parsed.app_name } }] }
             default { [] }
         },
-        switch coalesce(workspace.lsis.parsed.http_request.url.url_string, workspace.lsis.parsed.url.url_string) != null {
-            true { [{ key: "url.full", value: { string_value: coalesce(workspace.lsis.parsed.http_request.url.url_string, workspace.lsis.parsed.url.url_string) } }] }
+        switch workspace.lsis.parsed.http_request.url.url_string != null {
+            true { [{ key: "url.full", value: { string_value: workspace.lsis.parsed.http_request.url.url_string } }] }
             default { [] }
         },
         switch workspace.lsis.parsed.http_request.http_method != null {

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -738,10 +738,12 @@ def function paloalto_syslog_otlp_event_category(class_uid) {
     }
 }
 
-def function paloalto_syslog_otlp_event_type(class_uid) {
+def function paloalto_syslog_otlp_event_type(class_uid, activity_id) {
     switch class_uid {
         2004    { "indicator" }
-        3002    { "start" }
+        3002 {
+            switch activity_id { 2 { "end" } default { "start" } }
+        }
         6004    { "access" }
         default { "connection" }
     }
@@ -775,7 +777,7 @@ def process paloalto_syslog_to_otlp {
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: paloalto_syslog_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: paloalto_syslog_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: paloalto_syslog_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: paloalto_syslog_otlp_event_type(workspace.lsis.parsed.class_uid, workspace.lsis.parsed.activity_id) }] } } }],
         switch coalesce(workspace.pan.EventID, workspace.pan.Subtype, workspace.pan.Type) != null {
             true { [{ key: "event.code", value: { string_value: coalesce(workspace.pan.EventID, workspace.pan.Subtype, workspace.pan.Type) } }] }
             default { [] }
@@ -832,12 +834,12 @@ def process paloalto_syslog_to_otlp {
             true { [{ key: "network.application", value: { string_value: workspace.lsis.parsed.app_name } }] }
             default { [] }
         },
-        switch workspace.lsis.parsed.traffic.bytes_in != null {
-            true { [{ key: "source.bytes", value: { int_value: workspace.lsis.parsed.traffic.bytes_in } }] }
+        switch workspace.lsis.parsed.traffic.bytes_out != null {
+            true { [{ key: "source.bytes", value: { int_value: workspace.lsis.parsed.traffic.bytes_out } }] }
             default { [] }
         },
-        switch workspace.lsis.parsed.traffic.bytes_out != null {
-            true { [{ key: "destination.bytes", value: { int_value: workspace.lsis.parsed.traffic.bytes_out } }] }
+        switch workspace.lsis.parsed.traffic.bytes_in != null {
+            true { [{ key: "destination.bytes", value: { int_value: workspace.lsis.parsed.traffic.bytes_in } }] }
             default { [] }
         },
         switch workspace.lsis.parsed.session_uid != null {

--- a/packaging/snippets/parsers/parse_sysmon.limpid
+++ b/packaging/snippets/parsers/parse_sysmon.limpid
@@ -277,6 +277,16 @@ def function sysmon_otlp_event_type(class_uid) {
 }
 
 def process sysmon_to_otlp {
+    let process_name = coalesce(workspace.lsis.parsed.process.name, workspace.lsis.parsed.actor.process.name)
+    let process_pid = coalesce(workspace.lsis.parsed.process.pid, workspace.lsis.parsed.actor.process.pid)
+    let parent_process_name = switch workspace.lsis.parsed.class_uid {
+        1007    { workspace.lsis.parsed.actor.process.name }
+        default { null }
+    }
+    let parent_process_pid = switch workspace.lsis.parsed.class_uid {
+        1007    { workspace.lsis.parsed.actor.process.pid }
+        default { null }
+    }
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Microsoft" } }],
         [{ key: "observer.product", value: { string_value: "Sysmon" } }],
@@ -293,10 +303,10 @@ def process sysmon_to_otlp {
         [{ key: "event.type", value: { array_value: { values: [{ string_value: sysmon_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
         [{ key: "event.code", value: { string_value: "${workspace.sysmon.body.EventID}" } }],
         switch workspace.lsis.parsed.actor.user.name != null { true { [{ key: "user.name", value: { string_value: workspace.lsis.parsed.actor.user.name } }] } default { [] } },
-        switch workspace.lsis.parsed.process.name != null { true { [{ key: "process.name", value: { string_value: workspace.lsis.parsed.process.name } }] } default { [] } },
-        switch workspace.lsis.parsed.process.pid != null { true { [{ key: "process.pid", value: { int_value: workspace.lsis.parsed.process.pid } }] } default { [] } },
-        switch workspace.lsis.parsed.process.parent_process.name != null { true { [{ key: "process.parent.name", value: { string_value: workspace.lsis.parsed.process.parent_process.name } }] } default { [] } },
-        switch workspace.lsis.parsed.process.parent_process.pid != null { true { [{ key: "process.parent.pid", value: { int_value: workspace.lsis.parsed.process.parent_process.pid } }] } default { [] } },
+        switch process_name != null { true { [{ key: "process.name", value: { string_value: process_name } }] } default { [] } },
+        switch process_pid != null { true { [{ key: "process.pid", value: { int_value: process_pid } }] } default { [] } },
+        switch parent_process_name != null { true { [{ key: "process.parent.name", value: { string_value: parent_process_name } }] } default { [] } },
+        switch parent_process_pid != null { true { [{ key: "process.parent.pid", value: { int_value: parent_process_pid } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.ip != null { true { [{ key: "source.ip", value: { string_value: workspace.lsis.parsed.src_endpoint.ip } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.port != null { true { [{ key: "source.port", value: { int_value: workspace.lsis.parsed.src_endpoint.port } }] } default { [] } },
         switch workspace.lsis.parsed.dst_endpoint.ip != null { true { [{ key: "destination.ip", value: { string_value: workspace.lsis.parsed.dst_endpoint.ip } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_winevent_json.limpid
+++ b/packaging/snippets/parsers/parse_winevent_json.limpid
@@ -504,13 +504,9 @@ def process winevent_json_to_otlp {
         switch workspace.winevent.EventID != null { true { [{ key: "event.code", value: { string_value: "${workspace.winevent.EventID}" } }] } default { [] } },
         switch winevent_json_otlp_event_outcome(workspace.lsis.parsed.status_id) != null { true { [{ key: "event.outcome", value: { string_value: winevent_json_otlp_event_outcome(workspace.lsis.parsed.status_id) } }] } default { [] } },
         switch workspace.lsis.parsed.actor.user.name != null { true { [{ key: "user.name", value: { string_value: workspace.lsis.parsed.actor.user.name } }] } default { [] } },
-        switch workspace.lsis.parsed.actor.user.uid != null { true { [{ key: "user.id", value: { string_value: workspace.lsis.parsed.actor.user.uid } }] } default { [] } },
         switch workspace.lsis.parsed.user.name != null { true { [{ key: "user.target.name", value: { string_value: workspace.lsis.parsed.user.name } }] } default { [] } },
-        switch workspace.lsis.parsed.user.uid != null { true { [{ key: "user.target.id", value: { string_value: workspace.lsis.parsed.user.uid } }] } default { [] } },
         switch workspace.lsis.parsed.process.name != null { true { [{ key: "process.name", value: { string_value: workspace.lsis.parsed.process.name } }] } default { [] } },
-        switch workspace.lsis.parsed.process.pid != null { true { [{ key: "process.pid", value: { int_value: workspace.lsis.parsed.process.pid } }] } default { [] } },
         switch workspace.lsis.parsed.process.parent_process.name != null { true { [{ key: "process.parent.name", value: { string_value: workspace.lsis.parsed.process.parent_process.name } }] } default { [] } },
-        switch workspace.lsis.parsed.process.parent_process.pid != null { true { [{ key: "process.parent.pid", value: { int_value: workspace.lsis.parsed.process.parent_process.pid } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.ip != null { true { [{ key: "source.ip", value: { string_value: workspace.lsis.parsed.src_endpoint.ip } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.port != null { true { [{ key: "source.port", value: { int_value: workspace.lsis.parsed.src_endpoint.port } }] } default { [] } }
     )

--- a/packaging/snippets/parsers/parse_zeek_default.limpid
+++ b/packaging/snippets/parsers/parse_zeek_default.limpid
@@ -588,6 +588,7 @@ def process parse_zeek_default_notice {
 
 def function zeek_default_otlp_event_kind(class_uid) { switch class_uid { 2004 { "alert" } default { "event" } } }
 def function zeek_default_otlp_event_category(class_uid) { switch class_uid { 2004 { "intrusion_detection" } 4002 { "web" } default { "network" } } }
+def function zeek_default_otlp_event_type(class_uid) { switch class_uid { 2004 { "info" } 4002 { "access" } default { "protocol" } } }
 def function zeek_default_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
 def process zeek_default_to_otlp {
@@ -604,7 +605,7 @@ def process zeek_default_to_otlp {
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: zeek_default_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: zeek_default_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: "protocol" }] } } }],
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: zeek_default_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
         switch workspace.zeek.body._path != null { true { [{ key: "event.code", value: { string_value: workspace.zeek.body._path } }] } default { [] } },
         switch zeek_default_otlp_event_outcome(workspace.lsis.parsed.status_id) != null { true { [{ key: "event.outcome", value: { string_value: zeek_default_otlp_event_outcome(workspace.lsis.parsed.status_id) } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.ip != null { true { [{ key: "source.ip", value: { string_value: workspace.lsis.parsed.src_endpoint.ip } }] } default { [] } },
@@ -612,8 +613,9 @@ def process zeek_default_to_otlp {
         switch workspace.lsis.parsed.dst_endpoint.ip != null { true { [{ key: "destination.ip", value: { string_value: workspace.lsis.parsed.dst_endpoint.ip } }] } default { [] } },
         switch workspace.lsis.parsed.dst_endpoint.port != null { true { [{ key: "destination.port", value: { int_value: workspace.lsis.parsed.dst_endpoint.port } }] } default { [] } },
         switch workspace.lsis.parsed.connection_info.protocol_name != null { true { [{ key: "network.transport", value: { string_value: workspace.lsis.parsed.connection_info.protocol_name } }] } default { [] } },
-        switch workspace.lsis.parsed.dns_query.hostname != null { true { [{ key: "dns.question.name", value: { string_value: workspace.lsis.parsed.dns_query.hostname } }] } default { [] } },
-        switch workspace.lsis.parsed.http_request.url.url_string != null { true { [{ key: "url.original", value: { string_value: workspace.lsis.parsed.http_request.url.url_string } }] } default { [] } },
+        switch workspace.lsis.parsed.query.hostname != null { true { [{ key: "dns.question.name", value: { string_value: workspace.lsis.parsed.query.hostname } }] } default { [] } },
+        switch workspace.lsis.parsed.http_request.url.hostname != null { true { [{ key: "url.domain", value: { string_value: workspace.lsis.parsed.http_request.url.hostname } }] } default { [] } },
+        switch workspace.lsis.parsed.http_request.url.path != null { true { [{ key: "url.path", value: { string_value: workspace.lsis.parsed.http_request.url.path } }] } default { [] } },
         switch workspace.lsis.parsed.http_response.code != null { true { [{ key: "http.response.status_code", value: { int_value: workspace.lsis.parsed.http_response.code } }] } default { [] } },
         switch workspace.lsis.parsed.finding_info.title != null { true { [{ key: "rule.name", value: { string_value: workspace.lsis.parsed.finding_info.title } }] } default { [] } }
     )

--- a/packaging/snippets/parsers/parse_zeek_full.limpid
+++ b/packaging/snippets/parsers/parse_zeek_full.limpid
@@ -412,6 +412,17 @@ def process parse_zeek_full_catchall {
 }
 
 def function zeek_full_otlp_event_kind(class_uid) { switch class_uid { 2004 { "alert" } default { "event" } } }
+def function zeek_full_otlp_event_category(class_uid) { switch class_uid { 2004 { "intrusion_detection" } 3002 { "authentication" } 4002 { "web" } 4009 { "email" } default { "network" } } }
+def function zeek_full_otlp_event_type(class_uid, activity_id) {
+    switch class_uid {
+        2004 { "info" }
+        3002 { switch activity_id { 2 { "end" } default { "start" } } }
+        4002 { "access" }
+        4009 { "info" }
+        default { "protocol" }
+    }
+}
+def function zeek_full_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
 def process zeek_full_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
@@ -426,15 +437,22 @@ def process zeek_full_to_otlp {
     workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: zeek_full_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
-        [{ key: "event.category", value: { array_value: { values: [{ string_value: "network" }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: "protocol" }] } } }],
+        [{ key: "event.category", value: { array_value: { values: [{ string_value: zeek_full_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: zeek_full_otlp_event_type(workspace.lsis.parsed.class_uid, workspace.lsis.parsed.activity_id) }] } } }],
         switch workspace.zeek.body._path != null { true { [{ key: "event.code", value: { string_value: workspace.zeek.body._path } }] } default { [] } },
+        switch zeek_full_otlp_event_outcome(workspace.lsis.parsed.status_id) != null { true { [{ key: "event.outcome", value: { string_value: zeek_full_otlp_event_outcome(workspace.lsis.parsed.status_id) } }] } default { [] } },
+        switch coalesce(workspace.lsis.parsed.actor.user.name, workspace.lsis.parsed.user.name) != null { true { [{ key: "user.name", value: { string_value: coalesce(workspace.lsis.parsed.actor.user.name, workspace.lsis.parsed.user.name) } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.ip != null { true { [{ key: "source.ip", value: { string_value: workspace.lsis.parsed.src_endpoint.ip } }] } default { [] } },
         switch workspace.lsis.parsed.src_endpoint.port != null { true { [{ key: "source.port", value: { int_value: workspace.lsis.parsed.src_endpoint.port } }] } default { [] } },
         switch workspace.lsis.parsed.dst_endpoint.ip != null { true { [{ key: "destination.ip", value: { string_value: workspace.lsis.parsed.dst_endpoint.ip } }] } default { [] } },
         switch workspace.lsis.parsed.dst_endpoint.port != null { true { [{ key: "destination.port", value: { int_value: workspace.lsis.parsed.dst_endpoint.port } }] } default { [] } },
         switch workspace.lsis.parsed.connection_info.protocol_name != null { true { [{ key: "network.transport", value: { string_value: workspace.lsis.parsed.connection_info.protocol_name } }] } default { [] } },
         switch workspace.lsis.parsed.app_name != null { true { [{ key: "network.application", value: { string_value: workspace.lsis.parsed.app_name } }] } default { [] } },
+        switch workspace.lsis.parsed.file.name != null { true { [{ key: "file.name", value: { string_value: workspace.lsis.parsed.file.name } }] } default { [] } },
+        switch workspace.lsis.parsed.query.hostname != null { true { [{ key: "dns.question.name", value: { string_value: workspace.lsis.parsed.query.hostname } }] } default { [] } },
+        switch workspace.lsis.parsed.http_request.url.hostname != null { true { [{ key: "url.domain", value: { string_value: workspace.lsis.parsed.http_request.url.hostname } }] } default { [] } },
+        switch workspace.lsis.parsed.http_request.url.path != null { true { [{ key: "url.path", value: { string_value: workspace.lsis.parsed.http_request.url.path } }] } default { [] } },
+        switch workspace.lsis.parsed.http_response.code != null { true { [{ key: "http.response.status_code", value: { int_value: workspace.lsis.parsed.http_response.code } }] } default { [] } },
         switch workspace.lsis.parsed.finding_info.title != null { true { [{ key: "rule.name", value: { string_value: workspace.lsis.parsed.finding_info.title } }] } default { [] } },
         switch workspace.lsis.parsed.finding_info.uid != null { true { [{ key: "rule.id", value: { string_value: workspace.lsis.parsed.finding_info.uid } }] } default { [] } }
     )

--- a/packaging/snippets/parsers/parse_zeek_soc.limpid
+++ b/packaging/snippets/parsers/parse_zeek_soc.limpid
@@ -393,6 +393,7 @@ def function zeek_smb_files_record(body, host, time_ns) {
             uid:           body.uid,
             protocol_name: "smb"
         },
+        file: { name: body.name },
         device:   { hostname: host },
         unmapped: {
             zeek_path:    body._path,
@@ -637,7 +638,17 @@ def process parse_zeek_soc_rdp {
         zeek_time_ns(workspace.zeek.body, workspace.zeek.time))
 }
 
-def function zeek_soc_otlp_event_category(class_uid) { switch class_uid { 3002 { "authentication" } 4009 { "email" } default { "network" } } }
+def function zeek_soc_otlp_event_kind(class_uid) { switch class_uid { 2004 { "alert" } default { "event" } } }
+def function zeek_soc_otlp_event_category(class_uid) { switch class_uid { 2004 { "intrusion_detection" } 3002 { "authentication" } 4002 { "web" } 4009 { "email" } default { "network" } } }
+def function zeek_soc_otlp_event_type(class_uid, activity_id) {
+    switch class_uid {
+        2004 { "info" }
+        3002 { switch activity_id { 2 { "end" } default { "start" } } }
+        4002 { "access" }
+        4009 { "info" }
+        default { "protocol" }
+    }
+}
 def function zeek_soc_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
 def process zeek_soc_to_otlp {
@@ -652,9 +663,9 @@ def process zeek_soc_to_otlp {
     workspace.lsis.shed.otlp.scope.name = workspace.zeek.body._path
     workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
-        [{ key: "event.kind", value: { string_value: "event" } }],
+        [{ key: "event.kind", value: { string_value: zeek_soc_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: zeek_soc_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
-        [{ key: "event.type", value: { array_value: { values: [{ string_value: "protocol" }] } } }],
+        [{ key: "event.type", value: { array_value: { values: [{ string_value: zeek_soc_otlp_event_type(workspace.lsis.parsed.class_uid, workspace.lsis.parsed.activity_id) }] } } }],
         switch workspace.zeek.body._path != null { true { [{ key: "event.code", value: { string_value: workspace.zeek.body._path } }] } default { [] } },
         switch zeek_soc_otlp_event_outcome(workspace.lsis.parsed.status_id) != null { true { [{ key: "event.outcome", value: { string_value: zeek_soc_otlp_event_outcome(workspace.lsis.parsed.status_id) } }] } default { [] } },
         switch coalesce(workspace.lsis.parsed.actor.user.name, workspace.lsis.parsed.user.name) != null { true { [{ key: "user.name", value: { string_value: coalesce(workspace.lsis.parsed.actor.user.name, workspace.lsis.parsed.user.name) } }] } default { [] } },
@@ -664,6 +675,11 @@ def process zeek_soc_to_otlp {
         switch workspace.lsis.parsed.dst_endpoint.port != null { true { [{ key: "destination.port", value: { int_value: workspace.lsis.parsed.dst_endpoint.port } }] } default { [] } },
         switch workspace.lsis.parsed.connection_info.protocol_name != null { true { [{ key: "network.transport", value: { string_value: workspace.lsis.parsed.connection_info.protocol_name } }] } default { [] } },
         switch workspace.lsis.parsed.app_name != null { true { [{ key: "network.application", value: { string_value: workspace.lsis.parsed.app_name } }] } default { [] } },
-        switch workspace.lsis.parsed.file.name != null { true { [{ key: "file.name", value: { string_value: workspace.lsis.parsed.file.name } }] } default { [] } }
+        switch workspace.lsis.parsed.file.name != null { true { [{ key: "file.name", value: { string_value: workspace.lsis.parsed.file.name } }] } default { [] } },
+        switch workspace.lsis.parsed.query.hostname != null { true { [{ key: "dns.question.name", value: { string_value: workspace.lsis.parsed.query.hostname } }] } default { [] } },
+        switch workspace.lsis.parsed.http_request.url.hostname != null { true { [{ key: "url.domain", value: { string_value: workspace.lsis.parsed.http_request.url.hostname } }] } default { [] } },
+        switch workspace.lsis.parsed.http_request.url.path != null { true { [{ key: "url.path", value: { string_value: workspace.lsis.parsed.http_request.url.path } }] } default { [] } },
+        switch workspace.lsis.parsed.http_response.code != null { true { [{ key: "http.response.status_code", value: { int_value: workspace.lsis.parsed.http_response.code } }] } default { [] } },
+        switch workspace.lsis.parsed.finding_info.title != null { true { [{ key: "rule.name", value: { string_value: workspace.lsis.parsed.finding_info.title } }] } default { [] } }
     )
 }


### PR DESCRIPTION
## Summary

- address 12 actionable CodeRabbit findings from PR #169, including four contract-preserving corrections to the suggested designs
- retain Juniper SecIntel numeric severity without synthesizing SeverityText; the original numeric source remains preserved as a vendor attribute
- fix two adjacent contract issues: treat OCSF severity ID 0 as canonical unset and correct Zeek protocol event classification
- add a 30-adapter AST read/write-path sweep and decoded OTLP route matrix, fixing nine additional parser/adapter path mismatches

## Validation

- `cargo test -p limpid packaged_`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo xtask lint-snippet-headers`
- `cargo xtask gen-snippet-inventory --check`
- ultra-strict full snippet include closure
- `git diff --check`

## Review context

The changes follow the parser-owned canonical fact and per-source OTLP adapter contracts. This PR does not merge PR #169 and is intended for review against `release/0.7.14`.