### PR TITLE
fix: align docs, analyzer, and snippet contracts with runtime behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Fixed — analyzer contracts match runtime value shapes
+
+Static checking now models ingress and egress as String-or-Bytes payloads,
+accepts both runtime input forms for `to_string` and the OTLP decoders, and
+preserves nullable returns for partial primitives instead of claiming a value
+is always present. `cef.parse` limits its data-driven workspace wildcard to
+`workspace.extension.*`, so unrelated workspace paths are no longer widened.
+User-defined function calls now report arity mismatches during `--check` with
+the same expected-versus-actual shape used by runtime diagnostics.
+
+The `strftime` and `strptime` timezone keywords `UTC` and `local` are now
+ASCII case-insensitive; IANA timezone names remain case-sensitive.
+
 ### Fixed — cef.parse honors the header escapes `\|` and `\\`
 
 The header splitter treated every `|` as a field separator, so a

--- a/crates/limpid/src/check/bindings.rs
+++ b/crates/limpid/src/check/bindings.rs
@@ -28,7 +28,7 @@
 //! [`super::outputs::check_pipeline_only_reference`] regardless of
 //! upstream binding status.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::dsl::field_schema::FieldType;
 
@@ -42,6 +42,9 @@ pub struct Bindings {
     /// analyzer can no longer tell which workspace keys exist, so any
     /// `workspace.*` read is admitted without flagging.
     wildcard: bool,
+    /// Data-driven subtrees admitted without widening unrelated workspace
+    /// paths, for example `workspace.extension.*` from `cef.parse`.
+    scoped_wildcards: HashSet<String>,
     /// Stack of `let` scopes; the innermost (top) scope wins on lookup.
     let_scopes: Vec<HashMap<String, FieldType>>,
 }
@@ -78,6 +81,20 @@ impl Bindings {
     /// (parse_json, parse_kv) ran without HashLit defaults.
     pub fn set_workspace_wildcard(&mut self) {
         self.wildcard = true;
+    }
+
+    pub fn set_workspace_scoped_wildcard(&mut self, path: &[String]) {
+        self.scoped_wildcards.insert(path.join("."));
+    }
+
+    pub fn is_workspace_path_wildcard(&self, path: &[String]) -> bool {
+        if self.wildcard {
+            return true;
+        }
+        let dotted = path.join(".");
+        self.scoped_wildcards
+            .iter()
+            .any(|scope| dotted == *scope || dotted.starts_with(&format!("{scope}.")))
     }
 
     #[allow(dead_code)] // currently consulted only from tests; kept on the
@@ -142,7 +159,19 @@ impl Bindings {
         self.workspace = merged;
         // Wildcard only survives if both sides wildcarded — otherwise
         // the precise side's known keys win.
-        self.wildcard = self.wildcard && other.wildcard;
+        let self_global = self.wildcard;
+        let other_global = other.wildcard;
+        self.wildcard = self_global && other_global;
+        self.scoped_wildcards = match (self_global, other_global) {
+            (true, true) => HashSet::new(),
+            (true, false) => other.scoped_wildcards.clone(),
+            (false, true) => self.scoped_wildcards.clone(),
+            (false, false) => self
+                .scoped_wildcards
+                .intersection(&other.scoped_wildcards)
+                .cloned()
+                .collect(),
+        };
     }
 }
 
@@ -235,5 +264,17 @@ mod tests {
         // so the precise side's `workspace.x` is dropped — paths must
         // be bound on *both* sides.
         assert!(a.get_workspace(&["workspace".into(), "x".into()]).is_none());
+    }
+
+    #[test]
+    fn scoped_wildcard_admits_only_its_subtree() {
+        let mut b = Bindings::new();
+        b.set_workspace_scoped_wildcard(&["workspace".into(), "extension".into()]);
+        assert!(b.is_workspace_path_wildcard(&[
+            "workspace".into(),
+            "extension".into(),
+            "src".into(),
+        ]));
+        assert!(!b.is_workspace_path_wildcard(&["workspace".into(), "unrelated".into(),]));
     }
 }

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -128,7 +128,7 @@ fn filter_return_type(input: FieldType) -> FieldType {
 /// reserved-event-ident table.
 ///
 /// Reserved idents (always present, fixed type):
-/// - `ingress` / `egress` — String (raw bytes UTF-8-decoded)
+/// - `ingress` / `egress` — String or Bytes (transport payload)
 /// - `source` — Object `{ ip: String, port: Int }` (since v0.5.6;
 ///   pre-0.5.6 this was a flat String). `source.ip` and `source.port`
 ///   are the canonical accessors.
@@ -145,8 +145,12 @@ fn ident_type(parts: &[String], bindings: &Bindings) -> FieldType {
     }
     // Reserved event idents: always exist, fixed type.
     match parts.first().map(String::as_str) {
-        Some("ingress") if parts.len() == 1 => return FieldType::String,
-        Some("egress") if parts.len() == 1 => return FieldType::String,
+        Some("ingress") if parts.len() == 1 => {
+            return FieldType::union(FieldType::String, FieldType::Bytes);
+        }
+        Some("egress") if parts.len() == 1 => {
+            return FieldType::union(FieldType::String, FieldType::Bytes);
+        }
         Some("received_at") if parts.len() == 1 => return FieldType::Timestamp,
         Some("error") if parts.len() == 1 => return FieldType::String,
         // `source` is an Object since v0.5.6 — `source.ip` (String) and
@@ -163,6 +167,9 @@ fn ident_type(parts: &[String], bindings: &Bindings) -> FieldType {
             }
             if let Some(t) = bindings.get_workspace(parts) {
                 return t.clone();
+            }
+            if bindings.is_workspace_path_wildcard(parts) {
+                return FieldType::Any;
             }
             // Walk up looking for an ancestor binding (Object).
             for i in (2..parts.len()).rev() {
@@ -594,14 +601,26 @@ fn check_fn_call(
         return;
     };
     if !arity_in_range(sig, args.len()) {
-        // Wrong-arity calls are caught loudly at runtime; double-flagging
-        // is just noise. Skip.
+        if namespace.is_none() && registry.is_user_function(name) {
+            diagnostics.push(warning(
+                pipeline_name,
+                format!(
+                    "function `{}` expects {}, got {}",
+                    name,
+                    expected_arity(sig),
+                    args.len()
+                ),
+                span,
+            ));
+        }
         return;
     }
     for (i, actual) in args.iter().enumerate() {
         let expected = expected_arg_type(sig, i);
         let actual_ty = infer(actual, bindings, registry);
-        if !type_compatible(expected, &actual_ty) {
+        if !type_compatible(expected, &actual_ty)
+            && !reserved_payload_matches_text(expected, actual, &actual_ty)
+        {
             let display = qualified_name(namespace, name);
             // Prefer the tight per-argument span from the AST; fall
             // back to the call-level span only when the arg came from
@@ -618,6 +637,45 @@ fn check_fn_call(
                 ),
                 arg_span,
             ));
+        }
+    }
+}
+
+/// `ingress` and `egress` are event-dependent transport payloads: valid
+/// UTF-8 arrives as `String`, while invalid UTF-8 remains `Bytes`. A direct
+/// text consumer is therefore valid for the String arm and may reject the
+/// Bytes arm at runtime. Keep this exception local to the reserved payloads;
+/// ordinary unions still require every member to satisfy the argument type.
+fn reserved_payload_matches_text(
+    expected: &FieldType,
+    actual: &Expr,
+    actual_ty: &FieldType,
+) -> bool {
+    if expected != &FieldType::String
+        || actual_ty != &FieldType::union(FieldType::String, FieldType::Bytes)
+    {
+        return false;
+    }
+
+    matches!(
+        &actual.kind,
+        ExprKind::Ident(parts)
+            if parts.len() == 1 && matches!(parts[0].as_str(), "ingress" | "egress")
+    )
+}
+
+fn expected_arity(sig: &FunctionSig) -> String {
+    match sig.arity {
+        Arity::Fixed => match sig.args.len() {
+            1 => "1 argument".to_string(),
+            n => format!("{n} arguments"),
+        },
+        Arity::Optional { required } => {
+            format!("{} to {} arguments", required, sig.args.len())
+        }
+        Arity::Variadic { min } => {
+            let noun = if min == 1 { "argument" } else { "arguments" };
+            format!("at least {min} {noun}")
         }
     }
 }

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -1599,9 +1599,7 @@ def pipeline p { input i; output o }
     fn function_call_site_resolves() {
         // Call sites referencing a user-defined function don't emit an
         // "unknown function" warning — `register_user_function` made
-        // the analyzer aware of it. (Arity mismatches are deferred to
-        // runtime by design; the analyzer skips wrong-arity warnings
-        // to avoid double-flagging.)
+        // the analyzer aware of it.
         let src = r#"
 def function takes_two(a, b) { a + b }
 def input i { type syslog_tcp bind "0.0.0.0:514" }
@@ -1618,6 +1616,83 @@ def pipeline p {
                 .iter()
                 .any(|w| w.message.contains("unknown function")),
             "user function should resolve at the call site, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn user_function_wrong_arity_is_reported() {
+        let src = r#"
+def function takes_two(a, b) { a + b }
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process { workspace.x = takes_two(1) }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            warnings(&diags).iter().any(|w| {
+                w.message
+                    .contains("function `takes_two` expects 2 arguments, got 1")
+            }),
+            "expected user-function arity warning, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn payload_consumers_accept_string_or_bytes_reserved_idents() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        workspace.parsed = parse_json(ingress)
+        workspace.syslog = syslog.parse(ingress)
+        workspace.text = to_string(ingress)
+        workspace.pb = otlp.decode_resourcelog_protobuf(ingress)
+        workspace.json = otlp.decode_resourcelog_json(egress)
+    }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            !warnings(&diags)
+                .iter()
+                .any(|w| w.message.contains("expects") && w.message.contains("got")),
+            "payload union should match the registered consumers: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn ordinary_string_bytes_union_remains_strict_for_text_consumers() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        if true { workspace.payload = "text" }
+        else { workspace.payload = to_bytes("binary") }
+        workspace.parsed = parse_json(workspace.payload)
+    }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            warnings(&diags).iter().any(|w| {
+                w.message
+                    .contains("function `parse_json` argument 1 expects String")
+                    && w.message.contains("Union(String | Bytes)")
+            }),
+            "ordinary unions must not inherit the reserved-payload exception: {:?}",
             diags
         );
     }

