### PR TITLE
feat(dsl): iterate object entries in block primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,17 @@ stages):
 | `parse_fortigate_cef \| ...` | `parse_syslog \| parse_cef \| parse_fortigate_cef \| ...` |
 | `parse_paloalto_cef \| ...` | `parse_syslog \| parse_cef \| parse_paloalto_cef \| ...` |
 
+### Added — block primitives iterate object entries
+
+`map`, `filter`, `find`, and `reduce` now accept Object values in addition to
+arrays. Object blocks bind each key as a String alongside its value, visit
+entries in insertion order without deduplicating repeated keys, and use
+type-specific arity checks so an array-shaped block cannot silently consume an
+object (or vice versa). `map` returns an array of block results, `filter`
+returns the retained object entries, `find` returns the first matching
+`[key, value]` pair, and `reduce` folds `|acc, key, value|` over the entries.
+Null inputs retain the existing array behavior.
+
 ### Changed — dependency dedupe
 
 Bumped `axum` to 0.8 and `webpki-roots` to 1.0 so the dependency graph no

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -56,12 +56,20 @@ pub fn infer(expr: &Expr, bindings: &Bindings, registry: &FunctionRegistry) -> F
         ExprKind::FuncCall {
             namespace,
             name,
-            args: _,
+            args,
             block_arg: _,
-        } => registry
-            .signature(namespace.as_deref(), name)
-            .map(|s| s.ret.clone())
-            .unwrap_or(FieldType::Any),
+        } => {
+            if namespace.is_none() && name == "filter" {
+                args.first()
+                    .map(|arg| filter_return_type(infer(arg, bindings, registry)))
+                    .unwrap_or(FieldType::Any)
+            } else {
+                registry
+                    .signature(namespace.as_deref(), name)
+                    .map(|s| s.ret.clone())
+                    .unwrap_or(FieldType::Any)
+            }
+        }
         ExprKind::BinOp(_l, op, _r) => match op {
             BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge => {
                 FieldType::Bool
@@ -98,6 +106,21 @@ pub fn infer(expr: &Expr, bindings: &Bindings, registry: &FunctionRegistry) -> F
                 FieldType::union(result, FieldType::Null)
             }
         }
+    }
+}
+
+fn filter_return_type(input: FieldType) -> FieldType {
+    match input {
+        FieldType::Array | FieldType::Null => FieldType::Array,
+        FieldType::Object => FieldType::Object,
+        FieldType::Union(members) => members
+            .into_iter()
+            .map(filter_return_type)
+            .reduce(FieldType::union)
+            .unwrap_or(FieldType::Any),
+        // An unknown or invalid input stays unknown to avoid cascading
+        // diagnostics after the call-site argument check.
+        _ => FieldType::Any,
     }
 }
 
@@ -225,18 +248,48 @@ pub fn check_types(
             namespace,
             name,
             args,
-            block_arg: _,
+            block_arg,
         } => {
-            walk_children(expr, |child| {
+            for arg in args {
                 check_types(
-                    child,
+                    arg,
                     pipeline_name,
                     bindings,
                     registry,
                     fallback_span,
                     diagnostics,
-                )
-            });
+                );
+            }
+            if let Some(block) = block_arg {
+                let mut block_bindings = bindings.clone();
+                block_bindings.push_let_scope();
+                for (index, param) in block.params.iter().enumerate() {
+                    block_bindings.bind_let(
+                        param,
+                        block_parameter_type(name, args, index, bindings, registry),
+                    );
+                }
+                for local in &block.body.lets {
+                    check_types(
+                        &local.value,
+                        pipeline_name,
+                        &block_bindings,
+                        registry,
+                        fallback_span,
+                        diagnostics,
+                    );
+                    let ty = infer(&local.value, &block_bindings, registry);
+                    block_bindings.bind_let(&local.name, ty);
+                }
+                check_types(
+                    &block.body.ret,
+                    pipeline_name,
+                    &block_bindings,
+                    registry,
+                    fallback_span,
+                    diagnostics,
+                );
+            }
             // Function-call-level diagnostic (unknown function, arg
             // type mismatch) anchors to the call expression itself; the
             // per-argument diagnostic below prefers the individual arg
@@ -295,6 +348,28 @@ pub fn check_types(
                 diagnostics,
             )
         }),
+    }
+}
+
+fn block_parameter_type(
+    name: &str,
+    args: &[Expr],
+    index: usize,
+    bindings: &Bindings,
+    registry: &FunctionRegistry,
+) -> FieldType {
+    let collection = args
+        .first()
+        .map(|arg| infer(arg, bindings, registry))
+        .unwrap_or(FieldType::Any);
+    match (name, collection, index) {
+        ("map" | "filter" | "find", FieldType::Object, 0) => FieldType::String,
+        ("reduce", _, 0) => args
+            .get(1)
+            .map(|arg| infer(arg, bindings, registry))
+            .unwrap_or(FieldType::Any),
+        ("reduce", FieldType::Object, 1) => FieldType::String,
+        _ => FieldType::Any,
     }
 }
 

--- a/crates/limpid/src/dsl/eval.rs
+++ b/crates/limpid/src/dsl/eval.rs
@@ -237,16 +237,15 @@ pub fn eval_expr_with_scope<'bump>(
     }
 }
 
-/// Evaluate a primitive call that carries a trailing `{ |id| body }`
-/// block argument.
+/// Evaluate a primitive call that carries a trailing block argument.
 ///
 /// Only `map` / `filter` / `find` / `reduce` accept block-args (other
