### PR TITLE
refactor: separate transport, format, and vocabulary layers for CEF parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — transport / format unwrapping separated from vocabulary parsing (breaking)
+
+Bundled vocabulary parsers no longer unwrap their transport or format
+layers internally: `parse_asa` / `parse_paloalto_syslog` stopped calling
+`syslog.parse(ingress)` and `parse_fortigate_cef` / `parse_paloalto_cef`
+additionally stopped calling `cef.parse(...)`. Each layer is its own
+pipeline stage — a new `parsers/parse_cef.limpid` (transport/format-style
+`parse_cef` + generic `cef_to_otlp` adapter for the vendor-independent
+ArcSight CEF surface) joins `parse_syslog`. The separation lets a
+pipeline inspect and drop events after each stage without paying the
+next stage's parse cost, and keeps the stages independently composable.
+`parse_fortigate_syslog` is deliberately unchanged: FortiGate's native
+`<PRI>date=...` wire is not RFC 3164, so there is no meaningful
+transport stage to split out (it keeps stripping the PRI itself).
+
+Out-of-tree pipelines using these four parsers must update their chains
+(extraction results are unchanged — the same primitives run at the new
+stages):
+
+| 0.7.14 chain | 0.7.15 chain |
+|---|---|
+| `parse_asa \| ...` | `parse_syslog \| parse_asa \| ...` |
+| `parse_paloalto_syslog \| ...` | `parse_syslog \| parse_paloalto_syslog \| ...` |
+| `parse_fortigate_cef \| ...` | `parse_syslog \| parse_cef \| parse_fortigate_cef \| ...` |
+| `parse_paloalto_cef \| ...` | `parse_syslog \| parse_cef \| parse_paloalto_cef \| ...` |
+
 ### Changed — dependency dedupe
 
 Bumped `axum` to 0.8 and `webpki-roots` to 1.0 so the dependency graph no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Fixed — cef.parse honors the header escapes `\|` and `\\`
+
+The header splitter treated every `|` as a field separator, so a
+spec-legal escaped pipe (`\|`) inside a header field shifted all
+subsequent fields — for `CEF:0|V|P|1.0|sig|deny\|drop|3|act=block` the
+name became `deny\`, the severity slot received the string `drop`, and
+the extension section received `3|act=block`, misclassifying telemetry
+severity downstream. The splitter now separates only on unescaped
+pipes and decodes the two generic structural escapes that participate
+in field splitting (`\|` → `|`, `\\` → `\`); sequences outside those
+two (`\x` etc.) are kept literally, and the spec's field-specific
+escaping for vulnerability spellings in deviceEventClassId / name is
+field-internal grammar the generic primitive passes through raw. The
+bug predates this release in the primitive itself; the new generic
+`parse_cef` / `cef_to_otlp` path widens its blast radius to every CEF
+pipeline, so it is fixed in 0.7.15. Extension-section escapes remain
+undecoded (unchanged, documented scope).
+
 ### Changed — cef.parse isolates Extension keys from the positional header (breaking)
 
 `cef.parse()` previously flattened the data-driven Extension key=value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — cef.parse isolates Extension keys from the positional header (breaking)
+
+`cef.parse()` previously flattened the data-driven Extension key=value
+pairs into the same object as the seven positionally-determined header
+fields. An extension named after a header field (`severity=`, `name=`
+— dialect quirk, buggy template, or log injection alike) was pushed as
+a duplicate sibling key: arena field reads resolved to the header
+(first-wins) but the persisted workspace snapshot resolved to the
+extension value (last-wins), so downstream processes saw the header
+silently replaced. Data of different trust levels must not share a
+plane, so the split pairs now land in a nested sub-object and the raw
+blob is renamed to avoid confusion with it:
+
+| 0.7.14 path | 0.7.15 path |
+|---|---|
+| `workspace.cef.<extension-key>` | `workspace.cef.extension.<extension-key>` |
+| `workspace.cef.ext` (raw blob) | `workspace.cef.extension_raw` |
+
+Header fields (`version` / `device_vendor` / `device_product` /
+`device_version` / `signature_id` / `name` / `severity`) are unchanged.
+Out-of-tree pipelines reading extension keys off `cef.parse()` output
+must add the `extension.` segment. The bundled CEF parsers
+(`parse_cef` / `parse_fortigate_cef` / `parse_paloalto_cef`) are
+updated accordingly.
+
 ### Changed — transport / format unwrapping separated from vocabulary parsing (breaking)
 
 Bundled vocabulary parsers no longer unwrap their transport or format

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ limpid is for you.
 
 It is a log pipeline daemon where most of the work is *picking which pieces to use*.
 
-Suppose you want to ship FortiGate firewall logs to a security data lake in OCSF format. With limpid, that is just chaining three things:
+Suppose you want to ship FortiGate firewall logs to a security data lake in OCSF format. With limpid, that is just chaining a handful of named pieces:
 
 ```limpid
 def pipeline fortigate_to_security_lake {
     input   fortigate_syslog
-    process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     output  security_lake
 }
 ```
 
-The flow is right there in the config. Bytes arrive on `fortigate_syslog`; `parse_fortigate_cef` extracts structured fields into `workspace.lsis.parsed.*` (the LSIS facts layer); `compose_ocsf` dispatches on `workspace.lsis.parsed.class_uid` and emits the matching OCSF JSON to `workspace.lsis.composed.ocsf`; the companion `ocsf_to_egress` hands that slot off to `egress` and the result leaves through `security_lake`. No hidden behavior. No plugin to install. No separate "transform" config.
+The flow is right there in the config. Bytes arrive on `fortigate_syslog`; `parse_syslog` unwraps the syslog transport into `workspace.syslog.*`; `parse_cef` decodes the CEF format from the syslog body into `workspace.cef.*`; `parse_fortigate_cef` interprets the FortiGate dialect and writes structured facts into `workspace.lsis.parsed.*` (the LSIS facts layer); `compose_ocsf` dispatches on `workspace.lsis.parsed.class_uid` and emits the matching OCSF JSON to `workspace.lsis.composed.ocsf`; the companion `ocsf_to_egress` hands that slot off to `egress` and the result leaves through `security_lake`. No hidden behavior. No plugin to install. No separate "transform" config.
 
 In limpid, anything you want to do to a log on its way from input to output is achieved by freely combining `process`es.
 
 ## So what is a `process`?
 
-A reusable chunk of pipeline logic — small, named, drop-in. You write them yourself, or you include them from the snippet library (a curated collection introduced in **v0.7.0** and expanded across the 0.7.x line: 31 parser files (29 source / vocabulary parsers plus 2 transport parsers), 30 sibling per-source OTLP adapters, the OCSF 1.3.0 27-class composer, an OTLP envelope composer, and shared helper functions; full list — machine-generated from snippet headers — in [Snippet Library](packaging/snippets/README.md)). Here is what an OCSF Detection Finding composer leaf looks like under the hood:
+A reusable chunk of pipeline logic — small, named, drop-in. You write them yourself, or you include them from the snippet library (a curated collection introduced in **v0.7.0** and expanded across the 0.7.x line: 32 parser files (29 source / vocabulary parsers plus 3 transport / format parsers), 31 sibling per-source OTLP adapters, the OCSF 1.3.0 27-class composer, an OTLP envelope composer, and shared helper functions; full list — machine-generated from snippet headers — in [Snippet Library](packaging/snippets/README.md)). Here is what an OCSF Detection Finding composer leaf looks like under the hood:
 
 ```limpid
 def process compose_ocsf_detection_finding {
@@ -66,7 +66,7 @@ The day you need to ship Cisco ASA logs to the same destination, you include the
 
 A few we have already covered:
 
-- **Composable pieces.** Pipelines are chains of small named processes — `parse_fortigate_cef | compose_ocsf | route_by_severity`. Each piece is one responsibility, swappable, and reusable across pipelines.
+- **Composable pieces.** Pipelines are chains of small named processes — `parse_cef | parse_fortigate_cef | compose_ocsf | route_by_severity`. Each piece is one responsibility, swappable, and reusable across pipelines.
 
 - **Durable recovery sink, built in.** `control { error_log "..." }` persists payloads that retry-exhaust or fail the shutdown flush — operators get the recovery guarantee without writing their own DLQ wiring. `--check --strict-warnings` enforces it on configs that need it.
 
@@ -147,9 +147,9 @@ See the [Getting Started guide](docs/src/getting-started.md) for installation, .
 
 Curated parser / composer / filter library, installed under `/usr/share/limpid/snippets/` and `include`-able by absolute path. Introduced in **v0.7.0**, with the transport layer split out as its own snippet category in **v0.7.1** and the vendor lineup expanded across the 0.7.x line:
 
-- **Transport parsers (2, v0.7.1)** — `parse_syslog` (RFC 3164 / 5424 syslog wire) · `parse_journald` (systemd journald JSON). These populate `workspace.<transport>.*` and feed any vocabulary parser downstream via an inline bridge.
+- **Transport / format parsers (3)** — `parse_syslog` (RFC 3164 / 5424 syslog wire, v0.7.1) · `parse_journald` (systemd journald JSON, v0.7.1) · `parse_cef` (ArcSight CEF format from a syslog body, with a generic `cef_to_otlp` adapter). These populate `workspace.<layer>.*` and feed any vocabulary parser downstream — vendor CEF parsers chain as `parse_syslog | parse_cef | parse_<vendor>_cef`.
 - **Source / vocabulary parsers (29)** — security devices / cloud audit: `parse_fortigate_cef` · `parse_fortigate_syslog` · `parse_paloalto_cef` · `parse_paloalto_syslog` · `parse_asa` · `parse_cloudtrail` · `parse_juniper_srx_sd_syslog` (Junos structured-data) · `parse_juniper_srx_syslog` (Junos unstructured RT_IDP) · `parse_checkpoint_leef` (LEEF 2.0 / QRadar) · `parse_checkpoint_syslog` (Check Point Syslog Exporter) · `parse_nsp` (Trellix Network Security Platform). OSS NDR: `parse_suricata` (EVE JSON) · `parse_zeek_default` / `parse_zeek_soc` / `parse_zeek_full` (Zeek 8 / 20 / 43 protocol scripts, nested-superset scopes, with `_native` / `_flat` convenience variants for raw Zeek vs Filebeat-flat upstream). Cloud (audit / data-plane / findings / identity / orchestration): `parse_aws_guardduty` · `parse_aws_vpc_flow` · `parse_azure_activity` · `parse_k8s_audit` · `parse_okta_system`. Server / host vocabulary: `parse_openssh` · `parse_sudo` · `parse_combined_log` (Apache / Nginx) · `parse_postfix` · `parse_winevent_json` · `parse_sysmon` · `parse_bind` · `parse_auditd` (7 LSIS classes). Vendor-neutral: `parse_ocsf`.
-- **Composers (4)** — `compose_ocsf` (OCSF 1.3.0 priority set, 27 classes, dispatched by `workspace.lsis.parsed.class_uid`) · `compose_rfc5424` (generic RFC 5424 record composer with a `journald_to_rfc5424` bridge for edge → syslog-relay use, v0.7.1) · `compose_replayable` (replay-shape capture) · `compose_otlp` (assembles OTLP 1.0.0 `ResourceLogs` proto bytes from 30 parser-owned source adapters, ten optional shed slots, and canonical parsed time/severity). Composers write to `workspace.lsis.composed.<slot>`; a companion `<slot>_to_egress` one-line process (shipped alongside each composer) moves the slot to `egress` under the egress single-writer invariant.
+- **Composers (4)** — `compose_ocsf` (OCSF 1.3.0 priority set, 27 classes, dispatched by `workspace.lsis.parsed.class_uid`) · `compose_rfc5424` (generic RFC 5424 record composer with a `journald_to_rfc5424` bridge for edge → syslog-relay use, v0.7.1) · `compose_replayable` (replay-shape capture) · `compose_otlp` (assembles OTLP 1.0.0 `ResourceLogs` proto bytes from 31 parser-owned source adapters, ten optional shed slots, and canonical parsed time/severity). Composers write to `workspace.lsis.composed.<slot>`; a companion `<slot>_to_egress` one-line process (shipped alongside each composer) moves the slot to `egress` under the egress single-writer invariant.
 - **Filters (1)** — `filter_openssh_journal` (drops PAM session double-count noise from journald sshd streams).
 
 Each parser writes facts to `workspace.lsis.parsed.*` (the LSIS facts layer — the Limpid Snippet Intermediate Schema, a three-layer gentleman's agreement documented in the [pack snippet README](packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema)); `compose_ocsf` reads from it and emits OCSF JSON to `workspace.lsis.composed.ocsf`, and the companion `ocsf_to_egress` hands the slot off to `egress`. Two `include` lines + a two-stage pipeline gets vendor logs into a SIEM / data lake in OCSF form. Full reference: [Snippet Library](packaging/snippets/README.md).

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -176,7 +176,8 @@ pub struct OwnedEvent {
     /// captured under a per-schema namespace
     /// (`workspace.syslog = syslog.parse(ingress)` then
     /// `workspace.syslog.timestamp`; CEF's `rt` extension surfaces as
-    /// `workspace.cef.rt` after `workspace.cef = cef.parse(...)`).
+    /// `workspace.cef.extension.rt` after
+    /// `workspace.cef = cef.parse(...)`).
     pub received_at: DateTime<Utc>,
     pub source: SocketAddr,
     pub ingress: Bytes,

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -79,28 +79,43 @@ fn parse_impl<'bump>(
         .strip_prefix("CEF:")
         .ok_or_else(|| anyhow::anyhow!("cef.parse(): input does not start with `CEF:`"))?;
 
+    // Of the escapes the CEF specification defines, two are generic
+    // structural escapes relevant to header field splitting: `\|`
+    // (literal pipe) and `\\` (literal backslash). Only an unescaped
+    // `|` is a field separator; a naive `find('|')` would split on the
+    // escaped form and shift every subsequent header field (name
+    // absorbs the fragment, severity receives the next field,
+    // extensions receive the severity). The spec's field-specific
+    // escaping (`=` / `%` / `#` when carrying vulnerability spellings
+    // in deviceEventClassId / name) is field-internal grammar this
+    // generic primitive does not interpret — those spellings pass
+    // through raw.
     let mut parts: [&str; 7] = [""; 7];
     let mut remaining = body;
     for slot in parts.iter_mut() {
-        if let Some(pos) = remaining.find('|') {
-            *slot = &remaining[..pos];
-            remaining = &remaining[pos + 1..];
+        if let Some((field, rest)) = split_unescaped_pipe(remaining) {
+            *slot = field;
+            remaining = rest;
         } else {
             bail!("cef.parse(): incomplete CEF header");
         }
     }
 
     let mut builder = ObjectBuilder::new(arena);
-    builder.push("version", Value::String(arena.alloc_str(parts[0])));
-    builder.push("device_vendor", Value::String(arena.alloc_str(parts[1])));
-    builder.push("device_product", Value::String(arena.alloc_str(parts[2])));
-    builder.push("device_version", Value::String(arena.alloc_str(parts[3])));
-    builder.push("signature_id", Value::String(arena.alloc_str(parts[4])));
-    builder.push("name", Value::String(arena.alloc_str(parts[5])));
-    let severity_value = parts[6]
+    builder.push("version", unescape_header_field(arena, parts[0]));
+    builder.push("device_vendor", unescape_header_field(arena, parts[1]));
+    builder.push("device_product", unescape_header_field(arena, parts[2]));
+    builder.push("device_version", unescape_header_field(arena, parts[3]));
+    builder.push("signature_id", unescape_header_field(arena, parts[4]));
+    builder.push("name", unescape_header_field(arena, parts[5]));
+    let severity_text = match unescape_header_field(arena, parts[6]) {
+        Value::String(s) => s,
+        _ => unreachable!("unescape_header_field always returns a String"),
+    };
+    let severity_value = severity_text
         .parse::<i64>()
         .map(Value::Int)
-        .unwrap_or_else(|_| Value::String(arena.alloc_str(parts[6])));
+        .unwrap_or(Value::String(severity_text));
     builder.push("severity", severity_value);
 
     // Emit the raw extension blob (omitted when empty, to mirror
@@ -129,6 +144,62 @@ fn parse_impl<'bump>(
     } else {
         Ok(parsed)
     }
+}
+
+/// Split the input at the first **unescaped** `|`, returning the raw
+/// (still-escaped) field and the rest after the separator.
+///
+/// A `\` consumes the following byte, so `\|` never separates and the
+/// pipe after `\\` (an escaped backslash) does — `a\\|b` splits into
+/// the field `a\\` and rest `b`. Scanning bytes is UTF-8-safe because
+/// `\` and `|` are ASCII and cannot occur inside a multi-byte sequence.
+fn split_unescaped_pipe(input: &str) -> Option<(&str, &str)> {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if i + 1 < bytes.len() => i += 2,
+            b'|' => return Some((&input[..i], &input[i + 1..])),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Decode the generic structural header escapes in a raw field:
+/// `\|` → `|` and `\\` → `\` — the two escapes that participate in
+/// field splitting. The spec's field-specific escaping (`=` / `%` /
+/// `#` for vulnerability spellings in deviceEventClassId / name) is
+/// field-internal grammar this generic primitive does not interpret;
+/// those spellings are preserved raw. Sequences outside the two
+/// structural escapes (`\x`, …) and a trailing lone `\` are kept
+/// literally — lenient by design, so a producer's stray backslash
+/// degrades to visible bytes instead of a parse error or silent data
+/// loss. Extension-section escapes are a separate scope and are
+/// deliberately not decoded here (see the `extension_raw` FieldSpec
+/// note).
+fn unescape_header_field<'bump>(arena: &'bump EventArena<'bump>, field: &str) -> Value<'bump> {
+    if !field.contains('\\') {
+        return Value::String(arena.alloc_str(field));
+    }
+    let mut out = String::with_capacity(field.len());
+    let mut chars = field.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('|') => out.push('|'),
+                Some('\\') => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    Value::String(arena.alloc_str(&out))
 }
 
 fn parse_cef_extensions<'bump>(
@@ -509,18 +580,14 @@ mod tests {
     }
 
     #[test]
-    fn header_with_escaped_pipe_keeps_literal() {
-        // CEF spec: `\|` inside a header field is a literal pipe, NOT
-        // a field separator. A regression that split on every `|`
-        // unconditionally would corrupt every CEF event with a piped
-        // value (common in proxy logs). Pin the current behaviour so
-        // a refactor of the header splitter can't silently drop the
-        // escape handling.
-        //
-        // NOTE: this test pins whatever behaviour parse_cef_header
-        // implements TODAY. If the parser doesn't currently handle
-        // `\|` as an escape it will assert on the byte-split result;
-        // either way the test guards against silent changes.
+    fn header_escaped_pipe_is_literal_not_separator() {
+        // CEF spec: `\|` inside a header field is a literal pipe, NOT a
+        // field separator. Splitting on it shifts every subsequent
+        // header field — name absorbed `deny\`, severity received
+        // `drop`, and the extension blob received `3|act=block`, so the
+        // positionally-determined severity was silently misclassified
+        // downstream. The splitter must honor the escape and the stored
+        // field must be unescaped.
         let bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let owned = dummy_event();
@@ -529,16 +596,154 @@ mod tests {
         // 7 fields; the `name` field contains an escaped pipe.
         let line = arena.alloc_str("CEF:0|V|P|1.0|sig|deny\\|drop|3|act=block");
         let v = parse_into(&reg, &bevent, &arena, line);
-        // Just verify parse succeeded and produced an Object — the
-        // exact name value depends on whether the parser unescapes.
-        // The regression we care about is "splitter doesn't blow up
-        // on escaped pipe AND the 7-field shape is preserved".
         let Value::Object(entries) = v else {
             panic!("expected Object on escaped-pipe input");
         };
-        // The trailing `act=block` is what tells us the 7-field
-        // count was respected (the 8th field is the extension blob).
+        assert_eq!(lookup(entries, "name"), Some(Value::String("deny|drop")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("act=block"))
+        );
         assert_eq!(ext_lookup(entries, "act"), Some(Value::String("block")));
+    }
+
+    #[test]
+    fn header_escaped_backslash_unescapes_to_single_backslash() {
+        // CEF spec: `\\` inside a header field is a literal backslash.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|A\\\\B|1.0|sig|name|3|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(
+            lookup(entries, "device_product"),
+            Some(Value::String("A\\B"))
+        );
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+    }
+
+    #[test]
+    fn header_pipe_after_escaped_backslash_separates() {
+        // `\\` consumes both backslashes, so the pipe that follows an
+        // escaped backslash IS a separator: the field `a\\` ends there
+        // and unescapes to `a\`.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|a\\\\|P|1.0|sig|name|3|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(lookup(entries, "device_vendor"), Some(Value::String("a\\")));
+        assert_eq!(lookup(entries, "device_product"), Some(Value::String("P")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+    }
+
+    #[test]
+    fn header_undefined_escape_is_preserved() {
+        // Only `\|` and `\\` are the generic structural escapes that
+        // participate in field splitting. A sequence outside those two
+        // (`\x`) is kept literally (lenient): a producer's stray
+        // backslash degrades to visible bytes rather than a parse
+        // error or silent loss.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|a\\xb|1.0|sig|tail\\|3|7|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        // `\x` is not a structural escape — both bytes survive.
+        assert_eq!(
+            lookup(entries, "device_product"),
+            Some(Value::String("a\\xb"))
+        );
+        // The `\|` inside `tail\|3` is consumed as an escape, so the
+        // name field runs through the literal pipe to the next
+        // unescaped separator — name `tail|3`, severity 7 from the
+        // following field.
+        assert_eq!(lookup(entries, "name"), Some(Value::String("tail|3")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(7)));
+    }
+
+    #[test]
+    fn header_unescape_preserves_trailing_backslash() {
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+
+        assert_eq!(
+            unescape_header_field(&arena, "tail\\"),
+            Value::String("tail\\")
+        );
+    }
+
+    #[test]
+    fn extension_raw_trailing_backslash_is_preserved() {
+        // A trailing lone `\` at the end of the *extension* section
+        // reaches `extension_raw` unmodified — the extension plane is
+        // not header-unescaped. (A complete header field ending in a
+        // lone `\` is structurally unobservable through the splitter:
+        // an odd backslash immediately before `|` always reads as the
+        // `\|` escape, so the header-side lone-backslash policy is
+        // exercised only via the unescape helper's terminal branch.)
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|P|1.0|sig|name|3|msg=x\\");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("msg=x\\"))
+        );
+    }
+
+    #[test]
+    fn header_escape_handles_utf8_and_odd_backslash_parity() {
+        // Pin two shapes the reviewer confirmed the splitter handles:
+        // multi-byte UTF-8 around an escaped pipe (the byte scan keys
+        // on ASCII `\` / `|`, which cannot occur inside a multi-byte
+        // sequence), and odd backslash parity before a pipe —
+        // `a\\\|b` is an escaped backslash followed by an escaped
+        // pipe, so nothing separates and the field unescapes to
+        // `a\|b`.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|日本\\|語|1.0|sig|a\\\\\\|b|3|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(
+            lookup(entries, "device_product"),
+            Some(Value::String("日本|語"))
+        );
+        assert_eq!(lookup(entries, "name"), Some(Value::String("a\\|b")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("act=block"))
+        );
     }
 
     #[test]

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -8,6 +8,18 @@
 //!
 //! The input must start with `CEF:` — syslog wrapper handling is the
 //! caller's responsibility.
+//!
+//! The seven positionally-determined header fields land as direct keys
+//! of the result object; the data-driven Extension key=value pairs are
+//! isolated under the nested `extension` sub-object (raw blob under
+//! `extension_raw`). The two planes carry different trust: header
+//! values are fixed by position, extension keys are whatever the
+//! producer (or an injected payload) put on the wire, so they must not
+//! share a namespace. Before this split, an extension such as
+//! `severity=9` or `name=x` was pushed as a duplicate sibling of the
+//! header key — arena field reads resolved first-wins (header) but the
+//! owned workspace snapshot resolved last-wins, so downstream processes
+//! saw the header value silently replaced by the extension value.
 
 use crate::dsl::arena::EventArena;
 use crate::dsl::value::{ObjectBuilder, Value};
@@ -37,15 +49,19 @@ pub fn register(reg: &mut FunctionRegistry) {
                 FieldType::Union(vec![FieldType::Int, FieldType::String]),
             ),
             // Raw extension blob, as it appeared on the wire (before
-            // the `key=value` split that flattens individual fields
-            // into siblings of the header keys). Present only when the
-            // Extension section was non-empty; omitted otherwise to
-            // mirror `syslog.parse`'s treatment of `msg`. Useful for
+            // the `key=value` split). Present only when the Extension
+            // section was non-empty; omitted otherwise to mirror
+            // `syslog.parse`'s treatment of `msg`. Useful for
             // passthrough / re-emission, debugging the splitter, or
             // surfacing dialect-specific extension content that the
             // splitter doesn't decode (escape sequences, custom
             // separators).
-            FieldSpec::new(&["workspace", "ext"], FieldType::String),
+            FieldSpec::new(&["workspace", "extension_raw"], FieldType::String),
+            // Split extension key=value pairs, isolated in their own
+            // sub-object so data-driven keys can never collide with the
+            // positional header fields above. Individual keys are
+            // data-driven (wildcards).
+            FieldSpec::new(&["workspace", "extension"], FieldType::Object),
         ],
         wildcards: true,
         defaults_arg_indices: &[1],
@@ -88,15 +104,17 @@ fn parse_impl<'bump>(
     builder.push("severity", severity_value);
 
     // Emit the raw extension blob (omitted when empty, to mirror
-    // `syslog.parse`'s treatment of `msg`). This must come BEFORE the
-    // split so the raw form is captured before the splitter consumes
-    // its input; the split itself does not mutate `remaining`, but
-    // keeping the ordering explicit avoids future regressions.
+    // `syslog.parse`'s treatment of `msg`), then the split pairs in
+    // their own `extension` sub-object. The nesting is the collision
+    // barrier: extension keys named after header fields (`severity=`,
+    // `name=`, dialect quirks or log injection alike) stay in the
+    // extension plane and can never shadow a positional header value.
     if !remaining.is_empty() {
-        builder.push("ext", Value::String(arena.alloc_str(remaining)));
+        builder.push("extension_raw", Value::String(arena.alloc_str(remaining)));
+        let mut ext_builder = ObjectBuilder::new(arena);
+        parse_cef_extensions(arena, remaining, &mut ext_builder);
+        builder.push("extension", ext_builder.finish());
     }
-
-    parse_cef_extensions(arena, remaining, &mut builder);
 
     let parsed = builder.finish();
 
@@ -210,6 +228,17 @@ mod tests {
             .expect("parse should succeed")
     }
 
+    /// Look a key up inside the nested `extension` sub-object.
+    fn ext_lookup<'bump>(
+        entries: &'bump [(&'bump str, Value<'bump>)],
+        key: &str,
+    ) -> Option<Value<'bump>> {
+        let Some(Value::Object(ext)) = lookup(entries, "extension") else {
+            return None;
+        };
+        lookup(ext, key)
+    }
+
     #[test]
     fn header_fields_extracted() {
         let bump = ::bumpalo::Bump::new();
@@ -241,11 +270,11 @@ mod tests {
     }
 
     #[test]
-    fn extension_split_into_flat_keys_and_raw_ext() {
-        // Both forms must be present: the flat per-key form
-        // (`workspace.cef.src` etc., the documented authoring
-        // surface) AND the raw `ext` blob (the spec-bug fix —
-        // previously the raw form was lost).
+    fn extension_split_into_nested_keys_and_raw_blob() {
+        // Both forms must be present: the split per-key form under the
+        // nested `extension` sub-object (the documented authoring
+        // surface, isolated from the positional header plane) AND the
+        // raw `extension_raw` blob.
         let bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let owned = dummy_event();
@@ -258,24 +287,24 @@ mod tests {
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        // Flat per-key form
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
-        assert_eq!(lookup(entries, "dst"), Some(Value::String("10.0.0.2")));
-        assert_eq!(lookup(entries, "act"), Some(Value::String("accept")));
-        // Raw ext blob
+        // Split per-key form, isolated under `extension`
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "dst"), Some(Value::String("10.0.0.2")));
+        assert_eq!(ext_lookup(entries, "act"), Some(Value::String("accept")));
+        // Raw blob
         assert_eq!(
-            lookup(entries, "ext"),
+            lookup(entries, "extension_raw"),
             Some(Value::String("src=10.0.0.1 dst=10.0.0.2 act=accept"))
         );
     }
 
     #[test]
-    fn empty_extensions_omits_ext_field() {
-        // CEF allows an empty Extension section. When empty, `ext`
-        // must be omitted entirely (mirrors syslog.parse's treatment
-        // of empty `msg`), so callers can write `if workspace.cef.ext
-        // { ... }` against a presence test rather than against an
-        // empty-string test.
+    fn empty_extensions_omits_extension_fields() {
+        // CEF allows an empty Extension section. When empty, both
+        // `extension_raw` and the `extension` sub-object must be
+        // omitted entirely (mirrors syslog.parse's treatment of empty
+        // `msg`), so callers can write presence tests rather than
+        // empty-string tests.
         let bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let owned = dummy_event();
@@ -289,10 +318,14 @@ mod tests {
         // Header still emitted.
         assert_eq!(lookup(entries, "version"), Some(Value::String("0")));
         assert_eq!(lookup(entries, "severity"), Some(Value::Int(5)));
-        // ext must be absent (not "" or null).
+        // Both extension planes must be absent (not "" or null).
         assert!(
-            lookup(entries, "ext").is_none(),
-            "ext key must be omitted when Extensions are empty"
+            lookup(entries, "extension_raw").is_none(),
+            "extension_raw must be omitted when Extensions are empty"
+        );
+        assert!(
+            lookup(entries, "extension").is_none(),
+            "extension sub-object must be omitted when Extensions are empty"
         );
     }
 
@@ -333,11 +366,11 @@ mod tests {
             panic!("expected Object");
         };
         assert_eq!(
-            lookup(entries, "msg"),
+            ext_lookup(entries, "msg"),
             Some(Value::String("Failed login attempt"))
         );
-        assert_eq!(lookup(entries, "user"), Some(Value::String("alice")));
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "user"), Some(Value::String("alice")));
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
     }
 
     #[test]
@@ -439,10 +472,10 @@ mod tests {
             panic!("expected Object");
         };
         assert_eq!(
-            lookup(entries, "request"),
+            ext_lookup(entries, "request"),
             Some(Value::String("https://x.example.com/a?b=1&c=2"))
         );
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
     }
 
     #[test]