--- a/crates/limpid/src/check/parser_effects.rs
+++ b/crates/limpid/src/check/parser_effects.rs
@@ -32,6 +32,9 @@ pub(super) fn apply_parser_effects(
     for spec in &info.produces {
         bindings.bind_workspace(&spec.path, spec.ty.clone());
     }
+    for path in &info.scoped_wildcards {
+        bindings.set_workspace_scoped_wildcard(path);
+    }
 
     // Defaults arg (HashLit): every declared key becomes a workspace
     // binding too, with type inferred from the literal value. This is
@@ -218,5 +221,25 @@ mod tests {
         apply_parser_effects(None, "regex_parse", &args, &reg, &mut bindings);
         assert!(bindings.is_workspace_wildcard());
         assert!(bindings.get_workspace(&ws("user")).is_none());
+    }
+
+    #[test]
+    fn cef_parse_wildcards_only_the_extension_subtree() {
+        let reg = registry();
+        let mut bindings = Bindings::new();
+        apply_parser_effects(
+            Some("cef"),
+            "parse",
+            &[ident("ingress")],
+            &reg,
+            &mut bindings,
+        );
+        assert!(!bindings.is_workspace_wildcard());
+        assert!(bindings.is_workspace_path_wildcard(&[
+            "workspace".into(),
+            "extension".into(),
+            "src".into(),
+        ]));
+        assert!(!bindings.is_workspace_path_wildcard(&["workspace".into(), "unrelated".into(),]));
     }
 }

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -63,7 +63,8 @@ pub fn register(reg: &mut FunctionRegistry) {
             // data-driven (wildcards).
             FieldSpec::new(&["workspace", "extension"], FieldType::Object),
         ],
-        wildcards: true,
+        wildcards: false,
+        scoped_wildcards: vec![vec!["workspace".to_string(), "extension".to_string()]],
         defaults_arg_indices: &[1],
         defaults_arg_extractor: None,
     });

--- a/crates/limpid/src/functions/mod.rs
+++ b/crates/limpid/src/functions/mod.rs
@@ -145,9 +145,10 @@ pub type DefaultsArgExtractor =
 /// needs to know *which keys* a bare `parse_xxx(text)` call contributes
 /// to workspace, with *what types*, so downstream `workspace.*` references
 /// type-check. `produces` is the static answer; `wildcards = true` means
-/// the key set is data-driven (e.g. `parse_json`) and the analyzer should
-/// fall back to wildcard unless the caller pins a schema via the
-/// optional defaults HashLit argument.
+/// the whole key set is data-driven (e.g. `parse_json`) and the analyzer
+/// should fall back to wildcard unless the caller pins a schema via the
+/// optional defaults HashLit argument. `scoped_wildcards` handles parsers
+/// such as `cef.parse`, where only one nested subtree is data-driven.
 ///
 /// Parsers are registered alongside their implementation; the analyzer
 /// looks them up via [`FunctionRegistry::parser`].
