### PR TITLE
Default undocumented RFC 3164-family timezones to host-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ is an upstream limitation and is documented as version-scoped skips in
 `tempfile`) is deliberately not skipped so any future additional split
 still warns.
 
+### Fixed — undocumented RFC 3164-family timezone default is host-local, not UTC
+
+Bundled parsers whose legacy timestamp format leaves the source zone
+undocumented (`parse_asa`, `parse_nsp`, `parse_paloalto_cef`,
+`parse_paloalto_syslog`) previously assumed UTC. No vendor specification
+documents UTC wall-clock for these formats, so the pack default now follows
+the ruling already applied to `parse_fortigate_cef` /
+`parse_juniper_srx_syslog`: a vendor-documented UTC format keeps UTC, and a
+documented device-local zone or a specification gap defaults to the limpid
+host's system timezone — the most likely assumption being that the device
+shares the host's zone. The `workspace.<parser>.timezone` override contract
+is unchanged: IANA names and fixed offsets are accepted, explicit `local`
+is still rejected.
+
 ### Fixed — OTLP Scope/Resource placement follows the spec's two-tier identity reading
 
 The bundled `<source>_to_otlp` adapters shipped in 0.7.14 placed program-level

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -2045,21 +2045,21 @@ def pipeline zeek_full_otlp {
             .unwrap()
             .timestamp_nanos_opt()
             .unwrap();
-        assert_eq!(nsp_default_timezone["time"], nsp_utc_expected);
-
-        let nsp_override = run_packaged_parser_json(
-            "parse_nsp",
-            Some("workspace.nsp = { body: ingress, timezone: \"America/New_York\" }"),
-            "parse_nsp",
-            nsp_body,
-        );
-        let nsp_override_expected = chrono_tz::America::New_York
+        let nsp_local_expected = chrono_tz::America::New_York
             .with_ymd_and_hms(2026, 5, 16, 10, 0, 0)
             .single()
             .unwrap()
             .timestamp_nanos_opt()
             .unwrap();
-        assert_eq!(nsp_override["time"], nsp_override_expected);
+        assert_eq!(nsp_default_timezone["time"], nsp_local_expected);
+
+        let nsp_override = run_packaged_parser_json(
+            "parse_nsp",
+            Some("workspace.nsp = { body: ingress, timezone: \"UTC\" }"),
+            "parse_nsp",
+            nsp_body,
+        );
+        assert_eq!(nsp_override["time"], nsp_utc_expected);
 
         let nsp_explicit_utc = run_packaged_parser_json(
             "parse_nsp",
@@ -2076,21 +2076,21 @@ def pipeline zeek_full_otlp {
             "parse_paloalto_syslog",
             &paloalto_wire,
         );
-        let paloalto_utc_expected = chrono::Utc
+        let paloalto_local_expected = chrono_tz::America::New_York
             .with_ymd_and_hms(2026, 4, 30, 10, 23, 45)
             .single()
             .unwrap()
             .timestamp_nanos_opt()
             .unwrap();
-        assert_eq!(paloalto_default_timezone["time"], paloalto_utc_expected);
+        assert_eq!(paloalto_default_timezone["time"], paloalto_local_expected);
 
         let paloalto_override = run_packaged_parser_json(
             "parse_paloalto_syslog",
-            Some("workspace.paloalto_syslog = { timezone: \"America/New_York\" }"),
+            Some("workspace.paloalto_syslog = { timezone: \"UTC\" }"),
             "parse_paloalto_syslog",
             &paloalto_wire,
         );
-        let paloalto_override_expected = chrono_tz::America::New_York
+        let paloalto_override_expected = chrono::Utc
             .with_ymd_and_hms(2026, 4, 30, 10, 23, 45)
             .single()
             .unwrap()
@@ -2247,11 +2247,10 @@ def pipeline zeek_full_otlp {
                 _ => None,
             };
             let defaulted = run_packaged_parser_json(parser, default_setup, parser, &ingress);
-            let default_expected = match parser {
-                "parse_fortigate_cef" | "parse_juniper_srx_syslog" => local_expected,
-                "parse_asa" | "parse_paloalto_cef" => expected,
-                _ => unreachable!(),
-            };
+            // All RFC 3164 parsers with an undocumented source zone default to
+            // the limpid host's system timezone (host-local most-likely
+            // assumption); only vendor-documented UTC formats default to UTC.
+            let default_expected = local_expected;
             assert_eq!(
                 defaulted["time"], default_expected,
                 "{parser} default timezone"

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -374,8 +374,9 @@ time. A deployment that intentionally overrides event time does so in
 the adapter output before composition.
 
 Timezone interpretation follows the source contract. A vendor-defined
-zone wins. Device-local timestamps default to the limpid host's system
-timezone, while a documented specification gap defaults to UTC. Parsers
+zone wins. Device-local timestamps and timestamps whose specification
+leaves the zone undocumented both default to the limpid host's system
+timezone (the device most likely shares the host's zone). Parsers
 that accept local timestamps expose a source-specific timezone override;
 their headers document the exact default and accepted values.
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -120,8 +120,9 @@ contracts.
   applies the current-year + future-clamp policy after the calling
   parser resolves its vendor-specific timezone default or explicit
   override. A vendor-defined fixed zone wins; documented device-local
-  formats default to `local` (the limpid host's system timezone), and
-  formats with no authoritative timezone contract default to `UTC`.
+  formats and formats with no authoritative timezone contract both
+  default to `local` (the limpid host's system timezone — the device
+  most likely shares the host's zone).
   IANA names and fixed offsets are also accepted as explicit overrides.
   For RFC 5424 / OTLP / OCSF input use the built-in
   `parse_datetime_rfc3339` primitive directly.

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -251,9 +251,10 @@ regions.
 <!-- END: inventory:functions -->
 
 Timestamp interpretation follows each source contract. A vendor-defined fixed
-zone wins; documented device-local formats default to `local` (the limpid
-host's system timezone), and formats with no authoritative timezone contract
-default to `UTC`. Source-specific timezone slots override those defaults with
+zone wins; documented device-local formats and formats with no authoritative
+timezone contract both default to `local` (the limpid host's system timezone —
+the most likely assumption is that the device shares the host's zone).
+Source-specific timezone slots override those defaults with
 an IANA name or fixed offset and reject invalid values loudly.
 Explicit `local` is not accepted in an override slot — `local` is a
 host-dependent internal default, not a source-device declaration; each

--- a/packaging/snippets/functions/parse_datetime_rfc3164.limpid
+++ b/packaging/snippets/functions/parse_datetime_rfc3164.limpid
@@ -9,11 +9,12 @@
 // shipped as LPL rather than Rust because RFC 3164 timestamps
 // require policy decisions that should be operator-editable:
 //
-//   1. The wire carries no year. We assume current year, with a
-//      future-clamp: if the parsed datetime is more than 24 hours
-//      ahead of `timestamp()`, it actually refers to the previous
-//      year (year-end rollover). This is what rsyslog / syslog-ng /
-//      Vector / Fluent Bit all converge on.
+//   1. The wire carries no year. Major syslog implementations solve
+//      the same year-rollover problem with per-product heuristics
+//      (e.g. Vector uses a Dec/Jan calendar test); limpid assumes the
+//      current year with a 24-hour future-clamp: if the parsed
+//      datetime is more than 24 hours ahead of `timestamp()`, it
+//      actually refers to the previous year (year-end rollover).
 //
 //   2. The wire carries no timezone. The caller resolves the vendor-specific
 //      default or an operator override before calling this helper. This helper

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -3,10 +3,11 @@
 // Reads:       ingress (raw wire) — syslog-wrapped %ASA-<level>-<msg_id> messages
 //              workspace.asa.timezone (optional, String) — source device
 //              timezone override as an IANA name or fixed offset; the legacy
-//              RFC 3164 timestamp defaults to UTC when this is absent
-//              (Cisco documents UTC only for RFC 5424; the accepted legacy
-//              RFC 3164 form has no documented zone, so UTC is the intentional
-//              pack default; override it when the device zone is known)
+//              RFC 3164 timestamp defaults to the limpid host's system
+//              timezone (Cisco documents UTC only for RFC 5424; the accepted
+//              legacy RFC 3164 form has no documented zone, so the pack
+//              assumes the device shares the host's zone — the most likely
+//              deployment; override it when the device zone is known)
 //              https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/I-R/asa-command-ref-I-R/m_log-lz.html
 // Writes:      workspace.lsis.parsed.* — 3002 (Authentication) and 4001 (Network
 //              asa_to_otlp additionally writes source-specific
@@ -117,7 +118,7 @@ def process validate_asa_severity_number {
         "local" { error "parse_asa: source timezone must be an IANA name or fixed offset, not local" }
     }
     workspace.asa.severity_number = asa_severity_number(to_int(workspace.asa.level))
-    let source_timezone = coalesce(workspace.asa.timezone, "UTC")
+    let source_timezone = coalesce(workspace.asa.timezone, "local")
     workspace.asa.time = switch workspace.asa.timestamp {
         null    { null }
         default { to_int(parse_datetime_rfc3164(workspace.asa.timestamp, source_timezone)) }

--- a/packaging/snippets/parsers/parse_nsp.limpid
+++ b/packaging/snippets/parsers/parse_nsp.limpid
@@ -5,11 +5,13 @@
 //                .hostname (optional, String) — collector-side hostname
 //                .timezone (optional, String) — source timezone override as an
 //                  IANA name or fixed offset for attack_time values without
-//                  ` UTC`; defaults to UTC when absent
+//                  ` UTC`; defaults to the limpid host's system timezone
 //                  (the standard-template timestamp zone is not specified in
 //                  the available vendor documentation; explicit ` UTC` is
-//                  interpreted as UTC. UTC is the intentional pack default;
-//                  override it or use a custom parser when the source differs)
+//                  interpreted as UTC. The default assumes the Manager and
+//                  limpid share the same correct system timezone — the most
+//                  likely deployment when the zone is undocumented; override
+//                  it or use a custom parser when the source differs)
 // Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding);
 //              nsp_to_otlp writes source-owned OTLP Resource, Body, and
 //              LogRecord attributes.
@@ -314,7 +316,7 @@ def process parse_nsp_normalize_time {
     switch workspace.nsp.timezone {
         "local" { error "parse_nsp: source timezone must be an IANA name or fixed offset, not local" }
     }
-    let source_timezone = coalesce(workspace.nsp.timezone, "UTC")
+    let source_timezone = coalesce(workspace.nsp.timezone, "local")
     workspace.nsp.timezone_probe = strptime(
         "2000-01-15 12:00:00",
         "%Y-%m-%d %H:%M:%S",

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -3,12 +3,14 @@
 // Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Palo Alto Networks|PAN-OS|...)
 //              workspace.paloalto_cef.timezone (optional, String) — source
 //              device timezone override as an IANA name or fixed offset; the
-//              legacy RFC 3164 wrapper defaults to UTC when this is absent
-//              (PAN-OS documents configurable device time zones but does not
-//              assign a zone to this legacy CEF wrapper timestamp)
+//              legacy RFC 3164 wrapper defaults to the limpid host's system
+//              timezone (PAN-OS documents configurable device time zones but
+//              does not assign a zone to this legacy CEF wrapper timestamp)
 //              https://docs.paloaltonetworks.com/ngfw/help/10-1/device/device-setup-management
-//              UTC is the intentional pack default; override this slot or use
-//              a custom parser when the source zone is known to differ.
+//              The default assumes the firewall and limpid share the same
+//              correct system timezone — the most likely deployment when the
+//              zone is undocumented. Override this slot with an IANA name or
+//              fixed offset when the source zone is known to differ.
 // Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT / WILDFIRE → 2004,
 //              URL → 6004, GLOBALPROTECT / AUTHENTICATION → 3002; see the
 //              subtype leaves below. paloalto_cef_to_otlp writes source-owned
@@ -76,7 +78,7 @@ def process parse_paloalto_cef_normalize_severity {
         "local" { error "parse_paloalto_cef: source timezone must be an IANA name or fixed offset, not local" }
     }
     let severity_number = paloalto_cef_severity_number(workspace.cef.severity)
-    let source_timezone = coalesce(workspace.paloalto_cef.timezone, "UTC")
+    let source_timezone = coalesce(workspace.paloalto_cef.timezone, "local")
     workspace.paloalto_cef.time = switch true {
         workspace.cef.timestamp == null { null }
         default                         { to_int(parse_datetime_rfc3164(workspace.cef.timestamp, source_timezone)) }

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -4,12 +4,14 @@
 //              (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
 //              workspace.paloalto_syslog.timezone (optional, String) — source
 //              timezone override as an IANA name or fixed offset; legacy
-//              Receive/Generated Time defaults to UTC when absent
-//              (PAN-OS defines Receive/Generated Time meanings but gives a
-//              zone only for the separate high-resolution timestamp)
+//              Receive/Generated Time defaults to the limpid host's system
+//              timezone (PAN-OS defines Receive/Generated Time meanings but
+//              gives a zone only for the separate high-resolution timestamp)
 //              https://docs.paloaltonetworks.com/ngfw/administration/monitoring/use-syslog-for-monitoring/syslog-field-descriptions/traffic-log-fields
-//              UTC is the intentional pack default; override this slot or use
-//              a custom parser when the source zone is known to differ.
+//              The default assumes the firewall and limpid share the same
+//              correct system timezone — the most likely deployment when the
+//              zone is undocumented. Override this slot with an IANA name or
+//              fixed offset when the source zone is known to differ.
 // Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT → 2004
 //              (url → 6004, wildfire → 2004), GLOBALPROTECT /
 //              AUTHENTICATION → 3002; paloalto_syslog_to_otlp writes
@@ -88,7 +90,7 @@ def process parse_paloalto_syslog_normalize_time {
     switch workspace.paloalto_syslog.timezone {
         "local" { error "parse_paloalto_syslog: source timezone must be an IANA name or fixed offset, not local" }
     }
-    let source_timezone = coalesce(workspace.paloalto_syslog.timezone, "UTC")
+    let source_timezone = coalesce(workspace.paloalto_syslog.timezone, "local")
     workspace.paloalto_syslog.time = switch true {
         workspace.pan.GenerateTime == null { null }
         workspace.pan.GenerateTime == ""   { null }


### PR DESCRIPTION
## Summary

One commit. The RFC 3164-family parsers whose vendor documentation does not pin a timestamp timezone (ASA, NSP, PAN-OS CEF, PAN-OS native) previously defaulted the source timezone to UTC. No appliance in the pack actually documents UTC wall-clock logging for these wire forms, so that default had no grounding. They now default to the limpid host's local timezone — the most likely assumption being that the device lives in the same zone as the host receiving its logs. Explicitly documented behaviours are unchanged: vendor-pinned UTC paths (ETW pass-through, RFC 3339 `Z`, NSP's explicit ` UTC` suffix) stay UTC, the IANA-name / fixed-offset operator override keeps working, and the explicit-`local` override rejection stays in place.

Also corrects the `parse_datetime_rfc3164` header, which claimed rsyslog / syslog-ng / Vector / Fluent Bit all converge on the current-year + 24-hour future-clamp heuristic; year inference is in fact per-product (Vector uses a Dec/Jan calendar test), so the header now presents the clamp as limpid's own documented choice.

## Verification

- `cargo test --workspace --locked` all green (contract tests updated to the new defaults; override cases inverted to keep their discriminating power)
- `cargo clippy -D warnings`, `cargo fmt --check`, snippet header lint, inventory check, `cargo deny`, `cargo audit`, `mdbook build` all clean
- Live E2E on the staging host (JST): ASA and PAN-OS native samples decode 10:00 wall time to 01:00Z under the new default, and to 14:00Z with an explicit `America/New_York` override; six-case matrix passed with zero DLQ entries
- uchgs push gate: 9/9 scopes PASS at HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)