-/// names bail with a clear error). For each, the array argument is
-/// evaluated up-front (so type errors surface deterministically), then
-/// the block body is re-evaluated per element with the bound identifier
-/// pushed onto a child copy of the caller's [`LocalScope`]. Locals
-/// introduced inside the block body do not leak back to the caller —
-/// each iteration runs against a fresh clone.
+/// names bail with a clear error). Each primitive evaluates its collection
+/// argument up-front and dispatches on its runtime `Array` / `Object` type.
+/// The block body is then re-evaluated per element or entry with its
+/// arguments pushed onto a child copy of the caller's [`LocalScope`]. Locals
+/// introduced inside the block body do not leak back to the caller; each
+/// iteration runs against a fresh clone.
 #[allow(clippy::too_many_arguments)]
 fn eval_block_primitive<'bump>(
     namespace: Option<&str>,
@@ -306,31 +305,52 @@ fn eval_block_body<'bump>(
     eval_expr_with_scope(&block.body.ret, event, funcs, &scope, arena)
 }
 
-fn expect_one_arg_array<'bump>(
+fn expect_collection_arg<'bump>(
     name: &str,
     args: &[Expr],
+    expected_args: usize,
     event: &BorrowedEvent<'bump>,
     funcs: &FunctionRegistry,
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
-) -> Result<&'bump [Value<'bump>]> {
-    if args.len() != 1 {
+) -> Result<Value<'bump>> {
+    if args.len() != expected_args {
         bail!(
-            "{}() with a block expects 1 array argument, got {}",
+            "{}() with a block expects {} argument(s), got {}",
             name,
+            expected_args,
             args.len()
         );
     }
     let v = eval_expr_with_scope(&args[0], event, funcs, scope, arena)?;
     match v {
-        Value::Array(items) => Ok(items),
-        Value::Null => Ok(&[]),
+        Value::Array(_) | Value::Object(_) | Value::Null => Ok(v),
         other => bail!(
-            "{}() expects an array as its first argument, got {}",
+            "{}() expects an array or object as its first argument, got {}",
             name,
             other.type_name()
         ),
     }
+}
+
+fn expect_block_arity(
+    name: &str,
+    block: &BlockArg,
+    collection_type: &str,
+    expected: usize,
+    example: &str,
+) -> Result<()> {
+    if block.params.len() != expected {
+        bail!(
+            "{}() over an {} requires exactly {} block parameter(s) (`{}`); got {}",
+            name,
+            collection_type,
+            expected,
+            example,
+            block.params.len()
+        );
+    }
+    Ok(())
 }
 
 fn eval_map<'bump>(