@@ -183,10 +184,14 @@ pub struct ParserInfo {
     /// `(workspace key, type)` pairs the parser is known to emit. Empty
     /// when `wildcards = true` and there's no static structure.
     pub produces: Vec<FieldSpec>,
-    /// True when the output key set is determined by the input rather
-    /// than statically known (parse_json, parse_kv, parse_cef
-    /// extensions, etc.).
+    /// True when the entire output key set is determined by the input
+    /// rather than statically known (for example `parse_json` or
+    /// `parse_kv`).
     pub wildcards: bool,
+    /// Dynamic output subtrees whose keys are data-driven while the rest
+    /// of workspace remains statically described. Each path includes the
+    /// `workspace` root (for example `workspace.extension`).
+    pub scoped_wildcards: Vec<Vec<String>>,
     /// Positional indices where a `defaults` HashLit may appear. The
     /// analyzer scans these slots and uses the first HashLit found to
     /// pin precise workspace keys; if none match, wildcard parsers fall
@@ -389,6 +394,11 @@ impl FunctionRegistry {
     pub fn parser(&self, namespace: Option<&str>, name: &str) -> Option<&ParserInfo> {
         let key = (namespace.map(str::to_string), name.to_string());
         self.parsers.get(&key)
+    }
+
+    /// Whether `name` resolves to a user-defined flat function.
+    pub fn is_user_function(&self, name: &str) -> bool {
+        self.user_definitions.contains_key(name)
     }
 
     /// Dispatch a function call. `namespace = None` hits the flat
@@ -597,6 +607,27 @@ mod tests {
         )
     }
 
+    #[test]
+    fn partial_primitive_signatures_are_nullable() {
+        let reg = make_registry();
+        for (namespace, name, present) in [
+            (None, "regex_extract", FieldType::String),
+            (Some("syslog"), "extract_pri", FieldType::Int),
+            (None, "to_int", FieldType::Int),
+            (None, "len", FieldType::Int),
+            (None, "csv_parse", FieldType::Object),
+            (None, "append", FieldType::Array),
+            (None, "prepend", FieldType::Array),
+            (None, "hostname", FieldType::String),
+        ] {
+            assert_eq!(
+                reg.signature(namespace, name).unwrap().ret,
+                FieldType::union(present, FieldType::Null),
+                "{name} return contract"
+            );
+        }
+    }
+
     fn ts_value(s: &str) -> Value<'static> {
         Value::Timestamp(
             chrono::DateTime::parse_from_rfc3339(s)
@@ -663,13 +694,36 @@ mod tests {
                 &[
                     ts_value("2026-04-19T10:30:45+09:00"),
                     Value::String(arena.alloc_str("%Y-%m-%dT%H:%M:%S%z")),
-                    Value::String(arena.alloc_str("UTC")),
+                    Value::String(arena.alloc_str("uTc")),
                 ],
                 &bevent,
                 &arena,
             )
             .unwrap();
         assert_eq!(result, Value::String("2026-04-19T01:30:45+0000"));
+    }
+
+    #[test]
+    fn strftime_local_keyword_is_ascii_case_insensitive() {
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_owned();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let result = reg
+            .call(
+                None,
+                "strftime",
+                &[
+                    ts_value("2026-04-19T10:30:45+00:00"),
+                    Value::String(arena.alloc_str("%Y-%m-%d")),
+                    Value::String(arena.alloc_str("LoCaL")),
+                ],
+                &bevent,
+                &arena,
+            )
+            .unwrap();
+        assert!(matches!(result, Value::String(_)));
     }
 
     #[test]

--- a/crates/limpid/src/functions/otlp/encode.rs
+++ b/crates/limpid/src/functions/otlp/encode.rs
@@ -68,7 +68,10 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_in_with_sig(
         "otlp",
         "decode_resourcelog_protobuf",
-        FunctionSig::fixed(&[FieldType::Bytes], FieldType::Object),
+        FunctionSig::fixed(
+            &[FieldType::union(FieldType::String, FieldType::Bytes)],
+            FieldType::Object,
+        ),
         |arena, args, _event| {
             let bytes: &[u8] = match &args[0] {
                 Value::Bytes(b) => b,
@@ -97,7 +100,10 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_in_with_sig(
         "otlp",
         "decode_resourcelog_json",
-        FunctionSig::fixed(&[FieldType::String], FieldType::Object),
+        FunctionSig::fixed(
+            &[FieldType::union(FieldType::String, FieldType::Bytes)],
+            FieldType::Object,
+        ),
         |arena, args, _event| {
             let s: &str = match &args[0] {
                 Value::String(s) => s,

--- a/crates/limpid/src/functions/primitives/append.rs
+++ b/crates/limpid/src/functions/primitives/append.rs
@@ -9,7 +9,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "append",
-        FunctionSig::fixed(&[FieldType::Array, FieldType::Any], FieldType::Array),
+        FunctionSig::fixed(
+            &[FieldType::Array, FieldType::Any],
+            FieldType::union(FieldType::Array, FieldType::Null),
+        ),
         |arena, args, _event| Ok(push_back(arena, &args[0], &args[1])),
     );
 }

--- a/crates/limpid/src/functions/primitives/csv_parse.rs
+++ b/crates/limpid/src/functions/primitives/csv_parse.rs
@@ -24,7 +24,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "csv_parse",
-        FunctionSig::fixed(&[FieldType::String, FieldType::Any], FieldType::Object),
+        FunctionSig::fixed(
+            &[FieldType::String, FieldType::Any],
+            FieldType::union(FieldType::Object, FieldType::Null),
+        ),
         |arena, args, _event| Ok(parse(arena, &args[0], &args[1])),
     );
 }

--- a/crates/limpid/src/functions/primitives/hostname.rs
+++ b/crates/limpid/src/functions/primitives/hostname.rs
@@ -22,7 +22,7 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "hostname",
-        FunctionSig::fixed(&[], FieldType::String),
+        FunctionSig::fixed(&[], FieldType::union(FieldType::String, FieldType::Null)),
         |arena, _args, _event| {
             let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                 gethostname::gethostname().to_string_lossy().into_owned()

--- a/crates/limpid/src/functions/primitives/len.rs
+++ b/crates/limpid/src/functions/primitives/len.rs
@@ -15,7 +15,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "len",
-        FunctionSig::fixed(&[FieldType::Any], FieldType::Int),
+        FunctionSig::fixed(
+            &[FieldType::Any],
+            FieldType::union(FieldType::Int, FieldType::Null),
+        ),
         |_arena, args, _event| Ok(measure(&args[0])),
     );
 }

--- a/crates/limpid/src/functions/primitives/parse_json.rs
+++ b/crates/limpid/src/functions/primitives/parse_json.rs
@@ -22,6 +22,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         name: "parse_json",
         produces: Vec::new(),
         wildcards: true,
+        scoped_wildcards: Vec::new(),
         defaults_arg_indices: &[1],
         defaults_arg_extractor: None,
     });

--- a/crates/limpid/src/functions/primitives/parse_kv.rs
+++ b/crates/limpid/src/functions/primitives/parse_kv.rs
@@ -34,6 +34,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         name: "parse_kv",
         produces: Vec::new(),
         wildcards: true,
+        scoped_wildcards: Vec::new(),
         // Retained for documentation; the extractor below takes over
         // the actual scan because parse_kv's defaults position depends
         // on the type of `args[1]`.

--- a/crates/limpid/src/functions/primitives/prepend.rs
+++ b/crates/limpid/src/functions/primitives/prepend.rs
@@ -9,7 +9,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "prepend",
-        FunctionSig::fixed(&[FieldType::Array, FieldType::Any], FieldType::Array),
+        FunctionSig::fixed(
+            &[FieldType::Array, FieldType::Any],
+            FieldType::union(FieldType::Array, FieldType::Null),
+        ),
         |arena, args, _event| Ok(push_front(arena, &args[0], &args[1])),
     );
 }

--- a/crates/limpid/src/functions/primitives/regex_extract.rs
+++ b/crates/limpid/src/functions/primitives/regex_extract.rs
@@ -15,7 +15,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "regex_extract",
-        FunctionSig::fixed(&[FieldType::String, FieldType::String], FieldType::String),
+        FunctionSig::fixed(
+            &[FieldType::String, FieldType::String],
+            FieldType::union(FieldType::String, FieldType::Null),
+        ),
         |arena, args, _event| {
             let target = val_to_str(&args[0])?;
             let pattern = val_to_str(&args[1])?;

--- a/crates/limpid/src/functions/primitives/regex_parse.rs
+++ b/crates/limpid/src/functions/primitives/regex_parse.rs
@@ -64,6 +64,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         name: "regex_parse",
         produces: Vec::new(),
         wildcards: true,
+        scoped_wildcards: Vec::new(),
         defaults_arg_indices: &[],
         defaults_arg_extractor: None,
     });