@@ -464,12 +497,15 @@ mod tests {
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        assert_eq!(lookup(entries, "vendor_field"), Some(Value::String("v1")));
         assert_eq!(
-            lookup(entries, "cs1Label"),
+            ext_lookup(entries, "vendor_field"),
+            Some(Value::String("v1"))
+        );
+        assert_eq!(
+            ext_lookup(entries, "cs1Label"),
             Some(Value::String("Source IP"))
         );
-        assert_eq!(lookup(entries, "cs1"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "cs1"), Some(Value::String("10.0.0.1")));
     }
 
     #[test]
@@ -502,7 +538,7 @@ mod tests {
         };
         // The trailing `act=block` is what tells us the 7-field
         // count was respected (the 8th field is the extension blob).
-        assert_eq!(lookup(entries, "act"), Some(Value::String("block")));
+        assert_eq!(ext_lookup(entries, "act"), Some(Value::String("block")));
     }
 
     #[test]
@@ -510,8 +546,9 @@ mod tests {
         // Some vendors emit the same key twice (intentionally for
         // multi-value sources, accidentally for buggy templates).
         // `ObjectBuilder` does not deduplicate, so both `src` entries
-        // are emitted in source order; `lookup` returns the first
-        // match, making the observable semantics first-one-wins. Pin
+        // are emitted in source order inside the `extension`
+        // sub-object; `ext_lookup` returns the first match, making the
+        // observable semantics first-one-wins. Pin
         // it here so a future change to dedup or reverse insertion
         // order is a visible, intentional break instead of a silent
         // downstream-pipeline behaviour flip.
@@ -526,7 +563,50 @@ mod tests {
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
-        assert_eq!(lookup(entries, "dst"), Some(Value::String("8.8.8.8")));
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "dst"), Some(Value::String("8.8.8.8")));
+    }
+
+    #[test]
+    fn header_named_extension_keys_cannot_shadow_header_fields() {
+        // Extensions named after header fields (`severity=`, `name=`,
+        // `ext=`) — dialect quirks, buggy templates, or log injection —
+        // must stay isolated in the `extension` sub-object. Before the
+        // split, `ObjectBuilder` pushed them as duplicate siblings of
+        // the header keys: arena field reads resolved first-wins (the
+        // header), but the owned workspace snapshot resolved last-wins,
+        // so a downstream process read `severity = "9"` in place of the
+        // positional header value 7. The nesting removes the duplicate
+        // keys entirely.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena
+            .alloc_str("CEF:0|Vendor|Product|1.0|100|realname|7|severity=9 name=fakename ext=x");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        // Header plane untouched.
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(7)));
+        assert_eq!(lookup(entries, "name"), Some(Value::String("realname")));
+        // No duplicate top-level keys: each header key appears once.
+        for key in ["severity", "name"] {
+            assert_eq!(
+                entries.iter().filter(|(k, _)| *k == key).count(),
+                1,
+                "header key {key} must appear exactly once"
+            );
+        }
+        // Colliding extensions isolated in the extension plane.
+        assert_eq!(ext_lookup(entries, "severity"), Some(Value::String("9")));
+        assert_eq!(ext_lookup(entries, "name"), Some(Value::String("fakename")));
+        assert_eq!(ext_lookup(entries, "ext"), Some(Value::String("x")));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("severity=9 name=fakename ext=x"))
+        );
     }
 }

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -1472,6 +1472,7 @@ def pipeline p {
             "packaging/snippets/parsers/parse_azure_activity.limpid",
             "packaging/snippets/parsers/parse_bind.limpid",
             "packaging/snippets/parsers/parse_checkpoint_leef.limpid",
+            "packaging/snippets/parsers/parse_cef.limpid",
             "packaging/snippets/parsers/parse_checkpoint_syslog.limpid",
             "packaging/snippets/parsers/parse_cloudtrail.limpid",
             "packaging/snippets/parsers/parse_combined_log.limpid",
@@ -1577,7 +1578,13 @@ def pipeline suricata_otlp {
 
 def pipeline asa_otlp {
     input i
-    process parse_asa | asa_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_asa | asa_to_otlp | compose_otlp | otlp_to_egress
+    output o
+}
+
+def pipeline cef_otlp {
+    input i
+    process parse_syslog | parse_cef | cef_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
@@ -1595,7 +1602,7 @@ def pipeline checkpoint_syslog_otlp {
 
 def pipeline fortigate_cef_otlp {
     input i
-    process parse_fortigate_cef | fortigate_cef_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | fortigate_cef_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
@@ -1619,13 +1626,13 @@ def pipeline nsp_otlp {
 
 def pipeline paloalto_cef_otlp {
     input i
-    process parse_paloalto_cef | paloalto_cef_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_cef | parse_paloalto_cef | paloalto_cef_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
 def pipeline paloalto_native_otlp {
     input i
-    process parse_paloalto_syslog | paloalto_syslog_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_paloalto_syslog | paloalto_syslog_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
@@ -1712,7 +1719,7 @@ def pipeline zeek_full_otlp {
     }
 
     fn run_packaged_parser_pipeline(
-        parser: &str,
+        parsers: &[&str],
         setup: Option<&str>,
         process: &str,
         ingress: &[u8],
@@ -1728,7 +1735,10 @@ def pipeline zeek_full_otlp {
             .prefix(".limpid-parser-test-")
             .tempfile_in(&snippets)
             .expect("temporary packaged parser config");
-        writeln!(config_file, "include \"parsers/{parser}.limpid\"").expect("write parser include");
+        for parser in parsers {
+            writeln!(config_file, "include \"parsers/{parser}.limpid\"")
+                .expect("write parser include");
+        }
         writeln!(
             config_file,
             "def input i {{ type syslog_tcp bind \"127.0.0.1:5514\" }}\n\
@@ -1781,12 +1791,12 @@ def pipeline zeek_full_otlp {
     }
 
     fn run_packaged_parser_json(
-        parser: &str,
+        parsers: &[&str],
         setup: Option<&str>,
         process: &str,
         ingress: &[u8],
     ) -> serde_json::Value {
-        let result = run_packaged_parser_pipeline(parser, setup, process, ingress);
+        let result = run_packaged_parser_pipeline(parsers, setup, process, ingress);
         assert_eq!(
             result.termination,
             PipelineTermination::Finished,
@@ -1847,9 +1857,9 @@ def pipeline zeek_full_otlp {
             .expect("fixture fits i64");
 
         let asa = run_packaged_parser_json(
-            "parse_asa",
+            &["parse_syslog", "parse_asa"],
             Some("workspace.asa = { timezone: \"UTC\" }"),
-            "parse_asa",
+            "parse_syslog | parse_asa",
             format!(
                 "<165>{rfc3164_wire} fw-asa01 : %ASA-6-605005: Login permitted from 192.0.2.10/54321 to outside:198.51.100.5/SSH for user admin"
             )
@@ -1858,7 +1868,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(asa["time"], rfc3164_expected);
 
         let auditd = run_packaged_parser_json(
-            "parse_auditd",
+            &["parse_auditd"],
             Some("workspace.auditd = { body: ingress }"),
             "parse_auditd",
             b"type=USER_LOGIN msg=audit(1710000000.123:1): pid=42 uid=0 auid=1000 ses=1 res=success acct=alice addr=192.0.2.10 terminal=pts/0 exe=/usr/bin/login",
@@ -1866,7 +1876,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(auditd["time"], 1_710_000_000_123_000_000_i64);
 
         let bind = run_packaged_parser_json(
-            "parse_bind",
+            &["parse_bind"],
             Some(
                 "workspace.bind = { body: ingress, hostname: \"dns01\", timezone: \"Asia/Tokyo\" }",
             ),
@@ -1876,7 +1886,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(bind["time"], 1_777_512_225_123_000_000_i64);
 
         let checkpoint_leef = run_packaged_parser_json(
-            "parse_checkpoint_leef",
+            &["parse_checkpoint_leef"],
             Some("workspace.checkpoint_leef = { body: ingress }"),
             "parse_checkpoint_leef",
             b"<14>1 2026-04-30T01:23:45.123456789Z cpgw01 CheckPoint - - LEEF:2.0|Check Point|VPN-1 & FireWall-1|R81|Accept|src=192.0.2.10\tdst=198.51.100.5\tsrcPort=51234\tdstPort=443\tproto=tcp\taction=Accept",
@@ -1884,7 +1894,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(checkpoint_leef["time"], 1_777_512_225_123_456_789_i64);
 
         let checkpoint_syslog = run_packaged_parser_json(
-            "parse_checkpoint_syslog",
+            &["parse_checkpoint_syslog"],
             Some("workspace.checkpoint_syslog = { body: ingress }"),
             "parse_checkpoint_syslog",
             b"<14>1 2026-04-30T01:23:45.123456789Z cpgw01 CheckPoint - - [action:\"Accept\"; src:\"192.0.2.10\"; dst:\"198.51.100.5\"; service:\"443\"; proto:\"tcp\"; product:\"VPN-1 & FireWall-1\"; severity:\"Low\"]",
@@ -1892,9 +1902,9 @@ def pipeline zeek_full_otlp {
         assert_eq!(checkpoint_syslog["time"], 1_777_512_225_123_456_789_i64);
 
         let fortigate_cef = run_packaged_parser_json(
-            "parse_fortigate_cef",
+            &["parse_syslog", "parse_cef", "parse_fortigate_cef"],
             Some("workspace.fortigate_cef = { timezone: \"UTC\" }"),
-            "parse_fortigate_cef",
+            "parse_syslog | parse_cef | parse_fortigate_cef",
             format!(
                 "<129>{rfc3164_wire} fw01 CEF:0|Fortinet|Fortigate|v7.4.11|16384|utm:ips signature|7|cat=utm:ips src=192.0.2.10 dst=198.51.100.5 proto=6 act=detected FTNTFGTattack=test FTNTFGTattackid=42"
             )
@@ -1903,7 +1913,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(fortigate_cef["time"], rfc3164_expected);
 
         let fortigate_native = run_packaged_parser_json(
-            "parse_fortigate_syslog",
+            &["parse_fortigate_syslog"],
             None,
             "parse_fortigate_syslog",
             b"<134>eventtime=1777284000123456789 level=notice type=traffic subtype=forward srcip=192.0.2.10 dstip=198.51.100.5 proto=6 action=accept",
@@ -1911,7 +1921,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(fortigate_native["time"], 1_777_284_000_123_456_789_i64);
 
         let juniper_sd = run_packaged_parser_json(
-            "parse_juniper_srx_sd_syslog",
+            &["parse_juniper_srx_sd_syslog"],
             Some("workspace.juniper_srx_sd_syslog = { body: ingress }"),
             "parse_juniper_srx_sd_syslog",
             b"<14>1 2026-04-30T01:23:45.123456789Z srx01 RT_FLOW - RT_FLOW_SESSION_CREATE [junos@2636 source-address=\"192.0.2.10\" source-port=\"54321\" destination-address=\"198.51.100.5\" destination-port=\"443\" protocol-id=\"6\" policy-name=\"allow-web\"]",
@@ -1919,7 +1929,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(juniper_sd["time"], 1_777_512_225_123_456_789_i64);
 
         let juniper_legacy = run_packaged_parser_json(
-            "parse_juniper_srx_syslog",
+            &["parse_juniper_srx_syslog"],
             Some(
                 "workspace.juniper_srx_syslog = { body: ingress, timezone: \"UTC\" }",
             ),
@@ -1932,7 +1942,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(juniper_legacy["time"], rfc3164_expected);
 
         let nsp = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some(
                 "workspace.nsp = { body: ingress, hostname: \"nsp01\", timezone: \"+09:00\" }",
             ),
@@ -1948,9 +1958,9 @@ def pipeline zeek_full_otlp {
         assert_eq!(nsp["time"], nsp_expected);
 
         let paloalto_cef = run_packaged_parser_json(
-            "parse_paloalto_cef",
+            &["parse_syslog", "parse_cef", "parse_paloalto_cef"],
             Some("workspace.paloalto_cef = { timezone: \"UTC\" }"),
-            "parse_paloalto_cef",
+            "parse_syslog | parse_cef | parse_paloalto_cef",
             format!(
                 "<134>{rfc3164_wire} fw-pan01 CEF:0|Palo Alto Networks|PAN-OS|10.2.0|end|TRAFFIC|3|src=192.0.2.10 dst=198.51.100.5 proto=tcp act=allow"
             )
@@ -1960,15 +1970,15 @@ def pipeline zeek_full_otlp {
 
         let paloalto_native_wire = paloalto_traffic_wire("2026/04/30 10:23:45");
         let paloalto_native = run_packaged_parser_json(
-            "parse_paloalto_syslog",
+            &["parse_syslog", "parse_paloalto_syslog"],
             Some("workspace.paloalto_syslog = { timezone: \"Asia/Tokyo\" }"),
-            "parse_paloalto_syslog",
+            "parse_syslog | parse_paloalto_syslog",
             &paloalto_native_wire,
         );
         assert_eq!(paloalto_native["time"], 1_777_512_225_000_000_000_i64);
 
         let sysmon = run_packaged_parser_json(
-            "parse_sysmon",
+            &["parse_sysmon"],
             Some("workspace.sysmon = { body: parse_json(ingress) }"),
             "parse_sysmon",
             br#"{"EventID":11,"EventTime":"2026-04-30T01:23:45.123456789Z","Computer":"host01","EventData":{"TargetFilename":"C:\\Temp\\x.txt","User":"alice","Image":"C:\\Windows\\cmd.exe","ProcessId":"42"}}"#,
@@ -1976,7 +1986,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(sysmon["time"], 1_777_512_225_123_456_789_i64);
 
         let vpc = run_packaged_parser_json(
-            "parse_aws_vpc_flow",
+            &["parse_aws_vpc_flow"],
             None,
             "parse_aws_vpc_flow",
             b"2 123456789012 eni-0a1b2c3d4e5f6a7b8 192.0.2.10 198.51.100.5 54321 443 6 10 4000 1714000000 1714000060 ACCEPT OK",
@@ -2003,7 +2013,7 @@ def pipeline zeek_full_otlp {
         }
 
         let bind_default_timezone = run_packaged_parser_json(
-            "parse_bind",
+            &["parse_bind"],
             Some("workspace.bind = { body: ingress }"),
             "parse_bind",
             b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)",
@@ -2018,7 +2028,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(bind_default_timezone["time"], bind_default_expected);
 
         let bind_override = run_packaged_parser_json(
-            "parse_bind",
+            &["parse_bind"],
             Some("workspace.bind = { body: ingress, timezone: \"UTC\" }"),
             "parse_bind",
             b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)",
@@ -2034,7 +2044,7 @@ def pipeline zeek_full_otlp {
 
         let nsp_body = b"admin_domain=Default alert_id=12345 alert_type=Signature app_protocol=HTTP confidence=Tentative attack_count=1 attack_id=42 attack_name=Example severity=High alert_signature=SIG attack_time=2026-05-16 10:00:00 category=Exploit dest_ip=192.0.2.10 dest_name=web01 dest_port=80 device_name=nsp01 direction=Inbound confidence= file_name= file_hash= file_type= virus_name= action_status= error_status= protocol=TCP result=Blocked src_ip=198.51.100.5 src_name= src_port=54321";
         let nsp_default_timezone = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some("workspace.nsp = { body: ingress }"),
             "parse_nsp",
             nsp_body,
@@ -2054,7 +2064,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(nsp_default_timezone["time"], nsp_local_expected);
 
         let nsp_override = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some("workspace.nsp = { body: ingress, timezone: \"UTC\" }"),
             "parse_nsp",
             nsp_body,
@@ -2062,7 +2072,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(nsp_override["time"], nsp_utc_expected);
 
         let nsp_explicit_utc = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some("workspace.nsp = { body: ingress }"),
             "parse_nsp",
             b"admin_domain=Default alert_id=12345 alert_type=Signature app_protocol=HTTP confidence=Tentative attack_count=1 attack_id=42 attack_name=Example severity=High alert_signature=SIG attack_time=2026-05-16 10:00:00 UTC category=Exploit dest_ip=192.0.2.10 dest_name=web01 dest_port=80 device_name=nsp01 direction=Inbound confidence= file_name= file_hash= file_type= virus_name= action_status= error_status= protocol=TCP result=Blocked src_ip=198.51.100.5 src_name= src_port=54321",
@@ -2071,9 +2081,9 @@ def pipeline zeek_full_otlp {
 
         let paloalto_wire = paloalto_traffic_wire("2026/04/30 10:23:45");
         let paloalto_default_timezone = run_packaged_parser_json(
-            "parse_paloalto_syslog",
+            &["parse_syslog", "parse_paloalto_syslog"],
             None,
-            "parse_paloalto_syslog",
+            "parse_syslog | parse_paloalto_syslog",
             &paloalto_wire,
         );
         let paloalto_local_expected = chrono_tz::America::New_York
@@ -2085,9 +2095,9 @@ def pipeline zeek_full_otlp {
         assert_eq!(paloalto_default_timezone["time"], paloalto_local_expected);
 
         let paloalto_override = run_packaged_parser_json(
-            "parse_paloalto_syslog",
+            &["parse_syslog", "parse_paloalto_syslog"],
             Some("workspace.paloalto_syslog = { timezone: \"UTC\" }"),
-            "parse_paloalto_syslog",
+            "parse_syslog | parse_paloalto_syslog",
             &paloalto_wire,
         );
         let paloalto_override_expected = chrono::Utc
@@ -2100,39 +2110,39 @@ def pipeline zeek_full_otlp {
 
         for (parser, setup, process, ingress) in [
             (
-                "parse_bind",
+                &["parse_bind"][..],
                 "workspace.bind = { body: ingress, timezone: \"Not/AZone\" }",
                 "parse_bind",
                 b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)".as_slice(),
             ),
             (
-                "parse_nsp",
+                &["parse_nsp"][..],
                 "workspace.nsp = { body: ingress, timezone: \"Not/AZone\" }",
                 "parse_nsp",
                 nsp_body.as_slice(),
             ),
             (
-                "parse_paloalto_syslog",
+                &["parse_syslog", "parse_paloalto_syslog"][..],
                 "workspace.paloalto_syslog = { timezone: \"Not/AZone\" }",
-                "parse_paloalto_syslog",
+                "parse_syslog | parse_paloalto_syslog",
                 paloalto_wire.as_slice(),
             ),
             (
-                "parse_bind",
+                &["parse_bind"][..],
                 "workspace.bind = { body: ingress, timezone: \"local\" }",
                 "parse_bind",
                 b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)".as_slice(),
             ),
             (
-                "parse_nsp",
+                &["parse_nsp"][..],
                 "workspace.nsp = { body: ingress, timezone: \"local\" }",
                 "parse_nsp",
                 nsp_body.as_slice(),
             ),
             (
-                "parse_paloalto_syslog",
+                &["parse_syslog", "parse_paloalto_syslog"][..],
                 "workspace.paloalto_syslog = { timezone: \"local\" }",
-                "parse_paloalto_syslog",
+                "parse_syslog | parse_paloalto_syslog",
                 paloalto_wire.as_slice(),
             ),
         ] {
@@ -2195,7 +2205,8 @@ def pipeline zeek_full_otlp {
 
         let cases = [
             (
-                "parse_asa",
+                &["parse_syslog", "parse_asa"][..],
+                "parse_syslog | parse_asa",
                 "workspace.asa = { timezone: \"UTC\" }",
                 "workspace.asa = { timezone: \"Not/AZone\" }",
                 "workspace.asa = { timezone: \"local\" }",
@@ -2205,7 +2216,8 @@ def pipeline zeek_full_otlp {
                 .into_bytes(),
             ),
             (
-                "parse_fortigate_cef",
+                &["parse_syslog", "parse_cef", "parse_fortigate_cef"][..],
+                "parse_syslog | parse_cef | parse_fortigate_cef",
                 "workspace.fortigate_cef = { timezone: \"UTC\" }",
                 "workspace.fortigate_cef = { timezone: \"Not/AZone\" }",
                 "workspace.fortigate_cef = { timezone: \"local\" }",
@@ -2215,6 +2227,7 @@ def pipeline zeek_full_otlp {
                 .into_bytes(),
             ),
             (
+                &["parse_juniper_srx_syslog"][..],
                 "parse_juniper_srx_syslog",
                 "workspace.juniper_srx_syslog = { body: ingress, timezone: \"UTC\" }",
                 "workspace.juniper_srx_syslog = { body: ingress, timezone: \"Not/AZone\" }",
@@ -2225,7 +2238,8 @@ def pipeline zeek_full_otlp {
                 .into_bytes(),
             ),
             (
-                "parse_paloalto_cef",
+                &["parse_syslog", "parse_cef", "parse_paloalto_cef"][..],
+                "parse_syslog | parse_cef | parse_paloalto_cef",
                 "workspace.paloalto_cef = { timezone: \"UTC\" }",
                 "workspace.paloalto_cef = { timezone: \"Not/AZone\" }",
                 "workspace.paloalto_cef = { timezone: \"local\" }",
@@ -2236,43 +2250,44 @@ def pipeline zeek_full_otlp {
             ),
         ];
 
-        for (parser, supplied_setup, invalid_setup, local_setup, ingress) in cases {
-            let supplied = run_packaged_parser_json(parser, Some(supplied_setup), parser, &ingress);
-            assert_eq!(supplied["time"], expected, "{parser} supplied timezone");
+        for (parsers, process, supplied_setup, invalid_setup, local_setup, ingress) in cases {
+            let supplied =
+                run_packaged_parser_json(parsers, Some(supplied_setup), process, &ingress);
+            assert_eq!(supplied["time"], expected, "{process} supplied timezone");
 
-            let default_setup = match parser {
+            let default_setup = match process {
                 "parse_juniper_srx_syslog" => {
                     Some("workspace.juniper_srx_syslog = { body: ingress }")
                 }
                 _ => None,
             };
-            let defaulted = run_packaged_parser_json(parser, default_setup, parser, &ingress);
+            let defaulted = run_packaged_parser_json(parsers, default_setup, process, &ingress);
             // All RFC 3164 parsers with an undocumented source zone default to
             // the limpid host's system timezone (host-local most-likely
             // assumption); only vendor-documented UTC formats default to UTC.
             let default_expected = local_expected;
             assert_eq!(
                 defaulted["time"], default_expected,
-                "{parser} default timezone"
+                "{process} default timezone"
             );
 
             for invalid_setup in [invalid_setup, local_setup] {
                 let invalid =
-                    run_packaged_parser_pipeline(parser, Some(invalid_setup), parser, &ingress);
+                    run_packaged_parser_pipeline(parsers, Some(invalid_setup), process, &ingress);
                 assert_eq!(
                     invalid.termination,
                     PipelineTermination::Errored,
-                    "{parser}"
+                    "{process}"
                 );
                 assert!(
                     invalid.outputs.is_empty(),
-                    "{parser} emitted invalid timezone"
+                    "{process} emitted invalid timezone"
                 );
                 let reason = match &invalid.errored[0] {
                     ErroredEventContext::Process { reason, .. } => reason,
                     other => panic!("expected process error, got {other:?}"),
                 };
-                assert!(reason.contains("timezone"), "{parser}: {reason}");
+                assert!(reason.contains("timezone"), "{process}: {reason}");
             }
         }
     }
@@ -2280,7 +2295,7 @@ def pipeline zeek_full_otlp {
     #[test]
     fn time_normalization_runs_at_public_leaf_boundaries() {
         let auditd = run_packaged_parser_json(
-            "parse_auditd",
+            &["parse_auditd"],
             Some(
                 "workspace.auditd = { body: ingress }; workspace.auditd_class = parse_auditd_classify(workspace.auditd.body)",
             ),
@@ -2290,7 +2305,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(auditd["time"], 1_710_000_000_123_000_000_i64);
 
         let juniper = run_packaged_parser_json(
-            "parse_juniper_srx_sd_syslog",
+            &["parse_juniper_srx_sd_syslog"],
             Some(
                 "workspace.juniper_srx_sd_syslog = { body: ingress }; workspace.srx_sd_class = parse_juniper_srx_sd_syslog_classify(workspace.juniper_srx_sd_syslog.body)",
             ),
@@ -2304,54 +2319,51 @@ def pipeline zeek_full_otlp {
     fn packaged_parser_public_leaves_reject_invalid_source_severity() {
         let cases = [
             (
-                "parse_asa",
+                &["parse_asa"][..],
                 "workspace.asa = { level: \"8\", body: \"Login permitted from 192.0.2.10/54321 to outside:198.51.100.5/SSH for user admin\" }",
                 "parse_asa_605005_login_permitted",
                 "invalid ASA payload severity level 8",
             ),
             (
-                "parse_aws_guardduty",
+                &["parse_aws_guardduty"][..],
                 "workspace.gd = { type: \"Recon:EC2/Test\", severity: 11 }; workspace.gd_type = aws_guardduty_split_type(workspace.gd.type); workspace.gd_tactic = \"Reconnaissance\"",
                 "parse_aws_guardduty_finding",
                 "invalid GuardDuty severity 11",
             ),
             (
-                "parse_azure_activity",
+                &["parse_azure_activity"][..],
                 "workspace.az = { level: \"TRACE\" }",
                 "parse_azure_activity_record",
                 "invalid Azure Activity Log level TRACE",
             ),
             (
-                "parse_fortigate_cef",
+                &["parse_fortigate_cef"][..],
                 "workspace.cef = { severity: 0 }",
                 "parse_fortigate_cef_traffic",
                 "invalid FortiGate CEF priority 0",
             ),
             (
-                "parse_okta_system",
+                &["parse_okta_system"][..],
                 "workspace.okta = { severity: \"TRACE\" }",
                 "parse_okta_user_authentication",
                 "invalid Okta System Log severity TRACE",
             ),
             (
-                "parse_winevent_json",
+                &["parse_winevent_json"][..],
                 "workspace.winevent = { EventType: \"TRACE\" }",
                 "parse_winevent_4624_logon_success",
                 "invalid NXLog Windows Event severity TRACE",
             ),
         ];
 
-        for (parser, setup, process, expected_error) in cases {
-            let result = run_packaged_parser_pipeline(parser, Some(setup), process, b"fixture");
+        for (parsers, setup, process, expected_error) in cases {
+            let result = run_packaged_parser_pipeline(parsers, Some(setup), process, b"fixture");
             assert_eq!(
                 result.termination,
                 PipelineTermination::Errored,
-                "{parser}:{process} unexpectedly succeeded"
+                "{process} unexpectedly succeeded"
             );
-            assert!(
-                result.outputs.is_empty(),
-                "{parser}:{process} emitted output"
-            );
+            assert!(result.outputs.is_empty(), "{process} emitted output");
             assert_eq!(result.errored.len(), 1);
             let reason = match &result.errored[0] {
                 ErroredEventContext::Process { reason, .. } => reason,
@@ -2359,7 +2371,7 @@ def pipeline zeek_full_otlp {
             };
             assert!(
                 reason.contains(expected_error),
-                "{parser}:{process} error was {reason:?}"
+                "{process} error was {reason:?}"
             );
         }
     }
@@ -2367,7 +2379,7 @@ def pipeline zeek_full_otlp {
     #[test]
     fn packaged_fortigate_dns_uses_rcode_not_error() {
         let with_rcode = run_packaged_parser_json(
-            "parse_fortigate_syslog",
+            &["parse_fortigate_syslog"],
             None,
             "parse_fortigate_syslog",
             b"<134>eventtime=1777284000123456789 level=notice type=utm subtype=dns action=blocked srcip=192.0.2.10 dstip=198.51.100.5 qname=example.test qtype=A rcode=NXDOMAIN error=SERVFAIL",
@@ -2375,7 +2387,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(with_rcode["rcode_id"], 3);
 
         let without_rcode = run_packaged_parser_json(
-            "parse_fortigate_syslog",
+            &["parse_fortigate_syslog"],
             None,
             "parse_fortigate_syslog",
             b"<134>eventtime=1777284000123456789 level=notice type=utm subtype=dns action=blocked srcip=192.0.2.10 dstip=198.51.100.5 qname=example.test qtype=A error=NXDOMAIN",
@@ -2785,7 +2797,7 @@ def pipeline zeek_full_otlp {
         adapters.sort();
         assert_eq!(
             adapters.len(),
-            30,
+            31,
             "packaged source adapter inventory drift"
         );
 
@@ -2829,7 +2841,7 @@ def pipeline zeek_full_otlp {
     #[test]
     fn packaged_ocsf_severity_unknown_and_other_normalize_without_canonical_zero() {
         let unknown = run_packaged_parser_json(
-            "parse_ocsf",
+            &["parse_ocsf"],
             None,
             "parse_ocsf",
             br#"{"class_uid":4001,"severity_id":0}"#,
@@ -2838,7 +2850,7 @@ def pipeline zeek_full_otlp {
         assert!(unknown["severity_number"].is_null());
 
         let other = run_packaged_parser_json(
-            "parse_ocsf",
+            &["parse_ocsf"],
             None,
             "parse_ocsf",
             br#"{"class_uid":4001,"severity_id":99}"#,
@@ -2847,7 +2859,7 @@ def pipeline zeek_full_otlp {
         assert!(other["severity_number"].is_null());
 
         let error = run_packaged_parser_json(
-            "parse_ocsf",
+            &["parse_ocsf"],
             None,
             "parse_ocsf",
             br#"{"class_uid":4001,"severity_id":3}"#,
@@ -3871,7 +3883,98 @@ def pipeline zeek_full_otlp {
             Some("302013")
         );
 
-        let leef_wire = b"<14>1 2026-04-30T01:23:45Z cpgw01 CheckPoint - - LEEF:2.0|Check Point|VPN-1 & FireWall-1|R81|Accept|cat=Firewall\tsrc=192.0.2.10\tdst=198.51.100.5\tsrcPort=51234\tdstPort=443\tproto=tcp\trule=12\trule_name=Allow-Internet\taction=Accept\tservice=https\tusrName=alice";
+        // Generic transport/format chain: parse_syslog | parse_cef |
+        // cef_to_otlp with no vendor stage. CEF header severity 7 sits in
+        // the spec's High band (7-8) and must land on ERROR (17); the raw
+        // header fields surface as event.code / cef.* attributes.
+        let generic_cef_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|7|src=192.0.2.10 spt=51234 dst=198.51.100.5 dpt=443 act=blocked msg=Example alert";
+        let generic_cef = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_record = &generic_cef.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_record.severity_number, 17);
+        assert_eq!(generic_cef_record.severity_text, "7");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "event.code"),
+            Some("100")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "cef.name"),
+            Some("alert raised")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "event.action"),
+            Some("blocked")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "source.ip"),
+            Some("192.0.2.10")
+        );
+        assert_eq!(
+            otlp_int_attribute(&generic_cef_record.attributes, "destination.port"),
+            Some(443)
+        );
+        assert_eq!(
+            otlp_string_attribute(
+                &generic_cef.resource.as_ref().expect("resource").attributes,
+                "observer.vendor"
+            ),
+            Some("ArcSight")
+        );
+        assert_eq!(
+            otlp_string_attribute(
+                &generic_cef.resource.as_ref().expect("resource").attributes,
+                "host.name"
+            ),
+            Some("host01")
+        );
+
+        // CEF also documents string Severity values (Unknown / Low /
+        // Medium / High / Very-High). A single band-wide value takes the
+        // band's smallest SeverityNumber: "High" → ERROR (17).
+        let generic_cef_string_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|High|src=192.0.2.10 act=blocked";
+        let generic_cef_string = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_string_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_string_record = &generic_cef_string.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_string_record.severity_number, 17);
+        assert_eq!(generic_cef_string_record.severity_text, "High");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_string_record.attributes, "cef.severity"),
+            Some("High")
+        );
+
+        // "Unknown" is spec-valid but makes no importance claim, so
+        // severity_number stays unset (proto default 0) while the raw
+        // value is preserved as severity_text / cef.severity.
+        let generic_cef_unknown_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|Unknown|src=192.0.2.10 act=blocked";
+        let generic_cef_unknown = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_unknown_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_unknown_record = &generic_cef_unknown.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_unknown_record.severity_number, 0);
+        assert_eq!(generic_cef_unknown_record.severity_text, "Unknown");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_unknown_record.attributes, "cef.severity"),
+            Some("Unknown")
+        );
+
+        let leef_wire =b"<14>1 2026-04-30T01:23:45Z cpgw01 CheckPoint - - LEEF:2.0|Check Point|VPN-1 & FireWall-1|R81|Accept|cat=Firewall\tsrc=192.0.2.10\tdst=198.51.100.5\tsrcPort=51234\tdstPort=443\tproto=tcp\trule=12\trule_name=Allow-Internet\taction=Accept\tservice=https\tusrName=alice";
         let checkpoint_leef = run_packaged_otlp_resource_logs_at(
             &cfg,
             &funcs,
@@ -4068,6 +4171,9 @@ def pipeline zeek_full_otlp {
 
         for resource_logs in [
             asa,
+            generic_cef,
+            generic_cef_string,
+            generic_cef_unknown,
             checkpoint_leef,
             checkpoint,
             fortigate_cef,

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -3934,6 +3934,36 @@ def pipeline zeek_full_otlp {
             Some("host01")
         );
 
+        // Collision isolation: extension keys named after header fields
+        // (`severity=`, `name=`, `ext=`) must not shadow the positional
+        // header values — cef.parse isolates them under the nested
+        // `extension` sub-object, so the record's severity still comes
+        // from the header (7 → ERROR 17), not the injected `severity=9`.
+        let generic_cef_collision_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|realname|7|severity=9 name=fakename ext=x src=192.0.2.10";
+        let generic_cef_collision = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_collision_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_collision_record = &generic_cef_collision.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_collision_record.severity_number, 17);
+        assert_eq!(generic_cef_collision_record.severity_text, "7");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_collision_record.attributes, "cef.severity"),
+            Some("7")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_collision_record.attributes, "cef.name"),
+            Some("realname")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_collision_record.attributes, "source.ip"),
+            Some("192.0.2.10")
+        );
+
         // CEF also documents string Severity values (Unknown / Low /
         // Medium / High / Very-High). A single band-wide value takes the
         // band's smallest SeverityNumber: "High" → ERROR (17).
@@ -4172,6 +4202,7 @@ def pipeline zeek_full_otlp {
         for resource_logs in [
             asa,
             generic_cef,
+            generic_cef_collision,
             generic_cef_string,
             generic_cef_unknown,
             checkpoint_leef,

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -3964,6 +3964,32 @@ def pipeline zeek_full_otlp {
             Some("192.0.2.10")
         );
 
+        // Header escape handling: `\|` inside a header field is a
+        // literal pipe per the CEF spec, not a separator. A split on it
+        // would shift severity into the extension blob and hand the
+        // name fragment to the severity slot — this wire must still
+        // classify from the real header severity 7 → ERROR (17).
+        let generic_cef_escape_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|deny\\|drop|7|act=block src=192.0.2.10";
+        let generic_cef_escape = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_escape_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_escape_record = &generic_cef_escape.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_escape_record.severity_number, 17);
+        assert_eq!(generic_cef_escape_record.severity_text, "7");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_escape_record.attributes, "cef.name"),
+            Some("deny|drop")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_escape_record.attributes, "event.action"),
+            Some("block")
+        );
+
         // CEF also documents string Severity values (Unknown / Low /
         // Medium / High / Very-High). A single band-wide value takes the
         // band's smallest SeverityNumber: "High" → ERROR (17).
@@ -4202,6 +4228,7 @@ def pipeline zeek_full_otlp {
         for resource_logs in [
             asa,
             generic_cef,
+            generic_cef_escape,
             generic_cef_collision,
             generic_cef_string,
             generic_cef_unknown,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -19,7 +19,7 @@ It contains `include` directives and global blocks (`geoip`, `control`, `table`)
 ```
 include "inputs/*.limpid"          // glob
 include "outputs/ama.limpid"       // single file
-include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"   // shipped snippet
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"             // shipped snippet
 ```
 
 Rules:

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -6,7 +6,7 @@ Built-in functions are primitives implemented in Rust and shipped with the daemo
 def process parse_cef_line {
     workspace.syslog = syslog.parse(ingress)
     workspace.cef    = cef.parse(workspace.syslog.msg)
-    workspace.payload = parse_json(workspace.cef.msg)
+    workspace.payload = parse_json(workspace.cef.extension.msg)
 }
 ```
 
@@ -40,7 +40,7 @@ def process parse_fw_flat {
 ```limpid
 def process parse_fw_namespaced {
     workspace.syslog = syslog.parse(ingress)   // workspace.syslog.hostname, workspace.syslog.msg, ...
-    workspace.cef    = cef.parse(ingress)      // workspace.cef.version, workspace.cef.src, ...
+    workspace.cef    = cef.parse(ingress)      // workspace.cef.version, workspace.cef.extension.src, ...
 }
 ```
 
@@ -539,8 +539,8 @@ let event_time = coalesce(
 
 // Parser: pick first source IP that is populated
 workspace.lsis.parsed.src_endpoint.ip = coalesce(
-    workspace.cef.src,
-    workspace.cef.sourceTranslatedAddress,
+    workspace.cef.extension.src,
+    workspace.cef.extension.sourceTranslatedAddress,
     workspace.syslog.hostname
 )
 ```
@@ -573,11 +573,11 @@ it would hide the signal.
 
 ```limpid
 workspace.payload = {
-    src: workspace.cef.src,
-    dst: workspace.cef.dst,
-    user: workspace.cef.suser,        // may be null on machine-only events
+    src: workspace.cef.extension.src,
+    dst: workspace.cef.extension.dst,
+    user: workspace.cef.extension.suser,        // may be null on machine-only events
     evidences: [
-        { file: workspace.cef.fname, hash: workspace.cef.fhash }
+        { file: workspace.cef.extension.fname, hash: workspace.cef.extension.fhash }
     ]
 }
 egress = to_json(null_omit(workspace.payload))
@@ -694,7 +694,7 @@ Text-only primitives (`upper`, `regex_*`, `format`, `to_int`,
 Coerces a value to a 64-bit signed integer. Returns `null` on unparseable input, matching the partial-data policy of `regex_extract` and `table_lookup`.
 
 ```limpid
-workspace.lsis.parsed.src_endpoint.port = to_int(workspace.cef.spt)  // CEF ext: "54321" → 54321
+workspace.lsis.parsed.src_endpoint.port = to_int(workspace.cef.extension.spt)  // CEF ext: "54321" → 54321
 ```
 
 | Input | Result |

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -19,8 +19,8 @@ Use one anywhere an expression goes:
 def process parse_fortigate_cef_traffic {
     workspace.lsis.parsed = {
         connection_info: {
-            protocol_num:  workspace.cef.proto,
-            protocol_name: normalize_proto(workspace.cef.proto)
+            protocol_num:  workspace.cef.extension.proto,
+            protocol_name: normalize_proto(workspace.cef.extension.proto)
         },
         // ... other canonical fields ...
     }
@@ -43,15 +43,15 @@ Anywhere an expression is evaluated — there's no callsite restriction on the f
   def output proto_udp { type file path "/var/log/limpid/udp/events.log" }
   def pipeline split {
       input syslog_udp
-      process parse_cef                                  // sets workspace.cef.proto
-      switch normalize_proto(workspace.cef.proto) {
+      process parse_cef                                  // sets workspace.cef.extension.proto
+      switch normalize_proto(workspace.cef.extension.proto) {
           "tcp" { output proto_tcp }
           "udp" { output proto_udp }
       }
   }
   ```
 - **HashLit values**: `workspace.lsis.parsed = { severity_number: severity_number_from_label(...), ... }`.
-- **Function arguments**: `lower(normalize_proto(workspace.cef.proto))`.
+- **Function arguments**: `lower(normalize_proto(workspace.cef.extension.proto))`.
 - **Binary operands**: `if double_score(s) > threshold { ... }`.
 
 The purity contract restricts the **body** of the function (no Event reads, no side effects). The call site is dispatch-wise unrestricted: it operates in the surrounding expression's evaluation context, which can read whatever that surface allows (full Event in process bodies / pipeline expressions; event-intrinsic only in output config templates) and pass concrete values into the function.

--- a/docs/src/pipelines/drop-finish-error.md
+++ b/docs/src/pipelines/drop-finish-error.md
@@ -35,7 +35,7 @@ Routes the event to the [error log](../operations/error-log.md) (DLQ) with an op
 
 ```
 def process parse_fortigate_cef {
-    workspace.cef = cef.parse(workspace.syslog.msg)
+    // workspace.cef.* was populated by `parse_syslog | parse_cef` upstream
     switch workspace.cef.name {
         "traffic" { process parse_fortigate_cef_traffic }
         "utm"     { process parse_fortigate_cef_utm }

--- a/docs/src/pipelines/examples.md
+++ b/docs/src/pipelines/examples.md
@@ -128,8 +128,8 @@ def pipeline siem {
     // Parse and enrich
     process {
         workspace.cef = cef.parse(ingress)
-        if workspace.cef.src != null {
-            workspace.geo = geoip(workspace.cef.src)
+        if workspace.cef.extension.src != null {
+            workspace.geo = geoip(workspace.cef.extension.src)
         }
         egress = to_json(workspace)
     }

--- a/docs/src/pipelines/routing.md
+++ b/docs/src/pipelines/routing.md
@@ -62,7 +62,7 @@ def pipeline main {
     // Parse and rewrite egress
     process {
         workspace.cef = cef.parse(ingress)
-        workspace.geo = geoip(workspace.cef.src)
+        workspace.geo = geoip(workspace.cef.extension.src)
         egress = to_json(workspace)
     }
 

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -272,7 +272,7 @@ The two-sided rule of thumb for `workspace.lsis.parsed.*`:
 - **Parsers fill `workspace.lsis.parsed` in canonical LSIS shape — OCSF-vocabulary, not OCSF-bound.** Whenever a vendor field has a clean OCSF home, use the OCSF field name (`src_endpoint.ip`, `actor.user.name`). When it doesn't, carry it on `workspace.lsis.parsed` under a vendor-meaningful name; do not throw the data away just because OCSF has no slot.
 - **Composers may assume `workspace.lsis.parsed` follows canonical LSIS shape — but they must not assume strict OCSF compliance.** A composer reads the fields it needs and tolerates extras / absences. An OCSF composer renders `workspace.lsis.parsed.*` to OCSF JSON in the `workspace.lsis.composed.ocsf` slot; an ECS composer would translate the same facts into an ECS JSON slot, taking advantage of the OCSF-vocabulary overlap without depending on it.
 
-A parser must not write vendor-specific format names into the facts layer (`workspace.cef.src`, `workspace.fgt_session_id` left at top level); a composer must not read vendor-specific format names directly (`workspace.cef.src`). The contract between them is `workspace.lsis.parsed.*`, full stop. Each rename or pass-through layer beyond that is a drift risk.
+A parser must not write vendor-specific format names into the facts layer (`workspace.cef.extension.src`, `workspace.fgt_session_id` left at top level); a composer must not read vendor-specific format names directly (`workspace.cef.extension.src`). The contract between them is `workspace.lsis.parsed.*`, full stop. Each rename or pass-through layer beyond that is a drift risk.
 
 ### Keep composers pure
 

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -132,7 +132,7 @@ Rule of thumb: if the catch block has nothing useful to do besides stamp `worksp
 
 ```limpid
 def process parse_asa {
-    workspace.syslog = syslog.parse(ingress)
+    // workspace.syslog.* was populated by `parse_syslog` upstream
     let mid = regex_extract(workspace.syslog.msg, "%ASA-\\d-(\\d+):")
     switch mid {
         "605004" { process parse_asa_auth_success }

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -10,11 +10,11 @@ You define a process with `def process <name> { ... }`. Inside the body you call
 def process enrich_fortigate {
     workspace.cef = cef.parse(workspace.syslog.msg)   // capture parser output
 
-    if workspace.cef.src != null {
-        workspace.geo = geoip(workspace.cef.src)
+    if workspace.cef.extension.src != null {
+        workspace.geo = geoip(workspace.cef.extension.src)
     }
 
-    egress = "${workspace.cef.device_product} ${workspace.cef.src} -> ${workspace.cef.dst} ${workspace.cef.act}"
+    egress = "${workspace.cef.device_product} ${workspace.cef.extension.src} -> ${workspace.cef.extension.dst} ${workspace.cef.extension.act}"
 }
 ```
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -9,10 +9,11 @@ a vendor adds a field (the snippet is plain DSL: edit the file and
 SIGHUP).
 
 > **Status:** the snippet library was introduced in v0.7.0 and has
-> expanded across the 0.7.x line. It currently ships 31 parser files
+> expanded across the 0.7.x line. It currently ships 32 parser files
 > (source / vocabulary parsers — FortiGate / ASA / Checkpoint / Palo Alto /
 > Sysmon / CloudTrail / Zeek / Suricata / OCSF / Juniper SRX / ... — plus the
-> transport parsers `parse_syslog` and `parse_journald`), 30 sibling
+> transport / format parsers `parse_syslog`, `parse_journald`, and
+> `parse_cef`), 31 sibling
 > per-source OTLP adapters, the OCSF 1.3.0 27-class composer, the RFC 5424
 > and replay-shape composers, one filter, and several reusable functions.
 > The inbound `parse_ocsf` compatibility parser is the sole parser without
@@ -29,12 +30,13 @@ SIGHUP).
 | **Transport** | | |
 | `parsers/parse_syslog.limpid` | RFC 3164 / 5424 syslog wire (transport, populates `workspace.syslog.*`) | n/a |
 | `parsers/parse_journald.limpid` | systemd journald JSON (transport, populates `workspace.journald.*`) | n/a |
+| `parsers/parse_cef.limpid` | ArcSight CEF format from a syslog body (populates `workspace.cef.*`; chains as `parse_syslog \| parse_cef \| parse_<vendor>_cef`) | n/a |
 | **Security devices / cloud audit** | | |
-| `parsers/parse_fortigate_cef.limpid` | FortiGate (CEF wrap) | 4001 / 2004 / 3002 / 6002 |
+| `parsers/parse_fortigate_cef.limpid` | FortiGate (CEF wrap; chain `parse_syslog \| parse_cef \|` upstream) | 4001 / 2004 / 3002 / 6002 |
 | `parsers/parse_fortigate_syslog.limpid` | FortiGate (native KV syslog) | (same as CEF) |
-| `parsers/parse_paloalto_cef.limpid` | PAN-OS (CEF wrap) | 4001 / 2004 / 6004 / 3002 |
-| `parsers/parse_paloalto_syslog.limpid` | PAN-OS (native CSV syslog) | (same as CEF) |
-| `parsers/parse_asa.limpid` | Cisco ASA / FTD-in-ASA-mode (syslog) | 3002 / 4001 |
+| `parsers/parse_paloalto_cef.limpid` | PAN-OS (CEF wrap; chain `parse_syslog \| parse_cef \|` upstream) | 4001 / 2004 / 6004 / 3002 |
+| `parsers/parse_paloalto_syslog.limpid` | PAN-OS (native CSV syslog; chain `parse_syslog \|` upstream) | (same as CEF) |
+| `parsers/parse_asa.limpid` | Cisco ASA / FTD-in-ASA-mode (syslog; chain `parse_syslog \|` upstream) | 3002 / 4001 |
 | `parsers/parse_cloudtrail.limpid` | AWS CloudTrail (JSON) | 6003 API Activity |
 | `parsers/parse_juniper_srx_sd_syslog.limpid` | Juniper SRX RT_FLOW (RFC 5424 + Junos SD, `set security log format sd-syslog` mode) | 4001 Network Activity |
 | `parsers/parse_juniper_srx_syslog.limpid` | Juniper SRX RT_IDP / IDP_ATTACK_LOG_EVENT (RFC 3164 unstructured, default `syslog` mode) | 2004 Detection Finding |
@@ -139,9 +141,12 @@ contracts.
 
 ## Quick start
 
-The basic pattern is two `include` lines + a two-stage pipeline:
+The basic pattern is a few `include` lines + a staged pipeline
+(transport → format → vendor vocabulary → composer):
 
 ```limpid
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 include "/usr/share/limpid/snippets/composers/compose_ocsf.limpid"
 
@@ -156,12 +161,13 @@ def output security_lake {
 
 def pipeline fw_to_security_lake {
     input fw_syslog
-    process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     output security_lake
 }
 ```
 
-`parse_fortigate_cef` writes facts to `workspace.lsis.parsed.*`;
+`parse_syslog` unwraps the transport, `parse_cef` decodes the CEF
+format, and `parse_fortigate_cef` writes facts to `workspace.lsis.parsed.*`;
 `compose_ocsf` reads from there and writes the OCSF JSON record to
 `workspace.lsis.composed.ocsf`; the one-line `ocsf_to_egress`
 companion at the tail of the pipeline moves the slot to `egress`.
@@ -176,11 +182,11 @@ For mixed-vendor inputs, dispatch upstream of the parser:
 def pipeline mixed_in {
     input multi_vendor_syslog
     if contains(ingress, "CEF:0|Palo Alto Networks") {
-        process parse_paloalto_cef | compose_ocsf | ocsf_to_egress
+        process parse_syslog | parse_cef | parse_paloalto_cef | compose_ocsf | ocsf_to_egress
     } else if contains(ingress, "CEF:0|Fortinet") {
-        process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+        process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     } else {
-        process parse_paloalto_syslog | compose_ocsf | ocsf_to_egress
+        process parse_syslog | parse_paloalto_syslog | compose_ocsf | ocsf_to_egress
     }
     output security_lake
 }

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -67,7 +67,7 @@ After editing the config, reload the daemon to pick up the change — either `su
 
 FortiGate `traffic` events are too noisy to forward to AMA, but you still want them in the on-disk archive for after-the-fact investigation. So: archive everything, then drop FortiGate traffic, then forward what's left.
 
-To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The wire is layered — syslog transport around a CEF-formatted body around FortiGate's dialect — and the library ships one parser per layer: `parse_syslog` unwraps the transport into `workspace.syslog.*`, `parse_cef` decodes the CEF header / extensions into `workspace.cef.*`, and `parse_fortigate_cef` interprets the FortiGate dialect and fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract). In particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) after `parse_cef`, and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
+To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The wire is layered — syslog transport around a CEF-formatted body around FortiGate's dialect — and the library ships one parser per layer: `parse_syslog` unwraps the transport into `workspace.syslog.*`, `parse_cef` decodes the CEF header / extensions into `workspace.cef.*`, and `parse_fortigate_cef` interprets the FortiGate dialect and fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract). In particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.extension.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) after `parse_cef`, and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
 
 ```limpid
 // /etc/limpid/limpid.conf  — add at the top
@@ -95,7 +95,7 @@ def pipeline main {
     input fw_tcp
     output archive                                            // everything goes to disk
     process parse_syslog | parse_cef | parse_fortigate_cef    // transport | format | vendor vocabulary
-    if workspace.cef.cat == "traffic:forward" { drop }        // drop the noise
+    if workspace.cef.extension.cat == "traffic:forward" { drop }        // drop the noise
     output ama                                                // only the survivors reach AMA
 }
 ```
@@ -106,7 +106,7 @@ The first is the magic from Step 2. Even though the `process` and `if drop` afte
 
 The second is what the pipeline body actually contains: an `input`, two `output`s, a `process`, and an `if/drop`. There is no separate "filter" or "router" abstraction — routing decisions live in the pipeline as ordinary statements, in the order they execute. That mirrors how you'd describe the pipeline in words: "archive everything, parse it as FortiGate, drop traffic events, forward the rest to AMA."
 
-Worth one more note: `parse_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) and `parse_fortigate_cef` builds `workspace.lsis.parsed.*` from it; the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
+Worth one more note: `parse_cef` populates `workspace.cef.extension.cat` (from the FortiGate `cat=` extension) and `parse_fortigate_cef` builds `workspace.lsis.parsed.*` from it; the `if` reads from `workspace.cef.extension.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
 
 ## Step 4 — Confirm the drop is actually happening
 
@@ -212,7 +212,7 @@ def pipeline main {
     input fw_tcp
     output archive
     process parse_syslog | parse_cef | parse_fortigate_cef
-    if workspace.cef.cat == "traffic:forward" { drop }
+    if workspace.cef.extension.cat == "traffic:forward" { drop }
     output ama
 }
 ```
@@ -244,7 +244,7 @@ table {
 ```limpid
 // /etc/limpid/processes/dedup_fortigate_traffic.limpid
 def process dedup_fortigate_traffic {
-    if workspace.cef.cat == "traffic:forward" {
+    if workspace.cef.extension.cat == "traffic:forward" {
         let key = workspace.lsis.parsed.src_endpoint.ip + "|" + workspace.lsis.parsed.dst_endpoint.ip
         if table_lookup("traffic_seen", key) != null {
             drop

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -67,10 +67,12 @@ After editing the config, reload the daemon to pick up the change — either `su
 
 FortiGate `traffic` events are too noisy to forward to AMA, but you still want them in the on-disk archive for after-the-fact investigation. So: archive everything, then drop FortiGate traffic, then forward what's left.
 
-To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The FortiGate CEF parser is provided as `parsers/parse_fortigate_cef.limpid` and exposes a `parse_fortigate_cef` process that fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract) — from a FortiGate CEF event. Before it builds the canonical intermediate, the parser also leaves the raw CEF header / extensions in `workspace.cef.*`; in particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
+To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The wire is layered — syslog transport around a CEF-formatted body around FortiGate's dialect — and the library ships one parser per layer: `parse_syslog` unwraps the transport into `workspace.syslog.*`, `parse_cef` decodes the CEF header / extensions into `workspace.cef.*`, and `parse_fortigate_cef` interprets the FortiGate dialect and fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract). In particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) after `parse_cef`, and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
 
 ```limpid
 // /etc/limpid/limpid.conf  — add at the top
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 
 def input fw_tcp {
@@ -92,7 +94,7 @@ def output ama {
 def pipeline main {
     input fw_tcp
     output archive                                            // everything goes to disk
-    process parse_fortigate_cef                               // populate workspace.cef.* + workspace.lsis.parsed.*
+    process parse_syslog | parse_cef | parse_fortigate_cef    // transport | format | vendor vocabulary
     if workspace.cef.cat == "traffic:forward" { drop }        // drop the noise
     output ama                                                // only the survivors reach AMA
 }
@@ -104,7 +106,7 @@ The first is the magic from Step 2. Even though the `process` and `if drop` afte
 
 The second is what the pipeline body actually contains: an `input`, two `output`s, a `process`, and an `if/drop`. There is no separate "filter" or "router" abstraction — routing decisions live in the pipeline as ordinary statements, in the order they execute. That mirrors how you'd describe the pipeline in words: "archive everything, parse it as FortiGate, drop traffic events, forward the rest to AMA."
 
-Worth one more note: `parse_fortigate_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) on its way to building `workspace.lsis.parsed.*`, and the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
+Worth one more note: `parse_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) and `parse_fortigate_cef` builds `workspace.lsis.parsed.*` from it; the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
 
 ## Step 4 — Confirm the drop is actually happening
 
@@ -164,6 +166,8 @@ The config is growing. The conventional layout: one file per module under `input
 
 ```limpid
 // /etc/limpid/limpid.conf
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 
 include "inputs/*.limpid"
@@ -207,7 +211,7 @@ def output ama {
 def pipeline main {
     input fw_tcp
     output archive
-    process parse_fortigate_cef
+    process parse_syslog | parse_cef | parse_fortigate_cef
     if workspace.cef.cat == "traffic:forward" { drop }
     output ama
 }
@@ -255,14 +259,14 @@ def process dedup_fortigate_traffic {
 def pipeline main {
     input fw_tcp
     output archive
-    process parse_fortigate_cef | dedup_fortigate_trafic
+    process parse_syslog | parse_cef | parse_fortigate_cef | dedup_fortigate_trafic
     output ama
 }
 ```
 
 A few things to read:
 
-- `process A | B` chains processes left to right — the event flows through `parse_fortigate_cef` first, then `dedup_fortigate_traffic`. Equivalent to writing them on two `process` lines; the `|` form just reads more naturally when several processes line up.
+- `process A | B` chains processes left to right — the event flows through the three parser stages first, then `dedup_fortigate_traffic`. Equivalent to writing them on two `process` lines; the `|` form just reads more naturally when several processes line up.
 - `workspace.lsis.parsed.src_endpoint.ip` and `workspace.lsis.parsed.dst_endpoint.ip` exist because `parse_fortigate_cef` ran first. Pipeline order is real order — what comes earlier has populated the canonical intermediate by the time later steps run.
 - `let key = ...` is a process-local scratch variable — scoped to this process invocation, gone when the event leaves. The binding can hold any value type (scalar, Object, or Array); for an Object, `key.x` reads through the binding the same way `workspace.x.y` does. The binding *name* itself is a single identifier (`let foo.bar = ...` is a parse error — the `let` LHS is a single identifier in the grammar; write into `workspace.*` if you need a path target).
 - `table_upsert` resets the TTL on every call, so a flow that keeps appearing keeps being suppressed; the dedup window only opens up once a flow has been quiet for five minutes (`ttl 300` on the table).
@@ -280,8 +284,8 @@ $ limpid --check --config /etc/limpid/limpid.conf
 error: unknown process 'dedup_fortigate_trafic' referenced in pipeline 'main'
   --> /etc/limpid/pipelines/main.limpid:5:30
    |
- 5 |     process parse_fortigate_cef | dedup_fortigate_trafic
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^ no such process is defined
+ 5 |     process parse_syslog | parse_cef | parse_fortigate_cef | dedup_fortigate_trafic
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^ no such process is defined
    |
    = help: did you mean `dedup_fortigate_traffic`?
 ```

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -139,7 +139,7 @@ RFC 5424 fields that the pack cannot synthesise on the caller's behalf).
 
 ## What's included
 
-The current pack contains 31 parser files. Thirty expose a sibling
+The current pack contains 32 parser files. Thirty-one expose a sibling
 `<source>_to_otlp` adapter; the inbound `parse_ocsf` compatibility parser is
 the sole exception.
 
@@ -157,6 +157,7 @@ regions.
 | File | Summary |
 |---|---|
 | **Transport** | |
+| `parsers/parse_cef.limpid` | ArcSight CEF message (from a syslog body) → workspace.cef.* format fields (format-layer parser; interpreting the vendor dialect on top is the next stage's job). |
 | `parsers/parse_journald.limpid` | journalctl -o json lines → workspace.journald.* transport fields (transport-layer parser). |
 | `parsers/parse_syslog.limpid` | RFC 3164 / RFC 5424 syslog wire → workspace.syslog.* transport fields (transport-layer parser; bridging the body into a vocabulary intake is the caller's job). |
 | **Network firewall / IPS** | |
@@ -288,6 +289,8 @@ process {
 Drop a snippet into your `/etc/limpid/limpid.conf`:
 
 ```limpid
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 include "/usr/share/limpid/snippets/composers/compose_ocsf.limpid"
 
@@ -302,12 +305,16 @@ def output ocsf_stdout {
 
 def pipeline fw_to_ocsf {
     input fw_syslog
-    process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     output ocsf_stdout
 }
 ```
 
-That's it. The parser writes facts to `workspace.lsis.parsed.*`;
+That's it. Each stage owns one layer: `parse_syslog` unwraps the
+transport, `parse_cef` decodes the CEF format, and the vendor parser
+interprets the dialect — so a pipeline can inspect and drop events
+between stages without paying the next parse. The vendor parser writes
+facts to `workspace.lsis.parsed.*`;
 `compose_ocsf` reads `workspace.lsis.parsed.*` and writes OCSF JSON
 to `workspace.lsis.composed.ocsf`; the one-line `ocsf_to_egress`
 step at the tail of the pipeline hands that slot off to `egress`.
@@ -356,17 +363,21 @@ The library follows four contracts:
 
 ## Pipeline shapes
 
-Schema wire form:
+Schema wire form (transport / format stages precede the vendor parser
+when the wire is layered — e.g. `parse_syslog | parse_asa`,
+`parse_syslog | parse_cef | parse_fortigate_cef`; single-layer wires
+such as FortiGate native KV or JSON-body sources go straight to the
+vendor parser):
 
 ```
-process <vendor_parser> | compose_ocsf | ocsf_to_egress
+process [<transport_parser> | [<format_parser> |]] <vendor_parser> | compose_ocsf | ocsf_to_egress
 ```
 
 Envelope-wrapped schema (OTLP wrapping the OCSF JSON as the log
 body):
 
 ```
-process <vendor_parser>
+process [<transport_parser> | [<format_parser> |]] <vendor_parser>
       | <vendor>_to_otlp
       | compose_ocsf
       | {

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -1,6 +1,12 @@
 // Summary:     Cisco ASA / FTD (ASA-syslog-compatibility) %ASA syslog
 //              messages → LSIS Authentication + Network Activity.
-// Reads:       ingress (raw wire) — syslog-wrapped %ASA-<level>-<msg_id> messages
+// Reads:       workspace.syslog.* (transport intake — populated by
+//              parse_syslog upstream)
+//                .msg (required, String) — syslog body carrying the
+//                     `%ASA-<level>-<msg_id>` message
+//                .timestamp (optional, String) — RFC 3164 wire timestamp
+//                .hostname (optional, String) — originating device, retained
+//                     by asa_to_otlp as Resource `host.name`
 //              workspace.asa.timezone (optional, String) — source device
 //              timezone override as an IANA name or fixed offset; the legacy
 //              RFC 3164 timestamp defaults to the limpid host's system
@@ -23,6 +29,16 @@
 // Firepower Threat Defense (FTD) running in ASA-syslog-compatibility mode.
 // Pure FTD eStreamer / Snort-3 / FMC syslog has its own format and would
 // land in a separate parser file (`parse_firepower_*.limpid`).
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_asa | compose_ocsf | ocsf_to_egress
+//
+// The transport wrapper is unwrapped by `parse_syslog` upstream; this
+// parser consumes the syslog body (and transport timestamp / hostname)
+// from `workspace.syslog.*`. Separating the stages lets a pipeline
+// inspect and drop events after `parse_syslog` without paying the
+// vocabulary parse cost.
 //
 // Wire —    syslog-wrapped ASA messages —
 //          `<priority>timestamp host : %ASA-<level>-<msg_id>: <body>`
@@ -138,7 +154,6 @@ def process validate_asa_severity_number {
 
 def process parse_asa {
     let source_timezone = workspace.asa.timezone
-    workspace.syslog = syslog.parse(ingress)
     workspace.asa = regex_parse(
         workspace.syslog.msg,
         "^(?:[^:]*: )?%ASA-(?P<level>\\d)-(?P<msg_id>\\d+): (?P<body>.*)$"

--- a/packaging/snippets/parsers/parse_cef.limpid
+++ b/packaging/snippets/parsers/parse_cef.limpid
@@ -8,8 +8,13 @@
 //                .hostname (optional, String) — originating host, retained
 //                     by cef_to_otlp as Resource `host.name`
 // Writes:      workspace.cef.{version, device_vendor, device_product,
-//              device_version, signature_id, name, severity, ext, <ext-key>…}
-//              — the CEF format namespace, not LSIS. cef_to_otlp writes
+//              device_version, signature_id, name, severity} — the seven
+//              positional header fields — plus workspace.cef.extension_raw
+//              (raw Extension blob) and workspace.cef.extension.<key>
+//              (split key=value pairs, isolated in their own sub-object
+//              so data-driven extension keys can never shadow a
+//              positional header field). The CEF format namespace, not
+//              LSIS. cef_to_otlp writes
 //              source-owned OTLP Resource, Body, LogRecord attributes, and
 //              the shed severity slots mapped from the CEF 0-10 scale.
 // Category:    Transport
@@ -128,10 +133,12 @@ def function cef_severity_number(sev) {
 //     ("alert raised", "utm:ips signature"), which does NOT meet OTel
 //     semconv `event.name`'s low-cardinality identifier contract — so it
 //     stays in the CEF namespace as `cef.name`.
-//   * Standard extension keys whose semconv equivalent is self-evident
-//     are placed under the semconv name (src → source.ip, request →
-//     url.full, …). Spec-defined keys without a self-evident semconv
-//     home are passed through under `cef.<key>`. The DSL has no
+//   * Standard extension keys (read from `workspace.cef.extension.*` —
+//     the data-driven plane, isolated from the positional header) whose
+//     semconv equivalent is self-evident are placed under the semconv
+//     name (src → source.ip, request → url.full, …). Spec-defined keys
+//     without a self-evident semconv home are passed through under
+//     `cef.<key>`. The DSL has no
 //     object-key iteration, so the passthrough is a curated table of
 //     the spec dictionary's common keys rather than a wildcard; nothing
 //     is lost — the Body carries the complete original CEF message.
@@ -171,80 +178,80 @@ def process cef_to_otlp {
             true { [{ key: "event.code", value: { string_value: workspace.cef.signature_id } }] }
             default { [] }
         },
-        switch workspace.cef.act != null {
-            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+        switch workspace.cef.extension.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.extension.act } }] }
             default { [] }
         },
-        switch workspace.cef.msg != null {
-            true { [{ key: "message", value: { string_value: workspace.cef.msg } }] }
+        switch workspace.cef.extension.msg != null {
+            true { [{ key: "message", value: { string_value: workspace.cef.extension.msg } }] }
             default { [] }
         },
-        switch workspace.cef.src != null {
-            true { [{ key: "source.ip", value: { string_value: workspace.cef.src } }] }
+        switch workspace.cef.extension.src != null {
+            true { [{ key: "source.ip", value: { string_value: workspace.cef.extension.src } }] }
             default { [] }
         },
-        switch workspace.cef.spt != null {
-            true { [{ key: "source.port", value: { int_value: to_int(workspace.cef.spt) } }] }
+        switch workspace.cef.extension.spt != null {
+            true { [{ key: "source.port", value: { int_value: to_int(workspace.cef.extension.spt) } }] }
             default { [] }
         },
-        switch workspace.cef.smac != null {
-            true { [{ key: "source.mac", value: { string_value: workspace.cef.smac } }] }
+        switch workspace.cef.extension.smac != null {
+            true { [{ key: "source.mac", value: { string_value: workspace.cef.extension.smac } }] }
             default { [] }
         },
-        switch workspace.cef.shost != null {
-            true { [{ key: "source.domain", value: { string_value: workspace.cef.shost } }] }
+        switch workspace.cef.extension.shost != null {
+            true { [{ key: "source.domain", value: { string_value: workspace.cef.extension.shost } }] }
             default { [] }
         },
-        switch workspace.cef.in != null {
-            true { [{ key: "source.bytes", value: { int_value: to_int(workspace.cef.in) } }] }
+        switch workspace.cef.extension.in != null {
+            true { [{ key: "source.bytes", value: { int_value: to_int(workspace.cef.extension.in) } }] }
             default { [] }
         },
-        switch workspace.cef.dst != null {
-            true { [{ key: "destination.ip", value: { string_value: workspace.cef.dst } }] }
+        switch workspace.cef.extension.dst != null {
+            true { [{ key: "destination.ip", value: { string_value: workspace.cef.extension.dst } }] }
             default { [] }
         },
-        switch workspace.cef.dpt != null {
-            true { [{ key: "destination.port", value: { int_value: to_int(workspace.cef.dpt) } }] }
+        switch workspace.cef.extension.dpt != null {
+            true { [{ key: "destination.port", value: { int_value: to_int(workspace.cef.extension.dpt) } }] }
             default { [] }
         },
-        switch workspace.cef.dmac != null {
-            true { [{ key: "destination.mac", value: { string_value: workspace.cef.dmac } }] }
+        switch workspace.cef.extension.dmac != null {
+            true { [{ key: "destination.mac", value: { string_value: workspace.cef.extension.dmac } }] }
             default { [] }
         },
-        switch workspace.cef.dhost != null {
-            true { [{ key: "destination.domain", value: { string_value: workspace.cef.dhost } }] }
+        switch workspace.cef.extension.dhost != null {
+            true { [{ key: "destination.domain", value: { string_value: workspace.cef.extension.dhost } }] }
             default { [] }
         },
-        switch workspace.cef.out != null {
-            true { [{ key: "destination.bytes", value: { int_value: to_int(workspace.cef.out) } }] }
+        switch workspace.cef.extension.out != null {
+            true { [{ key: "destination.bytes", value: { int_value: to_int(workspace.cef.extension.out) } }] }
             default { [] }
         },
-        switch workspace.cef.suser != null {
-            true { [{ key: "user.name", value: { string_value: workspace.cef.suser } }] }
+        switch workspace.cef.extension.suser != null {
+            true { [{ key: "user.name", value: { string_value: workspace.cef.extension.suser } }] }
             default { [] }
         },
-        switch workspace.cef.duser != null {
-            true { [{ key: "destination.user.name", value: { string_value: workspace.cef.duser } }] }
+        switch workspace.cef.extension.duser != null {
+            true { [{ key: "destination.user.name", value: { string_value: workspace.cef.extension.duser } }] }
             default { [] }
         },
-        switch workspace.cef.proto != null {
-            true { [{ key: "network.transport", value: { string_value: lower(workspace.cef.proto) } }] }
+        switch workspace.cef.extension.proto != null {
+            true { [{ key: "network.transport", value: { string_value: lower(workspace.cef.extension.proto) } }] }
             default { [] }
         },
-        switch workspace.cef.app != null {
-            true { [{ key: "network.application", value: { string_value: workspace.cef.app } }] }
+        switch workspace.cef.extension.app != null {
+            true { [{ key: "network.application", value: { string_value: workspace.cef.extension.app } }] }
             default { [] }
         },
-        switch workspace.cef.request != null {
-            true { [{ key: "url.full", value: { string_value: workspace.cef.request } }] }
+        switch workspace.cef.extension.request != null {
+            true { [{ key: "url.full", value: { string_value: workspace.cef.extension.request } }] }
             default { [] }
         },
-        switch workspace.cef.requestMethod != null {
-            true { [{ key: "http.request.method", value: { string_value: workspace.cef.requestMethod } }] }
+        switch workspace.cef.extension.requestMethod != null {
+            true { [{ key: "http.request.method", value: { string_value: workspace.cef.extension.requestMethod } }] }
             default { [] }
         },
-        switch workspace.cef.fname != null {
-            true { [{ key: "file.name", value: { string_value: workspace.cef.fname } }] }
+        switch workspace.cef.extension.fname != null {
+            true { [{ key: "file.name", value: { string_value: workspace.cef.extension.fname } }] }
             default { [] }
         },
         // CEF namespace — header fields and spec keys without a
@@ -261,32 +268,32 @@ def process cef_to_otlp {
             true { [{ key: "cef.severity", value: { string_value: "${workspace.cef.severity}" } }] }
             default { [] }
         },
-        switch workspace.cef.cat != null {
-            true { [{ key: "cef.cat", value: { string_value: workspace.cef.cat } }] }
+        switch workspace.cef.extension.cat != null {
+            true { [{ key: "cef.cat", value: { string_value: workspace.cef.extension.cat } }] }
             default { [] }
         },
-        switch workspace.cef.outcome != null {
-            true { [{ key: "cef.outcome", value: { string_value: workspace.cef.outcome } }] }
+        switch workspace.cef.extension.outcome != null {
+            true { [{ key: "cef.outcome", value: { string_value: workspace.cef.extension.outcome } }] }
             default { [] }
         },
-        switch workspace.cef.reason != null {
-            true { [{ key: "cef.reason", value: { string_value: workspace.cef.reason } }] }
+        switch workspace.cef.extension.reason != null {
+            true { [{ key: "cef.reason", value: { string_value: workspace.cef.extension.reason } }] }
             default { [] }
         },
-        switch workspace.cef.externalId != null {
-            true { [{ key: "cef.externalId", value: { string_value: workspace.cef.externalId } }] }
+        switch workspace.cef.extension.externalId != null {
+            true { [{ key: "cef.externalId", value: { string_value: workspace.cef.extension.externalId } }] }
             default { [] }
         },
-        switch workspace.cef.deviceExternalId != null {
-            true { [{ key: "cef.deviceExternalId", value: { string_value: workspace.cef.deviceExternalId } }] }
+        switch workspace.cef.extension.deviceExternalId != null {
+            true { [{ key: "cef.deviceExternalId", value: { string_value: workspace.cef.extension.deviceExternalId } }] }
             default { [] }
         },
-        switch workspace.cef.fileHash != null {
-            true { [{ key: "cef.fileHash", value: { string_value: workspace.cef.fileHash } }] }
+        switch workspace.cef.extension.fileHash != null {
+            true { [{ key: "cef.fileHash", value: { string_value: workspace.cef.extension.fileHash } }] }
             default { [] }
         },
-        switch workspace.cef.cnt != null {
-            true { [{ key: "cef.cnt", value: { int_value: to_int(workspace.cef.cnt) } }] }
+        switch workspace.cef.extension.cnt != null {
+            true { [{ key: "cef.cnt", value: { int_value: to_int(workspace.cef.extension.cnt) } }] }
             default { [] }
         }
     )

--- a/packaging/snippets/parsers/parse_cef.limpid
+++ b/packaging/snippets/parsers/parse_cef.limpid
@@ -1,0 +1,293 @@
+// Summary:     ArcSight CEF message (from a syslog body) → workspace.cef.*
+//              format fields (format-layer parser; interpreting the
+//              vendor dialect on top is the next stage's job).
+// Reads:       workspace.syslog.* (transport intake — populated by
+//              parse_syslog upstream)
+//                .msg (required, String) — syslog body carrying the
+//                     `CEF:...` message
+//                .hostname (optional, String) — originating host, retained
+//                     by cef_to_otlp as Resource `host.name`
+// Writes:      workspace.cef.{version, device_vendor, device_product,
+//              device_version, signature_id, name, severity, ext, <ext-key>…}
+//              — the CEF format namespace, not LSIS. cef_to_otlp writes
+//              source-owned OTLP Resource, Body, LogRecord attributes, and
+//              the shed severity slots mapped from the CEF 0-10 scale.
+// Category:    Transport
+// Test corpus: synthetic (sample wires in this header)
+//
+// Wire —    ArcSight CEF as carried in a syslog body —
+//          `CEF:Version|Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|Extensions`
+//          The outer syslog wrapper (`<PRI>`, timestamp, hostname) is
+//          transport, unwrapped by `parse_syslog` upstream; this parser
+//          consumes the body only.
+//
+// Thin wrapper around the `cef.parse()` primitive, mirroring
+// parse_syslog's role one layer up the stack. Exists so a pipeline can
+// express format stacking explicitly:
+//
+//   process parse_syslog | parse_cef | parse_<vendor>_cef | compose_<target>
+//
+// rather than having every vendor CEF parser inline
+// `cef.parse(workspace.syslog.msg)` itself. The separation buys two
+// things: a pipeline can inspect `workspace.syslog.*` / `workspace.cef.*`
+// and drop or route events *before* paying the next stage's parse cost,
+// and each stage stays independently composable (a non-syslog CEF
+// carrier only needs a different bridge into `workspace.syslog.msg` —
+// the CEF stage is unchanged).
+//
+// Non-CEF or absent bodies are loud errors (DLQ), matching the pack's
+// loud-fail-fast policy: `cef.parse` itself rejects input that does not
+// start with `CEF:` or lacks the 7 header fields.
+//
+// Sample input (RFC 3164 wrapper, generic ArcSight example):
+//   <134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|7|src=192.0.2.10 spt=51234 dst=198.51.100.5 dpt=443 act=blocked msg=Example alert
+//
+// Sample input (RFC 5424 wrapper):
+//   <134>1 2026-04-30T01:23:45Z host01 - - - - CEF:0|Vendor|Product|1.0|100|name|5|src=192.0.2.10 dst=198.51.100.5
+//
+// Vendor dialects (FortiGate `cat=` routing, PAN-OS `name`-encoded log
+// types, `FTNTFGT*` extension prefixes, …) are out of scope here — they
+// belong to the per-vendor parsers (`parse_fortigate_cef`,
+// `parse_paloalto_cef`) stacked after this stage.
+
+def process parse_cef {
+    switch workspace.syslog.msg {
+        null    { error "parse_cef: no syslog body to parse (workspace.syslog.msg is null)" }
+        default { workspace.cef = cef.parse(workspace.syslog.msg) }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generic OTLP source adapter
+// ---------------------------------------------------------------------------
+//
+// The CEF header and the standard extension dictionary are defined by the
+// ArcSight CEF specification independent of any vendor, so a generic
+// adapter is legitimate here — unlike the vendor severity dialects
+// (FortiGate's 1-8, PAN-OS's 1-5) that need their own adapters.
+//
+// Severity — the CEF specification defines header Severity with two
+// valid notations: an integer 0-10 reflecting event importance, grouped
+// as 0-3 Low / 4-6 Medium / 7-8 High / 9-10 Very-High, and the string
+// values Unknown / Low / Medium / High / Very-High naming those groups
+// directly. The OTel Logs Data Model defines SeverityNumber bands
+// INFO 9-12 / WARN 13-16 / ERROR 17-20 / FATAL 21-24, with unspecified
+// band-internal steps available for finer source scales. The Data Model
+// appendix carries no official CEF mapping example, so this table
+// follows the Data Model body's mapping principles — place each source
+// band on a target band, order finer values inside the band, and give a
+// single band-wide value the band's smallest number:
+//
+//   CEF band            CEF value → SeverityNumber
+//   Low       (0-3)     0 → 9   1 → 10   2 → 11   3 → 12   (INFO..INFO4)
+//   Medium    (4-6)     4 → 13  5 → 14   6 → 15            (WARN..WARN3)
+//   High      (7-8)     7 → 17  8 → 18                     (ERROR..ERROR2)
+//   Very-High (9-10)    9 → 21  10 → 22                    (FATAL..FATAL2)
+//
+//   CEF string          "Low" → 9   "Medium" → 13   "High" → 17
+//                       "Very-High" → 21   (band minimum each)
+//                       "Unknown" → unset (no importance claim to map)
+//
+// Low maps to INFO (not TRACE/DEBUG — CEF 0 is a least-important event,
+// not diagnostic verbosity), Very-High to FATAL; consecutive CEF values
+// take consecutive numbers from each band floor, so the integer mapping
+// is order-preserving and injective — distinct source severities remain
+// distinguishable after conversion. String values are matched exactly
+// in the specification's capitalized spelling (the CEF guide documents
+// no case-insensitive allowance). True out-of-domain values (integers
+// outside 0-10, strings other than the five documented words) leave
+// severity_number unset; the raw value is retained as severity_text and
+// the `cef.severity` attribute either way.
+def function cef_severity_number(sev) {
+    switch sev {
+        0           { 9 }
+        1           { 10 }
+        2           { 11 }
+        3           { 12 }
+        4           { 13 }
+        5           { 14 }
+        6           { 15 }
+        7           { 17 }
+        8           { 18 }
+        9           { 21 }
+        10          { 22 }
+        "Low"       { 9 }
+        "Medium"    { 13 }
+        "High"      { 17 }
+        "Very-High" { 21 }
+        "Unknown"   { null }
+        default     { null }
+    }
+}
+
+// Attribute placement notes —
+//
+//   * `event.code` ← Signature ID: the CEF header's unique per-event-type
+//     identifier, which is exactly ECS `event.code`'s contract.
+//   * The CEF header Name is a free-form human-readable description
+//     ("alert raised", "utm:ips signature"), which does NOT meet OTel
+//     semconv `event.name`'s low-cardinality identifier contract — so it
+//     stays in the CEF namespace as `cef.name`.
+//   * Standard extension keys whose semconv equivalent is self-evident
+//     are placed under the semconv name (src → source.ip, request →
+//     url.full, …). Spec-defined keys without a self-evident semconv
+//     home are passed through under `cef.<key>`. The DSL has no
+//     object-key iteration, so the passthrough is a curated table of
+//     the spec dictionary's common keys rather than a wildcard; nothing
+//     is lost — the Body carries the complete original CEF message.
+//   * Timestamp extensions (rt / start / end) are not parsed here: CEF
+//     permits both epoch-milliseconds and several textual formats, so
+//     interpreting them needs vendor knowledge. Vendor parsers own time.
+def process cef_to_otlp {
+    workspace.lsis.shed.otlp.resource.attributes = concat(
+        switch workspace.cef.device_vendor != null {
+            true { [{ key: "observer.vendor", value: { string_value: workspace.cef.device_vendor } }] }
+            default { [] }
+        },
+        switch workspace.cef.device_product != null {
+            true { [{ key: "observer.product", value: { string_value: workspace.cef.device_product } }] }
+            default { [] }
+        },
+        switch workspace.cef.device_version != null {
+            true { [{ key: "observer.version", value: { string_value: workspace.cef.device_version } }] }
+            default { [] }
+        },
+        switch workspace.syslog.hostname != null {
+            true { [{ key: "host.name", value: { string_value: workspace.syslog.hostname } }] }
+            default { [] }
+        },
+        [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
+        [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
+    )
+    workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.syslog.msg }
+    workspace.lsis.shed.otlp.log_record.severity_number = cef_severity_number(workspace.cef.severity)
+    workspace.lsis.shed.otlp.log_record.severity_text = switch workspace.cef.severity {
+        null    { null }
+        default { "${workspace.cef.severity}" }
+    }
+    workspace.lsis.shed.otlp.log_record.attributes = concat(
+        [{ key: "event.kind", value: { string_value: "event" } }],
+        switch workspace.cef.signature_id != null {
+            true { [{ key: "event.code", value: { string_value: workspace.cef.signature_id } }] }
+            default { [] }
+        },
+        switch workspace.cef.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+            default { [] }
+        },
+        switch workspace.cef.msg != null {
+            true { [{ key: "message", value: { string_value: workspace.cef.msg } }] }
+            default { [] }
+        },
+        switch workspace.cef.src != null {
+            true { [{ key: "source.ip", value: { string_value: workspace.cef.src } }] }
+            default { [] }
+        },
+        switch workspace.cef.spt != null {
+            true { [{ key: "source.port", value: { int_value: to_int(workspace.cef.spt) } }] }
+            default { [] }
+        },
+        switch workspace.cef.smac != null {
+            true { [{ key: "source.mac", value: { string_value: workspace.cef.smac } }] }
+            default { [] }
+        },
+        switch workspace.cef.shost != null {
+            true { [{ key: "source.domain", value: { string_value: workspace.cef.shost } }] }
+            default { [] }
+        },
+        switch workspace.cef.in != null {
+            true { [{ key: "source.bytes", value: { int_value: to_int(workspace.cef.in) } }] }
+            default { [] }
+        },
+        switch workspace.cef.dst != null {
+            true { [{ key: "destination.ip", value: { string_value: workspace.cef.dst } }] }
+            default { [] }
+        },
+        switch workspace.cef.dpt != null {
+            true { [{ key: "destination.port", value: { int_value: to_int(workspace.cef.dpt) } }] }
+            default { [] }
+        },
+        switch workspace.cef.dmac != null {
+            true { [{ key: "destination.mac", value: { string_value: workspace.cef.dmac } }] }
+            default { [] }
+        },
+        switch workspace.cef.dhost != null {
+            true { [{ key: "destination.domain", value: { string_value: workspace.cef.dhost } }] }
+            default { [] }
+        },
+        switch workspace.cef.out != null {
+            true { [{ key: "destination.bytes", value: { int_value: to_int(workspace.cef.out) } }] }
+            default { [] }
+        },
+        switch workspace.cef.suser != null {
+            true { [{ key: "user.name", value: { string_value: workspace.cef.suser } }] }
+            default { [] }
+        },
+        switch workspace.cef.duser != null {
+            true { [{ key: "destination.user.name", value: { string_value: workspace.cef.duser } }] }
+            default { [] }
+        },
+        switch workspace.cef.proto != null {
+            true { [{ key: "network.transport", value: { string_value: lower(workspace.cef.proto) } }] }
+            default { [] }
+        },
+        switch workspace.cef.app != null {
+            true { [{ key: "network.application", value: { string_value: workspace.cef.app } }] }
+            default { [] }
+        },
+        switch workspace.cef.request != null {
+            true { [{ key: "url.full", value: { string_value: workspace.cef.request } }] }
+            default { [] }
+        },
+        switch workspace.cef.requestMethod != null {
+            true { [{ key: "http.request.method", value: { string_value: workspace.cef.requestMethod } }] }
+            default { [] }
+        },
+        switch workspace.cef.fname != null {
+            true { [{ key: "file.name", value: { string_value: workspace.cef.fname } }] }
+            default { [] }
+        },
+        // CEF namespace — header fields and spec keys without a
+        // self-evident semconv home.
+        switch workspace.cef.version != null {
+            true { [{ key: "cef.version", value: { string_value: workspace.cef.version } }] }
+            default { [] }
+        },
+        switch workspace.cef.name != null {
+            true { [{ key: "cef.name", value: { string_value: workspace.cef.name } }] }
+            default { [] }
+        },
+        switch workspace.cef.severity != null {
+            true { [{ key: "cef.severity", value: { string_value: "${workspace.cef.severity}" } }] }
+            default { [] }
+        },
+        switch workspace.cef.cat != null {
+            true { [{ key: "cef.cat", value: { string_value: workspace.cef.cat } }] }
+            default { [] }
+        },
+        switch workspace.cef.outcome != null {
+            true { [{ key: "cef.outcome", value: { string_value: workspace.cef.outcome } }] }
+            default { [] }
+        },
+        switch workspace.cef.reason != null {
+            true { [{ key: "cef.reason", value: { string_value: workspace.cef.reason } }] }
+            default { [] }
+        },
+        switch workspace.cef.externalId != null {
+            true { [{ key: "cef.externalId", value: { string_value: workspace.cef.externalId } }] }
+            default { [] }
+        },
+        switch workspace.cef.deviceExternalId != null {
+            true { [{ key: "cef.deviceExternalId", value: { string_value: workspace.cef.deviceExternalId } }] }
+            default { [] }
+        },
+        switch workspace.cef.fileHash != null {
+            true { [{ key: "cef.fileHash", value: { string_value: workspace.cef.fileHash } }] }
+            default { [] }
+        },
+        switch workspace.cef.cnt != null {
+            true { [{ key: "cef.cnt", value: { int_value: to_int(workspace.cef.cnt) } }] }
+            default { [] }
+        }
+    )
+}

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -2,15 +2,16 @@
 //              dispatched by CEF cat subtype.
 // Reads:       workspace.cef.* (format intake — populated by
 //              parse_syslog | parse_cef upstream)
-//                .cat (required, String) — FortiGate `cat=<category>:<subtype>`
-//                     extension, the dispatch key
+//                .extension.cat (required, String) — FortiGate
+//                     `cat=<category>:<subtype>` extension, the dispatch key
 //                .severity (optional, Int) — CEF header priority
 //                     (FortiGate dialect 1-8)
 //                .device_vendor (optional, String) — CEF header vendor
 //                .device_product (optional, String) — CEF header product
 //                .device_version (optional, String) — CEF header version
 //                (plus the per-leaf standard / `FTNTFGT*` extension keys
-//                documented on each subtype leaf below)
+//                under workspace.cef.extension.*, documented on each
+//                subtype leaf below)
 //              workspace.syslog.* (transport intake)
 //                .timestamp (optional, String) — RFC 3164 wire timestamp
 //                .msg (optional, String) — syslog body, retained by
@@ -190,7 +191,7 @@ def function fortigate_cef_metadata(vendor, product, version) {
 
 def process parse_fortigate_cef {
     workspace.cef.timestamp = workspace.syslog.timestamp
-    switch workspace.cef.cat {
+    switch workspace.cef.extension.cat {
         // Traffic logs (Network Activity 4001)
         "traffic:forward"    { process parse_fortigate_cef_traffic }
         "traffic:local"      { process parse_fortigate_cef_traffic }
@@ -216,7 +217,7 @@ def process parse_fortigate_cef {
         "event:system"           { process parse_fortigate_cef_event_system }
         "event:wireless"         { process parse_fortigate_cef_event_wireless }
         "event:security-rating"  { process parse_fortigate_cef_event_security_rating }
-        default { error "parse_fortigate_cef: unsupported FortiGate CEF cat: ${workspace.cef.cat}" }
+        default { error "parse_fortigate_cef: unsupported FortiGate CEF cat: ${workspace.cef.extension.cat}" }
     }
 }
 
@@ -228,30 +229,30 @@ def process parse_fortigate_cef {
 //   src / spt / dst / dpt / proto / act / app / in / out / msg
 def process parse_fortigate_cef_traffic {
     process validate_fortigate_cef_severity_number
-    let proto_num = to_int(workspace.cef.proto)
+    let proto_num = to_int(workspace.cef.extension.proto)
     workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
-        activity_id:  fortigate_cef_action_to_activity_id(workspace.cef.act),
+        activity_id:  fortigate_cef_action_to_activity_id(workspace.cef.extension.act),
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         connection_info: {
             protocol_num:  proto_num,
             protocol_name: fortigate_cef_proto_name(proto_num)
         },
         traffic: {
-            bytes_in:  to_int(workspace.cef.in),
-            bytes_out: to_int(workspace.cef.out)
+            bytes_in:  to_int(workspace.cef.extension.in),
+            bytes_out: to_int(workspace.cef.extension.out)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -277,25 +278,25 @@ def process parse_fortigate_cef_utm_ips {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTattack,
-            uid:   workspace.cef.FTNTFGTattackid,
+            title: workspace.cef.extension.FTNTFGTattack,
+            uid:   workspace.cef.extension.FTNTFGTattackid,
             types: ["IDS/IPS"],
-            src_url: { url_string: workspace.cef.FTNTFGTref }
+            src_url: { url_string: workspace.cef.extension.FTNTFGTref }
         },
         attack: {
-            technique: { name: workspace.cef.FTNTFGTattack }
+            technique: { name: workspace.cef.extension.FTNTFGTattack }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -317,7 +318,7 @@ def process parse_fortigate_cef_utm_ips {
 //   suser                  — authenticated username (standard CEF)
 def process parse_fortigate_cef_utm_webfilter {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "blocked"     { 2 }
         "block"       { 2 }
         "passthrough" { 1 }
@@ -333,27 +334,27 @@ def process parse_fortigate_cef_utm_webfilter {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         http_request: {
-            url:        { url_string: workspace.cef.request },
-            http_method: workspace.cef.requestMethod
+            url:        { url_string: workspace.cef.extension.request },
+            http_method: workspace.cef.extension.requestMethod
         },
         web_resources: [
             {
-                url:      { url_string: workspace.cef.request },
-                category: workspace.cef.FTNTFGTcatdesc
+                url:      { url_string: workspace.cef.extension.request },
+                category: workspace.cef.extension.FTNTFGTcatdesc
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -379,16 +380,16 @@ def process parse_fortigate_cef_utm_antivirus {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title:   workspace.cef.FTNTFGTvirus,
-            uid:     workspace.cef.FTNTFGTvirusid,
+            title:   workspace.cef.extension.FTNTFGTvirus,
+            uid:     workspace.cef.extension.FTNTFGTvirusid,
             types:   ["Malware"],
-            src_url: { url_string: workspace.cef.FTNTFGTref }
+            src_url: { url_string: workspace.cef.extension.FTNTFGTref }
         },
         malware: [
             {
-                name:               workspace.cef.FTNTFGTvirus,
+                name:               workspace.cef.extension.FTNTFGTvirus,
                 classification_ids: [1]
             }
         ],
@@ -399,21 +400,21 @@ def process parse_fortigate_cef_utm_antivirus {
         evidences: [
             {
                 file: {
-                    name:   workspace.cef.fname,
-                    hashes: [{ value: workspace.cef.FTNTFGTanalyticscksum }]
+                    name:   workspace.cef.extension.fname,
+                    hashes: [{ value: workspace.cef.extension.FTNTFGTanalyticscksum }]
                 },
-                url: { url_string: workspace.cef.request }
+                url: { url_string: workspace.cef.extension.request }
             }
         ],
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -433,32 +434,32 @@ def process parse_fortigate_cef_utm_dlp {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTfiltername,
-            uid:   workspace.cef.FTNTFGTfilteridx,
+            title: workspace.cef.extension.FTNTFGTfiltername,
+            uid:   workspace.cef.extension.FTNTFGTfilteridx,
             types: ["Data Loss"]
         },
         evidences: [
             {
                 file: {
-                    name: workspace.cef.FTNTFGTfilename,
-                    size: to_int(workspace.cef.FTNTFGTfilesize)
+                    name: workspace.cef.extension.FTNTFGTfilename,
+                    size: to_int(workspace.cef.extension.FTNTFGTfilesize)
                 }
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -480,27 +481,27 @@ def process parse_fortigate_cef_utm_appctrl {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.app,
-            uid:   workspace.cef.FTNTFGTappid,
+            title: workspace.cef.extension.app,
+            uid:   workspace.cef.extension.FTNTFGTappid,
             types: ["Application"]
         },
         evidences: [
-            { process: { name: workspace.cef.app } }
+            { process: { name: workspace.cef.extension.app } }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -516,13 +517,13 @@ def process parse_fortigate_cef_utm_appctrl {
 // FortiGate DNS filter — qname / qtype / response code / verdict.
 def process parse_fortigate_cef_utm_dns {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "blocked"     { 1 }
         "redirected"  { 1 }
         "passthrough" { 6 }
         default       { 6 }
     }
-    let rcode = switch workspace.cef.FTNTFGTerror {
+    let rcode = switch workspace.cef.extension.FTNTFGTerror {
         "NOERROR"  { 0 }
         "FORMERR"  { 1 }
         "SERVFAIL" { 2 }
@@ -538,13 +539,13 @@ def process parse_fortigate_cef_utm_dns {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         rcode_id:     rcode,
-        src_endpoint: { ip: workspace.cef.src },
-        dst_endpoint: { ip: workspace.cef.dst },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        dst_endpoint: { ip: workspace.cef.extension.dst },
         query: {
-            hostname: workspace.cef.FTNTFGTqname,
-            type:     workspace.cef.FTNTFGTqtype
+            hostname: workspace.cef.extension.FTNTFGTqname,
+            type:     workspace.cef.extension.FTNTFGTqtype
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -560,7 +561,7 @@ def process parse_fortigate_cef_utm_dns {
 // FortiGate email filter — sender / recipient / subject / message-id.
 def process parse_fortigate_cef_utm_emailfilter {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "blocked"     { 6 }
         "quarantined" { 6 }
         "passthrough" { 6 }
@@ -573,15 +574,15 @@ def process parse_fortigate_cef_utm_emailfilter {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         direction_id: 0,
-        src_endpoint: { ip: workspace.cef.src },
-        dst_endpoint: { ip: workspace.cef.dst },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        dst_endpoint: { ip: workspace.cef.extension.dst },
         email: {
-            from:        workspace.cef.suser,
-            to:          [workspace.cef.duser],
-            subject:     workspace.cef.FTNTFGTsubject,
-            message_uid: workspace.cef.FTNTFGTmsgid
+            from:        workspace.cef.extension.suser,
+            to:          [workspace.cef.extension.duser],
+            subject:     workspace.cef.extension.FTNTFGTsubject,
+            message_uid: workspace.cef.extension.FTNTFGTmsgid
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -603,35 +604,35 @@ def process parse_fortigate_cef_utm_waf {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTsignature,
-            uid:   workspace.cef.FTNTFGTsignatureid,
+            title: workspace.cef.extension.FTNTFGTsignature,
+            uid:   workspace.cef.extension.FTNTFGTsignatureid,
             types: ["WAF"]
         },
         attack: {
-            technique: { name: workspace.cef.FTNTFGTsignature }
+            technique: { name: workspace.cef.extension.FTNTFGTsignature }
         },
         evidences: [
             {
                 http_request: {
-                    url:         { url_string: workspace.cef.request },
-                    http_method: workspace.cef.requestMethod
+                    url:         { url_string: workspace.cef.extension.request },
+                    http_method: workspace.cef.extension.requestMethod
                 }
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -664,26 +665,26 @@ def process parse_fortigate_cef_utm_ssl {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTeventsubtype,
-            desc:  workspace.cef.msg,
+            title: workspace.cef.extension.FTNTFGTeventsubtype,
+            desc:  workspace.cef.extension.msg,
             types: ["TLS Anomaly"]
         },
         tls: {
-            version: workspace.cef.FTNTFGTtlsver,
-            sni:     workspace.cef.FTNTFGTsni
+            version: workspace.cef.extension.FTNTFGTtlsver,
+            sni:     workspace.cef.extension.FTNTFGTsni
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:       workspace.cef.dst,
-            port:     to_int(workspace.cef.dpt),
-            hostname: workspace.cef.dhost
+            ip:       workspace.cef.extension.dst,
+            port:     to_int(workspace.cef.extension.dpt),
+            hostname: workspace.cef.extension.dhost
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -713,7 +714,7 @@ def process parse_fortigate_cef_utm_ssl {
 //   proto              — IP proto (17 UDP / 6 TCP)
 def process parse_fortigate_cef_utm_voip {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.outcome {
+    let activity = switch workspace.cef.extension.outcome {
         "start"  { 1 }
         "end"    { 2 }
         default  { 6 }
@@ -725,19 +726,19 @@ def process parse_fortigate_cef_utm_voip {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         connection_info: {
-            protocol_num:  to_int(workspace.cef.proto),
-            protocol_name: fortigate_cef_proto_name(to_int(workspace.cef.proto))
+            protocol_num:  to_int(workspace.cef.extension.proto),
+            protocol_name: fortigate_cef_proto_name(to_int(workspace.cef.extension.proto))
         },
-        app_name: workspace.cef.FTNTFGTvoip_proto,
-        message:  "VoIP " + workspace.cef.FTNTFGTkind + " " + workspace.cef.suser + " -> " + workspace.cef.duser + " (call_id=" + workspace.cef.FTNTFGTcall_id + ")",
+        app_name: workspace.cef.extension.FTNTFGTvoip_proto,
+        message:  "VoIP " + workspace.cef.extension.FTNTFGTkind + " " + workspace.cef.extension.suser + " -> " + workspace.cef.extension.duser + " (call_id=" + workspace.cef.extension.FTNTFGTcall_id + ")",
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -751,7 +752,7 @@ def process parse_fortigate_cef_utm_voip {
 // ---------------------------------------------------------------------------
 def process parse_fortigate_cef_event_user {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "login"           { 1 }
         "logon"           { 1 }
         "auth-logon"      { 1 }
@@ -763,7 +764,7 @@ def process parse_fortigate_cef_event_user {
         "login-failed"    { 1 }
         default           { 0 }
     }
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "auth-fail"       { 2 }
         "failed-login"    { 2 }
         "login-failed"    { 2 }
@@ -777,12 +778,12 @@ def process parse_fortigate_cef_event_user {
         time:            workspace.cef.time,
         status_id:    status,
         user: {
-            name: workspace.cef.suser
+            name: workspace.cef.extension.suser
         },
         src_endpoint: {
-            ip: workspace.cef.src
+            ip: workspace.cef.extension.src
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -796,7 +797,7 @@ def process parse_fortigate_cef_event_user {
 // ---------------------------------------------------------------------------
 def process parse_fortigate_cef_event_vpn {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "tunnel-up"       { 1 }
         "ssl-login-fail"  { 1 }
         "ssl-new-con"     { 1 }
@@ -804,7 +805,7 @@ def process parse_fortigate_cef_event_vpn {
         "ssl-disconnect"  { 2 }
         default           { 0 }
     }
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "ssl-login-fail"  { 2 }
         default           { 1 }
     }
@@ -816,12 +817,12 @@ def process parse_fortigate_cef_event_vpn {
         time:            workspace.cef.time,
         status_id:    status,
         user: {
-            name: workspace.cef.suser
+            name: workspace.cef.extension.suser
         },
         src_endpoint: {
-            ip: workspace.cef.src
+            ip: workspace.cef.extension.src
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -847,14 +848,14 @@ def process parse_fortigate_cef_event_system {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         finding_info: {
-            title: workspace.cef.act,
-            desc:  workspace.cef.FTNTFGTlogdesc,
+            title: workspace.cef.extension.act,
+            desc:  workspace.cef.extension.FTNTFGTlogdesc,
             types: ["System Event"]
         },
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -868,7 +869,7 @@ def process parse_fortigate_cef_event_system {
 // ---------------------------------------------------------------------------
 def process parse_fortigate_cef_event_wireless {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "client-connect"    { 1 }
         "client-associate"  { 1 }
         "client-disconnect" { 2 }
@@ -882,14 +883,14 @@ def process parse_fortigate_cef_event_wireless {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:  workspace.cef.src,
-            mac: workspace.cef.FTNTFGTsrcmac
+            ip:  workspace.cef.extension.src,
+            mac: workspace.cef.extension.FTNTFGTsrcmac
         },
         dst_endpoint: {
-            ip:  workspace.cef.dst,
-            mac: workspace.cef.FTNTFGTapmac
+            ip:  workspace.cef.extension.dst,
+            mac: workspace.cef.extension.FTNTFGTapmac
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -925,18 +926,18 @@ def process parse_fortigate_cef_event_security_rating {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         finding_info: {
-            title: "Security Rating " + workspace.cef.FTNTFGTauditreporttype,
-            uid:   workspace.cef.FTNTFGTauditid,
-            desc:  workspace.cef.FTNTFGTlogdesc,
+            title: "Security Rating " + workspace.cef.extension.FTNTFGTauditreporttype,
+            uid:   workspace.cef.extension.FTNTFGTauditid,
+            desc:  workspace.cef.extension.FTNTFGTlogdesc,
             types: ["Security Audit"]
         },
         unmapped: {
-            audit_score:    workspace.cef.FTNTFGTauditscore,
-            critical_count: to_int(workspace.cef.FTNTFGTcriticalcount),
-            high_count:     to_int(workspace.cef.FTNTFGThighcount),
-            medium_count:   to_int(workspace.cef.FTNTFGTmediumcount),
-            low_count:      to_int(workspace.cef.FTNTFGTlowcount),
-            passed_count:   to_int(workspace.cef.FTNTFGTpassedcount)
+            audit_score:    workspace.cef.extension.FTNTFGTauditscore,
+            critical_count: to_int(workspace.cef.extension.FTNTFGTcriticalcount),
+            high_count:     to_int(workspace.cef.extension.FTNTFGThighcount),
+            medium_count:   to_int(workspace.cef.extension.FTNTFGTmediumcount),
+            low_count:      to_int(workspace.cef.extension.FTNTFGTlowcount),
+            passed_count:   to_int(workspace.cef.extension.FTNTFGTpassedcount)
         },
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
@@ -1012,8 +1013,8 @@ def process fortigate_cef_to_otlp {
         [{ key: "event.kind", value: { string_value: fortigate_cef_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: fortigate_cef_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
         [{ key: "event.type", value: { array_value: { values: [{ string_value: fortigate_cef_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
-        switch workspace.cef.act != null {
-            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+        switch workspace.cef.extension.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.extension.act } }] }
             default { [] }
         },
         switch fortigate_cef_otlp_event_outcome(workspace.lsis.parsed.status_id) != null {

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -1,6 +1,20 @@
 // Summary:     Fortinet FortiGate CEF (FortiOS set format cef) → LSIS,
 //              dispatched by CEF cat subtype.
-// Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Fortinet|Fortigate|...)
+// Reads:       workspace.cef.* (format intake — populated by
+//              parse_syslog | parse_cef upstream)
+//                .cat (required, String) — FortiGate `cat=<category>:<subtype>`
+//                     extension, the dispatch key
+//                .severity (optional, Int) — CEF header priority
+//                     (FortiGate dialect 1-8)
+//                .device_vendor (optional, String) — CEF header vendor
+//                .device_product (optional, String) — CEF header product
+//                .device_version (optional, String) — CEF header version
+//                (plus the per-leaf standard / `FTNTFGT*` extension keys
+//                documented on each subtype leaf below)
+//              workspace.syslog.* (transport intake)
+//                .timestamp (optional, String) — RFC 3164 wire timestamp
+//                .msg (optional, String) — syslog body, retained by
+//                     fortigate_cef_to_otlp as the OTLP Body
 //              workspace.fortigate_cef.timezone (optional, String) — source
 //              device timezone override as an IANA name or fixed offset; the
 //              RFC 3164 timestamp defaults to the limpid host's system timezone
@@ -16,6 +30,16 @@
 // Category:    Network firewall / IPS
 // Test corpus: real (anonymised FortiGate captures — the dialect-quirks
 //              block below was verified against them)
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+//
+// Transport (`parse_syslog`) and format (`parse_cef`) are separate
+// upstream stages; this parser interprets the FortiGate dialect on the
+// already-parsed `workspace.cef.*`. Separating the stages lets a
+// pipeline inspect and drop events after each stage without paying the
+// next stage's parse cost.
 //
 // Wire —    syslog-wrapped CEF — `<PRI>Mmm DD HH:MM:SS host CEF:0|Fortinet|Fortigate|...`
 //          ArcSight CEF header + FortiGate-specific extension keys
@@ -151,7 +175,7 @@ def function fortigate_cef_metadata(vendor, product, version) {
 }
 
 // ---------------------------------------------------------------------------
-// Top-level dispatcher: parse syslog wrapper + CEF body, dispatch on `cat`
+// Top-level dispatcher: read the parsed CEF intake, dispatch on `cat`
 // ---------------------------------------------------------------------------
 //
 // The CEF `cat` extension carries the canonical `<category>:<subtype>`
@@ -159,10 +183,12 @@ def function fortigate_cef_metadata(vendor, product, version) {
 // dispatchers (the previous `name=utm` then `subtype=ips` form fails on
 // real FortiGate output where `name=utm:ips signature` and
 // `cat=utm:ips`).
+//
+// The RFC 3164 wrapper timestamp is copied into the CEF namespace here
+// because the CEF wrapper itself carries no timestamp; the per-leaf
+// validate process interprets it in the declared device timezone.
 
 def process parse_fortigate_cef {
-    workspace.syslog = syslog.parse(ingress)
-    workspace.cef    = cef.parse(workspace.syslog.msg)
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.cat {
         // Traffic logs (Network Activity 4001)

--- a/packaging/snippets/parsers/parse_fortigate_syslog.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_syslog.limpid
@@ -1,6 +1,9 @@
 // Summary:     Fortinet FortiGate native key=value syslog (FortiOS
 //              "default" format) → same LSIS shape as parse_fortigate_cef.
-// Reads:       ingress (raw wire) — syslog priority + KV body
+// Reads:       ingress (raw wire) — `<PRI>` + FortiGate KV body, NOT RFC 3164
+//              (no timestamp/hostname header between the priority and the
+//              body, so there is no meaningful `parse_syslog` stage to
+//              front this parser with; it strips the PRI itself)
 //              (`eventtime` is epoch seconds on older FortiOS and
 //              epoch nanoseconds on FortiOS 6.2.1+)
 // Writes:      workspace.lsis.parsed.* — same classes as parse_fortigate_cef

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -10,7 +10,8 @@
 //                .device_product (optional, String) — CEF header product
 //                .device_version (optional, String) — CEF header version
 //                (plus the per-leaf standard / `cs<n>` extension keys
-//                documented on each subtype leaf below)
+//                under workspace.cef.extension.*, documented on each
+//                subtype leaf below)
 //              workspace.syslog.* (transport intake)
 //                .timestamp (optional, String) — RFC 3164 wire timestamp
 //                .msg (optional, String) — syslog body, retained by
@@ -207,28 +208,28 @@ def process parse_paloalto_cef_traffic {
     workspace.lsis.parsed = {
         class_uid:       4001,
         category_uid:    4,
-        activity_id:     paloalto_cef_traffic_action_to_activity_id(workspace.cef.act),
+        activity_id:     paloalto_cef_traffic_action_to_activity_id(workspace.cef.extension.act),
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         connection_info: {
-            protocol_num:  proto_num(workspace.cef.proto),
-            protocol_name: lower(workspace.cef.proto)
+            protocol_num:  proto_num(workspace.cef.extension.proto),
+            protocol_name: lower(workspace.cef.extension.proto)
         },
         traffic: {
-            bytes_in:  to_int(workspace.cef.in),
-            bytes_out: to_int(workspace.cef.out)
+            bytes_in:  to_int(workspace.cef.extension.in),
+            bytes_out: to_int(workspace.cef.extension.out)
         },
-        app_name: workspace.cef.app,
+        app_name: workspace.cef.extension.app,
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         unmapped: {
             cef_severity: workspace.cef.severity
@@ -274,7 +275,7 @@ def process parse_paloalto_cef_threat {
         activity_id:     1,
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
-        disposition_id: paloalto_cef_threat_disposition_id(workspace.cef.act),
+        disposition_id: paloalto_cef_threat_disposition_id(workspace.cef.extension.act),
         finding_info: {
             title: workspace.cef.signature_id,
             types: ["Threat"]
@@ -283,15 +284,15 @@ def process parse_paloalto_cef_threat {
             technique: { name: workspace.cef.signature_id }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         unmapped: {
             cef_severity: workspace.cef.severity
@@ -326,7 +327,7 @@ def process parse_paloalto_cef_threat {
 //   app                     — application context
 def process parse_paloalto_cef_url {
     process parse_paloalto_cef_normalize_severity
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "block-url" { 2 }
         "block"     { 2 }
         "deny"      { 2 }
@@ -344,25 +345,25 @@ def process parse_paloalto_cef_url {
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         http_request: {
-            url:         { url_string: workspace.cef.request },
-            http_method: workspace.cef.requestMethod
+            url:         { url_string: workspace.cef.extension.request },
+            http_method: workspace.cef.extension.requestMethod
         },
         web_resources: [
             {
-                url:      { url_string: workspace.cef.request },
-                category: workspace.cef.cs2
+                url:      { url_string: workspace.cef.extension.request },
+                category: workspace.cef.extension.cs2
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         unmapped: {
             cef_severity: workspace.cef.severity
@@ -396,7 +397,7 @@ def process parse_paloalto_cef_url {
 //   request                — fetch URL when HTTP-delivered
 def process parse_paloalto_cef_wildfire {
     process parse_paloalto_cef_normalize_severity
-    let disposition = switch workspace.cef.cs1 {
+    let disposition = switch workspace.cef.extension.cs1 {
         "malicious" { 2 }
         "phishing"  { 2 }
         "grayware"  { 6 }
@@ -411,26 +412,26 @@ def process parse_paloalto_cef_wildfire {
         time:            workspace.paloalto_cef.time,
         disposition_id: disposition,
         finding_info: {
-            title: workspace.cef.cs1,
-            uid:   workspace.cef.cs2,
+            title: workspace.cef.extension.cs1,
+            uid:   workspace.cef.extension.cs2,
             types: ["Malware"]
         },
         malware: [
             {
-                name:               workspace.cef.cs1,
+                name:               workspace.cef.extension.cs1,
                 classification_ids: [1]
             }
         ],
         evidences: [
             {
                 file: {
-                    name:   workspace.cef.fname,
-                    hashes: [{ value: workspace.cef.fileHash }]
+                    name:   workspace.cef.extension.fname,
+                    hashes: [{ value: workspace.cef.extension.fileHash }]
                 }
             }
         ],
-        src_endpoint: { ip: workspace.cef.src },
-        dst_endpoint: { ip: workspace.cef.dst },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        dst_endpoint: { ip: workspace.cef.extension.dst },
         unmapped: {
             cef_severity: workspace.cef.severity
         },
@@ -458,7 +459,7 @@ def process parse_paloalto_cef_wildfire {
 //   reason           — failure reason (when applicable)
 def process parse_paloalto_cef_globalprotect {
     process parse_paloalto_cef_normalize_severity
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "login"        { 1 }
         "connected"    { 1 }
         "logout"       { 2 }
@@ -466,7 +467,7 @@ def process parse_paloalto_cef_globalprotect {
         "failed"       { 1 }
         default        { 0 }
     }
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "failed" { 2 }
         default  { 1 }
     }
@@ -477,9 +478,9 @@ def process parse_paloalto_cef_globalprotect {
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         status_id:       status,
-        user: { name: workspace.cef.suser },
-        src_endpoint: { ip: workspace.cef.src },
-        message:      workspace.cef.reason,
+        user: { name: workspace.cef.extension.suser },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        message:      workspace.cef.extension.reason,
         unmapped: {
             cef_severity: workspace.cef.severity
         },
@@ -506,7 +507,7 @@ def process parse_paloalto_cef_globalprotect {
 //   reason  — failure reason
 def process parse_paloalto_cef_authentication {
     process parse_paloalto_cef_normalize_severity
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "success" { 1 }
         "failure" { 2 }
         default   { 0 }
@@ -518,9 +519,9 @@ def process parse_paloalto_cef_authentication {
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         status_id:       status,
-        user:         { name: workspace.cef.suser },
-        src_endpoint: { ip: workspace.cef.src },
-        message:      workspace.cef.reason,
+        user:         { name: workspace.cef.extension.suser },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        message:      workspace.cef.extension.reason,
         unmapped: {
             cef_severity: workspace.cef.severity
         },
@@ -597,8 +598,8 @@ def process paloalto_cef_to_otlp {
             true { [{ key: "event.code", value: { string_value: workspace.cef.name } }] }
             default { [] }
         },
-        switch workspace.cef.act != null {
-            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+        switch workspace.cef.extension.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.extension.act } }] }
             default { [] }
         },
         switch paloalto_cef_otlp_event_outcome(workspace.lsis.parsed.status_id) != null {

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -1,6 +1,20 @@
 // Summary:     Palo Alto Networks PAN-OS CEF → LSIS, dispatched by CEF
 //              name (TRAFFIC / THREAT / URL / …).
-// Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Palo Alto Networks|PAN-OS|...)
+// Reads:       workspace.cef.* (format intake — populated by
+//              parse_syslog | parse_cef upstream)
+//                .name (required, String) — CEF header Name, which PAN-OS
+//                     uses to encode the log type (the dispatch key)
+//                .severity (optional, Int) — CEF header severity
+//                     (PAN-OS dialect 1-5)
+//                .device_vendor (optional, String) — CEF header vendor
+//                .device_product (optional, String) — CEF header product
+//                .device_version (optional, String) — CEF header version
+//                (plus the per-leaf standard / `cs<n>` extension keys
+//                documented on each subtype leaf below)
+//              workspace.syslog.* (transport intake)
+//                .timestamp (optional, String) — RFC 3164 wire timestamp
+//                .msg (optional, String) — syslog body, retained by
+//                     paloalto_cef_to_otlp as the OTLP Body
 //              workspace.paloalto_cef.timezone (optional, String) — source
 //              device timezone override as an IANA name or fixed offset; the
 //              legacy RFC 3164 wrapper defaults to the limpid host's system
@@ -17,6 +31,16 @@
 //              OTLP Resource, Body, and LogRecord attributes.
 // Category:    Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_cef | parse_paloalto_cef | compose_ocsf | ocsf_to_egress
+//
+// Transport (`parse_syslog`) and format (`parse_cef`) are separate
+// upstream stages; this parser interprets the PAN-OS dialect on the
+// already-parsed `workspace.cef.*`. Separating the stages lets a
+// pipeline inspect and drop events after each stage without paying the
+// next stage's parse cost.
 //
 // Wire —    syslog-wrapped CEF — `<priority>timestamp host CEF:0|Palo Alto Networks|PAN-OS|...`
 //          ArcSight CEF header + PAN-OS-specific extension keys
@@ -37,10 +61,11 @@
 // Sample input (RFC 3164 syslog wrapper around CEF, TRAFFIC subtype):
 //   <134>Apr 27 10:00:00 fw-pan01 CEF:0|Palo Alto Networks|PAN-OS|10.2.0|end|TRAFFIC|3|src=192.0.2.10 spt=54321 dst=198.51.100.5 dpt=443 proto=tcp act=allow in=2048 out=1024 app=ssl suser=alice
 //
-// Direct call (skip syslog wrapper, supply raw CEF in `ingress`):
+// Direct call (no syslog wrapper, raw CEF in `ingress` — bridge the body
+// into the transport intake so the shared `parse_cef` stage applies):
 //   def pipeline x {
 //     input bare_cef
-//     process { workspace.cef = cef.parse(ingress) } | parse_paloalto_cef_traffic | compose_ocsf | ocsf_to_egress
+//     process { workspace.syslog = { msg: ingress } } | parse_cef | parse_paloalto_cef_traffic | compose_ocsf | ocsf_to_egress
 //     output ...
 //   }
 
@@ -137,12 +162,14 @@ def function paloalto_cef_threat_disposition_id(act) {
 include "../functions/proto_num.limpid"
 
 // ---------------------------------------------------------------------------
-// Dispatcher: parse syslog wrapper + CEF body, dispatch by cef.name
+// Dispatcher: read the parsed CEF intake, dispatch by cef.name
 // ---------------------------------------------------------------------------
+//
+// The RFC 3164 wrapper timestamp is copied into the CEF namespace here
+// because the CEF wrapper itself carries no timestamp; the per-leaf
+// normalize process interprets it in the declared device timezone.
 
 def process parse_paloalto_cef {
-    workspace.syslog = syslog.parse(ingress)
-    workspace.cef    = cef.parse(workspace.syslog.msg)
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.name {
         "TRAFFIC"        { process parse_paloalto_cef_traffic }

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -1,7 +1,9 @@
 // Summary:     Palo Alto Networks PAN-OS native CSV syslog → LSIS,
 //              dispatched by the positional Type field.
-// Reads:       ingress (raw wire) — syslog-wrapped positional CSV
-//              (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
+// Reads:       workspace.syslog.* (transport intake — populated by
+//              parse_syslog upstream)
+//                .msg (required, String) — syslog body carrying the positional
+//                     CSV row (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
 //              workspace.paloalto_syslog.timezone (optional, String) — source
 //              timezone override as an IANA name or fixed offset; legacy
 //              Receive/Generated Time defaults to the limpid host's system
@@ -18,6 +20,15 @@
 //              source-owned OTLP Resource, Body, and LogRecord attributes.
 // Category:    Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_paloalto_syslog | compose_ocsf | ocsf_to_egress
+//
+// The syslog wrapper is unwrapped by `parse_syslog` upstream; this
+// parser consumes the CSV row from `workspace.syslog.msg`. Separating
+// the stages lets a pipeline inspect and drop events after
+// `parse_syslog` without paying the vocabulary parse cost.
 //
 // Wire —    syslog-wrapped CSV — `<priority>timestamp host FUTURE_USE,RecvTime,Serial,Type,Subtype,...`
 //          PAN-OS native CSV log format (positional, ~60-117 fields per
@@ -152,7 +163,6 @@ include "../functions/proto_num.limpid"
 // its own schema.
 
 def process parse_paloalto_syslog {
-    workspace.syslog = syslog.parse(ingress)
     workspace.pan_header = csv_parse(workspace.syslog.msg, ["", "", "", "Type", "Subtype"])
     switch workspace.pan_header.Type {
         "TRAFFIC"        { process parse_paloalto_syslog_traffic }


### PR DESCRIPTION
## Summary

Separates the three layers previously conflated in the CEF parser stack — syslog
transport (`parse_syslog`), CEF format unwrap (`parse_cef`), and vendor
vocabulary (`parse_fortigate_cef` / `parse_paloalto_cef` / `parse_asa`) — so
each stage is independently composable and a drop filter can run at the
earliest possible point. FortiGate native syslog stays as the documented
exception (its wire is not RFC 3164-compliant, so no transport stage exists to
separate).

Also lands two `cef.parse` primitive fixes surfaced by this refactor:

- **Extension isolation** — data-driven Extension key=value pairs move under a
  nested `workspace.cef.extension.*` sub-object so a key named after a header
  field (`severity=`, `name=`, dialect quirk or log injection alike) can no
  longer shadow the positional header value. Pre-fix behaviour split by read
  path (arena first-wins, workspace snapshot last-wins).
- **Header escape** — the header splitter now honours the CEF-spec generic
  structural escapes `\|` and `\\`, so a wire like `deny\|drop` in `name`
  no longer shifts every downstream field by one position and no longer
  misclassifies `severity`.

Adds a generic `cef_to_otlp` adapter alongside the vendor-specific ones,
producing OTel semconv attributes for the semconv-self-evident CEF extension
keys and passthrough under `cef.<key>` for the spec-defined dictionary
remainder.

## Test plan

- [x] `cargo test --workspace --locked` — 982 passed / 1 ignored
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] mdBook build, snippet header lint (42/0), inventory in sync
- [x] Independent audit (uchgs push, 9/9 scopes PASS)
- [x] Independent code review of CEF header escape fix against ArcSight
      CEF spec
- [x] End-to-end verification on Splunk Enterprise 10.4.1 via Splunk Connect
      for OTLP: three vendor chains (ASA/FortiGate CEF/PAN CEF) reach the
      Collector with DLQ 0; generic \`parse_cef\` chain maps CEF severity
      0..10 to OTel SeverityNumber {9,10,11,12,13,14,15,17,18,21,22};
      \`deny\\|drop\` header escape recovers correctly; header-vs-extension
      collision does not corrupt severity; FortiGate native byte-equivalent
      to base

## Breaking changes

- \`cef.parse\` output shape: Extension keys move from top-level siblings of
  the header fields to a nested \`extension\` sub-object; the raw blob field
  is renamed \`ext\` → \`extension_raw\`. Bundled parsers, docs, and tests are
  updated. Out-of-tree readers of these keys must add the \`extension.\`
  segment (mapping table in CHANGELOG).
- Snippet chains for CEF vendors change from \`parse_syslog | parse_<vendor>\`
  to \`parse_syslog | parse_cef | parse_<vendor>\`. Old form emits a lint
  warning; migration is mechanical.