@@ -341,19 +361,43 @@ fn eval_map<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 1 {
-        bail!(
-            "map block takes exactly 1 parameter (`{{ |x| ... }}`); got {}",
-            block.params.len()
-        );
+    match expect_collection_arg("map", args, 1, event, funcs, scope, arena)? {
+        Value::Array(items) => {
+            expect_block_arity("map", block, "array", 1, "{ |x| ... }")?;
+            let mut out = ArrayBuilder::with_capacity(arena, items.len());
+            for item in items {
+                out.push(eval_block_body(
+                    block,
+                    &[*item],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?);
+            }
+            Ok(out.finish())
+        }
+        Value::Object(entries) => {
+            expect_block_arity("map", block, "object", 2, "{ |key, value| ... }")?;
+            let mut out = ArrayBuilder::with_capacity(arena, entries.len());
+            for (key, value) in entries {
+                out.push(eval_block_body(
+                    block,
+                    &[Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?);
+            }
+            Ok(out.finish())
+        }
+        Value::Null => {
+            expect_block_arity("map", block, "array", 1, "{ |x| ... }")?;
+            Ok(ArrayBuilder::new(arena).finish())
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    let items = expect_one_arg_array("map", args, event, funcs, scope, arena)?;
-    let mut out = ArrayBuilder::with_capacity(arena, items.len());
-    for item in items {
-        let v = eval_block_body(block, &[*item], event, funcs, scope, arena)?;
-        out.push(v);
-    }
-    Ok(out.finish())
 }
 
 fn eval_filter<'bump>(
@@ -364,21 +408,42 @@ fn eval_filter<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 1 {
-        bail!(
-            "filter block takes exactly 1 parameter (`{{ |x| ... }}`); got {}",
-            block.params.len()
-        );
-    }
-    let items = expect_one_arg_array("filter", args, event, funcs, scope, arena)?;
-    let mut out = ArrayBuilder::new(arena);
-    for item in items {
-        let v = eval_block_body(block, &[*item], event, funcs, scope, arena)?;
-        if v.is_truthy() {
-            out.push(*item);
+    match expect_collection_arg("filter", args, 1, event, funcs, scope, arena)? {
+        Value::Array(items) => {
+            expect_block_arity("filter", block, "array", 1, "{ |x| ... }")?;
+            let mut out = ArrayBuilder::new(arena);
+            for item in items {
+                if eval_block_body(block, &[*item], event, funcs, scope, arena)?.is_truthy() {
+                    out.push(*item);
+                }
+            }
+            Ok(out.finish())
         }
+        Value::Object(entries) => {
+            expect_block_arity("filter", block, "object", 2, "{ |key, value| ... }")?;
+            let mut out = ObjectBuilder::with_capacity(arena, entries.len());
+            for (key, value) in entries {
+                if eval_block_body(
+                    block,
+                    &[Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?
+                .is_truthy()
+                {
+                    out.push(key, *value);
+                }
+            }
+            Ok(out.finish())
+        }
+        Value::Null => {
+            expect_block_arity("filter", block, "array", 1, "{ |x| ... }")?;
+            Ok(ArrayBuilder::new(arena).finish())
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    Ok(out.finish())
 }
 
 fn eval_find<'bump>(
@@ -389,20 +454,43 @@ fn eval_find<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 1 {
-        bail!(
-            "find block takes exactly 1 parameter (`{{ |x| ... }}`); got {}",
-            block.params.len()
-        );
-    }
-    let items = expect_one_arg_array("find", args, event, funcs, scope, arena)?;
-    for item in items {
-        let v = eval_block_body(block, &[*item], event, funcs, scope, arena)?;
-        if v.is_truthy() {
-            return Ok(*item);
+    match expect_collection_arg("find", args, 1, event, funcs, scope, arena)? {
+        Value::Array(items) => {
+            expect_block_arity("find", block, "array", 1, "{ |x| ... }")?;
+            for item in items {
+                if eval_block_body(block, &[*item], event, funcs, scope, arena)?.is_truthy() {
+                    return Ok(*item);
+                }
+            }
+            Ok(Value::Null)
         }
+        Value::Object(entries) => {
+            expect_block_arity("find", block, "object", 2, "{ |key, value| ... }")?;
+            for (key, value) in entries {
+                if eval_block_body(
+                    block,
+                    &[Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?
+                .is_truthy()
+                {
+                    let mut pair = ArrayBuilder::with_capacity(arena, 2);
+                    pair.push(Value::String(key));
+                    pair.push(*value);
+                    return Ok(pair.finish());
+                }
+            }
+            Ok(Value::Null)
+        }
+        Value::Null => {
+            expect_block_arity("find", block, "array", 1, "{ |x| ... }")?;
+            Ok(Value::Null)
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    Ok(Value::Null)
 }
 
 fn eval_reduce<'bump>(
@@ -413,30 +501,37 @@ fn eval_reduce<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 2 {
-        bail!(
-            "reduce block takes exactly 2 parameters (`{{ |acc, x| ... }}`); got {}",
-            block.params.len()
-        );
+    let collection = expect_collection_arg("reduce", args, 2, event, funcs, scope, arena)?;
+    match collection {
+        Value::Array(_) | Value::Null => {
+            expect_block_arity("reduce", block, "array", 2, "{ |acc, x| ... }")?;
+        }
+        Value::Object(_) => {
+            expect_block_arity("reduce", block, "object", 3, "{ |acc, key, value| ... }")?;
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    if args.len() != 2 {
-        bail!(
-            "reduce() with a block expects 2 arguments (array, init), got {}",
-            args.len()
-        );
-    }
-    let arr_val = eval_expr_with_scope(&args[0], event, funcs, scope, arena)?;
-    let items: &[Value<'bump>] = match arr_val {
-        Value::Array(items) => items,
-        Value::Null => &[],
-        other => bail!(
-            "reduce() expects an array as its first argument, got {}",
-            other.type_name()
-        ),
-    };
     let mut acc = eval_expr_with_scope(&args[1], event, funcs, scope, arena)?;
-    for item in items {
-        acc = eval_block_body(block, &[acc, *item], event, funcs, scope, arena)?;
+    match collection {
+        Value::Array(items) => {
+            for item in items {
+                acc = eval_block_body(block, &[acc, *item], event, funcs, scope, arena)?;
+            }
+        }
+        Value::Object(entries) => {
+            for (key, value) in entries {
+                acc = eval_block_body(
+                    block,
+                    &[acc, Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?;
+            }
+        }
+        Value::Null => {}
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
     Ok(acc)
 }

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -1003,6 +1003,38 @@ mod tests {
         })
     }
 
+    fn int_object(entries: &[(&str, i64)]) -> Expr {
+        e(ExprKind::HashLit(
+            entries
+                .iter()
+                .map(|(key, value)| ((*key).into(), e(ExprKind::IntLit(*value))))
+                .collect(),
+        ))
+    }
+
+    fn block_call_error(name: &str, collection: Expr, params: Vec<&str>) -> String {
+        let _bump = ::bumpalo::Bump::new();
+        let arena = crate::dsl::arena::EventArena::new(&_bump);
+        let event = make_event();
+        let bevent = event.view_in(&arena);
+        let mut args = vec![collection];
+        if name == "reduce" {
+            args.push(e(ExprKind::IntLit(0)));
+        }
+        let stmts = vec![ProcessStatement::Assign(
+            AssignTarget::Workspace(vec!["result".into()]),
+            block_call(name, args, params, e(ExprKind::BoolLit(true))),
+        )];
+        expect_exec_err(exec_process_body(
+            &stmts,
+            bevent,
+            &NoopRegistry,
+            &make_funcs(),
+            &arena,
+        ))
+        .to_string()
+    }
+
     #[test]
     fn test_exec_array_literal_into_workspace() {
         let _bump = ::bumpalo::Bump::new();
@@ -1232,6 +1264,245 @@ mod tests {
             }
             ExecResult::Dropped => panic!("unexpected drop"),
         }
+    }
+
+    #[test]
+    fn test_exec_block_object_primitives_preserve_entry_order_and_duplicates() {
+        let _bump = ::bumpalo::Bump::new();
+        let arena = crate::dsl::arena::EventArena::new(&_bump);
+        let event = make_event();
+        let bevent = event.view_in(&arena);
+        let entries = || e(ExprKind::Ident(vec!["workspace".into(), "entries".into()]));
+        let key = || e(ExprKind::Ident(vec!["key".into()]));
+        let value = || e(ExprKind::Ident(vec!["value".into()]));
+        let stmts = vec![
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["entries".into()]),
+                int_object(&[("a", 1), ("a", 2), ("b", 3)]),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["mapped".into()]),
+                block_call(
+                    "map",
+                    vec![entries()],
+                    vec!["key", "value"],
+                    e(ExprKind::ArrayLit(vec![key(), value()])),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["filtered".into()]),
+                block_call(
+                    "filter",
+                    vec![entries()],
+                    vec!["key", "value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["found".into()]),
+                block_call(
+                    "find",
+                    vec![entries()],
+                    vec!["key", "value"],
+                    e(ExprKind::BinOp(
+                        Box::new(value()),
+                        BinOp::Eq,
+                        Box::new(e(ExprKind::IntLit(2))),
+                    )),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["total".into()]),
+                block_call(
+                    "reduce",
+                    vec![entries(), e(ExprKind::IntLit(0))],
+                    vec!["acc", "key", "value"],
+                    e(ExprKind::BinOp(
+                        Box::new(e(ExprKind::Ident(vec!["acc".into()]))),
+                        BinOp::Add,
+                        Box::new(value()),
+                    )),
+                ),
+            ),
+        ];
+
+        match exec_process_body(&stmts, bevent, &NoopRegistry, &make_funcs(), &arena).unwrap() {
+            ExecResult::Continue(ev) => {
+                assert_eq!(
+                    ev.workspace_get("mapped").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![
+                        OwnedValue::Array(
+                            vec![OwnedValue::String("a".into()), OwnedValue::Int(1),]
+                        ),
+                        OwnedValue::Array(
+                            vec![OwnedValue::String("a".into()), OwnedValue::Int(2),]
+                        ),
+                        OwnedValue::Array(
+                            vec![OwnedValue::String("b".into()), OwnedValue::Int(3),]
+                        ),
+                    ])
+                );
+                let Some(Value::Object(filtered)) = ev.workspace_get("filtered") else {
+                    panic!("filter(object) did not return an object");
+                };
+                assert_eq!(
+                    filtered,
+                    &[
+                        ("a", Value::Int(1)),
+                        ("a", Value::Int(2)),
+                        ("b", Value::Int(3)),
+                    ]
+                );
+                assert_eq!(
+                    ev.workspace_get("found").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![OwnedValue::String("a".into()), OwnedValue::Int(2),])
+                );
+                assert_eq!(ev.workspace_get("total"), Some(Value::Int(6)));
+            }
+            ExecResult::Dropped => panic!("unexpected drop"),
+        }
+    }
+
+    #[test]
+    fn test_exec_block_object_primitives_handle_empty_and_null_collections() {
+        let _bump = ::bumpalo::Bump::new();
+        let arena = crate::dsl::arena::EventArena::new(&_bump);
+        let event = make_event();
+        let bevent = event.view_in(&arena);
+        let empty = || e(ExprKind::HashLit(vec![]));
+        let null = || e(ExprKind::Null);
+        let stmts = vec![
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["map_empty".into()]),
+                block_call(
+                    "map",
+                    vec![empty()],
+                    vec!["key", "value"],
+                    e(ExprKind::Null),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["filter_empty".into()]),
+                block_call(
+                    "filter",
+                    vec![empty()],
+                    vec!["key", "value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["find_empty".into()]),
+                block_call(
+                    "find",
+                    vec![empty()],
+                    vec!["key", "value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["reduce_empty".into()]),
+                block_call(
+                    "reduce",
+                    vec![empty(), e(ExprKind::IntLit(7))],
+                    vec!["acc", "key", "value"],
+                    e(ExprKind::Ident(vec!["acc".into()])),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["map_null".into()]),
+                block_call("map", vec![null()], vec!["value"], e(ExprKind::Null)),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["filter_null".into()]),
+                block_call(
+                    "filter",
+                    vec![null()],
+                    vec!["value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["find_null".into()]),
+                block_call(
+                    "find",
+                    vec![null()],
+                    vec!["value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["reduce_null".into()]),
+                block_call(
+                    "reduce",
+                    vec![null(), e(ExprKind::IntLit(7))],
+                    vec!["acc", "value"],
+                    e(ExprKind::Ident(vec!["acc".into()])),
+                ),
+            ),
+        ];
+
+        match exec_process_body(&stmts, bevent, &NoopRegistry, &make_funcs(), &arena).unwrap() {
+            ExecResult::Continue(ev) => {
+                assert_eq!(
+                    ev.workspace_get("map_empty").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![])
+                );
+                assert!(matches!(
+                    ev.workspace_get("filter_empty"),
+                    Some(Value::Object(entries)) if entries.is_empty()
+                ));
+                assert_eq!(ev.workspace_get("find_empty"), Some(Value::Null));
+                assert_eq!(ev.workspace_get("reduce_empty"), Some(Value::Int(7)));
+                assert_eq!(
+                    ev.workspace_get("map_null").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![])
+                );
+                assert_eq!(
+                    ev.workspace_get("filter_null").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![])
+                );
+                assert_eq!(ev.workspace_get("find_null"), Some(Value::Null));
+                assert_eq!(ev.workspace_get("reduce_null"), Some(Value::Int(7)));
+            }
+            ExecResult::Dropped => panic!("unexpected drop"),
+        }
+    }
+
+    #[test]
+    fn test_exec_block_primitives_reject_collection_arity_mismatches() {
+        for name in ["map", "filter", "find"] {
+            let err = block_call_error(name, int_object(&[("a", 1)]), vec!["value"]);
+            assert!(
+                err.contains(&format!("{}() over an object requires exactly 2", name)),
+                "unexpected {name} object arity error: {err}"
+            );
+
+            let err = block_call_error(
+                name,
+                e(ExprKind::ArrayLit(vec![e(ExprKind::IntLit(1))])),
+                vec!["key", "value"],
+            );
+            assert!(
+                err.contains(&format!("{}() over an array requires exactly 1", name)),
+                "unexpected {name} array arity error: {err}"
+            );
+        }
+
+        let err = block_call_error("reduce", int_object(&[("a", 1)]), vec!["acc", "value"]);
+        assert!(
+            err.contains("reduce() over an object requires exactly 3"),
+            "unexpected reduce object arity error: {err}"
+        );
+
+        let err = block_call_error(
+            "reduce",
+            e(ExprKind::ArrayLit(vec![e(ExprKind::IntLit(1))])),
+            vec!["acc", "key", "value"],
+        );
+        assert!(
+            err.contains("reduce() over an array requires exactly 2"),
+            "unexpected reduce array arity error: {err}"
+        );
     }
 
     #[test]

--- a/crates/limpid/src/dsl/value.rs
+++ b/crates/limpid/src/dsl/value.rs
@@ -657,9 +657,9 @@ impl<'bump> ObjectBuilder<'bump> {
         }
     }
 
-    /// Push an entry. Insertion order is preserved by the underlying
-    /// arena vec; duplicate keys are NOT detected here (debug builds may
-    /// add a `debug_assert!` later — release stays linear-scan-fast).
+    /// Push an entry. Insertion order and duplicate keys are intentionally
+    /// preserved by the underlying arena vec; callers that iterate an Object
+    /// must observe every stored entry.
     pub fn push(&mut self, key: &'bump str, value: Value<'bump>) {
         self.entries.push((key, value));
     }

--- a/crates/limpid/src/functions/primitives/filter.rs
+++ b/crates/limpid/src/functions/primitives/filter.rs
@@ -1,4 +1,11 @@
-//! `filter(arr) { |x| body }` — block-arg primitive.
+//! `filter(array) { |value| predicate }` /
+//! `filter(object) { |key, value| predicate }` — block-arg primitive.
+//!
+//! Arrays bind one block parameter and return an Array containing the
+//! truthy elements. Objects bind the entry key and value as two
+//! parameters and return an Object containing the truthy entries in
+//! insertion order. `Null` follows the empty-Array form, requires one
+//! block parameter, and returns an empty Array.
 //!
 //! See `map.rs` for the dispatch story (real evaluation in
 //! `eval::eval_block_primitive`; this stub installs the signature and
@@ -7,10 +14,15 @@ use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "filter",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Array),
+        FunctionSig::fixed(
+            &[block_collection_type()],
+            FieldType::Union(vec![FieldType::Array, FieldType::Object]),
+        ),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!(
                 "filter() requires a block argument: `filter(arr) {{ |x| <predicate> }}`"

--- a/crates/limpid/src/functions/primitives/find.rs
+++ b/crates/limpid/src/functions/primitives/find.rs
@@ -1,5 +1,11 @@
-//! `find(arr) { |x| body }` — return the first element where the block
-//! returns truthy, or `null`.
+//! `find(array) { |value| predicate }` /
+//! `find(object) { |key, value| predicate }` — find the first match.
+//!
+//! Arrays bind one block parameter and return the first matching
+//! element. Objects bind the entry key and value as two parameters and
+//! return the first match as a `[key, value]` Array. A miss returns
+//! `Null`; `Null` input follows the empty-Array form and requires one
+//! block parameter.
 //!
 //! Replaces the v0.7.3-and-earlier `find_by(arr, key, value)`. Real
 //! evaluation lives in `eval::eval_block_primitive`; this stub installs
@@ -10,10 +16,12 @@ use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "find",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Any),
+        FunctionSig::fixed(&[block_collection_type()], FieldType::Any),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!("find() requires a block argument: `find(arr) {{ |x| <predicate> }}`");
         },

--- a/crates/limpid/src/functions/primitives/map.rs
+++ b/crates/limpid/src/functions/primitives/map.rs
@@ -1,7 +1,13 @@
-//! `map(arr) { |x| body }` — block-arg primitive.
+//! `map(array) { |value| body }` /
+//! `map(object) { |key, value| body }` — block-arg primitive.
+//!
+//! Arrays bind one block parameter per element. Objects bind the entry
+//! key and value as two parameters. Both forms collect block results
+//! into an Array in insertion order. `Null` follows the empty-Array
+//! form, requires one block parameter, and returns an empty Array.
 //!
 //! Real evaluation happens in [`crate::dsl::eval::eval_block_primitive`];
-//! call sites with a trailing `{ |x| body }` are intercepted at the
+//! call sites with a trailing block are intercepted at the
 //! `ExprKind::FuncCall` arm before ordinary primitive dispatch. The
 //! registration here exists so that:
 //!
@@ -9,16 +15,19 @@
 //! - a call site missing its block (e.g. `map(arr)`) routes through this
 //!   stub, which loud-fails with a clear error.
 //!
-//! Signature: `map(Array) -> Array`. The body's per-element return type
-//! is `Any` (block bodies are not pinned by FieldType today).
+//! Signature: `map(Array | Object | Null) -> Array`. The body's
+//! per-element return type is `Any` (block bodies are not pinned by
+//! FieldType today).
 use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "map",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Array),
+        FunctionSig::fixed(&[block_collection_type()], FieldType::Array),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!("map() requires a block argument: `map(arr) {{ |x| <body> }}`");
         },

--- a/crates/limpid/src/functions/primitives/mod.rs
+++ b/crates/limpid/src/functions/primitives/mod.rs
@@ -18,6 +18,8 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
+use crate::dsl::field_schema::FieldType;
+
 use super::FunctionRegistry;
 use super::table::TableStore;
 
@@ -119,6 +121,11 @@ pub fn register(reg: &mut FunctionRegistry, table_store: TableStore) {
 // ---------------------------------------------------------------------------
 // Shared helpers used by multiple primitive implementations.
 // ---------------------------------------------------------------------------
+
+/// Static input contract shared by block collection primitives.
+pub(super) fn block_collection_type() -> FieldType {
+    FieldType::Union(vec![FieldType::Array, FieldType::Object, FieldType::Null])
+}
 
 /// Coerce a value to a string the way DSL arithmetic / string
 /// primitives expect: string-through, null-as-empty, everything else via

--- a/crates/limpid/src/functions/primitives/reduce.rs
+++ b/crates/limpid/src/functions/primitives/reduce.rs
@@ -1,16 +1,23 @@
-//! `reduce(arr, init) { |acc, x| body }` — left fold.
+//! `reduce(array, init) { |acc, value| step }` /
+//! `reduce(object, init) { |acc, key, value| step }` — left fold.
 //!
-//! Block takes two parameters: the running accumulator and the current
-//! element. Real evaluation lives in `eval::eval_block_primitive`; this
-//! stub installs the signature and the missing-block error.
+//! Arrays bind the accumulator and current element as two block
+//! parameters. Objects bind the accumulator, entry key, and entry value
+//! as three parameters. Both forms fold in insertion order and return
+//! the final accumulator. `Null` follows the empty-Array form, requires
+//! two block parameters, and returns `init` unchanged. Real evaluation
+//! lives in `eval::eval_block_primitive`; this stub installs the
+//! signature and the missing-block error.
 use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "reduce",
-        FunctionSig::fixed(&[FieldType::Array, FieldType::Any], FieldType::Any),
+        FunctionSig::fixed(&[block_collection_type(), FieldType::Any], FieldType::Any),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!(
                 "reduce() requires a block argument: `reduce(arr, init) {{ |acc, x| <step> }}`"

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -497,6 +497,55 @@ def pipeline p {
     assert_eq!(out.status.code(), Some(2));
 }
 
+#[test]
+fn block_collection_overloads_pass_strict_static_checking() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("block_collections.conf");
+    fs::write(
+        &conf,
+        r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        let fields = {alpha: 1, beta: 2}
+        let mapped = map(fields) { |key, value| "${key}:${value}" }
+        let selected = filter(fields) { |key, value| value > 0 }
+        let found = find(fields) { |key, value| key == "alpha" }
+        let total = reduce(fields, 0) { |acc, key, value| acc + value }
+
+        let array_mapped = map([1, 2]) { |value| value + 1 }
+        let array_selected = filter([1, 2]) { |value| value > 0 }
+        let array_found = find([1, 2]) { |value| value == 2 }
+        let array_total = reduce([1, 2], 0) { |acc, value| acc + value }
+        let empty_mapped = map(null) { |value| value }
+        let empty_filtered = filter(null) { |value| value }
+        let empty_found = find(null) { |value| value != null }
+        let empty_total = reduce(null, 0) { |acc, value| acc + value }
+
+        workspace.object_shape = parse_kv("gamma=3", " ", selected)
+        workspace.array_shape = append(array_selected, 3)
+        workspace.results = [
+            mapped, found, total,
+            array_mapped, array_found, array_total,
+            empty_mapped, empty_filtered, empty_found, empty_total,
+        ]
+    }
+    output o
+}
+"#,
+    )
+    .unwrap();
+
+    let out = run_with_flags(&conf, &["--strict-warnings"]);
+    assert!(
+        out.status.success(),
+        "strict check failed: stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Global block schema (v0.7.2)
 // ---------------------------------------------------------------------------

--- a/docs/src/dsl-syntax.md
+++ b/docs/src/dsl-syntax.md
@@ -262,7 +262,7 @@ The expression form has no side effects (no `workspace.x = …`, no `process foo
 
 The constructs not detailed above live on the page they semantically belong to:
 
-- **`try-catch`** — process-body only. See [User-defined Processes → Control flow](./processing/user-defined.md#control-flow) for the syntax and the `error` name binding inside `catch`. Iteration over arrays is *not* a control-flow construct in limpid: use the block-arg primitives (`map`, `filter`, `find`, `reduce`) instead — see [Arrays](./processing/user-defined.md#arrays).
+- **`try-catch`** — process-body only. See [User-defined Processes → Control flow](./processing/user-defined.md#control-flow) for the syntax and the `error` name binding inside `catch`. Iteration over arrays and objects is *not* a control-flow construct in limpid: use the block-arg primitives (`map`, `filter`, `find`, `reduce`) instead — see [Arrays](./processing/user-defined.md#arrays).
 - **`drop` / `finish` / `error`** — pipeline routing. `drop` terminates the event silently (intended discard, counted as `events_dropped`); `finish` ends the pipeline early without dropping (counted as `events_finished`); `error <expr?>` routes the event to the [error log](./operations/error-log.md) with an operator-readable reason (counted as `events_errored`, same as a runtime process failure). `drop` and `error` are also allowed inside a process body; `finish` is pipeline-only. See [Pipelines → drop, finish, and error](./pipelines/drop-finish-error.md) for when to choose which.
 
 ## Pipe operator
@@ -289,22 +289,24 @@ The right-hand side can be:
 - A bare identifier (zero-arg form): `arr |> first` ≡ `arr |> first()`.
 - A bare identifier with a trailing block argument: `arr |> map { |x| x.id }` ≡ `arr |> map() { |x| x.id }`.
 
-All three forms produce identical FuncCall AST after the parser splices the LHS as the first argument. The bare form is purely ergonomic — useful when the pipe is the only argument source and the function has no other positional inputs (`first` / `last` / `distinct` / `sum`) or only takes a block (`map` / `filter` / `find` over the pipe-fed array).
+All three forms produce identical FuncCall AST after the parser splices the LHS as the first argument. The bare form is purely ergonomic — useful when the pipe is the only argument source and the function has no other positional inputs (`first` / `last` / `distinct` / `sum`) or only takes a block (`map` / `filter` / `find` over the pipe-fed collection).
 
 ## Block argument
 
-The block-arg primitives — `map`, `filter`, `find`, `reduce` — accept a trailing block argument that binds one (or, for `reduce`, two) identifier per element and runs the body against it:
+The block-arg primitives — `map`, `filter`, `find`, `reduce` — accept a trailing block argument. Arrays bind one identifier per element (two for `reduce`); objects bind `key, value` per entry (three including the accumulator for `reduce`):
 
 ```limpid
 let evens = filter(workspace.nums) { |n| n % 2 == 0 }
 let doubled = map(workspace.nums) { |n| n * 2 }
 let user_alert = find(workspace.alerts) { |a| a.user == "alice" }
 let total = reduce(workspace.amounts, 0) { |acc, x| acc + x }
+let headers = map(workspace.headers) { |key, value| "${key}: ${value}" }
+let byte_total = reduce(workspace.fields, 0) { |acc, key, value| acc + value }
 ```
 
 The body has the same shape as a `def function` body: zero or more `let` bindings followed by a required trailing return expression. Locals introduced inside the body do not leak back to the caller — each iteration starts with a fresh child of the caller's scope.
 
-Only `map` / `filter` / `find` / `reduce` accept block-args today; attaching one to any other function is a clear error. See [Built-in Functions → Array operations](./functions/expression-functions.md) for the per-primitive details and edge cases.
+Only `map` / `filter` / `find` / `reduce` accept block-args today; attaching one to any other function, or using the wrong number of block parameters for the runtime collection type, is a clear error. See [Built-in Functions → Collection helpers](./functions/expression-functions.md#collection-helpers) for the per-primitive details and edge cases.
 
 ## Reserved identifiers
 

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -709,31 +709,37 @@ workspace.lsis.parsed.src_endpoint.port = to_int(workspace.cef.extension.spt)  /
 
 Motivation: CEF extension values and CSV column values arrive as strings even when carrying numeric content. OCSF schemas commonly require `Integer` for those same fields (ports, session IDs, byte counts). `to_int` is the schema-agnostic cast used by SIEM parser snippets.
 
-## Array helpers
+## Collection helpers
 
 Arrays in limpid are **ordered but index-hidden** — you construct them with `[a, b, c]` literals, but the DSL deliberately omits positional access (`arr[n]`) and positional writes (`arr[n] = v`). Element identity (or whole-array transforms) is the addressing model; see [User-defined Processes → Arrays](../processing/user-defined.md#arrays) for the rationale and the per-primitive references below.
 
-Four primitives — `map`, `filter`, `find`, `reduce` — take a **block argument** (`{ |x| ... }`) per element. Block syntax and the universal pipe operator `|>` are documented in [DSL Syntax Basics → Block argument](../dsl-syntax.md#block-argument).
+Four primitives — `map`, `filter`, `find`, `reduce` — take a **block argument** per array element or object entry. Array blocks bind `{ |x| ... }`; object blocks bind `{ |key, value| ... }`. Block syntax and the universal pipe operator `|>` are documented in [DSL Syntax Basics → Block argument](../dsl-syntax.md#block-argument).
 
-### map(array) { |x| body }
+### map(array) { |x| body } / map(object) { |key, value| body }
 
 Per-element transform; returns a new array of the same length, with each element replaced by the block's return value. Construction order is preserved. `Null` input → empty array.
 
+For an object, visits each entry in insertion order and returns an array containing each block result. Keys are bound as strings. Duplicate keys remain separate visits.
+
 ```limpid
 workspace.upper_users = map(workspace.events) { |e| upper(e.user) }
+workspace.headers = map(workspace.headers_by_name) { |key, value| "${key}: ${value}" }
 ```
 
-### filter(array) { |x| predicate }
+### filter(array) { |x| predicate } / filter(object) { |key, value| predicate }
 
 Keep elements where the block returns a truthy value. Order-preserving; non-truthy elements (`false`, `null`, `0`, `""`, empty containers) are dropped.
 
+For an object, returns an object containing the original entries whose block result is truthy. Entry order and duplicate keys are preserved. `Null` retains the established array behavior and returns an empty array.
+
 ```limpid
 workspace.alerts = filter(workspace.events) { |e| e.severity >= 7 }
+workspace.public = filter(workspace.fields) { |key, value| not starts_with(key, "_") }
 ```
 
 Equivalent to `compact` for null removal: `filter(arr) { |x| x != null }` drops `null` entries (no separate `compact` primitive ships — `null_omit` operates on objects, not arrays).
 
-### find(array) { |x| predicate }
+### find(array) { |x| predicate } / find(object) { |key, value| predicate }
 
 First element where the block returns truthy, or `null` if no match. An earlier `find_by(arr, key, value)` shape was removed in the 0.7.x cycle; the block-arg form composes for arbitrary predicates:
 
@@ -743,16 +749,23 @@ workspace.user    = find(workspace.evidence) { |e| e.entityType == "User" }
 workspace.recent  = find(workspace.events)   { |e| e.received_at > workspace.cutoff }
 ```
 
+For an object, returns the first matching entry as a two-element `[key, value]` array, or `null` when no entry matches.
+
 Non-object elements no longer have to be skipped silently — predicate logic decides what counts as a match.
 
-### reduce(array, init) { |acc, x| step }
+### reduce(array, init) { |acc, x| step } / reduce(object, init) { |acc, key, value| step }
 
 Left fold. The block takes two parameters: the running accumulator (`init` on the first iteration) and the current element. The block's return value becomes the new accumulator. Empty array → `init` unchanged.
+
+For an object, the block takes the accumulator, key, and value. Entries are folded in insertion order, including duplicate keys. Empty object → `init` unchanged. `Null` follows the array convention and also returns `init`.
 
 ```limpid
 let total = reduce(workspace.amounts, 0) { |acc, x| acc + x }
 let joined = reduce(workspace.tags, "") { |acc, t| acc + "," + t }
+let total_bytes = reduce(workspace.byte_fields, 0) { |acc, key, value| acc + value }
 ```
+
+Block arity is checked against the evaluated collection type. Array calls require one block parameter (`map` / `filter` / `find`) or two (`reduce`); object calls require two or three respectively. A mismatch is an error rather than an ignored binding.
 
 ### first(array) / last(array)
 
@@ -878,7 +891,7 @@ is_array(null)          // false
 is_array({a: 1})        // false (Object, not Array)
 ```
 
-Designed for snippet parsers that consume vendor JSON whose nominally-array fields may arrive as scalars when upstream is malformed. The pattern is **pre-validate intake shape, emit a parser-authored error on mismatch** — rather than fall through to `find()` / `map()` / `filter()` and surface a generic `<primitive>() expects an array` runtime error:
+Designed for snippet parsers that consume vendor JSON whose nominally-array fields may arrive as scalars when upstream is malformed. The pattern is **pre-validate intake shape, emit a parser-authored error on mismatch** — rather than fall through to `find()` / `map()` / `filter()` and surface a generic `<primitive>() expects an array or object` runtime error:
 
 ```limpid
 def process parse_okta_system {

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -132,7 +132,7 @@ def function endpoint_label(host, port) {
 }
 ```
 
-Anything an expression can do (binary ops, primitive calls, hash literals, array literals, nested function calls) is fair game inside `let` RHS or the trailing expression. The block-arg primitives — `map`, `filter`, `find`, `reduce` — are pure expressions over arrays and compose freely inside a function body. What you cannot do is write a *statement* — no assignments to anything, no `drop` / `error` / `process foo` / `output foo`, no statement-form `if` / `switch` / `try-catch`. Use the expression-form alternatives.
+Anything an expression can do (binary ops, primitive calls, hash literals, array literals, nested function calls) is fair game inside `let` RHS or the trailing expression. The block-arg primitives — `map`, `filter`, `find`, `reduce` — are pure expressions over arrays or objects and compose freely inside a function body. Array blocks bind the element (plus the accumulator for `reduce`); object blocks bind key and value (plus the accumulator for `reduce`). What you cannot do is write a *statement* — no assignments to anything, no `drop` / `error` / `process foo` / `output foo`, no statement-form `if` / `switch` / `try-catch`. Use the expression-form alternatives.
 
 ## Restrictions (enforced at `--check` time)
 

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -2,7 +2,7 @@
 
 limpid ships a [Snippet Library](../snippets/README.md) of pre-built processes for common parsing / mapping work (introduced in v0.7.0, expanded across the 0.7.x line). Sooner or later you'll hit a situation the library doesn't cover — a vendor format we haven't shipped, a one-off enrichment, a dedup or rate-limit shape that's specific to your environment — and want to write your own. This page covers how.
 
-You define a process with `def process <name> { ... }`. Inside the body you call functions, assign to event slots and workspace, branch with `if` / `switch` / `try`, transform arrays with the block-arg primitives (`map`, `filter`, `find`, `reduce`), and call other processes by name.
+You define a process with `def process <name> { ... }`. Inside the body you call functions, assign to event slots and workspace, branch with `if` / `switch` / `try`, transform arrays and objects with the block-arg primitives (`map`, `filter`, `find`, `reduce`), and call other processes by name.
 
 ## Defining a process
 
@@ -182,6 +182,17 @@ The library steers toward identity-based access so snippets stay correct under u
 | Dynamic key access | `path(obj, "k1", "k2", ...)` (object only; integer keys rejected) |
 | Add to back / front | `append(arr, v)`, `prepend(arr, v)` |
 | Serialise to JSON | `to_json(arr)` |
+
+The same four block primitives iterate objects in insertion order with explicit key/value bindings:
+
+| Operation | Object form | Result |
+|-----------|-------------|--------|
+| Transform | `map(obj) { \|key, value\| <expr> }` | Array of block results |
+| Filter | `filter(obj) { \|key, value\| <bool> }` | Object containing the retained entries |
+| Pick | `find(obj) { \|key, value\| <bool> }` | First `[key, value]` pair or `null` |
+| Fold | `reduce(obj, init) { \|acc, key, value\| <step> }` | Final accumulator |
+
+Object iteration sees every stored entry as-is. Insertion order is preserved and duplicate keys are visited and retained; these primitives do not normalize an object into a unique-key map. A `null` collection follows the established array behavior: `map` / `filter` return an empty array, `find` returns `null`, and `reduce` returns `init`.
 
 Block-arg primitives (`map`, `filter`, `find`, `reduce`) and the pipe operator (`|>`) are documented in [DSL Syntax Basics → Block argument](../dsl-syntax.md#block-argument) and [Pipe operator](../dsl-syntax.md#pipe-operator).
 


### PR DESCRIPTION
## Summary

Extends the DSL block primitives `map`, `filter`, `find`, `reduce` to iterate
object entries in addition to array elements. The parser is unchanged —
dispatch is by evaluated-argument type at runtime and mirrored in the static
analyzer.

Object forms bind the block to `|key, value|` (or `|acc, key, value|` for
`reduce`) and traverse in insertion order. Duplicate keys — permitted by the
DSL's object representation — are visited as they appear, not deduplicated;
this is pinned by tests.

| primitive | input | block | returns |
|-----------|-------|-------|---------|
| `map` | Object | `\|k, v\|` | Array |
| `filter` | Object | `\|k, v\|` | Object (truthy entries, insertion order) |
| `find` | Object | `\|k, v\|` | `[key, value]` or `null` |
| `reduce` | Object, init | `\|acc, k, v\|` | accumulator |

Array behaviour is unchanged. `Null` follows the array convention (empty for
`map` / `filter` / `find`, init for `reduce`).

## Analyzer / static checking

The analyzer signatures are precise `Union(Array | Object | Null)` — no `Any`
relaxation. `filter` return inference is input-shape-preserving (Array→Array,
Object→Object, Null→Array, union→corresponding union). A CLI regression test
exercises each primitive under `--check --strict-warnings` for all three
shapes.

Also fixes a pre-existing analyzer gap: block parameters were unresolved
identifiers in strict mode. Block bodies now open a child let scope for
parameters and block-local lets; the runtime evaluator is unchanged.

## Test plan

- [x] `cargo test --workspace --locked` — 910 passed / 1 ignored
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] mdBook build, snippet header lint (42/0), inventory in sync
- [x] Independent push-gate audit (uchgs, 9/9 scopes PASS)
- [x] Targeted tests cover: normal object traversal, duplicate-key visit
      order, empty object, null argument, block-arity errors per input type,
      array-path regression