--- a/crates/limpid/src/functions/primitives/strftime.rs
+++ b/crates/limpid/src/functions/primitives/strftime.rs
@@ -47,8 +47,10 @@ pub fn register(reg: &mut FunctionRegistry) {
 
             let formatted = match tz.as_deref() {
                 None => dt.format(&fmt).to_string(),
-                Some("local") => dt.with_timezone(&chrono::Local).format(&fmt).to_string(),
-                Some("UTC") | Some("utc") => {
+                Some(timezone) if timezone.eq_ignore_ascii_case("local") => {
+                    dt.with_timezone(&chrono::Local).format(&fmt).to_string()
+                }
+                Some(timezone) if timezone.eq_ignore_ascii_case("UTC") => {
                     dt.with_timezone(&chrono::Utc).format(&fmt).to_string()
                 }
                 Some(timezone) => {

--- a/crates/limpid/src/functions/primitives/strptime.rs
+++ b/crates/limpid/src/functions/primitives/strptime.rs
@@ -72,7 +72,7 @@ fn parse_with_tz(value: &str, fmt: &str, tz: Option<&str>) -> Result<DateTime<Fi
         )
     })?;
     match tz {
-        "local" => Ok(chrono::Local
+        timezone if timezone.eq_ignore_ascii_case("local") => Ok(chrono::Local
             .from_local_datetime(&naive)
             .single()
             .ok_or_else(|| {
@@ -82,7 +82,7 @@ fn parse_with_tz(value: &str, fmt: &str, tz: Option<&str>) -> Result<DateTime<Fi
                 )
             })?
             .fixed_offset()),
-        "UTC" | "utc" => {
+        timezone if timezone.eq_ignore_ascii_case("UTC") => {
             let offset = FixedOffset::east_opt(0).unwrap();
             Ok(offset.from_utc_datetime(&naive))
         }
@@ -142,5 +142,13 @@ mod tests {
                 .to_string()
                 .contains("ambiguous or invalid local time")
         );
+    }
+
+    #[test]
+    fn timezone_keywords_are_ascii_case_insensitive() {
+        let utc = parse_with_tz("2026-04-30 10:23:45", "%Y-%m-%d %H:%M:%S", Some("uTc")).unwrap();
+        assert_eq!(utc.offset().local_minus_utc(), 0);
+
+        parse_with_tz("2026-04-30 10:23:45", "%Y-%m-%d %H:%M:%S", Some("LoCaL")).unwrap();
     }
 }

--- a/crates/limpid/src/functions/primitives/to_int.rs
+++ b/crates/limpid/src/functions/primitives/to_int.rs
@@ -19,7 +19,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "to_int",
-        FunctionSig::fixed(&[FieldType::Any], FieldType::Int),
+        FunctionSig::fixed(
+            &[FieldType::Any],
+            FieldType::union(FieldType::Int, FieldType::Null),
+        ),
         |_arena, args, _event| coerce(&args[0]),
     );
 }

--- a/crates/limpid/src/functions/primitives/to_string.rs
+++ b/crates/limpid/src/functions/primitives/to_string.rs
@@ -12,7 +12,11 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "to_string",
         FunctionSig::optional(
-            &[FieldType::Bytes, FieldType::String, FieldType::Bool],
+            &[
+                FieldType::union(FieldType::String, FieldType::Bytes),
+                FieldType::String,
+                FieldType::Bool,
+            ],
             1,
             FieldType::String,
         ),

--- a/crates/limpid/src/functions/syslog/extract_pri.rs
+++ b/crates/limpid/src/functions/syslog/extract_pri.rs
@@ -12,7 +12,10 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_in_with_sig(
         "syslog",
         "extract_pri",
-        FunctionSig::fixed(&[FieldType::String], FieldType::Int),
+        FunctionSig::fixed(
+            &[FieldType::String],
+            FieldType::union(FieldType::Int, FieldType::Null),
+        ),
         |_arena, args, _event| {
             let input = val_to_str(&args[0])?;
             Ok(parse_leading_pri(&input)

--- a/crates/limpid/src/functions/syslog/parse.rs
+++ b/crates/limpid/src/functions/syslog/parse.rs
@@ -52,6 +52,7 @@ pub fn register(reg: &mut FunctionRegistry) {
             FieldSpec::new(&["workspace", "msg"], FieldType::String),
         ],
         wildcards: false,
+        scoped_wildcards: Vec::new(),
         defaults_arg_indices: &[1],
         defaults_arg_extractor: None,
     });

--- a/docs/src/dsl-syntax.md
+++ b/docs/src/dsl-syntax.md
@@ -138,6 +138,7 @@ Evaluated values are coerced to strings:
 | Bool | `true` / `false` |
 | Null | empty string |
 | Timestamp | RFC3339 (`2026-04-19T10:30:45+00:00`) |
+| Bytes | `<bytes>` (use `to_string(...)` for an intentional text decoding) |
 | Object / Array | JSON |
 
 For full control over structured values, wrap them in `to_json(...)` yourself.

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -25,7 +25,7 @@ Errors raised by these primitives (a `parse_json` on malformed input, a `to_int`
 
 ### Bare statements vs assignments
 
-A parser function returns a `Value::Object` whose keys are taken from the parse — `hostname`, `appname`, `msg` for `syslog.parse`; `version`, `name`, `severity`, plus CEF extension keys (`src`, `dst`, `act`, …) for `cef.parse`; whatever the source JSON contains for `parse_json`. There are two ways to consume that object inside a process body.
+A parser function returns a `Value::Object` whose keys are taken from the parse — `hostname`, `appname`, `msg` for `syslog.parse`; `version`, `name`, `severity`, `extension_raw`, plus nested CEF extension keys (`extension.src`, `extension.dst`, `extension.act`, …) for `cef.parse`; whatever the source JSON contains for `parse_json`. There are two ways to consume that object inside a process body.
 
 **Bare statement** — the returned object's top-level keys are merged directly into `workspace`:
 
@@ -165,9 +165,10 @@ Returns a `Value::Object`:
 | `signature_id`   | String         | vendor-specific event id |
 | `name`           | String         | human-readable event name |
 | `severity`       | Int \| String  | vendor severity (0–10), or the raw string when the producer sent garbage |
-| `ext`            | String         | raw extension blob from the wire — present only when the Extension section was non-empty (mirrors `syslog.parse`'s treatment of `msg`) |
+| `extension_raw`  | String         | raw extension blob from the wire — present only when the Extension section was non-empty (mirrors `syslog.parse`'s treatment of `msg`) |
+| `extension`      | Object         | split Extension `key=value` pairs; keys are data-driven |
 
-Extension `key=value` pairs from the CEF tail (e.g. `src=10.0.0.1 dst=192.168.1.1 act=block`) are emitted **both** as the raw blob in `ext` **and** split into siblings of the header keys (`src`, `dst`, `act`, … — those names are part of CEF, not a limpid convention). The split form is what authors typically read from downstream; the raw `ext` is for passthrough / re-emission, debugging the splitter, or surfacing dialect-specific extension content the splitter doesn't decode (escape sequences, custom separators).
+Extension `key=value` pairs from the CEF tail (e.g. `src=10.0.0.1 dst=192.168.1.1 act=block`) are emitted both as the raw blob in `extension_raw` and under `extension.<key>` (`extension.src`, `extension.dst`, `extension.act`, …). Isolating the data-driven keys prevents them from shadowing positional header fields. The raw form is for passthrough / re-emission, debugging the splitter, or dialect-specific extension content the splitter does not decode.
 
 The optional `defaults` argument behaves the same as in `syslog.parse`.
 
@@ -231,9 +232,10 @@ Encode the HashLit as a `ResourceLogs` proto3 message and return
 the raw wire bytes. Pair with the [`otlp_http` output](../outputs/otlp_http.md) / [`otlp_grpc` output](../outputs/otlp_grpc.md)'s
 `http_protobuf` or `grpc` protocol.
 
-### otlp.decode_resourcelog_protobuf(bytes) → Object
+### otlp.decode_resourcelog_protobuf(bytes_or_string) → Object
 
-Inverse of `encode_resourcelog_protobuf`. Used by snippets that
+Inverse of `encode_resourcelog_protobuf`. Accepts `Bytes` or a `String`
+whose UTF-8 storage contains the protobuf octets. Used by snippets that
 need to inspect / transform an inbound OTLP record:
 
 ```limpid
@@ -256,7 +258,7 @@ manually through `output http` to a non-OTLP-aware HTTP receiver.
 > `http_json` / `http_protobuf` choice) should keep using
 > `otlp.encode_resourcelog_protobuf` for the egress bytes.
 
-### otlp.decode_resourcelog_json(s) → Object
+### otlp.decode_resourcelog_json(string_or_bytes) → Object
 
 Decode an OTLP/JSON-encoded `ResourceLogs` string (or UTF-8 bytes)
 back into the snake_case HashLit form.
@@ -455,7 +457,7 @@ strftime(received_at, "%H:%M", "+09:00")   // fixed offset
 |----------|-------------|
 | `timestamp` | a `Value::Timestamp` (from `received_at`, `timestamp()`, or `strptime`). Passing a string is a type error. |
 | `format` | `chrono` strftime format. |
-| `timezone` *(optional)* | `"local"`, `"UTC"` (case-insensitive), or `±HH:MM` / `±HHMM`. If omitted, the timestamp's own offset is used. |
+| `timezone` *(optional)* | `"local"` or `"UTC"` (case-insensitive), an IANA name such as `Asia/Tokyo` (case-sensitive), or `±HH:MM` / `±HHMM`. If omitted, output is UTC. |
 
 An invalid timezone specifier is a loud error — `strftime` never silently returns an empty string.
 
@@ -473,7 +475,7 @@ strptime("2026-04-15 10:30:00", "%Y-%m-%d %H:%M:%S", "local")  // naive + local
 |----------|-------------|
 | `value` | timestamp string |
 | `format` | `chrono` strftime format |
-| `timezone` *(required when format produces a naive datetime)* | `"local"`, `"UTC"`, or `±HH:MM` / `±HHMM` |
+| `timezone` *(required when format produces a naive datetime)* | `"local"` or `"UTC"` (case-insensitive), an IANA name such as `Asia/Tokyo` (case-sensitive), or `±HH:MM` / `±HHMM` |
 
 If the format includes an offset specifier (`%z`, `%:z`, `%#z`), the third argument is rejected as conflicting. If the format produces a naive datetime, the third argument is required — limpid never silently assumes UTC.
 
@@ -668,9 +670,10 @@ Errors on unknown encoding or malformed input (odd hex length,
 invalid hex digit, malformed base64). The default `utf8` form is
 lossless because Rust strings are always valid UTF-8.
 
-### to_string(b, encoding="utf8", strict=true)
+### to_string(string_or_bytes, encoding="utf8", strict=true)
 
-Convert raw bytes to a string. Counterpart of `to_bytes`.
+Interpret a raw `Bytes` value as text, or pass a `String` through the same
+encoding operation. Counterpart of `to_bytes`.
 
 | Encoding | `strict` | Behaviour |
 |----------|----------|-----------|
@@ -685,7 +688,7 @@ workspace.message = to_string(ingress, "utf8", false)        // lossy fallback
 workspace.signature_b64 = to_string(workspace.sig, "base64") // bytes → printable
 ```
 
-Text-only primitives (`upper`, `regex_*`, `format`, `to_int`,
+Text-only primitives (`upper`, `regex_*`, `strftime`, `to_int`,
 `contains`, etc.) reject `Bytes` to keep failure modes explicit;
 `to_string` is the way to opt into a textual interpretation.
 
@@ -780,7 +783,7 @@ Use these only when the order is itself the contract (chronology, "most recent",
 
 ### concat(a, b, ...)
 
-Variadic array concatenation; every argument must be an `Array`. Mixed input bails (no scalar auto-wrap — wrap explicitly if you want a single element: `concat(arr, [x])`).
+Variadic array concatenation with at least one argument; every argument must be an `Array`. Mixed input bails (no scalar auto-wrap — wrap explicitly if you want a single element: `concat(arr, [x])`).
 
 ```limpid
 workspace.all_tags = concat(workspace.host_tags, workspace.role_tags, ["pii"])
@@ -867,6 +870,7 @@ Cardinality primitive — works for every container-like type:
 |-------|--------|
 | `Array` | Number of elements |
 | `String` | Number of Unicode characters (not bytes) |
+| `Bytes` | Number of bytes |
 | `Object` | Number of top-level keys |
 | `Null` | `Null` |
 | Scalars (`Int` / `Float` / `Bool`) | `Null` |

--- a/docs/src/pipelines/multi-host.md
+++ b/docs/src/pipelines/multi-host.md
@@ -87,15 +87,15 @@ def output to_relay {
 
 def pipeline app_to_relay {
     input app_journal
-    process parse_journald | compose_rfc5424 | rfc5424_to_egress
+    process parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress
     output to_relay
 }
 ```
 
 Three design points worth calling out:
 
-- **PRI carries through the journald entry's own labels.** `app.service`'s `PRIORITY` / `SYSLOG_FACILITY` (set by libsystemd according to how the program writes — direct `sd_journal_send`, `printf` to stderr, syslog API) survive into the RFC 5424 frame. When the entry has neither, `compose_rfc5424` defaults to `<14>` (user.info) so the frame is always valid. Either way the edge does not invent routing; the relay still picks the final facility based on its own criteria.
-- **Parsing is mechanical, not vendor-specific.** `parse_journald` is `parse_json(ingress)` plus a docstring — the edge does not extract individual fields, it just hands the structured form to the composer. If the relay needs more (e.g. `parse_openssh | compose_ocsf | ocsf_to_egress`), it runs there, where the cycles can be amortised across many edge hosts. The edge's per-event work stays tiny.
+- **The bridge performs the field mapping.** `parse_journald` only exposes the journal record under `workspace.journald.*`. `journald_to_rfc5424` then selects the RFC 5424 PRI, timestamp, hostname, app name, process id, and message shed slots. `compose_rfc5424` serializes those slots; it does not read journal fields directly.
+- **Parsing is mechanical, not vendor-specific.** `parse_journald` parses the JSON record without promoting `PRIORITY` to LSIS severity. The named bridge is the explicit journald-to-RFC-5424 policy boundary. If the relay needs vocabulary parsing (for example `parse_openssh | compose_ocsf | ocsf_to_egress`), that runs after transport unwrap at the hop where the vocabulary is consumed.
 - **Disk queue on the edge.** Network to the relay can blip; we do not want the composer blocking the journal cursor. The queue lets the output layer absorb the blip without pushing backpressure into the pipeline.
 
 ## Central host: relay

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -62,18 +62,25 @@ The split config is longer. It is also easier to test, easier to tap between ste
 
 Every process has an implicit contract with its neighbours in the pipeline: *what do I expect to be present when I run, and what do I leave behind for the next stage?*
 
-Because the DSL does not check that contract today, you document it in comments using a small, machine-parseable convention. The grammar is parseable enough that a future static-analysis pass could promote these tags to a real check (warning when a pipeline links a composer to a parser that does not produce the required fields), but limpid does not commit to that — write them because they help the next reader, not because the analyzer will catch you. Pretending the contracts do not exist costs the first person who has to modify the snippet a year later.
+The shipped snippet pack declares its file-level contract in the canonical
+header schema (`Summary`, `Reads`, `Writes`, and kind-specific fields) described
+in the [pack README](../../../packaging/snippets/README.md#authoring-conventions).
+Inside a large file, leaf-local `@requires` / `@produces` comments may add useful
+detail, but they do not replace the canonical header and the analyzer does not
+consume them.
 
 ### The `@requires` / `@produces` tag convention
 
-Put tags in the first block of comments inside the process body. One tag per line. Each tag names a field path in `workspace.*` (or, less commonly, `egress`).
+When a file contains several leaves, put supplemental tags in the first comment
+block inside the leaf. One tag per line. Each tag names a field path in
+`workspace.*` (or, less commonly, `egress`).
 
 ```
 def process compose_ocsf_authentication {
     // @requires: workspace.lsis.parsed.severity_number      (optional; normalized OTel SeverityNumber)
     // @requires: workspace.lsis.parsed.severity             (optional; exact source severity text)
     // @requires: workspace.lsis.parsed.src_endpoint.ip      (recommended)
-    // @requires: workspace.lsis.parsed.actor.user.name      (recommended)
+    // @requires: workspace.lsis.parsed.user.name            (recommended)
     // @produces: workspace.lsis.composed.ocsf  (OCSF Authentication Activity, JSON string)
     //
     // Expects: the calling pipeline has run a vendor parser that
@@ -89,9 +96,27 @@ def process compose_ocsf_authentication {
     // single-writer invariant — see the [pack
     // README](../../../packaging/snippets/README.md#slot-registry--composed-layer).
 
-    workspace.lsis.parsed.class_uid   = 3002
-    workspace.lsis.parsed.activity_id = 1
-    workspace.lsis.composed.ocsf      = to_json(workspace.lsis.parsed)
+    process validate_ocsf_severity_number
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
+        class_uid: 3002,
+        category_uid: 3,
+        activity_id: activity,
+        type_uid: 3002 * 100 + activity,
+        time: timestamp_ns_to_ms(coalesce(workspace.lsis.parsed.time, received_at)),
+        severity_id: compose_ocsf_severity_id(
+            workspace.lsis.parsed.severity_number,
+            workspace.lsis.parsed.severity_id,
+            workspace.lsis.parsed.severity
+        ),
+        severity: workspace.lsis.parsed.severity,
+        status_id: workspace.lsis.parsed.status_id,
+        user: workspace.lsis.parsed.user,
+        actor: workspace.lsis.parsed.actor,
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        metadata: workspace.lsis.parsed.metadata
+    }))
 }
 ```
 
@@ -103,7 +128,9 @@ Requirement levels follow the OCSF / ECS convention:
 | `recommended` | The process will run without it, but output quality degrades (lower fidelity, missing enrichment). |
 | `optional` | Nice to have. Documented so a future reader knows the field exists and is consumed. |
 
-Free-form prose comments explaining "what this process does" are fine *in addition to* the tags — but they are not a substitute. Prose drifts; structured tags survive review because tooling can check them.
+Free-form prose comments explaining "what this process does" are fine in
+addition to the tags. For shipped snippets, neither form substitutes for the
+canonical file header that header lint and inventory generation validate.
 
 ### Why make contracts explicit
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -3,10 +3,12 @@
 A maintained set of vendor parsers and target-schema composers,
 shipped with the `limpid` package and installed under
 `/usr/share/limpid/snippets/`. Operators get vendor logs into a
-SIEM / data lake in OCSF form by adding a single `include` line to
-their config — no parser to write from scratch, no recompile when
-a vendor adds a field (the snippet is plain DSL: edit the file and
-SIGHUP).
+SIEM / data lake in OCSF form by including the parser, its declared
+helper dependencies, and the target composer. No parser has to be
+written from scratch, and changing DSL does not require recompiling
+the daemon. Copy an installed snippet into an operator-owned path
+before customising it; package upgrades replace files under
+`/usr/share/limpid/snippets/`.
 
 > **Status:** the snippet library was introduced in v0.7.0 and has
 > expanded across the 0.7.x line. It currently ships 32 parser files
@@ -25,7 +27,7 @@ SIGHUP).
 
 ### Parsers
 
-| Snippet | Source | OCSF class(es) emitted |
+| Snippet | Source | LSIS class facts produced |
 |---|---|---|
 | **Transport** | | |
 | `parsers/parse_syslog.limpid` | RFC 3164 / 5424 syslog wire (transport, populates `workspace.syslog.*`) | n/a |
@@ -37,7 +39,12 @@ SIGHUP).
 | `parsers/parse_paloalto_cef.limpid` | PAN-OS (CEF wrap; chain `parse_syslog \| parse_cef \|` upstream) | 4001 / 2004 / 6004 / 3002 |
 | `parsers/parse_paloalto_syslog.limpid` | PAN-OS (native CSV syslog; chain `parse_syslog \|` upstream) | (same as CEF) |
 | `parsers/parse_asa.limpid` | Cisco ASA / FTD-in-ASA-mode (syslog; chain `parse_syslog \|` upstream) | 3002 / 4001 |
+| `parsers/parse_aws_guardduty.limpid` | AWS GuardDuty findings (JSON) | 2004 Detection Finding |
+| `parsers/parse_aws_vpc_flow.limpid` | AWS VPC Flow Logs (text v2/v5) | 4001 Network Activity |
+| `parsers/parse_azure_activity.limpid` | Azure Activity Log (JSON) | 6003 API Activity |
 | `parsers/parse_cloudtrail.limpid` | AWS CloudTrail (JSON) | 6003 API Activity |
+| `parsers/parse_k8s_audit.limpid` | Kubernetes Audit API events (JSON) | 6003 / 3002 |
+| `parsers/parse_okta_system.limpid` | Okta System Log events (JSON) | 3001 / 3002 / 3005 / 3006 |
 | `parsers/parse_juniper_srx_sd_syslog.limpid` | Juniper SRX RT_FLOW (RFC 5424 + Junos SD, `set security log format sd-syslog` mode) | 4001 Network Activity |
 | `parsers/parse_juniper_srx_syslog.limpid` | Juniper SRX RT_IDP / IDP_ATTACK_LOG_EVENT (RFC 3164 unstructured, default `syslog` mode) | 2004 Detection Finding |
 | `parsers/parse_nsp.limpid` | Trellix / McAfee Network Security Platform IPS alerts (standard syslog KV template, real-traffic verified) | 2004 Detection Finding |
@@ -128,6 +135,11 @@ contracts.
   IANA names and fixed offsets are also accepted as explicit overrides.
   For RFC 5424 / OTLP / OCSF input use the built-in
   `parse_datetime_rfc3339` primitive directly.
+- `functions/timestamp_converter.limpid` — exact integer boundary helpers
+  `timestamp_ns_to_ms(value) → Int | null` and
+  `timestamp_ms_to_ns(value) → Int | null`. `compose_ocsf` uses the first;
+  `parse_ocsf` uses the second. Helpers shared by multiple source schemas
+  live under `functions/`; source-local helpers stay beside their parser.
 - `functions/http_method_activity_id.limpid` —
   `http_method_activity_id(method) → Int`. HTTP request method
   (`GET` / `POST` / `PUT` / `DELETE` / `HEAD` / `OPTIONS` /
@@ -268,11 +280,11 @@ systems below):
   attack-scenario dataset (Empire mimikatz logonpasswords trace,
   702 Security-channel events).
 
-The remaining classes for which `compose_ocsf` has a leaf but no
-parser yet emits to (most of category 2 Findings; some of category
-4 sub-protocols like DNS / DHCP / RDP / SMB / SSH / FTP /
-NetworkFile; some of category 6 like Datastore / Scan) are
-candidates for upcoming snippets in 0.7.x point releases.
+The remaining classes for which `compose_ocsf` has a leaf but no bundled
+parser currently produces facts are Registry Key Activity (1008), Registry
+Value Activity (1009), Compliance Finding (2003), Incident Finding (2005),
+Network File Activity (4010), Datastore Activity (6005), and Scan Activity
+(6007). These are candidates for future snippets.
 
 ## Authoring your own snippets
 
@@ -283,10 +295,13 @@ conventions are:
   (`parse_fortigate_cef` + `parse_fortigate_syslog`) because CEF and
   native KV are different wire shapes; OpenSSH is one file because
   sshd's wire is one shape across syslog and journald.
-- **File header** carries `// Vendor:` / `// Wire:` / `// Output:`
-  lines describing the source, plus per-shape sample lines anonymised
-  to RFC 5321 / 5737 forms (`example.com`, `192.0.2.x`,
-  `198.51.100.x`).
+- **Canonical file header** follows the per-kind schema documented in the
+  [pack README](../../../packaging/snippets/README.md#authoring-conventions):
+  parser files declare `Summary`, `Reads`, `Writes`, `Category`, and
+  `Test corpus`; composers and shared functions use their corresponding
+  schemas. The header is the source for generated inventory. Keep sample
+  wires in the header and anonymise them with documentation domains and
+  RFC 5737 addresses.
 - **Two-tier dispatch**: the top-level `def process parse_<vendor>`
   strips the wrapper and routes by header field (`switch
   workspace.<vendor>.<key>`); per-leaf `def process` re-parses the

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -457,8 +457,9 @@ passed through unchanged, `hostname()`) is not declared in `Reads:`
 ### `Writes:` — LSIS-slot contract
 
 `Writes:` names the LSIS slot(s) the snippet produces. Parsers
-write facts to `workspace.lsis.parsed.*` and enumerate the OCSF
-class(es) their dispatcher emits; composers write a single
+write facts to `workspace.lsis.parsed.*` and enumerate the LSIS
+`class_uid` facts their dispatcher produces (using OCSF class identifiers);
+composers write a single
 `workspace.lsis.composed.<slot>` from the composed-layer registry
 above.
 

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -16,10 +16,10 @@
 //              deployment; override it when the device zone is known)
 //              https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/I-R/asa-command-ref-I-R/m_log-lz.html
 // Writes:      workspace.lsis.parsed.* — 3002 (Authentication) and 4001 (Network
-//              asa_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              Activity), dispatched by message ID; unmapped IDs route to
-//              error_log. Per-ID table below.
+//              error_log. Per-ID table below. asa_to_otlp additionally writes
+//              source-specific workspace.lsis.shed.otlp Resource, Body, and
+//              LogRecord attributes.
 // Category:    Network firewall / IPS
 // Test corpus: synthetic (sample wires in this header; several message-ID
 //              leaves are not yet exercised against live captures — see

--- a/packaging/snippets/parsers/parse_aws_guardduty.limpid
+++ b/packaging/snippets/parsers/parse_aws_guardduty.limpid
@@ -4,9 +4,9 @@
 // Reads:       ingress (raw wire) — one GuardDuty finding object per ingress
 //              (identical across EventBridge / SNS / S3 delivery)
 // Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding), one finding → one
+//              record; unknown ThreatPurpose values route to error_log.
 //              aws_guardduty_to_otlp additionally writes source-specific
 //              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              record; unknown ThreatPurpose values route to error_log.
 // Category:    Cloud security findings
 // Test corpus: spec-only (AWS documentation per-finding-type sample bodies;
 //              cross-referenced against the CreateSampleFindings API shape —

--- a/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
+++ b/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
@@ -5,9 +5,9 @@
 // Reads:       ingress (raw wire) — one space-separated flow-log record per
 //              line; dispatch by the leading version token
 // Writes:      workspace.lsis.parsed.* — 4001 (Network Activity); unknown version
-//              aws_vpc_flow_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              tokens route to error_log.
+//              tokens route to error_log. aws_vpc_flow_to_otlp additionally writes
+//              source-specific workspace.lsis.shed.otlp Resource, Body, and
+//              LogRecord attributes.
 // Category:    Cloud network (data plane)
 // Test corpus: spec-only (AWS VPC Flow Logs documentation column layouts;
 //              synthesised sample lines below cover ACCEPT / REJECT / NODATA /

--- a/packaging/snippets/parsers/parse_azure_activity.limpid
+++ b/packaging/snippets/parsers/parse_azure_activity.limpid
@@ -4,10 +4,9 @@
 // Reads:       ingress (raw wire) — one Activity Log event per ingress (flat
 //              per-record form; unwrap Event Hub batches upstream)
 // Writes:      workspace.lsis.parsed.* — 6003 (API Activity), dispatched over the
+//              8 documented categories; unknown categories route to error_log.
 //              azure_activity_to_otlp additionally writes source-specific
 //              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              8 documented categories; unknown categories route to
-//              error_log.
 // Category:    Cloud audit (API control plane)
 // Test corpus: spec-only (Microsoft Learn Azure Activity Log schema reference
 //              + documentation samples for the 8 categories; no live capture)

--- a/packaging/snippets/parsers/parse_journald.limpid
+++ b/packaging/snippets/parsers/parse_journald.limpid
@@ -14,9 +14,8 @@
 // `parse_journald` is a thin LOTL wrapper: limpid's `input journal`
 // emits ingress as `journalctl -o json`-byte-identical JSON, and this
 // snippet just hands it to `parse_json`. No vendor-specific decoding
-// happens here — field names stay journald-canonical so downstream
-// composers (e.g. `compose_rfc5424`) can read them by their original
-// name.
+// happens here — field names stay journald-canonical. Target-specific
+// adapters or named bridges read that namespace; generic composers do not.
 //
 // Field naming notes —
 //   PRIORITY               — syslog severity (0-7), JSON string ("6")
@@ -50,7 +49,7 @@
 //    "MESSAGE":"Accepted publickey for alice from 192.0.2.10 port 51234 ssh2"}
 //
 // Typical pipeline —
-//   process parse_journald | compose_rfc5424 | rfc5424_to_egress
+//   process parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress
 //   process parse_journald | parse_openssh | compose_ocsf | ocsf_to_egress
 
 def process parse_journald {

--- a/packaging/snippets/parsers/parse_k8s_audit.limpid
+++ b/packaging/snippets/parsers/parse_k8s_audit.limpid
@@ -5,10 +5,10 @@
 // Reads:       ingress (raw wire) — one audit Event object per ingress
 //              (no {"items":[...]} envelope)
 // Writes:      workspace.lsis.parsed.* — 6003 (API Activity) for resource requests,
-//              k8s_audit_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              3002 (Authentication) for authentication.k8s.io objectRefs;
-//              unknown kinds route to error_log.
+//              unknown kinds route to error_log. k8s_audit_to_otlp additionally
+//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
+//              and LogRecord attributes.
 // Category:    Container / orchestration
 // Test corpus: spec-only (Kubernetes audit policy reference, kube-apiserver
 //              v1.29 audit.k8s.io/v1 schema; verb → activity_id per the OCSF

--- a/packaging/snippets/parsers/parse_okta_system.limpid
+++ b/packaging/snippets/parsers/parse_okta_system.limpid
@@ -5,10 +5,10 @@
 // Reads:       ingress (raw wire) — one LogEvent object per ingress (unwrap
 //              Event Hooks data.events[] upstream)
 // Writes:      workspace.lsis.parsed.* — user.session/user.authentication → 3002,
-//              okta_system_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              user.lifecycle → 3001, user.account → 3005, group.* → 3006;
-//              other eventTypes route to error_log.
+//              other eventTypes route to error_log. okta_system_to_otlp additionally
+//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
+//              and LogRecord attributes.
 // Category:    Identity / IdP
 // Test corpus: synthetic (synthesised from the Okta System Log API reference
 //              — eventType taxonomy and LogEvent schema; live-corpus

--- a/packaging/snippets/parsers/parse_suricata.limpid
+++ b/packaging/snippets/parsers/parse_suricata.limpid
@@ -6,10 +6,10 @@
 //   .hostname (optional, String) — collector override
 //   .time (optional, Int) — epoch ns override
 // Writes:      workspace.lsis.parsed.* — alert → 2004, dns → 4003, http → 4002,
-//              suricata_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              tls / flow / fileinfo → 4001; stats dropped; other
-//              event_types route to error_log.
+//              tls / flow / fileinfo → 4001; stats dropped; other event_types
+//              route to error_log. suricata_to_otlp additionally writes
+//              source-specific workspace.lsis.shed.otlp Resource, Body, and
+//              LogRecord attributes.
 // Category:    OSS NDR
 // Test corpus: public (elastic/integrations suricata corpus — 63 events
 //              across alert / dns / http / tls / flow / fileinfo / stats;


### PR DESCRIPTION
## Summary

Resolves 16 of the 17 drift findings surfaced by an audit of docs vs
registered functions and snippet headers vs shipped behavior (finding F2
was ruled a documented pragmatic default and left in place). The changes
fall into two commits by concern:

**`c3822ab` — analyzer / signature side.** Six semantic corrections
where the static checker's contracts had fallen behind the runtime:

- **Scoped wildcards for `cef.parse`.** The primitive previously widened
  the entire `workspace.*` namespace to wildcard, silently accepting typo
  reads of any workspace path. It now declares `workspace.extension.*`
  as its only wildcard scope; unrelated workspace typos surface as
  `unknown identifier`.
- **`ingress` / `egress` typed as `String | Bytes`.** The runtime has
  emitted `Value::Bytes` for non-UTF-8 payloads since bytes-clean parsing
  landed; the static checker had them pinned to `String`, so any DSL that
  handled binary data was silently under-typed. Consumers that only read
  UTF-8 (`upper`, `regex_*`, string interpolation) still narrow correctly.
- **Nullable primitive returns.** `regex_extract`, `syslog.extract_pri`,
  `to_int`, `len`, `csv_parse`, `append`, `prepend`, `hostname` all
  return `null` on their documented miss cases at runtime. Signatures
  now declare `Union(T, Null)`.
- **User-defined function arity check.** `docs/functions/user-defined.md`
  promises the analyzer catches arity mismatches on user-defined
  functions the same way it does for built-ins. The check was skipped
  in the analyzer and only surfaced at runtime; now enforced statically.
- **Timezone lookup case-insensitive.** `strftime` / `strptime` accepted
  only `UTC` / `utc` and `local`. The docs promised case-insensitive
  reserved names; both are now matched by ASCII case-insensitive compare
  (IANA names remain case-sensitive per chrono-tz).
- **Small primitive corrections.** `to_string`'s registered signature
  now matches its runtime acceptance surface; the OTLP protobuf / JSON
  decoders similarly.

**`209c506` — docs / snippet header side.** Ten header and doc updates
where the shipped snippet library or expression-functions reference had
drifted from the code:

- `pipelines/multi-host.md` shows the journald→RFC 5424 pipeline as
  `parse_journald | journald_to_rfc5424 | compose_rfc5424 |
  rfc5424_to_egress` (the bridge was omitted, and the surrounding prose
  about PRI survival was corrected to match actual composer behavior).
- `snippets/README.md` authoring guidance replaced with a pointer to the
  current canonical schema in the package README (Summary / Reads /
  Writes / Category / Test corpus per file).
- Design-guide OCSF composer example rewritten to match the shipped
  `compose_ocsf` leaf shape (parsed as read-only intake, explicit OCSF
  object, ns→ms conversion).
- Hand-maintained parser inventory brought current (previously 27/32
  files, missing `aws_guardduty` / `aws_vpc_flow` / `azure_activity` /
  `k8s_audit` / `okta_system`); the "not yet covered" list recalculated.
- Include / edit guidance realigned with the installed library being
  read-only (customization via operator-owned copies).
- Functions list adds `timestamp_converter`; helper-locality wording
  updated for shared-helpers reality.
- Seven parser headers had adapter sentences fragmenting the primary
  `Writes:` sentence — moved to their own paragraph. `parse_asa` was the
  worst case (a sentence split by an interposed clause).
- `cef.parse` shape reference in `expression-functions.md` now shows
  the nested `extension.<key>` form (the flat form was left behind by
  the extension-isolation refactor).
- Small function-reference gaps: `len(Bytes)` byte-count row, Bytes
  rejection in the interpolation coercion table, a phantom `format`
  primitive replaced with the actual registered name, `concat`'s minimum
  arity corrected.

## Not in scope

- **F2 (RFC 5424 `.msg` required contract).** The composer header
  documents `.msg` as required from the composer's contract point of
  view AND explicitly notes the empty-MSG fallback is a documented
  pragmatic default (RFC 5424 §6 grammar makes MSG optional). Ruled a
  correct documented contract, not drift.
- **Canonical-header applicability** (per-primary vs whole-file) and
  **multi-root Reads grammar** — both surfaced by the same audit and
  held for a follow-up branch with an owner-approved design (Facade
  manifest + per-member headers, and multi-root grammar extension).

## Test plan

- [x] `cargo test --workspace --locked` — 918 passed / 1 ignored
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] mdBook build, snippet header lint (42/0), inventory in sync
- [x] Independent push-gate audit (uchgs, 9/9 scopes PASS, findings 0)
- [ ] End-to-end verification on Splunk Enterprise 10.4.1 — deferred to
      the follow-up branch (header-schema migration will re-run SPK once
      atop the combined state, avoiding two real-machine runs)