### PR TITLE
feat(snippets): declare per-member contracts behind file facades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — snippet headers declare file facades and member contracts
+
+Packaged snippets now separate file-level metadata from the contracts of each
+public process or function. A `Facade:` list names the externally callable
+members, and an adjacent `Process:` or `Function:` block documents each public
+member without forcing internal dispatch leaves into the public surface.
+`Reads:` and `Writes:` accept multiple independently validated workspace roots,
+so adapters and bridges can state their real cross-namespace boundaries. The
+header linter rejects missing, orphaned, misplaced, and signature-mismatched
+member blocks, and the generated inventory consumes the same facade metadata.
+
 ### Fixed — analyzer contracts match runtime value shapes
 
 Static checking now models ingress and egress as String-or-Bytes payloads,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Fixed — nullable expression inference follows runtime control flow
+
+The static analyzer now removes skipped `Null` members from non-final
+`coalesce` arguments while preserving the final argument's nullability, and
+infers `len` from its concrete input type. Equality checks against `null` are
+treated as presence guards rather than incompatible-type comparisons. These
+rules prevent reusable composers from producing strict-check false positives
+after a source adapter specializes an otherwise optional field.
+
 ### Changed — snippet headers declare file facades and member contracts
 
 Packaged snippets now separate file-level metadata from the contracts of each

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -59,10 +59,24 @@ pub fn infer(expr: &Expr, bindings: &Bindings, registry: &FunctionRegistry) -> F
             args,
             block_arg: _,
         } => {
-            if namespace.is_none() && name == "filter" {
-                args.first()
-                    .map(|arg| filter_return_type(infer(arg, bindings, registry)))
-                    .unwrap_or(FieldType::Any)
+            if namespace.is_none() {
+                match name.as_str() {
+                    "filter" => args
+                        .first()
+                        .map(|arg| filter_return_type(infer(arg, bindings, registry)))
+                        .unwrap_or(FieldType::Any),
+                    "coalesce" => {
+                        coalesce_return_type(args.iter().map(|arg| infer(arg, bindings, registry)))
+                    }
+                    "len" => args
+                        .first()
+                        .map(|arg| len_return_type(infer(arg, bindings, registry)))
+                        .unwrap_or(FieldType::Any),
+                    _ => registry
+                        .signature(None, name)
+                        .map(|s| s.ret.clone())
+                        .unwrap_or(FieldType::Any),
+                }
             } else {
                 registry
                     .signature(namespace.as_deref(), name)
@@ -121,6 +135,67 @@ fn filter_return_type(input: FieldType) -> FieldType {
         // An unknown or invalid input stays unknown to avoid cascading
         // diagnostics after the call-site argument check.
         _ => FieldType::Any,
+    }
+}
+
+/// Infer the first non-null result of `coalesce` without losing the
+/// possibility that its final argument is null. Earlier arguments contribute
+/// only their non-null members because runtime evaluation skips their nulls.
+fn coalesce_return_type(types: impl IntoIterator<Item = FieldType>) -> FieldType {
+    let types: Vec<FieldType> = types.into_iter().collect();
+    let final_can_be_null = types.last().is_some_and(type_can_be_null);
+    let mut result = types
+        .into_iter()
+        .filter_map(type_without_null)
+        .reduce(FieldType::union);
+
+    if final_can_be_null {
+        result = Some(match result {
+            Some(non_null) => FieldType::union(non_null, FieldType::Null),
+            None => FieldType::Null,
+        });
+    }
+    result.unwrap_or(FieldType::Any)
+}
+
+fn type_can_be_null(ty: &FieldType) -> bool {
+    match ty {
+        FieldType::Null | FieldType::Any => true,
+        FieldType::Union(members) => members.iter().any(type_can_be_null),
+        _ => false,
+    }
+}
+
+fn type_without_null(ty: FieldType) -> Option<FieldType> {
+    match ty {
+        FieldType::Null => None,
+        FieldType::Union(members) => members
+            .into_iter()
+            .filter_map(type_without_null)
+            .reduce(FieldType::union),
+        other => Some(other),
+    }
+}
+
+/// `len` returns null exactly for null or non-collection scalar inputs. Keep
+/// the registered broad contract for `Any`, but preserve precise input types
+/// after expression-level narrowing.
+fn len_return_type(input: FieldType) -> FieldType {
+    match input {
+        FieldType::String | FieldType::Object | FieldType::Array | FieldType::Bytes => {
+            FieldType::Int
+        }
+        FieldType::Null
+        | FieldType::Bool
+        | FieldType::Int
+        | FieldType::Float
+        | FieldType::Timestamp => FieldType::Null,
+        FieldType::Union(members) => members
+            .into_iter()
+            .map(len_return_type)
+            .reduce(FieldType::union)
+            .unwrap_or(FieldType::Any),
+        FieldType::Any => FieldType::union(FieldType::Int, FieldType::Null),
     }
 }
 
@@ -501,7 +576,12 @@ fn check_binop(
 
     match op {
         BinOp::Eq | BinOp::Ne => {
-            if !type_compatible(&lt, &rt) && !type_compatible(&rt, &lt) {
+            // Equality against null is a presence check. A reusable process
+            // may receive a concrete call-site type in one pipeline and a
+            // nullable type in another, so call-site specialization must not
+            // turn its generic guard into an always-same warning.
+            let null_presence_check = lt == FieldType::Null || rt == FieldType::Null;
+            if !null_presence_check && !type_compatible(&lt, &rt) && !type_compatible(&rt, &lt) {
                 diagnostics.push(warning(
                     pipeline_name,
                     format!(
@@ -732,5 +812,57 @@ fn warning(pipeline: &str, message: String, span: Option<Span>) -> Diagnostic {
         message: format!("[pipeline {}] {}", pipeline, message),
         span,
         help: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalesce_removes_null_from_non_final_arguments() {
+        assert_eq!(
+            coalesce_return_type([
+                FieldType::union(FieldType::Array, FieldType::Null),
+                FieldType::Array,
+            ]),
+            FieldType::Array
+        );
+        assert_eq!(
+            coalesce_return_type([
+                FieldType::union(FieldType::String, FieldType::Null),
+                FieldType::Null,
+                FieldType::Int,
+            ]),
+            FieldType::union(FieldType::String, FieldType::Int)
+        );
+    }
+
+    #[test]
+    fn coalesce_preserves_null_only_from_the_final_argument() {
+        assert_eq!(
+            coalesce_return_type([
+                FieldType::String,
+                FieldType::union(FieldType::Int, FieldType::Null),
+            ]),
+            FieldType::union(
+                FieldType::union(FieldType::String, FieldType::Int),
+                FieldType::Null,
+            )
+        );
+        assert_eq!(
+            coalesce_return_type([FieldType::Null, FieldType::Null]),
+            FieldType::Null
+        );
+    }
+
+    #[test]
+    fn len_reflects_nullable_and_non_nullable_inputs() {
+        assert_eq!(len_return_type(FieldType::Array), FieldType::Int);
+        assert_eq!(len_return_type(FieldType::Null), FieldType::Null);
+        assert_eq!(
+            len_return_type(FieldType::union(FieldType::Array, FieldType::Null)),
+            FieldType::union(FieldType::Int, FieldType::Null)
+        );
     }
 }

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -1100,6 +1100,72 @@ def pipeline p {
         );
     }
 
+    #[test]
+    fn coalesce_narrows_nullable_collection_before_len() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        if true { workspace.items = [] }
+        else { workspace.items = null }
+        workspace.has_items = len(coalesce(workspace.items, [])) > 0
+    }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(warnings(&diags).is_empty(), "got: {:?}", diags);
+    }
+
+    #[test]
+    fn null_presence_checks_do_not_warn_after_call_site_specialization() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def process guard_optional_fields {
+    if true { workspace.optional = "value" }
+    else { workspace.optional = null }
+    workspace.has_optional = workspace.optional != null
+    workspace.has_name = workspace.name != null
+    workspace.has_labels = workspace.labels != null
+}
+def pipeline p {
+    input i
+    process {
+        workspace.name = "source"
+        workspace.labels = []
+    }
+    process guard_optional_fields
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(warnings(&diags).is_empty(), "got: {:?}", diags);
+    }
+
+    #[test]
+    fn non_null_equality_type_mismatches_still_warn() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process { workspace.mismatch = "1" == 1 }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            warnings(&diags)
+                .iter()
+                .any(|warning| warning.message.contains("always evaluates the same")),
+            "got: {:?}",
+            diags
+        );
+    }
+
     // ----- DiagKind tagging / promotion -----------------------------------
 
     #[test]

--- a/crates/xtask/src/header.rs
+++ b/crates/xtask/src/header.rs
@@ -1,13 +1,10 @@
-//! Snippet-header schema (parse + lint) — 4 kinds, LSIS-era.
+//! Snippet-header schema (parse + lint) — file facade plus member contracts.
 //!
 //! The schema is documented in
 //! `packaging/snippets/README.md` § *Authoring conventions > Header
-//! schema*. Each snippet kind has its own canonical key set:
-//!
-//!   parser   (5 keys): Summary / Reads / Writes / Category / Test corpus
-//!   composer (4 keys): Summary / Reads / Writes / Test corpus
-//!   filter   (4 keys): Summary / Reads / Effect / Test corpus
-//!   function (3 keys): Summary / Signature / Test corpus
+//! schema*. File-level metadata declares `Facade`, `Category` (parser
+//! only), and `Test corpus`. Every facade process/function has a
+//! directly-adjacent member block carrying its authored contract.
 //!
 //! The kind is determined by the file's parent directory
 //! (`packaging/snippets/{parsers,composers,filters,functions}/`), not
@@ -21,9 +18,8 @@
 //! rather than authored, and why `Category:` on composers/filters
 //! (where it would duplicate Reads/Writes/Effect) is rejected.
 //!
-//! Unknown `// <Key>:` lines are tolerated with a warning — parsers
-//! historically carry vendor-specific prose blocks like `// FortiGate
-//! CEF dialect quirks:`.
+//! Top-level definitions omitted from `Facade` are private implementation
+//! details and do not need member blocks.
 
 use std::collections::BTreeMap;
 use std::error::Error;
@@ -98,30 +94,12 @@ impl SnippetKind {
         }
     }
 
-    /// Canonical required-key list in the order they must appear.
-    ///
-    /// Governing principle applied per kind:
-    /// - `Summary` and `Test corpus` are universal (all kinds).
-    /// - `Reads` is universal for stream kinds (parser/composer/filter).
-    /// - `Writes` (translator) / `Effect` (filter) split the stream
-    ///   kind by what happens to the payload.
-    /// - `Category` is parser-only — the composer and filter would-be
-    ///   category duplicates `Writes` / `Effect` / `Reads` and fails
-    ///   the authored-knowledge test.
-    /// - `Signature` is function-only.
+    /// Canonical file-level keys in source order.
     pub fn required_keys(&self) -> &'static [&'static str] {
         match self {
-            Self::Parser => &["Summary", "Reads", "Writes", "Category", "Test corpus"],
-            Self::Composer => &["Summary", "Reads", "Writes", "Test corpus"],
-            Self::Filter => &["Summary", "Reads", "Effect", "Test corpus"],
-            Self::Function => &["Summary", "Signature", "Test corpus"],
+            Self::Parser => &["Facade", "Category", "Test corpus"],
+            _ => &["Facade", "Test corpus"],
         }
-    }
-
-    /// True for kinds that flow events (have a `Reads:` key). The
-    /// universal Reads-dot-line grammar applies to all of these.
-    pub fn is_stream(&self) -> bool {
-        matches!(self, Self::Parser | Self::Composer | Self::Filter)
     }
 
     /// Allowed first-word prefixes for the `Test corpus:` value.
@@ -140,29 +118,88 @@ impl SnippetKind {
 // SnippetHeader — parsed key/value bag + kind + original content.
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MemberKind {
+    Process,
+    Function,
+}
+
+impl MemberKind {
+    fn keyword(self) -> &'static str {
+        match self {
+            Self::Process => "process",
+            Self::Function => "function",
+        }
+    }
+
+    fn heading(self) -> &'static str {
+        match self {
+            Self::Process => "Process",
+            Self::Function => "Function",
+        }
+    }
+
+    fn required_keys(self) -> &'static [&'static str] {
+        match self {
+            Self::Process => &["Process", "Summary", "Reads", "Writes"],
+            Self::Function => &["Function", "Summary", "Signature"],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FacadeMember {
+    pub kind: MemberKind,
+    pub name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct MemberHeader {
+    pub kind: MemberKind,
+    pub name: String,
+    pub keys: BTreeMap<String, String>,
+    pub observed_order: Vec<String>,
+    pub declaration: Option<FacadeMember>,
+    pub line: usize,
+}
+
+impl MemberHeader {
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.keys.get(key).map(String::as_str)
+    }
+}
+
 /// A parsed snippet header. Fields:
 /// - `file`: source file path (for diagnostics + inventory rendering).
 /// - `kind`: derived from the file's parent directory.
-/// - `keys`: insertion-collapsed key → value bag. Multi-line values
+/// - `keys`: file-level key → value bag. Multi-line values
 ///   are joined with `\n`. Stored as `BTreeMap` only for stable
 ///   iteration in tests; the observed-in-source order lives
 ///   separately in `observed_order` so the order-lint stays honest.
 /// - `observed_order`: keys in the order they appeared in the source.
-/// - `content`: full file content, kept for cross-checks that need to
-///   see the body (specifically: `Signature:` vs `def function`
-///   declaration for the Function kind).
+/// - `facade`: parsed public process/function declarations.
+/// - `members`: per-facade contract blocks found throughout the file.
+/// - `content`: full file content, retained for inventory caller scans.
 #[derive(Debug, Clone)]
 pub struct SnippetHeader {
     pub file: PathBuf,
     pub kind: SnippetKind,
     pub keys: BTreeMap<String, String>,
     pub observed_order: Vec<String>,
+    pub facade: Vec<FacadeMember>,
+    pub members: Vec<MemberHeader>,
     pub content: String,
 }
 
 impl SnippetHeader {
     pub fn get(&self, key: &str) -> Option<&str> {
         self.keys.get(key).map(String::as_str)
+    }
+
+    pub fn member(&self, kind: MemberKind, name: &str) -> Option<&MemberHeader> {
+        self.members
+            .iter()
+            .find(|member| member.kind == kind && member.name == name)
     }
 }
 
@@ -219,38 +256,48 @@ pub fn parse_str(
     kind: SnippetKind,
     content: &str,
 ) -> Result<SnippetHeader, Box<dyn Error>> {
-    let mut keys: BTreeMap<String, String> = BTreeMap::new();
-    let mut observed_order: Vec<String> = Vec::new();
-    let mut current_key: Option<String> = None;
+    let lines: Vec<&str> = content.lines().collect();
+    let file_block_end = lines
+        .iter()
+        .position(|line| !line.starts_with("//"))
+        .unwrap_or(lines.len());
+    let (keys, observed_order) = parse_comment_keys(&lines[..file_block_end]);
+    let facade = keys
+        .get("Facade")
+        .map(|value| parse_facade(value).0)
+        .unwrap_or_default();
 
-    for line in content.lines() {
-        let Some(after_slashes) = line.strip_prefix("//") else {
-            // first non-`//` line ends the header
-            break;
+    let mut members = Vec::new();
+    let mut index = 0usize;
+    while index < lines.len() {
+        if !lines[index].starts_with("//") {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        while index < lines.len() && lines[index].starts_with("//") {
+            index += 1;
+        }
+        let (member_keys, member_order) = parse_comment_keys(&lines[start..index]);
+        let process_name = member_keys.get("Process").map(|name| name.trim());
+        let function_name = member_keys.get("Function").map(|name| name.trim());
+        let heading = match (process_name, function_name) {
+            (Some(name), None) => Some((MemberKind::Process, name)),
+            (None, Some(name)) => Some((MemberKind::Function, name)),
+            (Some(name), Some(_)) => Some((MemberKind::Process, name)),
+            (None, None) => None,
         };
-
-        // A `// <Key>: <value>` line: detect key pattern.
-        if let Some((key, value)) = parse_key_line(after_slashes) {
-            keys.insert(key.clone(), value.to_string());
-            observed_order.push(key.clone());
-            current_key = Some(key);
-            continue;
-        }
-
-        // Otherwise it's either a blank `//` (= section divider,
-        // skip — does not end the header) or a continuation line.
-        let trimmed = after_slashes.trim();
-        if trimmed.is_empty() {
-            current_key = None;
-            continue;
-        }
-
-        // Continuation: only counts if there's a current key.
-        // Otherwise it's freeform prose (sample lines, intro).
-        if let Some(ref key) = current_key {
-            let value = keys.get_mut(key).expect("current_key must exist");
-            value.push('\n');
-            value.push_str(after_slashes.trim_start_matches(' '));
+        if let Some((member_kind, name)) = heading {
+            members.push(MemberHeader {
+                kind: member_kind,
+                name: name.to_string(),
+                keys: member_keys,
+                observed_order: member_order,
+                declaration: lines
+                    .get(index)
+                    .and_then(|line| parse_def_declaration(line)),
+                line: start + 1,
+            });
         }
     }
 
@@ -259,7 +306,86 @@ pub fn parse_str(
         kind,
         keys,
         observed_order,
+        facade,
+        members,
         content: content.to_string(),
+    })
+}
+
+fn parse_comment_keys(lines: &[&str]) -> (BTreeMap<String, String>, Vec<String>) {
+    let mut keys = BTreeMap::new();
+    let mut observed_order = Vec::new();
+    let mut current_key: Option<String> = None;
+
+    for line in lines {
+        let Some(after_slashes) = line.strip_prefix("//") else {
+            break;
+        };
+        if let Some((key, value)) = parse_key_line(after_slashes) {
+            keys.insert(key.clone(), value.to_string());
+            observed_order.push(key.clone());
+            current_key = Some(key);
+            continue;
+        }
+        let trimmed = after_slashes.trim();
+        if trimmed.is_empty() {
+            current_key = None;
+            continue;
+        }
+        if let Some(ref key) = current_key {
+            let value = keys.get_mut(key).expect("current_key must exist");
+            value.push('\n');
+            value.push_str(after_slashes.trim_start_matches(' '));
+        }
+    }
+    (keys, observed_order)
+}
+
+fn parse_facade(value: &str) -> (Vec<FacadeMember>, Vec<String>) {
+    let mut members = Vec::new();
+    let mut errors = Vec::new();
+    for raw_entry in value.split(',') {
+        let entry = raw_entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = entry.split_whitespace().collect();
+        let kind = match parts.first().copied() {
+            Some("process") => Some(MemberKind::Process),
+            Some("function") => Some(MemberKind::Function),
+            _ => None,
+        };
+        if parts.len() != 2
+            || kind.is_none()
+            || !is_ascii_ident(parts.get(1).copied().unwrap_or(""))
+        {
+            errors.push(format!(
+                "invalid `Facade:` entry {entry:?}; expected `process name` or `function name`"
+            ));
+            continue;
+        }
+        members.push(FacadeMember {
+            kind: kind.expect("checked above"),
+            name: parts[1].to_string(),
+        });
+    }
+    (members, errors)
+}
+
+fn parse_def_declaration(line: &str) -> Option<FacadeMember> {
+    let trimmed = line.trim_start();
+    let (kind, rest) = if let Some(rest) = trimmed.strip_prefix("def process ") {
+        (MemberKind::Process, rest)
+    } else {
+        (MemberKind::Function, trimmed.strip_prefix("def function ")?)
+    };
+    let name = rest
+        .split(|character: char| character == '(' || character == '{' || character.is_whitespace())
+        .next()
+        .unwrap_or("");
+    is_ascii_ident(name).then(|| FacadeMember {
+        kind,
+        name: name.to_string(),
     })
 }
 
@@ -297,55 +423,19 @@ fn parse_key_line(after_slashes: &str) -> Option<(String, &str)> {
 // Lint.
 // ---------------------------------------------------------------------------
 
-/// Lint a parsed header. Returns findings; empty means clean.
-///
-/// Rules (all enforced regardless of kind, dispatched per kind):
-///   1. all required keys present, in canonical order
-///   2. `Category:` is parser-only and its value is in the whitelist
-///   3. `Test corpus:` prefix is in the kind's allowed set
-///   4. `Reads:` dot-line grammar (universal for stream kinds)
-///   5. `Signature:` cross-check against `def function <name>(params)`
-///      in the same file (function only)
-///   6. Summary present (falls out of rule 1)
-///   7. Unknown keys → warning (not error), so vendor-specific prose
-///      blocks are tolerated but visible.
+/// Lint file-level facade metadata and every public member contract.
 pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
     let mut findings = Vec::new();
     let kind = header.kind;
 
-    // 1a. All required keys present.
-    for key in kind.required_keys() {
-        if !header.keys.contains_key(*key) {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!("missing required key `{key}:` for {} header", kind.label()),
-            });
-        }
-    }
-
-    // 1b. Required keys appear in canonical order.
-    let canonical: Vec<&str> = kind
-        .required_keys()
-        .iter()
-        .filter(|k| header.keys.contains_key(**k))
-        .copied()
-        .collect();
-    let observed_required: Vec<&str> = header
-        .observed_order
-        .iter()
-        .filter(|k| kind.required_keys().contains(&k.as_str()))
-        .map(String::as_str)
-        .collect();
-    if observed_required != canonical {
-        findings.push(Finding {
-            file: header.file.clone(),
-            severity: Severity::Error,
-            message: format!(
-                "required keys appear out of order: observed {observed_required:?}, expected {canonical:?}"
-            ),
-        });
-    }
+    lint_required_keys(
+        header,
+        "file",
+        &header.keys,
+        &header.observed_order,
+        kind.required_keys(),
+        &mut findings,
+    );
 
     // 2. Category: parser-only; value in whitelist.
     if let Some(cat) = header.get("Category") {
@@ -374,7 +464,7 @@ pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
         }
     }
 
-    // 3. Test corpus prefix.
+    // Test corpus stays file-level because all facade members share evidence.
     if let Some(tc) = header.get("Test corpus") {
         let first_word = tc.split_whitespace().next().unwrap_or("");
         let trimmed = first_word.trim_end_matches([':', ',', ';']);
@@ -391,21 +481,81 @@ pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
         }
     }
 
-    // 4. Reads dot-line grammar (universal for stream kinds).
-    if kind.is_stream()
-        && let Some(reads) = header.get("Reads")
-    {
-        findings.extend(lint_reads_grammar(header, reads));
+    let (parsed_facade, facade_errors) = header.get("Facade").map(parse_facade).unwrap_or_default();
+    for message in facade_errors {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message,
+        });
+    }
+    let mut facade_counts: BTreeMap<FacadeMember, usize> = BTreeMap::new();
+    for member in &parsed_facade {
+        *facade_counts.entry(member.clone()).or_default() += 1;
+    }
+    for (member, count) in &facade_counts {
+        if *count > 1 {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "duplicate `Facade:` entry `{} {}`",
+                    member.kind.keyword(),
+                    member.name
+                ),
+            });
+        }
     }
 
-    // 5. Signature cross-check (function only).
-    if kind == SnippetKind::Function
-        && let Some(sig) = header.get("Signature")
-    {
-        findings.extend(lint_signature(header, sig));
+    for facade_member in facade_counts.keys() {
+        let matching: Vec<&MemberHeader> = header
+            .members
+            .iter()
+            .filter(|member| member.kind == facade_member.kind && member.name == facade_member.name)
+            .collect();
+        match matching.as_slice() {
+            [] => findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "`Facade:` lists `{} {}` but no matching per-member block was found",
+                    facade_member.kind.keyword(),
+                    facade_member.name
+                ),
+            }),
+            [member] => findings.extend(lint_member(header, member)),
+            _ => findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "multiple per-member blocks found for `{} {}`",
+                    facade_member.kind.keyword(),
+                    facade_member.name
+                ),
+            }),
+        }
     }
 
-    // 7. Unknown keys → warning.
+    for member in &header.members {
+        if !facade_counts.contains_key(&FacadeMember {
+            kind: member.kind,
+            name: member.name.clone(),
+        }) {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "orphan `{}: {}` block at line {} is not listed in `Facade:`",
+                    member.kind.heading(),
+                    member.name,
+                    member.line
+                ),
+            });
+        }
+    }
+
+    // Unknown file-level keys remain warnings so authored design prose that
+    // looks like a key is visible without making migration brittle.
     for key in &header.observed_order {
         if !kind.required_keys().contains(&key.as_str()) {
             // Category on a non-parser is already an error above; don't
@@ -424,8 +574,122 @@ pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
     findings
 }
 
+fn lint_required_keys(
+    header: &SnippetHeader,
+    context: &str,
+    keys: &BTreeMap<String, String>,
+    observed_order: &[String],
+    required: &[&str],
+    findings: &mut Vec<Finding>,
+) {
+    for key in required {
+        if !keys.contains_key(*key) {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!("missing required key `{key}:` for {context} header"),
+            });
+        }
+    }
+    let canonical: Vec<&str> = required
+        .iter()
+        .filter(|key| keys.contains_key(**key))
+        .copied()
+        .collect();
+    let observed: Vec<&str> = observed_order
+        .iter()
+        .filter(|key| required.contains(&key.as_str()))
+        .map(String::as_str)
+        .collect();
+    if observed != canonical {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "{context} required keys appear out of order: observed {observed:?}, expected {canonical:?}"
+            ),
+        });
+    }
+}
+
+fn lint_member(header: &SnippetHeader, member: &MemberHeader) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let context = format!("{} `{}`", member.kind.keyword(), member.name);
+    lint_required_keys(
+        header,
+        &context,
+        &member.keys,
+        &member.observed_order,
+        member.kind.required_keys(),
+        &mut findings,
+    );
+
+    match &member.declaration {
+        Some(declaration) if declaration.kind == member.kind && declaration.name == member.name => {
+        }
+        Some(declaration) => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`{}: {}` block at line {} is followed by `def {} {}`",
+                member.kind.heading(),
+                member.name,
+                member.line,
+                declaration.kind.keyword(),
+                declaration.name
+            ),
+        }),
+        None => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`{}: {}` block at line {} must be immediately followed by its definition",
+                member.kind.heading(),
+                member.name,
+                member.line
+            ),
+        }),
+    }
+
+    match member.kind {
+        MemberKind::Process => {
+            if let Some(reads) = member.get("Reads") {
+                findings.extend(lint_io_grammar(header, "Reads", reads, &["ingress"]));
+            }
+            if let Some(writes) = member.get("Writes") {
+                findings.extend(lint_io_grammar(
+                    header,
+                    "Writes",
+                    writes,
+                    &["ingress", "egress"],
+                ));
+            }
+        }
+        MemberKind::Function => {
+            if let Some(signature) = member.get("Signature") {
+                findings.extend(lint_signature(header, member, signature));
+            }
+        }
+    }
+
+    for key in &member.observed_order {
+        if !member.kind.required_keys().contains(&key.as_str()) {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Warning,
+                message: format!(
+                    "unknown key `{key}:` in {} `{}` block",
+                    member.kind.keyword(),
+                    member.name
+                ),
+            });
+        }
+    }
+    findings
+}
+
 // ---------------------------------------------------------------------------
-// Rule 4: Reads dot-line grammar.
+// Process Reads/Writes root grammar.
 // ---------------------------------------------------------------------------
 
 /// A parsed `.<name> (required|optional, <Type>)` intake row.
@@ -442,7 +706,7 @@ pub struct DotLineDecl {
     pub ty: String,
 }
 
-/// The 7 acceptable intake types on a dot-line. Kept in sync with the
+/// The 8 acceptable intake types on a dot-line. Kept in sync with the
 /// grammar documented in the packaging README's Authoring Conventions
 /// section. String-form so we can report unknowns verbatim.
 const INTAKE_TYPES: &[&str] = &[
@@ -453,121 +717,100 @@ const INTAKE_TYPES: &[&str] = &[
     "Object",
     "Array",
     "Timestamp",
+    "Bytes",
 ];
 
-/// Enforce the universal `Reads:` grammar across all stream kinds.
-///
-/// - First line's first token is `ingress` → dot-lines FORBIDDEN.
-/// - First line's first token matches `workspace.<ns>.*` → ≥1
-///   dot-line REQUIRED; each dot-line matches
-///   `^\.<ASCII_IDENT>\s+\((required|optional), <TYPE>\)`.
-/// - Non-dot continuation lines are prose (permissive) and ignored.
-fn lint_reads_grammar(header: &SnippetHeader, reads_value: &str) -> Vec<Finding> {
+/// Enforce reserved-value or one-or-more workspace-root contracts.
+/// Each workspace root owns the following dot declarations until the next
+/// root and must declare at least one field.
+fn lint_io_grammar(
+    header: &SnippetHeader,
+    key: &str,
+    value: &str,
+    reserved: &[&str],
+) -> Vec<Finding> {
     let mut findings = Vec::new();
+    let lines: Vec<&str> = value.lines().map(str::trim_start).collect();
+    let first = lines.first().copied().unwrap_or("");
+    let first_token = first.split_whitespace().next().unwrap_or("");
 
-    let (first_line, rest) = match reads_value.split_once('\n') {
-        Some((f, r)) => (f.trim(), Some(r)),
-        None => (reads_value.trim(), None),
-    };
-
-    let shape = classify_reads_first_line(first_line);
-
-    match shape {
-        ReadsShape::Ingress => {
-            // Any dot-shaped continuation is an error.
-            if let Some(rest) = rest {
-                for (idx, line) in rest.split('\n').enumerate() {
-                    let trimmed = line.trim_start();
-                    if trimmed.starts_with('.') {
-                        findings.push(Finding {
-                            file: header.file.clone(),
-                            severity: Severity::Error,
-                            message: format!(
-                                "`Reads:` first token is `ingress`, so dot-line intake rows \
-                                 are forbidden; found `{}` on continuation line {}",
-                                trimmed,
-                                idx + 2
-                            ),
-                        });
-                    }
-                }
-            }
-        }
-        ReadsShape::WorkspaceNamespace => {
-            // Require ≥1 dot line; each dot line must parse.
-            let mut dot_lines_seen = 0usize;
-            if let Some(rest) = rest {
-                for (idx, line) in rest.split('\n').enumerate() {
-                    let trimmed = line.trim_start();
-                    if !trimmed.starts_with('.') {
-                        continue; // prose line; permitted
-                    }
-                    match parse_dot_line(trimmed) {
-                        Some(_) => dot_lines_seen += 1,
-                        None => findings.push(Finding {
-                            file: header.file.clone(),
-                            severity: Severity::Error,
-                            message: format!(
-                                "`Reads:` dot-line at continuation line {} does not match the \
-                                 required grammar `^\\.<IDENT>\\s+\\((required|optional), \
-                                 <String|Int|Float|Bool|Object|Array|Timestamp>\\)`: {}",
-                                idx + 2,
-                                trimmed
-                            ),
-                        }),
-                    }
-                }
-            }
-            if dot_lines_seen == 0 {
+    if reserved.contains(&first_token) {
+        for (index, line) in lines.iter().enumerate().skip(1) {
+            if line.starts_with('.') || classify_workspace_root(line) {
                 findings.push(Finding {
                     file: header.file.clone(),
                     severity: Severity::Error,
                     message: format!(
-                        "`Reads:` first token is a workspace namespace (`{first_line}`), \
-                         so at least one dot-line intake row is required (e.g. \
-                         `.body (required, String) — sshd application body`)"
+                        "`{key}:` starts with reserved `{first_token}`, so workspace roots and dot declarations are forbidden; found `{line}` on line {}",
+                        index + 1
                     ),
                 });
             }
         }
-        ReadsShape::Unknown => findings.push(Finding {
+        return findings;
+    }
+
+    if !classify_workspace_root(first) {
+        findings.push(Finding {
             file: header.file.clone(),
             severity: Severity::Error,
             message: format!(
-                "`Reads:` first token must be `ingress` (raw wire) or `workspace.<ns>.*` \
-                 (bridge/reader); found: {first_line}"
+                "`{key}:` first token must be one of {reserved:?} or `workspace.<ns>.*`; found: {first}"
             ),
-        }),
+        });
+        return findings;
     }
 
+    let mut current_root = first_token.to_string();
+    let mut declarations = 0usize;
+    for (index, line) in lines.iter().enumerate().skip(1) {
+        if classify_workspace_root(line) {
+            if declarations == 0 {
+                findings.push(missing_root_declaration(header, key, &current_root));
+            }
+            current_root = line.split_whitespace().next().unwrap_or("").to_string();
+            declarations = 0;
+            continue;
+        }
+        if !line.starts_with('.') {
+            continue;
+        }
+        match parse_dot_line(line) {
+            Some(_) => declarations += 1,
+            None => findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "`{key}:` dot-line {} does not match `.<IDENT> (required|optional, <TYPE>)`: {line}",
+                    index + 1
+                ),
+            }),
+        }
+    }
+    if declarations == 0 {
+        findings.push(missing_root_declaration(header, key, &current_root));
+    }
     findings
 }
 
-enum ReadsShape {
-    Ingress,
-    WorkspaceNamespace,
-    Unknown,
+fn missing_root_declaration(header: &SnippetHeader, key: &str, root: &str) -> Finding {
+    Finding {
+        file: header.file.clone(),
+        severity: Severity::Error,
+        message: format!("`{key}:` workspace root `{root}` requires at least one dot declaration"),
+    }
 }
 
-fn classify_reads_first_line(first_line: &str) -> ReadsShape {
-    let first_token = first_line.split_whitespace().next().unwrap_or("");
-    if first_token == "ingress" {
-        return ReadsShape::Ingress;
-    }
-    // workspace.<ident>[.<ident>]*.*  — a dot-separated path of ascii
-    // idents ending in `.*`. Multi-segment paths surface the LSIS
-    // strata (`workspace.lsis.parsed.*`, `workspace.lsis.shed.otlp.*`)
-    // and any future nested transport namespace; single-segment paths
-    // (`workspace.journald.*`, `workspace.cef.*`) still classify the
-    // same way.
+fn classify_workspace_root(line: &str) -> bool {
+    let first_token = line.split_whitespace().next().unwrap_or("");
     if let Some(after_workspace) = first_token.strip_prefix("workspace.")
         && let Some(path) = after_workspace.strip_suffix(".*")
         && !path.is_empty()
         && path.split('.').all(is_ascii_ident)
     {
-        return ReadsShape::WorkspaceNamespace;
+        return true;
     }
-    ReadsShape::Unknown
+    false
 }
 
 /// Parse a `.<name> (required|optional, <Type>)` line into a
@@ -639,113 +882,69 @@ fn is_ascii_ident(s: &str) -> bool {
 // Rule 5: Signature cross-check.
 // ---------------------------------------------------------------------------
 
-/// Cross-check the authored `Signature:` entries against every
-/// `def function <name>(<params>) { ... }` declaration in the same
-/// file. The return contract stays authored (the DSL has no
-/// return-type declaration to derive from), so we do not check it.
-fn lint_signature(header: &SnippetHeader, sig_value: &str) -> Vec<Finding> {
+/// Cross-check the authored typed `Signature:` against the adjacent
+/// definition's name and arity. Parameter and return types remain authored
+/// knowledge because the DSL declaration itself carries no type annotation.
+fn lint_signature(header: &SnippetHeader, member: &MemberHeader, sig_value: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
     let entries: Vec<&str> = signature_entries(sig_value).collect();
-    if entries.is_empty() {
+    if entries.len() != 1 {
         findings.push(Finding {
             file: header.file.clone(),
             severity: Severity::Error,
-            message: "`Signature:` must contain at least one non-blank entry".to_string(),
+            message: format!(
+                "`Function: {}` must have exactly one `Signature:` entry",
+                member.name
+            ),
         });
         return findings;
     }
 
-    let declarations = find_def_functions(&header.content);
-    let mut listed = Vec::new();
-    let mut listed_counts: BTreeMap<String, usize> = BTreeMap::new();
-
-    for entry in entries {
-        let Some((name, params)) = parse_signature(entry) else {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`Signature:` entry must have shape `name(param1, param2, ...) → ReturnType`; \
-                     could not parse: {entry:?}"
-                ),
-            });
-            continue;
-        };
-        *listed_counts.entry(name.clone()).or_default() += 1;
-        listed.push((name, params));
+    let entry = entries[0];
+    let Some((name, params)) = parse_signature(entry) else {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`Signature:` must have shape `name(Type1, Type2, ...) → ReturnType`; could not parse: {entry:?}"
+            ),
+        });
+        return findings;
+    };
+    if name != member.name {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!("`Function: {}` has `Signature:` for `{name}`", member.name),
+        });
+        return findings;
     }
-
-    for (name, count) in &listed_counts {
-        if *count > 1 {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "duplicate `Signature:` entry for `{name}`; each function must be listed exactly once"
-                ),
-            });
-        }
-    }
-
-    let mut declaration_counts: BTreeMap<String, usize> = BTreeMap::new();
-    for declaration in &declarations {
-        *declaration_counts
-            .entry(declaration.name.clone())
-            .or_default() += 1;
-    }
-    for (name, count) in &declaration_counts {
-        if *count > 1 {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "duplicate `def function {name}(...)` declaration; the `Signature:` contract requires one declaration per name"
-                ),
-            });
-        }
-    }
-
-    for (name, params) in &listed {
-        if listed_counts[name] != 1 {
-            continue;
-        }
-        let matching: Vec<&FunctionDecl> = declarations
-            .iter()
-            .filter(|declaration| declaration.name == *name)
-            .collect();
-        match matching.as_slice() {
-            [] => findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`Signature:` names `{name}` but no `def function {name}(...)` \
-                     declaration was found in the same file"
-                ),
-            }),
-            [declaration] if declaration.params != *params => findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`Signature:` parameter list {params:?} does not match the \
-                     `def function {name}` declaration's parameters {:?}",
-                    declaration.params
-                ),
-            }),
-            _ => {}
-        }
-    }
-
-    for name in declaration_counts.keys() {
-        if !listed_counts.contains_key(name) {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`def function {name}(...)` is declared in this file but missing from \
-                     the `Signature:` field; list every function the file defines"
-                ),
-            });
-        }
+    let declarations: Vec<FunctionDecl> = find_def_functions(&header.content)
+        .into_iter()
+        .filter(|declaration| declaration.name == member.name)
+        .collect();
+    match declarations.as_slice() {
+        [] => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!("no `def function {}(...)` declaration found", member.name),
+        }),
+        [declaration] if declaration.params.len() != params.len() => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`Signature:` declares {} parameter type(s), but `def function {}` has {} parameter(s)",
+                params.len(),
+                member.name,
+                declaration.params.len()
+            ),
+        }),
+        [_] => {}
+        _ => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!("duplicate `def function {}(...)` declarations", member.name),
+        }),
     }
 
     findings
@@ -756,15 +955,15 @@ pub(crate) fn signature_entries(value: &str) -> impl Iterator<Item = &str> {
     value.lines().map(str::trim).filter(|line| !line.is_empty())
 }
 
-/// Parse the header value of a `Signature:` key into (name, params).
+/// Parse the header value of a `Signature:` key into (name, parameter types).
 ///
-/// Accepts shapes like `proto_num(name) → Int | null`,
-/// `foo(a, b, c) → Object`. Whitespace within the paren list is
-/// tolerated. The return part (everything from `→` on) is discarded.
+/// Accepts shapes like `proto_num(String) → Int | Null` and
+/// `foo(Object, String | Null) → Object`. Both parameter and return type
+/// expressions are validated against the DSL value-type vocabulary.
 pub fn parse_signature(value: &str) -> Option<(String, Vec<String>)> {
     let value = value.trim();
     let (head, return_type) = value.split_once('→')?;
-    if return_type.trim().is_empty() || return_type.contains('→') {
+    if return_type.contains('→') || !is_type_expr(return_type) {
         return None;
     }
     let head = head.trim();
@@ -778,8 +977,37 @@ pub fn parse_signature(value: &str) -> Option<(String, Vec<String>)> {
     if !after[paren_close + 1..].trim().is_empty() {
         return None;
     }
-    let params = parse_params(&after[..paren_close])?;
+    let params = parse_signature_params(&after[..paren_close])?;
     Some((name, params))
+}
+
+const SIGNATURE_TYPES: &[&str] = &[
+    "Any",
+    "String",
+    "Int",
+    "Float",
+    "Bool",
+    "Object",
+    "Array",
+    "Timestamp",
+    "Bytes",
+    "Null",
+];
+
+fn is_type_expr(value: &str) -> bool {
+    let mut parts = value.split('|').map(str::trim).peekable();
+    parts.peek().is_some() && parts.all(|part| SIGNATURE_TYPES.contains(&part))
+}
+
+fn parse_signature_params(value: &str) -> Option<Vec<String>> {
+    if value.trim().is_empty() {
+        return Some(Vec::new());
+    }
+    value
+        .split(',')
+        .map(str::trim)
+        .map(|param| is_type_expr(param).then(|| param.to_string()))
+        .collect()
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -840,546 +1068,247 @@ fn parse_params(value: &str) -> Option<Vec<String>> {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
+mod facade_tests {
     use super::*;
 
-    fn parser(s: &str) -> SnippetHeader {
+    fn parser(source: &str) -> SnippetHeader {
         parse_str(
-            Path::new("packaging/snippets/parsers/x.limpid"),
+            Path::new("packaging/snippets/parsers/example.limpid"),
             SnippetKind::Parser,
-            s,
+            source,
         )
         .unwrap()
     }
-    fn composer(s: &str) -> SnippetHeader {
+
+    fn function(source: &str) -> SnippetHeader {
         parse_str(
-            Path::new("packaging/snippets/composers/x.limpid"),
-            SnippetKind::Composer,
-            s,
-        )
-        .unwrap()
-    }
-    fn filter(s: &str) -> SnippetHeader {
-        parse_str(
-            Path::new("packaging/snippets/filters/x.limpid"),
-            SnippetKind::Filter,
-            s,
-        )
-        .unwrap()
-    }
-    fn function(s: &str) -> SnippetHeader {
-        parse_str(
-            Path::new("packaging/snippets/functions/x.limpid"),
+            Path::new("packaging/snippets/functions/example.limpid"),
             SnippetKind::Function,
-            s,
+            source,
         )
         .unwrap()
     }
 
-    // --- Kind dispatch from path ---
-    #[test]
-    fn kind_from_path_walks_upward() {
-        assert_eq!(
-            SnippetKind::from_path(Path::new(
-                "/home/user/repo/packaging/snippets/parsers/parse_x.limpid"
-            )),
-            Some(SnippetKind::Parser)
-        );
-        assert_eq!(
-            SnippetKind::from_path(Path::new(
-                "/home/user/repo/packaging/snippets/functions/f.limpid"
-            )),
-            Some(SnippetKind::Function)
-        );
-        assert_eq!(
-            SnippetKind::from_path(Path::new("/tmp/unknown/loc.limpid")),
-            None
-        );
-    }
+    fn clean_parser() -> &'static str {
+        r#"// Facade: process parse_example, process example_to_otlp
+// Category: Transport
+// Test corpus: synthetic (unit fixtures)
 
-    // --- Rule 1: required keys + order ---
-    #[test]
-    fn parser_clean_canonical_header() {
-        let h = parser(
-            "\
-// Summary:     OpenSSH events → LSIS Authentication
-// Reads:       workspace.openssh.* (bridge from parse_syslog | parse_journald)
-//                .body     (required, String)  — sshd body
-//                .pid      (optional, String)  — pid
-// Writes:      workspace.lsis.* — class_uid 3002 (Authentication)
-// Category:    Endpoint / host audit (Unix)
-// Test corpus: real (OpenSSH sample)
+// Process: parse_example
+// Summary: parses an example event
+// Reads: ingress (raw wire)
+// Writes: workspace.lsis.parsed.*
+//   .class_uid (required, Int)
+def process parse_example { }
 
-def process foo {}
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
+def function private_helper(value) { value }
+
+// Process: example_to_otlp
+// Summary: places example facts in OTLP fields
+// Reads: workspace.lsis.parsed.*
+//   .class_uid (required, Int)
+//   workspace.example.*
+//   .source (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//   .body (required, Bytes)
+def process example_to_otlp { }
+"#
     }
 
     #[test]
-    fn parser_missing_summary_is_error() {
-        let h = parser(
-            "\
-// Reads:       ingress (raw wire) — X CEF wire
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("missing required key `Summary:`"))
-        );
+    fn canonical_facade_and_private_definition_are_clean() {
+        let header = parser(clean_parser());
+        assert_eq!(header.facade.len(), 2);
+        assert_eq!(header.members.len(), 2);
+        assert!(lint(&header).is_empty(), "{:?}", lint(&header));
     }
 
     #[test]
-    fn parser_order_violation_caught() {
-        let h = parser(
-            "\
-// Reads:       ingress (raw wire) — X
-// Summary:     X
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
+    fn facade_continuation_is_comma_separated() {
+        let source = clean_parser().replace(
+            "process parse_example, process example_to_otlp",
+            "process parse_example,\n//         process example_to_otlp",
         );
-        assert!(lint(&h).iter().any(|f| f.message.contains("out of order")));
-    }
-
-    // --- Rule 2: Category ---
-    #[test]
-    fn composer_with_category_is_error() {
-        let h = composer(
-            "\
-// Summary:     OCSF renderer
-// Reads:       workspace.lsis.* (LSIS)
-//                .class_uid (required, Int) — dispatch discriminator
-// Writes:      workspace.lsis.ocsf — OCSF 1.3.0 JSON string
-// Category:    OCSF 1.3.0
-// Test corpus: real (x)
-",
-        );
-        let findings = lint(&h);
-        assert!(
-            findings.iter().any(|f| f
-                .message
-                .contains("`Category:` is not permitted on composer")),
-            "findings: {findings:?}"
-        );
+        let header = parser(&source);
+        assert_eq!(header.facade.len(), 2);
+        assert!(lint(&header).is_empty(), "{:?}", lint(&header));
     }
 
     #[test]
-    fn parser_category_value_must_be_in_whitelist() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       ingress (raw wire) — X
-// Writes:      workspace.lsis.* — 4001
-// Category:    Made up category
-// Test corpus: real (x)
-",
+    fn malformed_and_duplicate_facade_entries_are_errors() {
+        let source = clean_parser().replace(
+            "process parse_example, process example_to_otlp",
+            "process parse_example, process parse_example, parser nope",
         );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("not in the allowed set"))
-        );
-    }
-
-    // --- Rule 3: Test corpus prefix ---
-    #[test]
-    fn function_needs_unit_prefix() {
-        let h = function(
-            "\
-// Summary:     IANA proto lookup
-// Signature:   proto_num(name) → Int | null
-// Test corpus: real (some corpus)
-
-def function proto_num(name) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("must start with"))
-        );
-    }
-
-    #[test]
-    fn parser_cannot_use_unit_prefix() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       ingress (raw wire) — X
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: unit (some source)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("must start with"))
-        );
-    }
-
-    // --- Rule 4: Reads dot-line grammar (universal) ---
-    #[test]
-    fn parser_bridge_needs_dot_lines() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       workspace.openssh.* (bridge from parse_syslog)
-// Writes:      workspace.lsis.* — 3002
-// Category:    Endpoint / host audit (Unix)
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("at least one dot-line"))
-        );
-    }
-
-    #[test]
-    fn parser_ingress_forbids_dot_lines() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       ingress (raw wire) — X CEF
-//                .body (required, String)
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("dot-line intake rows are forbidden"))
-        );
-    }
-
-    #[test]
-    fn composer_reads_grammar_applies() {
-        // Composer with the LSIS shape but zero dot lines → error.
-        let h = composer(
-            "\
-// Summary:     OCSF renderer
-// Reads:       workspace.lsis.* (LSIS)
-// Writes:      workspace.lsis.ocsf — OCSF 1.3.0 JSON string
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("at least one dot-line"))
-        );
-    }
-
-    #[test]
-    fn filter_reads_grammar_applies() {
-        let h = filter(
-            "\
-// Summary:     sshd journal noise drop
-// Reads:       workspace.journald.* (from parse_journald)
-//                .MESSAGE (required, String) — sshd body candidate
-// Effect:      drop pam_unix(sshd:session): ... / else pass-through
-// Test corpus: real (x)
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn dot_line_regex_accepts_leading_underscore() {
-        // journald's `_PID` / `__REALTIME_TIMESTAMP` are real intake fields.
-        let d = parse_dot_line("._PID (optional, String) — kernel-verified pid").unwrap();
-        assert_eq!(d.name, "_PID");
-        assert!(!d.required);
-        assert_eq!(d.ty, "String");
-        let d = parse_dot_line(".__REALTIME_TIMESTAMP (optional, Int) — µs").unwrap();
-        assert_eq!(d.name, "__REALTIME_TIMESTAMP");
-    }
-
-    #[test]
-    fn dot_line_regex_rejects_wrong_shape() {
-        assert!(parse_dot_line(".body (mandatory, String)").is_none());
-        assert!(parse_dot_line(".body (required, Blob)").is_none());
-        assert!(parse_dot_line(".body [required, String]").is_none());
-        assert!(parse_dot_line(".1body (required, String)").is_none());
-    }
-
-    #[test]
-    fn dot_line_regex_tolerates_trailing_prose() {
-        let d = parse_dot_line(".body (required, String)  — sshd body").unwrap();
-        assert_eq!(d.name, "body");
-        assert!(d.required);
-    }
-
-    #[test]
-    fn reads_multi_segment_workspace_namespace_accepted() {
-        // LSIS strata surface as multi-segment paths:
-        // workspace.lsis.parsed.*, workspace.lsis.shed.otlp.*, etc.
-        // Also dot-line intake names may be dotted (log_record.body).
-        let h = composer(
-            "\
-// Summary:     Composer reading a multi-segment shed sub-tree
-// Reads:       workspace.lsis.shed.otlp.* — per-slot intake
-//                .log_record.body       (required, String) — body
-//                .log_record.attributes (optional, Array)  — attrs
-// Writes:      workspace.lsis.composed.otlp — proto bytes
-// Test corpus: spec-only (OTLP proto shape)
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn reads_unknown_first_token_is_error() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       nothing sensible
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("first token must be"))
-        );
-    }
-
-    // --- Rule 5: Signature cross-check ---
-    #[test]
-    fn function_signature_matches_declaration() {
-        let h = function(
-            "\
-// Summary:     IANA proto lookup
-// Signature:   proto_num(name) → Int | null
-// Test corpus: unit (IANA proto registry, RFC 5237)
-
-def function proto_num(name) {
-    switch lower(name) {
-        \"tcp\" { 6 }
-        default { null }
-    }
-}
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn function_signature_name_mismatch_is_error() {
-        let h = function(
-            "\
-// Summary:     IANA proto lookup
-// Signature:   proto_num(name) → Int | null
-// Test corpus: unit (IANA proto registry)
-
-def function protonum(name) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("no `def function proto_num"))
-        );
-    }
-
-    #[test]
-    fn function_signature_param_mismatch_is_error() {
-        let h = function(
-            "\
-// Summary:     Two-arg thing
-// Signature:   foo(a, b) → Int
-// Test corpus: unit (docs)
-
-def function foo(a, b, c) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("parameter list"))
-        );
-    }
-
-    #[test]
-    fn function_family_signatures_match_all_declarations() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              timestamp_ns_to_ms(value) → Int
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-def function timestamp_ns_to_ms(value) {}
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn function_declaration_missing_from_signature_is_error() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-def function timestamp_ns_to_ms(value) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("timestamp_ns_to_ms") && f.message.contains("missing"))
-        );
-    }
-
-    #[test]
-    fn function_family_second_param_mismatch_is_error() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              timestamp_ns_to_ms(value, divisor) → Int
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-def function timestamp_ns_to_ms(value) {}
-",
-        );
-        let findings = lint(&h);
-        assert!(findings.iter().any(|f| {
-            f.message.contains("timestamp_ns_to_ms") && f.message.contains("parameter list")
-        }));
-    }
-
-    #[test]
-    fn malformed_signature_entry_is_error() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              not a signature
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-",
-        );
-        assert!(lint(&h).iter().any(
-            |f| f.message.contains("could not parse") && f.message.contains("not a signature")
-        ));
-    }
-
-    #[test]
-    fn blank_signature_is_error() {
-        let h = function(
-            "\
-// Summary:     Empty family
-// Signature:
-// Test corpus: unit (header lint)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("at least one non-blank entry"))
-        );
-    }
-
-    #[test]
-    fn duplicate_signature_name_is_error() {
-        let h = function(
-            "\
-// Summary:     Duplicate surface
-// Signature:   convert(value) → Int
-//              convert(other) → Int
-// Test corpus: unit (header lint)
-
-def function convert(value) {}
-",
-        );
-        assert!(lint(&h).iter().any(|f| {
-            f.message
-                .contains("duplicate `Signature:` entry for `convert`")
-        }));
-    }
-
-    #[test]
-    fn duplicate_function_declaration_is_error() {
-        let h = function(
-            "\
-// Summary:     Duplicate declaration
-// Signature:   convert(value) → Int
-// Test corpus: unit (header lint)
-
-def function convert(value) {}
-def function convert(value) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("duplicate `def function convert"))
-        );
-    }
-
-    // --- Rule 7: unknown key → warning ---
-    #[test]
-    fn unknown_key_is_warning_not_error() {
-        let h = parser(
-            "\
-// Summary:     FortiGate CEF
-// Reads:       ingress (raw wire) — FortiGate CEF
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// FortiGate CEF dialect quirks: some prose
-// Test corpus: real (fortigate)
-",
-        );
-        let f = lint(&h);
-        let errors: Vec<_> = f.iter().filter(|x| x.severity == Severity::Error).collect();
-        let warnings: Vec<_> = f
-            .iter()
-            .filter(|x| x.severity == Severity::Warning)
+        let messages: Vec<String> = lint(&parser(&source))
+            .into_iter()
+            .map(|finding| finding.message)
             .collect();
-        assert!(errors.is_empty(), "errors: {errors:?}");
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].message.contains("FortiGate CEF dialect quirks"));
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("duplicate `Facade:`"))
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("invalid `Facade:`"))
+        );
     }
 
-    // --- Signature parser corner cases ---
+    #[test]
+    fn missing_and_orphan_member_blocks_are_errors() {
+        let missing = clean_parser().replace("// Process: example_to_otlp", "// Adapter contract");
+        assert!(
+            lint(&parser(&missing))
+                .iter()
+                .any(|finding| finding.message.contains("no matching per-member block"))
+        );
+
+        let orphan = clean_parser().replace(
+            "process parse_example, process example_to_otlp",
+            "process parse_example",
+        );
+        assert!(lint(&parser(&orphan)).iter().any(|finding| {
+            finding
+                .message
+                .contains("orphan `Process: example_to_otlp`")
+        }));
+    }
+
+    #[test]
+    fn member_block_must_be_immediately_followed_by_matching_def() {
+        let source = clean_parser().replace(
+            "def process parse_example { }",
+            "def process parse_other { }",
+        );
+        assert!(lint(&parser(&source)).iter().any(|finding| {
+            finding
+                .message
+                .contains("followed by `def process parse_other`")
+        }));
+    }
+
+    #[test]
+    fn process_member_requires_canonical_keys() {
+        let source = clean_parser().replace("// Summary: parses an example event\n", "");
+        assert!(
+            lint(&parser(&source))
+                .iter()
+                .any(|finding| finding.message.contains("missing required key `Summary:`"))
+        );
+    }
+
+    #[test]
+    fn multi_root_contract_validates_each_root() {
+        let clean = parser(clean_parser());
+        assert!(lint(&clean).is_empty(), "{:?}", lint(&clean));
+
+        let source = clean_parser().replace(
+            "//   workspace.example.*\n//   .source (optional, String)",
+            "//   workspace.example.*",
+        );
+        assert!(lint(&parser(&source)).iter().any(|finding| {
+            finding.message.contains("workspace.example.*")
+                && finding
+                    .message
+                    .contains("requires at least one dot declaration")
+        }));
+    }
+
+    #[test]
+    fn reserved_io_shapes_reject_field_declarations() {
+        let source = clean_parser().replace(
+            "// Reads: ingress (raw wire)",
+            "// Reads: ingress (raw wire)\n//   .body (required, String)",
+        );
+        assert!(lint(&parser(&source)).iter().any(|finding| {
+            finding
+                .message
+                .contains("workspace roots and dot declarations are forbidden")
+        }));
+    }
+
+    #[test]
+    fn egress_write_is_valid_without_dot_declarations() {
+        let source = clean_parser().replace(
+            "// Writes: workspace.lsis.shed.otlp.*\n//   .body (required, Object)",
+            "// Writes: egress (OTLP protobuf bytes)",
+        );
+        assert!(
+            lint(&parser(&source)).is_empty(),
+            "{:?}",
+            lint(&parser(&source))
+        );
+    }
+
+    #[test]
+    fn function_member_signature_matches_adjacent_definition() {
+        let source = r#"// Facade: function convert
+// Test corpus: unit (conversion table)
+
+// Function: convert
+// Summary: converts a value
+// Signature: convert(String) → Int | Null
+def function convert(value) { value }
+
+def function private_helper(value) { value }
+"#;
+        let header = function(source);
+        assert!(lint(&header).is_empty(), "{:?}", lint(&header));
+    }
+
+    #[test]
+    fn function_signature_name_and_parameters_are_checked() {
+        let source = r#"// Facade: function convert
+// Test corpus: unit (conversion table)
+
+// Function: convert
+// Summary: converts a value
+// Signature: other(Int, Int) → Int
+def function convert(value) { value }
+"#;
+        assert!(
+            lint(&function(source))
+                .iter()
+                .any(|finding| finding.message.contains("has `Signature:` for `other`"))
+        );
+    }
+
+    #[test]
+    fn file_metadata_order_category_and_corpus_are_checked() {
+        let source = clean_parser().replace(
+            "// Category: Transport\n// Test corpus: synthetic",
+            "// Test corpus: unit\n// Category: Unknown\n// Note: synthetic",
+        );
+        let findings = lint(&parser(&source));
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("out of order"))
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("allowed set"))
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("must start"))
+        );
+    }
+
     #[test]
     fn parse_signature_variants() {
         assert_eq!(
-            parse_signature("proto_num(name) → Int | null"),
-            Some(("proto_num".to_string(), vec!["name".to_string()]))
-        );
-        assert_eq!(
-            parse_signature("foo(a, b, c) → Object"),
+            parse_signature("convert(String, Object | Null) → Object | Null"),
             Some((
-                "foo".to_string(),
-                vec!["a".to_string(), "b".to_string(), "c".to_string()]
+                "convert".to_string(),
+                vec!["String".to_string(), "Object | Null".to_string()]
             ))
         );
-        assert_eq!(
-            parse_signature("nullary() → Bool"),
-            Some(("nullary".to_string(), vec![]))
-        );
-        assert_eq!(parse_signature("no parens"), None);
-        assert_eq!(parse_signature("no_return(value)"), None);
-        assert_eq!(parse_signature("empty_return(value) →"), None);
+        assert_eq!(parse_signature("missing return"), None);
+        assert_eq!(parse_signature("convert(value) → Object"), None);
     }
 }

--- a/crates/xtask/src/inventory.rs
+++ b/crates/xtask/src/inventory.rs
@@ -10,7 +10,7 @@
 //!   <!-- BEGIN: inventory:filters -->   ... <!-- END: inventory:filters -->
 //!   <!-- BEGIN: inventory:functions --> ... <!-- END: inventory:functions -->
 //!
-//! Governing principle: header values that are AUTHORED (Summary /
+//! Governing principle: facade-member values that are AUTHORED (Summary /
 //! Writes / Signature) are copied verbatim into the table cells.
 //! Derived values (function Used-by, composer Writes first token)
 //! are computed here from the shipped snippet bodies rather than
@@ -28,7 +28,7 @@
 
 use std::path::Path;
 
-use crate::header::{SnippetHeader, SnippetKind, parse_signature, signature_entries};
+use crate::header::{MemberKind, SnippetHeader, SnippetKind, parse_signature};
 
 /// Ordered, authoritative list of allowed parser categories.
 ///
@@ -164,7 +164,15 @@ pub fn render_functions_table(all_headers: &[SnippetHeader]) -> String {
         .iter()
         .filter(|h| h.kind == SnippetKind::Function)
     {
-        for sig in signature_entries(h.get("Signature").unwrap_or("")) {
+        for facade in h
+            .facade
+            .iter()
+            .filter(|member| member.kind == MemberKind::Function)
+        {
+            let sig = h
+                .member(MemberKind::Function, &facade.name)
+                .and_then(|member| member.get("Signature"))
+                .unwrap_or("");
             let name = parse_signature(sig).map(|(n, _)| n).unwrap_or_default();
             let callers = derive_used_by(&name, &h.file, all_headers);
             let callers_cell = if callers.is_empty() {
@@ -286,23 +294,50 @@ fn contains_call(line: &str, func_name: &str) -> bool {
 /// cell renders on a single row. Missing Summary → empty string
 /// (lint has already reported it as an error before we get here).
 fn summary_of(h: &SnippetHeader) -> String {
-    h.get("Summary")
+    h.facade
+        .first()
+        .and_then(|facade| h.member(facade.kind, &facade.name))
+        .and_then(|member| member.get("Summary"))
         .unwrap_or("")
         .replace('\n', " ")
         .trim()
         .to_string()
 }
 
-/// The first whitespace-separated token of the Writes value's first
-/// line (e.g. `workspace.lsis.ocsf`). Empty when Writes is missing.
+/// The concrete slot described by the first root and dot declaration in
+/// `Writes:` (e.g. `workspace.lsis.composed.*` + `.ocsf` becomes
+/// `workspace.lsis.composed.ocsf`). Reserved `egress` is returned as-is.
 fn writes_first_token(h: &SnippetHeader) -> String {
-    let writes = h.get("Writes").unwrap_or("");
-    let first_line = writes.split('\n').next().unwrap_or("");
-    first_line
-        .split_whitespace()
+    let writes = h
+        .facade
+        .iter()
+        .find(|facade| facade.kind == MemberKind::Process)
+        .and_then(|facade| h.member(MemberKind::Process, &facade.name))
+        .and_then(|member| member.get("Writes"))
+        .unwrap_or("");
+    let mut lines = writes.lines();
+    let root = lines
         .next()
         .unwrap_or("")
-        .to_string()
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    if root == "egress" || root == "ingress" {
+        return root.to_string();
+    }
+    let Some(prefix) = root.strip_suffix(".*") else {
+        return root.to_string();
+    };
+    let field = lines
+        .map(str::trim_start)
+        .find_map(|line| line.strip_prefix('.'))
+        .and_then(|line| line.split_whitespace().next())
+        .unwrap_or("");
+    if field.is_empty() {
+        root.to_string()
+    } else {
+        format!("{prefix}.{field}")
+    }
 }
 
 /// Escape characters that would break markdown table cells. Pipe is
@@ -388,7 +423,7 @@ mod tests {
         let def_file = "/repo/packaging/snippets/functions/proto_num.limpid";
         let def_content = "\
 // Summary:     IANA proto
-// Signature:   proto_num(name) → Int | null
+// Signature:   proto_num(String) → Int | Null
 // Test corpus: unit (registry)
 
 def function proto_num(name) {
@@ -469,7 +504,7 @@ def process z {
         // the guardrail should be surgical.
         let def_content = "\
 // Summary:     Self-caller
-// Signature:   selfy(x) → Int
+// Signature:   selfy(Int) → Int
 // Test corpus: unit (docs)
 
 def function selfy(x) {
@@ -491,12 +526,17 @@ def function selfy(x) {
             SnippetKind::Function,
             "/repo/packaging/snippets/functions/timestamp_converter.limpid",
             "\
-// Summary:     Timestamp unit conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              timestamp_ns_to_ms(value) → Int
+// Facade: function timestamp_ms_to_ns, function timestamp_ns_to_ms
 // Test corpus: unit (timestamp boundaries)
 
+// Function: timestamp_ms_to_ns
+// Summary: converts milliseconds to nanoseconds
+// Signature: timestamp_ms_to_ns(Int) → Int
 def function timestamp_ms_to_ns(value) {}
+
+// Function: timestamp_ns_to_ms
+// Summary: converts nanoseconds to milliseconds
+// Signature: timestamp_ns_to_ms(Int) → Int
 def function timestamp_ns_to_ms(value) {}
 ",
         );
@@ -532,13 +572,13 @@ def process compose_ms {
         );
 
         let out = render_functions_table(&[family, ms_caller, ns_caller]);
-        assert_eq!(out.matches("timestamp_ms_to_ns(value)").count(), 1);
-        assert_eq!(out.matches("timestamp_ns_to_ms(value)").count(), 1);
+        assert_eq!(out.matches("timestamp_ms_to_ns(Int)").count(), 1);
+        assert_eq!(out.matches("timestamp_ns_to_ms(Int)").count(), 1);
         assert!(out.contains(
-            "| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(value) → Int` | `parse_ms` |"
+            "| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(Int) → Int` | `parse_ms` |"
         ));
         assert!(out.contains(
-            "| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(value) → Int` | `compose_ms` |"
+            "| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(Int) → Int` | `compose_ms` |"
         ));
     }
 
@@ -581,15 +621,20 @@ def process compose_ms {
             SnippetKind::Composer,
             "/r/packaging/snippets/composers/compose_ocsf.limpid",
             "\
-// Summary:     Renders LSIS to OCSF 1.3.0
-// Reads:       workspace.lsis.* (LSIS)
-//                .class_uid (required, Int) — dispatch discriminator
-// Writes:      workspace.lsis.ocsf — OCSF 1.3.0 JSON string
+// Facade: process compose_ocsf
 // Test corpus: real (r)
+
+// Process: compose_ocsf
+// Summary: Renders LSIS to OCSF 1.3.0
+// Reads: workspace.lsis.parsed.*
+//                .class_uid (required, Int) — dispatch discriminator
+// Writes: workspace.lsis.composed.*
+//                .ocsf (required, Object)
+def process compose_ocsf {}
 ",
         );
         let out = render_composers_table(&[c]);
-        assert!(out.contains("`workspace.lsis.ocsf`"));
+        assert!(out.contains("`workspace.lsis.composed.ocsf`"));
         assert!(out.contains("Renders LSIS to OCSF 1.3.0"));
     }
 

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -62,12 +62,13 @@ The split config is longer. It is also easier to test, easier to tap between ste
 
 Every process has an implicit contract with its neighbours in the pipeline: *what do I expect to be present when I run, and what do I leave behind for the next stage?*
 
-The shipped snippet pack declares its file-level contract in the canonical
-header schema (`Summary`, `Reads`, `Writes`, and kind-specific fields) described
+The shipped snippet pack declares its public surface in the canonical header
+schema: a file-level `Facade` plus adjacent per-member `Summary`, `Reads`,
+`Writes`, or `Signature` contracts described
 in the [pack README](../../../packaging/snippets/README.md#authoring-conventions).
-Inside a large file, leaf-local `@requires` / `@produces` comments may add useful
-detail, but they do not replace the canonical header and the analyzer does not
-consume them.
+Inside a large file, private leaf-local `@requires` / `@produces` comments may
+add useful detail, but they do not replace a facade member block and the
+analyzer does not consume them.
 
 ### The `@requires` / `@produces` tag convention
 
@@ -130,7 +131,8 @@ Requirement levels follow the OCSF / ECS convention:
 
 Free-form prose comments explaining "what this process does" are fine in
 addition to the tags. For shipped snippets, neither form substitutes for the
-canonical file header that header lint and inventory generation validate.
+canonical facade and member headers that header lint and inventory generation
+validate.
 
 ### Why make contracts explicit
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -102,7 +102,9 @@ before customising it; package upgrades replace files under
 See the [pack
 README](../../../packaging/snippets/README.md#slot-registry--composed-layer)
 for the full composed / shed slot registries and the LSIS layer
-contracts.
+contracts. The same README defines the authoring schema: each file declares a
+`Facade`, and every listed process or function has an adjacent contract block.
+Private dispatch leaves remain unlisted and need no public header.
 
 ### Filters
 
@@ -123,7 +125,7 @@ contracts.
   `severity` text rather than an invented OTel number.
 
 - `functions/parse_datetime_rfc3164.limpid` —
-  `parse_datetime_rfc3164(text, timezone) → Timestamp | null`. LPL
+  `parse_datetime_rfc3164(String, String) → Timestamp | Null`. LPL
   counterpart to the built-in `parse_datetime_rfc3339` primitive.
   RFC 3164 wire carries neither year nor timezone, so the helper
   applies the current-year + future-clamp policy after the calling
@@ -136,16 +138,17 @@ contracts.
   For RFC 5424 / OTLP / OCSF input use the built-in
   `parse_datetime_rfc3339` primitive directly.
 - `functions/timestamp_converter.limpid` — exact integer boundary helpers
-  `timestamp_ns_to_ms(value) → Int | null` and
-  `timestamp_ms_to_ns(value) → Int | null`. `compose_ocsf` uses the first;
+  `timestamp_ns_to_ms(Int | Timestamp | Null) → Int | Null` and
+  `timestamp_ms_to_ns(Int | Null) → Int | Null`.
+  `compose_ocsf` uses the first;
   `parse_ocsf` uses the second. Helpers shared by multiple source schemas
   live under `functions/`; source-local helpers stay beside their parser.
 - `functions/http_method_activity_id.limpid` —
-  `http_method_activity_id(method) → Int`. HTTP request method
+  `http_method_activity_id(String) → Int`. HTTP request method
   (`GET` / `POST` / `PUT` / `DELETE` / `HEAD` / `OPTIONS` /
   `CONNECT` / `TRACE`) → OCSF 4002 HTTP Activity `activity_id`,
   with `99` (Other) for anything outside the OCSF 1.3.0 enumeration.
-- `functions/proto_num.limpid` — `proto_num(name) → Int | null`.
+- `functions/proto_num.limpid` — `proto_num(String) → Int | Null`.
   Transport-layer protocol name (case-insensitive `tcp` / `udp` /
   `icmp` / …) → IANA protocol number for OCSF
   `connection_info.protocol_num`. Returns `null` rather than a

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -241,14 +241,13 @@ regions.
 
 | File | Signature | Used by |
 |---|---|---|
-| `functions/http_method_activity_id.limpid` | `http_method_activity_id(method) → Int` | `parse_combined_log`, `parse_suricata`, `parse_zeek_default` |
-| `functions/parse_datetime_rfc3164.limpid` | `parse_datetime_rfc3164(text, timezone) → Timestamp \| null;` | `parse_asa`, `parse_fortigate_cef`, `parse_juniper_srx_syslog`, `parse_paloalto_cef` |
-| `functions/parse_datetime_rfc3164.limpid` | `parse_datetime_rfc3164_in_timezone(text, timezone) → Timestamp` | `parse_datetime_rfc3164` |
-| `functions/proto_num.limpid` | `proto_num(name) → Int \| null` | `parse_checkpoint_leef`, `parse_checkpoint_syslog`, `parse_juniper_srx_sd_syslog`, `parse_juniper_srx_syslog`, `parse_paloalto_cef`, `parse_paloalto_syslog`, `parse_suricata`, `parse_sysmon`, `parse_zeek_default`, `parse_zeek_full` |
-| `functions/severity_converter.limpid` | `ocsf_severity_id_to_otel_severity_number(severity_id) → Int \| null` | `parse_ocsf` |
-| `functions/severity_converter.limpid` | `otel_severity_number_to_ocsf_severity_id(severity_number) → Int \| null` | `compose_ocsf` |
-| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(value) → Int \| null` | `compose_ocsf` |
-| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(value) → Int \| null` | `parse_ocsf` |
+| `functions/http_method_activity_id.limpid` | `http_method_activity_id(String) → Int` | `parse_combined_log`, `parse_suricata`, `parse_zeek_default` |
+| `functions/parse_datetime_rfc3164.limpid` | `parse_datetime_rfc3164(String, String) → Timestamp \| Null` | `parse_asa`, `parse_fortigate_cef`, `parse_juniper_srx_syslog`, `parse_paloalto_cef` |
+| `functions/proto_num.limpid` | `proto_num(String) → Int \| Null` | `parse_checkpoint_leef`, `parse_checkpoint_syslog`, `parse_juniper_srx_sd_syslog`, `parse_juniper_srx_syslog`, `parse_paloalto_cef`, `parse_paloalto_syslog`, `parse_suricata`, `parse_sysmon`, `parse_zeek_default`, `parse_zeek_full` |
+| `functions/severity_converter.limpid` | `ocsf_severity_id_to_otel_severity_number(Int \| Null) → Int \| Null` | `parse_ocsf` |
+| `functions/severity_converter.limpid` | `otel_severity_number_to_ocsf_severity_id(Int \| Null) → Int \| Null` | `compose_ocsf` |
+| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(Int \| Timestamp \| Null) → Int \| Null` | `compose_ocsf` |
+| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(Int \| Null) → Int \| Null` | `parse_ocsf` |
 <!-- END: inventory:functions -->
 
 Timestamp interpretation follows each source contract. A vendor-defined fixed
@@ -401,29 +400,54 @@ appropriate parser per branch.
 
 ## Authoring conventions
 
-Every snippet header carries a canonical key set determined by the
-file's parent directory:
+Every snippet has one file-level facade header followed by a contract block
+immediately above each public member. The file's parent directory still
+determines its inventory kind.
 
-| Kind | Directory | Required keys (canonical order) |
-|---|---|---|
-| parser | `parsers/` | `Summary`, `Reads`, `Writes`, `Category`, `Test corpus` |
-| composer | `composers/` | `Summary`, `Reads`, `Writes`, `Test corpus` |
-| filter | `filters/` | `Summary`, `Reads`, `Effect`, `Test corpus` |
-| function | `functions/` | `Summary`, `Signature`, `Test corpus` |
+| Scope | Required keys (canonical order) |
+|---|---|
+| parser file | `Facade`, `Category`, `Test corpus` |
+| composer / filter / function file | `Facade`, `Test corpus` |
+| facade process | `Process`, `Summary`, `Reads`, `Writes` |
+| facade function | `Function`, `Summary`, `Signature` |
+
+`Facade:` is a comma-separated list of `process <name>` and `function <name>`
+entries. A leading-space continuation line extends the list. Every listed
+member must have exactly one adjacent member block whose heading and following
+definition agree. A top-level definition omitted from `Facade:` is private to
+the file and has no member block; an unlisted member block is an error.
+
+```limpid
+// Facade: process parse_example, process example_to_otlp,
+//         function example_kind
+// Category: Vendor-neutral
+// Test corpus: synthetic (header examples)
+//
+// File-wide design prose follows here.
+
+// Process: parse_example
+// Summary: Normalize one example event into canonical facts.
+// Reads: workspace.example.*
+//        .body (required, Object)
+//        workspace.example_config.*
+//        .mode (optional, String)
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
+def process parse_example { ... }
+```
 
 **Governing principle.** A header holds only knowledge the author
 alone knows. Anything derivable from other keys, other files, or
 the body is banned from the header and surfaces in the generated
 inventory instead — that is why parsers carry `Category` but
 composers / filters do not (their axis would duplicate
-Reads/Writes/Effect), and why `Used by:` for a function is derived
+their process contracts), and why `Used by:` for a function is derived
 by the inventory generator rather than authored.
 
-### `Reads:` — universal stream-contract grammar
+### `Reads:` / `Writes:` — per-process contract grammar
 
-Every kind that flows events (parser / composer / filter) declares
-its input contract on the `Reads:` value. The first token of the
-first line names the stream source:
+Every facade process declares its input and output contracts. A contract is
+either a reserved event field or one or more workspace roots:
 
 - **Raw wire.** First token `ingress` — the snippet reads bytes off
   the wire. Dot-line intake rows are forbidden.
@@ -432,20 +456,20 @@ first line names the stream source:
   // Reads:       ingress (raw wire) — syslog-wrapped %ASA messages
   ```
 
-- **Bridge / reader.** First token `workspace.<ns>.*` — the snippet
-  reads a workspace namespace populated by an upstream process. At
-  least one dot-line intake row is required per intake field:
+- **Workspace roots.** A root is `workspace.<ns>.*`. Each root owns the
+  following dot-lines until the next root and requires at least one dot-line.
+  Multiple roots are permitted:
 
   ```
-  // Reads:       workspace.openssh.* (bridge — see Bridges below)
-  //                .body       (required, String)  — sshd body
-  //                .pid        (optional, String)  — process id
-  //                .hostname   (optional, String)  — SSH server host
-  //                .time       (optional, Int)     — epoch nanoseconds
+  // Reads: workspace.openssh.*
+  //        .body       (required, String)  — sshd body
+  //        .pid        (optional, String)  — process id
+  //        workspace.pipeline_options.*
+  //        .hostname   (optional, String)  — source-backed override
   ```
 
   Each dot-line matches the regex
-  `^\.<IDENT>\s+\((required|optional), <String|Int|Float|Bool|Object|Array|Timestamp>\)`.
+  `^\.<IDENT>\s+\((required|optional), <String|Int|Float|Bool|Object|Array|Timestamp|Bytes>\)`.
   Trailing prose after the closing paren is permitted. Leading
   underscores in the identifier are permitted (journald's `_PID` /
   `__REALTIME_TIMESTAMP` are real intake fields).
@@ -454,14 +478,11 @@ Ambient event metadata (`received_at`, `source`, `ingress` when
 passed through unchanged, `hostname()`) is not declared in `Reads:`
 — every process can read those unconditionally.
 
-### `Writes:` — LSIS-slot contract
-
-`Writes:` names the LSIS slot(s) the snippet produces. Parsers
-write facts to `workspace.lsis.parsed.*` and enumerate the LSIS
-`class_uid` facts their dispatcher produces (using OCSF class identifiers);
-composers write a single
-`workspace.lsis.composed.<slot>` from the composed-layer registry
-above.
+`Writes:` uses the same multi-root grammar. It additionally accepts the
+reserved `egress` and `ingress` forms. Parsers normally write canonical facts
+under `workspace.lsis.parsed.*`; transport and format parsers instead name
+their transport namespace. Composers write a composed-layer slot, while their
+terminal facade process writes `egress`.
 
 ### `Category:` — parser-only, closed vocabulary
 
@@ -470,9 +491,8 @@ Parsers pick a `Category:` value from the 17-entry whitelist in
 groups rows by this key. To add a category, extend the slice and
 document the addition here.
 
-Composers and filters have no `Category:` axis — the LSIS slot the
-composer writes and the drop / pass predicate the filter enforces
-are already visible on their `Writes:` / `Effect:` keys.
+Composers and filters have no `Category:` axis — their process contracts expose
+the relevant composition slot or pass/drop boundary.
 
 ### `Test corpus:` — provenance vocabulary
 

--- a/packaging/snippets/composers/compose_ocsf.limpid
+++ b/packaging/snippets/composers/compose_ocsf.limpid
@@ -1,18 +1,5 @@
-// Summary:     Renders the LSIS intermediate to OCSF 1.3.0 JSON
-//              (27-class priority set), dispatched by class_uid.
-// Reads:       workspace.lsis.parsed.* (the canonical intermediate produced
-//              by vocabulary parsers)
-//                .class_uid (required, Int) — dispatch discriminator;
-//                            unknown values route to error_log
-//              Remaining fields are read per class by the
-//              `compose_ocsf_<class>` leaves (see class coverage
-//              below); root `time` is emitted in OCSF epoch milliseconds
-//              and falls back to `received_at` when LSIS has no event time.
-// Writes:      workspace.lsis.composed.ocsf — OCSF 1.3.0 JSON, one object per
-//              event (String). Pipe `| ocsf_to_egress` (defined at
-//              the foot of this file) to emit it as the wire form;
-//              a source adapter may be followed by a target-specific
-//              adjustment that selects this slot as an envelope body.
+// Facade: process compose_ocsf,
+//         process ocsf_to_egress
 // Test corpus: spec-only (OCSF 1.3.0 schema; per-class leaf shapes
 //              cross-checked against schema.ocsf.io class definitions)
 //
@@ -111,6 +98,12 @@ def function compose_ocsf_severity_id(severity_number, legacy_severity_id, sever
 // Top-level dispatcher
 // ---------------------------------------------------------------------------
 
+// Process: compose_ocsf
+// Summary: Renders the LSIS intermediate to OCSF 1.3.0 JSON (27-class priority set), dispatched by class_uid.
+// Reads: workspace.lsis.parsed.* (the canonical intermediate produced
+//        .class_uid (required, Int) — dispatch discriminator;
+// Writes: workspace.lsis.composed.*
+//         .ocsf (required, Object)
 def process compose_ocsf {
     switch workspace.lsis.parsed.class_uid {
         // System Activity (category 1)
@@ -949,6 +942,12 @@ def process compose_ocsf_scan_activity {
 // `compose_ocsf | ocsf_to_egress`. When wrapping into another
 // envelope (e.g. OTLP), skip this step and feed the slot directly
 // into the envelope's input.
+
+// Process: ocsf_to_egress
+// Summary: Emit the composed OCSF object as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .ocsf (required, Object)
+// Writes: egress
 def process ocsf_to_egress {
     egress = workspace.lsis.composed.ocsf
 }

--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -1,45 +1,5 @@
-// Summary:     Assembles one OTLP-1.0.0 ResourceLogs envelope from canonical
-//              LSIS scalars and source-adapter shed slots. Emits protobuf
-//              bytes for both otlp_http and otlp_grpc.
-// Reads:       workspace.lsis.parsed.* — canonical scalar facts:
-//                .time             (optional, Int) — event time in
-//                                  epoch nanoseconds.
-//                .severity_number  (optional, Int) — OTel SeverityNumber.
-//                .severity         (optional, String) — exact source text.
-//              workspace.lsis.shed.otlp.* — source-adapter output in OTLP
-//              vocabulary. Each slot is optional and replaces, rather than
-//              merges with, any lower-priority value:
-//                .resource.attributes (optional, Array) — OTLP KeyValue list.
-//                .scope.name (optional, String) — instrumentation scope name.
-//                .scope.version (optional, String) — instrumentation scope version.
-//                .scope.attributes (optional, Array) — OTLP KeyValue list.
-//                .log_record.time_unix_nano (optional, Int) — event-time override.
-//                .log_record.observed_time_unix_nano (optional, Int) — observation-time override.
-//                .log_record.severity_number (optional, Int) — severity override.
-//                .log_record.severity_text (optional, String) — severity-text override.
-//                .log_record.body (optional, Object) — tagged OTLP AnyValue.
-//                .log_record.attributes (optional, Array) — OTLP KeyValue list.
-//              `resource.attributes`, all scope slots, `body`, and LogRecord
-//              attributes are adapter-owned because their construction or
-//              placement is source-specific. Body is an OTLP AnyValue object;
-//              the adapter chooses its variant. Missing slots are omitted.
-//              Canonical scalar fallback chains are
-//                time             = coalesce(shed override, parsed.time)
-//                severity_number  = coalesce(shed override,
-//                                            parsed.severity_number)
-//                severity_text    = coalesce(shed override, parsed.severity)
-//                observed_time    = coalesce(shed override, received_at)
-//              Event time never falls back to `received_at`.
-//
-// Slots deliberately NOT exposed today — `log_record.trace_id`,
-// `log_record.span_id`, `log_record.event_name`, and the
-// `dropped_attributes_count` / `flags` housekeeping fields. These have
-// no implementation-driving caller in the pack today; they are added
-// on the same coalesce-with-default pattern above when a real caller
-// needs them.
-// Writes:      workspace.lsis.composed.otlp — ResourceLogs proto bytes
-//              (Bytes). Pipe `| otlp_to_egress` (foot of file) to emit
-//              for `output otlp_http` / `output otlp_grpc`.
+// Facade: process compose_otlp,
+//         process otlp_to_egress
 // Test corpus: spec-only (OTLP/1.0.0 proto shape;
 //              otlp.encode_resourcelog_protobuf reference in
 //              docs/src/functions/expression-functions.md)
@@ -56,6 +16,25 @@
 // canonical-scalar overrides. `compose_otlp` performs no source placement,
 // hostname synthesis, fixed scope naming, or Body coercion.
 
+// Process: compose_otlp
+// Summary: Assembles one OTLP-1.0.0 ResourceLogs envelope from canonical LSIS scalars and source-adapter shed slots. Emits protobuf bytes for both otlp_http and otlp_grpc.
+// Reads: workspace.lsis.parsed.* — canonical scalar facts:
+//        .time             (optional, Int) — event time in
+//        .severity_number  (optional, Int) — OTel SeverityNumber.
+//        .severity         (optional, String) — exact source text.
+//        workspace.lsis.shed.otlp.* — source-adapter output in OTLP
+//        .resource.attributes (optional, Array) — OTLP KeyValue list.
+//        .scope.name (optional, String) — instrumentation scope name.
+//        .scope.version (optional, String) — instrumentation scope version.
+//        .scope.attributes (optional, Array) — OTLP KeyValue list.
+//        .log_record.time_unix_nano (optional, Int) — event-time override.
+//        .log_record.observed_time_unix_nano (optional, Int) — observation-time override.
+//        .log_record.severity_number (optional, Int) — severity override.
+//        .log_record.severity_text (optional, String) — severity-text override.
+//        .log_record.body (optional, Object) — tagged OTLP AnyValue.
+//        .log_record.attributes (optional, Array) — OTLP KeyValue list.
+// Writes: workspace.lsis.composed.*
+//         .otlp (required, Bytes)
 def process compose_otlp {
     workspace.lsis.composed.otlp = otlp.encode_resourcelog_protobuf(null_omit({
         resource: switch len(coalesce(workspace.lsis.shed.otlp.resource.attributes, [])) > 0 {
@@ -108,6 +87,12 @@ def process compose_otlp {
 // Moves the OTLP ResourceLogs proto bytes from `workspace.lsis.composed.otlp`
 // to `egress`. Pipelines that emit OTLP as the wire form pipe
 // `compose_otlp | otlp_to_egress`.
+
+// Process: otlp_to_egress
+// Summary: Emit the composed OTLP protobuf bytes as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .otlp (required, Bytes)
+// Writes: egress
 def process otlp_to_egress {
     egress = workspace.lsis.composed.otlp
 }

--- a/packaging/snippets/composers/compose_replayable.limpid
+++ b/packaging/snippets/composers/compose_replayable.limpid
@@ -1,13 +1,5 @@
-// Summary:     Serialises the event into the minimal replay-record
-//              shape `{ received_at, source, ingress }` — the same
-//              three fields the error_log (DLQ) preserves and
-//              `inject --json` consumes.
-// Reads:       ingress (passed through verbatim) — plus the ambient
-//              event metadata `received_at` / `source`, which every
-//              process can read unconditionally.
-// Writes:      workspace.lsis.composed.replayable — replay record JSONL line
-//              (String). Pipe `| replayable_to_egress` (foot of
-//              file) to emit it as the capture stream.
+// Facade: process compose_replayable,
+//         process replayable_to_egress
 // Test corpus: spec-only (mirrors the error_log DLQ record shape;
 //              round-trips through `limpidctl inject --json`)
 //
@@ -42,6 +34,11 @@
 // captures *all* events. Both round-trip through `inject --json`
 // without preprocessing.
 
+// Process: compose_replayable
+// Summary: Serialises the event into the minimal replay-record shape `{ received_at, source, ingress }` — the same three fields the error_log (DLQ) preserves and `inject --json` consumes.
+// Reads: ingress
+// Writes: workspace.lsis.composed.*
+//         .replayable (required, String)
 def process compose_replayable {
     // Since v0.5.6 the DSL `source` ident is the canonical
     // `{ip, port}` object — same shape `inject --json` expects — so
@@ -61,6 +58,12 @@ def process compose_replayable {
 // Moves the replay record from `workspace.lsis.composed.replayable` to
 // `egress`. Pipelines that emit the capture stream as the wire form
 // pipe `compose_replayable | replayable_to_egress`.
+
+// Process: replayable_to_egress
+// Summary: Emit the composed replay record as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .replayable (required, String)
+// Writes: egress
 def process replayable_to_egress {
     egress = workspace.lsis.composed.replayable
 }

--- a/packaging/snippets/composers/compose_rfc5424.limpid
+++ b/packaging/snippets/composers/compose_rfc5424.limpid
@@ -1,28 +1,6 @@
-// Summary:     Assembles a single-line RFC 5424 syslog record from
-//              per-field shed slots
-//              (https://datatracker.ietf.org/doc/html/rfc5424).
-// Reads:       workspace.lsis.shed.rfc5424.* — per-field intake
-//              (RFC 5424 ABNF vocabulary):
-//                .pri        (optional, Int)    — default 14 (user.info)
-//                .timestamp  (optional, String) — default is `received_at`
-//                             formatted as RFC 3339 with microsecond UTC
-//                             precision. Callers supplying their own value
-//                             MUST also supply the RFC 5424 wire form.
-//                .hostname   (optional, String) — default hostname()
-//                .app_name   (optional, String) — default "-"
-//                .procid     (optional, String) — default "-"
-//                .msgid      (optional, String) — default "-"
-//                .sd         (optional, String) — default "-"
-//                .msg        (required, String) — the log body. If the slot
-//                             is absent the record still assembles with an
-//                             empty MSG, which is spec-compliant (RFC 5424
-//                             § 6 grammar makes MSG optional); required is
-//                             the intended contract from the composer's
-//                             point of view, and absence is a caller bug
-//                             to flag.
-// Writes:      workspace.lsis.composed.rfc5424 — single-line RFC 5424
-//              record (String). Pipe `| rfc5424_to_egress` (foot of file)
-//              to emit it as the wire form.
+// Facade: process compose_rfc5424,
+//         process journald_to_rfc5424,
+//         process rfc5424_to_egress
 // Test corpus: spec-only (RFC 5424 § 6 frame shape; field decisions
 //              documented below)
 //
@@ -97,6 +75,19 @@ def function rfc5424_pri_from(facility_str, severity_str) {
 // Generic RFC 5424 body composer — reads shed.rfc5424.*, writes composed.
 // ---------------------------------------------------------------------------
 
+// Process: compose_rfc5424
+// Summary: Assembles a single-line RFC 5424 syslog record from per-field shed slots (https://datatracker.ietf.org/doc/html/rfc5424).
+// Reads: workspace.lsis.shed.rfc5424.* — per-field intake
+//        .pri        (optional, Int)    — default 14 (user.info)
+//        .timestamp  (optional, String) — default is `received_at`
+//        .hostname   (optional, String) — default hostname()
+//        .app_name   (optional, String) — default "-"
+//        .procid     (optional, String) — default "-"
+//        .msgid      (optional, String) — default "-"
+//        .sd         (optional, String) — default "-"
+//        .msg        (required, String) — the log body. If the slot
+// Writes: workspace.lsis.composed.*
+//         .rfc5424 (required, String)
 def process compose_rfc5424 {
     let pri       = coalesce(workspace.lsis.shed.rfc5424.pri, 14)
     let ts        = coalesce(
@@ -158,6 +149,12 @@ def process compose_rfc5424 {
 //       output relay
 //   }
 
+// Process: journald_to_rfc5424
+// Summary: Bridge parsed journald transport fields into RFC 5424 shed slots.
+// Reads: workspace.journald.*
+//        .MESSAGE (required, String)
+// Writes: workspace.lsis.shed.rfc5424.*
+//         .msg (required, String)
 def process journald_to_rfc5424 {
     workspace.lsis.shed.rfc5424.pri      = rfc5424_pri_from(
                                               workspace.journald.SYSLOG_FACILITY,
@@ -183,6 +180,12 @@ def process journald_to_rfc5424 {
 // `egress`. Pipelines that emit RFC 5424 as the wire form pipe
 // `compose_rfc5424 | rfc5424_to_egress` (usually preceded by a bridge
 // or glue block that populates the shed slots).
+
+// Process: rfc5424_to_egress
+// Summary: Emit the composed RFC 5424 record as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .rfc5424 (required, String)
+// Writes: egress
 def process rfc5424_to_egress {
     egress = workspace.lsis.composed.rfc5424
 }

--- a/packaging/snippets/filters/filter_openssh_journal.limpid
+++ b/packaging/snippets/filters/filter_openssh_journal.limpid
@@ -1,10 +1,4 @@
-// Summary:     Strip PAM-stack noise from a journal-sourced sshd
-//              stream ahead of parse_openssh.
-// Reads:       workspace.journald.* (from parse_journald)
-//                .MESSAGE (required, String) — sshd body candidate
-// Effect:      drop lines matching `^pam_unix(sshd:<module>):`
-//              (PAM lifecycle noise riding sshd's syslogtag); pass
-//              everything else through unchanged.
+// Facade: process filter_openssh_journal
 // Test corpus: synthetic (pam_unix / sshd sample bodies referenced
 //              in this header's drop/pass tables)
 //
@@ -51,6 +45,11 @@
 // string`, …). Those flow through unchanged for `parse_openssh` to
 // classify.
 
+// Process: filter_openssh_journal
+// Summary: Strip PAM-stack noise from a journal-sourced sshd stream ahead of parse_openssh.
+// Reads: workspace.journald.* (from parse_journald)
+//        .MESSAGE (required, String) — sshd body candidate
+// Writes: ingress
 def process filter_openssh_journal {
     let body = coalesce(workspace.journald.MESSAGE, "")
     if regex_match(body, "^pam_unix\\(sshd:[a-z]+\\):") {

--- a/packaging/snippets/functions/http_method_activity_id.limpid
+++ b/packaging/snippets/functions/http_method_activity_id.limpid
@@ -1,7 +1,4 @@
-// Summary:     HTTP request method → OCSF 4002 HTTP Activity
-//              `activity_id` (spec-standard enumeration,
-//              vendor-independent).
-// Signature:   http_method_activity_id(method) → Int
+// Facade: function http_method_activity_id
 // Test corpus: unit (OCSF 1.3.0 class 4002 activity_id enumeration)
 //
 // This mapping is OCSF spec standard (4002 class definition,
@@ -25,6 +22,9 @@
 // Lowercase / mixed-case method strings (rare, non-compliant) fall
 // through to 99.
 
+// Function: http_method_activity_id
+// Summary: HTTP request method → OCSF 4002 HTTP Activity `activity_id` (spec-standard enumeration, vendor-independent).
+// Signature: http_method_activity_id(String) → Int
 def function http_method_activity_id(method) {
     switch method {
         "CONNECT" { 1 }

--- a/packaging/snippets/functions/parse_datetime_rfc3164.limpid
+++ b/packaging/snippets/functions/parse_datetime_rfc3164.limpid
@@ -1,7 +1,4 @@
-// Summary:     RFC 3164 BSD syslog timestamp (`Apr 30 01:23:45`) plus
-//              a resolved source timezone → Timestamp, with year-rollover clamp.
-// Signature:   parse_datetime_rfc3164(text, timezone) → Timestamp | null;
-//              parse_datetime_rfc3164_in_timezone(text, timezone) → Timestamp
+// Facade: function parse_datetime_rfc3164
 // Test corpus: unit (RFC 3164 timestamp shapes; year-end rollover
 //              clamp cases)
 //
@@ -55,6 +52,9 @@ def function parse_datetime_rfc3164_in_timezone(text, timezone) {
     }
 }
 
+// Function: parse_datetime_rfc3164
+// Summary: RFC 3164 BSD syslog timestamp (`Apr 30 01:23:45`) plus a resolved source timezone → Timestamp, with year-rollover clamp.
+// Signature: parse_datetime_rfc3164(String, String) → Timestamp | Null
 def function parse_datetime_rfc3164(text, timezone) {
     switch timezone {
         null    { null }

--- a/packaging/snippets/functions/proto_num.limpid
+++ b/packaging/snippets/functions/proto_num.limpid
@@ -1,7 +1,4 @@
-// Summary:     IANA protocol number for a transport-layer protocol
-//              name — the universal mapping for filling
-//              `connection_info.protocol_num` on an LSIS record.
-// Signature:   proto_num(name) → Int | null
+// Facade: function proto_num
 // Test corpus: unit (IANA "Assigned Internet Protocol Numbers"
 //              registry, RFC 5237)
 //
@@ -30,6 +27,9 @@
 // Out of scope (return null): OSPF, IGMP, IPv4/IPv6 encapsulated,
 // EtherIP, PIM, etc. Add when a vendor parser surfaces them.
 
+// Function: proto_num
+// Summary: IANA protocol number for a transport-layer protocol name — the universal mapping for filling `connection_info.protocol_num` on an LSIS record.
+// Signature: proto_num(String) → Int | Null
 def function proto_num(name) {
     switch lower(name) {
         "tcp"    { 6 }

--- a/packaging/snippets/functions/severity_converter.limpid
+++ b/packaging/snippets/functions/severity_converter.limpid
@@ -1,8 +1,7 @@
-// Summary:     Converts severity values between OCSF 1.3.0 severity_id and
-//              OpenTelemetry SeverityNumber without guessing unknown values.
-// Signature:   ocsf_severity_id_to_otel_severity_number(severity_id) → Int | null
-//              otel_severity_number_to_ocsf_severity_id(severity_number) → Int | null
+// Facade: function ocsf_severity_id_to_otel_severity_number,
+//         function otel_severity_number_to_ocsf_severity_id
 // Test corpus: unit (OCSF 1.3.0 and OTel severity boundary tables)
+//
 
 // These partial functions encode only the published standard-to-standard
 // boundary. Null stays null. OCSF Unknown (0) maps to an unset canonical
@@ -12,6 +11,9 @@
 // processes compare the source and result and raise an operator-readable
 // error for invalid non-null input.
 
+// Function: ocsf_severity_id_to_otel_severity_number
+// Summary: Converts severity values between OCSF 1.3.0 severity_id and OpenTelemetry SeverityNumber without guessing unknown values.
+// Signature: ocsf_severity_id_to_otel_severity_number(Int | Null) → Int | Null
 def function ocsf_severity_id_to_otel_severity_number(severity_id) {
     switch severity_id {
         0       { null }
@@ -26,6 +28,9 @@ def function ocsf_severity_id_to_otel_severity_number(severity_id) {
     }
 }
 
+// Function: otel_severity_number_to_ocsf_severity_id
+// Summary: Converts severity values between OCSF 1.3.0 severity_id and OpenTelemetry SeverityNumber without guessing unknown values.
+// Signature: otel_severity_number_to_ocsf_severity_id(Int | Null) → Int | Null
 def function otel_severity_number_to_ocsf_severity_id(severity_number) {
     switch severity_number {
         1       { 1 }

--- a/packaging/snippets/functions/timestamp_converter.limpid
+++ b/packaging/snippets/functions/timestamp_converter.limpid
@@ -1,8 +1,7 @@
-// Summary:     Converts record-level Unix epoch timestamps between the LSIS
-//              nanosecond scale and the OCSF millisecond scale.
-// Signature:   timestamp_ns_to_ms(value) → Int | null
-//              timestamp_ms_to_ns(value) → Int | null
+// Facade: function timestamp_ns_to_ms,
+//         function timestamp_ms_to_ns
 // Test corpus: unit (exact epoch arithmetic and null passthrough)
+//
 
 // LSIS retains record-level timestamps as Unix epoch nanoseconds. OCSF
 // `timestamp_t` uses Unix epoch milliseconds. These helpers make that output
@@ -14,6 +13,9 @@
 // `compose_ocsf`; Int inputs remain exact. Null remains null, and arithmetic
 // errors such as an overflowing ms-to-ns conversion propagate to the caller.
 
+// Function: timestamp_ns_to_ms
+// Summary: Converts record-level Unix epoch timestamps between the LSIS nanosecond scale and the OCSF millisecond scale.
+// Signature: timestamp_ns_to_ms(Int | Timestamp | Null) → Int | Null
 def function timestamp_ns_to_ms(value) {
     switch value == null {
         true    { null }
@@ -21,6 +23,9 @@ def function timestamp_ns_to_ms(value) {
     }
 }
 
+// Function: timestamp_ms_to_ns
+// Summary: Converts record-level Unix epoch timestamps between the LSIS nanosecond scale and the OCSF millisecond scale.
+// Signature: timestamp_ms_to_ns(Int | Null) → Int | Null
 def function timestamp_ms_to_ns(value) {
     switch value == null {
         true    { null }

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -1,26 +1,6 @@
-// Summary:     Cisco ASA / FTD (ASA-syslog-compatibility) %ASA syslog
-//              messages → LSIS Authentication + Network Activity.
-// Reads:       workspace.syslog.* (transport intake — populated by
-//              parse_syslog upstream)
-//                .msg (required, String) — syslog body carrying the
-//                     `%ASA-<level>-<msg_id>` message
-//                .timestamp (optional, String) — RFC 3164 wire timestamp
-//                .hostname (optional, String) — originating device, retained
-//                     by asa_to_otlp as Resource `host.name`
-//              workspace.asa.timezone (optional, String) — source device
-//              timezone override as an IANA name or fixed offset; the legacy
-//              RFC 3164 timestamp defaults to the limpid host's system
-//              timezone (Cisco documents UTC only for RFC 5424; the accepted
-//              legacy RFC 3164 form has no documented zone, so the pack
-//              assumes the device shares the host's zone — the most likely
-//              deployment; override it when the device zone is known)
-//              https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/I-R/asa-command-ref-I-R/m_log-lz.html
-// Writes:      workspace.lsis.parsed.* — 3002 (Authentication) and 4001 (Network
-//              Activity), dispatched by message ID; unmapped IDs route to
-//              error_log. Per-ID table below. asa_to_otlp additionally writes
-//              source-specific workspace.lsis.shed.otlp Resource, Body, and
-//              LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_asa,
+//         process asa_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (sample wires in this header; several message-ID
 //              leaves are not yet exercised against live captures — see
 //              per-leaf NOTEs)
@@ -152,6 +132,16 @@ def process validate_asa_severity_number {
 // switch can dispatch by message ID. Each leaf re-parses the
 // remaining body text against its message-ID-specific shape.
 
+// Process: parse_asa
+// Summary: Cisco ASA / FTD (ASA-syslog-compatibility) %ASA syslog messages → LSIS Authentication + Network Activity.
+// Reads: workspace.syslog.* (transport intake — populated by
+//        .msg (required, String) — syslog body carrying the
+//        .timestamp (optional, String) — RFC 3164 wire timestamp
+//        .hostname (optional, String) — originating device, retained
+//        workspace.asa.*
+//        .timezone (optional, String) — source device
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_asa {
     let source_timezone = workspace.asa.timezone
     workspace.asa = regex_parse(
@@ -567,6 +557,18 @@ def function asa_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: asa_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.syslog.*
+//        .hostname (optional, String)
+//        workspace.asa.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process asa_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Cisco" } }],

--- a/packaging/snippets/parsers/parse_auditd.limpid
+++ b/packaging/snippets/parsers/parse_auditd.limpid
@@ -1,14 +1,6 @@
-// Summary:     Linux kernel audit records (auditd / audispd / auditbeat wire
-//              text) → LSIS, dispatched by record type.
-// Reads:       workspace.auditd.* (bridge — see Bridges below)
-//                .body (required, String) — the auditd record
-//                .hostname (optional, String) — host where audit ran
-// Writes:      workspace.lsis.parsed.* — 3002 (Authentication), 3001 (Account Change),
-//              1007 (Process Activity), 1001 (File System Activity), 2004
-//              (Detection Finding), dispatched by record type; unmapped types
-//              route to error_log. auditd_to_otlp writes source-owned OTLP
-//              Resource, Body, and LogRecord attributes.
-// Category:    Endpoint / host audit (Unix)
+// Facade: process parse_auditd,
+//         process auditd_to_otlp
+// Category: Endpoint / host audit (Unix)
 // Test corpus: public (elastic/integrations auditd corpus — 69 records across
 //              ~45 record types)
 //
@@ -413,6 +405,13 @@ def process parse_auditd_normalize_time {
     }
 }
 
+// Process: parse_auditd
+// Summary: Linux kernel audit records (auditd / audispd / auditbeat wire text) → LSIS, dispatched by record type.
+// Reads: workspace.auditd.* (bridge — see Bridges below)
+//        .body (required, String) — the auditd record
+//        .hostname (optional, String) — host where audit ran
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_auditd {
     // @requires: workspace.auditd.body      (required, String)
     // @requires: workspace.auditd.hostname  (optional, String)
@@ -908,6 +907,18 @@ def function auditd_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: auditd_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.auditd.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+//        workspace.auditd_class.*
+//        .type (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process auditd_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Linux" } }],

--- a/packaging/snippets/parsers/parse_aws_guardduty.limpid
+++ b/packaging/snippets/parsers/parse_aws_guardduty.limpid
@@ -1,16 +1,11 @@
-// AWS GuardDuty finding JSON parser
-//
-// Summary:     AWS GuardDuty findings JSON → LSIS Detection Finding.
-// Reads:       ingress (raw wire) — one GuardDuty finding object per ingress
-//              (identical across EventBridge / SNS / S3 delivery)
-// Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding), one finding → one
-//              record; unknown ThreatPurpose values route to error_log.
-//              aws_guardduty_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-// Category:    Cloud security findings
+// Facade: process parse_aws_guardduty,
+//         process aws_guardduty_to_otlp
+// Category: Cloud security findings
 // Test corpus: spec-only (AWS documentation per-finding-type sample bodies;
 //              cross-referenced against the CreateSampleFindings API shape —
 //              verify against live findings before production rollout)
+//
+// AWS GuardDuty finding JSON parser
 //
 // Vendor notes — Amazon Web Services GuardDuty — the AWS-native threat
 //           detection service. Findings synthesise signals from
@@ -289,6 +284,11 @@ def function aws_guardduty_finding_record(body, type_parts, attack_tactic, sever
 // vocabulary (loud-fail-fast on a category AWS hasn't published
 // yet) and to populate the MITRE-aligned `attacks[].tactic.name`.
 
+// Process: parse_aws_guardduty
+// Summary: AWS GuardDuty findings JSON → LSIS Detection Finding.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_aws_guardduty {
     workspace.gd = parse_json(ingress)
     workspace.gd_type = aws_guardduty_split_type(workspace.gd.type)
@@ -435,6 +435,16 @@ def function aws_guardduty_otlp_tactic_name(category) {
     }
 }
 
+// Process: aws_guardduty_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.gd.*
+//        .accountId (optional, String)
+//        workspace.gd_type.*
+//        .category (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process aws_guardduty_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "aws" } }],

--- a/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
+++ b/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
@@ -1,18 +1,12 @@
-// AWS VPC Flow Logs parser
-//
-// Summary:     AWS VPC Flow Logs text records (v2 default + v5 custom
-//              formats) → LSIS Network Activity.
-// Reads:       ingress (raw wire) — one space-separated flow-log record per
-//              line; dispatch by the leading version token
-// Writes:      workspace.lsis.parsed.* — 4001 (Network Activity); unknown version
-//              tokens route to error_log. aws_vpc_flow_to_otlp additionally writes
-//              source-specific workspace.lsis.shed.otlp Resource, Body, and
-//              LogRecord attributes.
-// Category:    Cloud network (data plane)
+// Facade: process parse_aws_vpc_flow,
+//         process aws_vpc_flow_to_otlp
+// Category: Cloud network (data plane)
 // Test corpus: spec-only (AWS VPC Flow Logs documentation column layouts;
 //              synthesised sample lines below cover ACCEPT / REJECT / NODATA /
 //              SKIPDATA and IPv4 + IPv6 — verify the v5 leaf against live
 //              delivery before production)
+//
+// AWS VPC Flow Logs parser
 //
 // Vendor notes — Amazon Web Services VPC Flow Logs — flow-level network
 //              telemetry emitted per ENI / subnet / VPC. Both v2 (the
@@ -169,6 +163,11 @@ def function aws_vpc_flow_epoch_seconds_to_nanos(s) {
 // re-parses the line against its own column count and writes a 4001
 // record. Unknown versions → error.
 
+// Process: parse_aws_vpc_flow
+// Summary: AWS VPC Flow Logs text records (v2 default + v5 custom formats) → LSIS Network Activity.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_aws_vpc_flow {
     let version = regex_parse(ingress, "^(?P<v>\\S+)")
     switch true {
@@ -369,6 +368,14 @@ def function aws_vpc_flow_otlp_event_types(status_id) {
     }
 }
 
+// Process: aws_vpc_flow_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.lsis.parsed.*
+//        .cloud.account.uid (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process aws_vpc_flow_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "aws" } }],

--- a/packaging/snippets/parsers/parse_azure_activity.limpid
+++ b/packaging/snippets/parsers/parse_azure_activity.limpid
@@ -1,15 +1,10 @@
-// Azure Activity Log JSON parser
-//
-// Summary:     Azure Activity Log events JSON → LSIS API Activity.
-// Reads:       ingress (raw wire) — one Activity Log event per ingress (flat
-//              per-record form; unwrap Event Hub batches upstream)
-// Writes:      workspace.lsis.parsed.* — 6003 (API Activity), dispatched over the
-//              8 documented categories; unknown categories route to error_log.
-//              azure_activity_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-// Category:    Cloud audit (API control plane)
+// Facade: process parse_azure_activity,
+//         process azure_activity_to_otlp
+// Category: Cloud audit (API control plane)
 // Test corpus: spec-only (Microsoft Learn Azure Activity Log schema reference
 //              + documentation samples for the 8 categories; no live capture)
+//
+// Azure Activity Log JSON parser
 //
 // Wire —        JSON — one Activity Log event per `ingress`. Azure emits
 //              Activity Log records in two delivery shapes (event hub
@@ -263,6 +258,11 @@ def process parse_azure_activity_record {
 // `error` so a future Azure RP addition surfaces in the DLQ on day
 // one rather than silently zero-mapping.
 
+// Process: parse_azure_activity
+// Summary: Azure Activity Log events JSON → LSIS API Activity.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_azure_activity {
     workspace.az = parse_json(ingress)
 
@@ -338,6 +338,16 @@ def function azure_activity_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: azure_activity_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.az.*
+//        .subscriptionId (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process azure_activity_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "azure" } }],

--- a/packaging/snippets/parsers/parse_bind.limpid
+++ b/packaging/snippets/parsers/parse_bind.limpid
@@ -1,16 +1,6 @@
-// Summary:     ISC BIND 9 querylog lines → LSIS DNS Activity.
-// Reads:       workspace.bind.* (bridge — see Bridges below)
-//                .body (required, String) — the query log line
-//                .pid (optional, String) — named pid
-//                .hostname (optional, String) — DNS server hostname
-//                .timezone (optional, String) — source timezone override as an
-//                  IANA name or fixed offset; defaults to the limpid host's
-//                  system timezone for BIND's local wall time
-//                  https://bind9.readthedocs.io/en/v9.18.13/reference.html#namedconf-statement-print-time
-// Writes:      workspace.lsis.parsed.* — 4003 (DNS Activity). Only the queries
-//              channel; bind_to_otlp writes source-owned OTLP Resource,
-//              Body, and LogRecord attributes.
-// Category:    DNS server
+// Facade: process parse_bind,
+//         process bind_to_otlp
+// Category: DNS server
 // Test corpus: synthetic (sample querylog lines in this header)
 //
 // Vendor notes — ISC BIND 9 (Internet Systems Consortium) — the dominant
@@ -139,6 +129,15 @@ def function bind_dns_record(client_ip, client_port_str, qname, qclass, qtype, s
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_bind
+// Summary: ISC BIND 9 querylog lines → LSIS DNS Activity.
+// Reads: workspace.bind.* (bridge — see Bridges below)
+//        .body (required, String) — the query log line
+//        .pid (optional, String) — named pid
+//        .hostname (optional, String) — DNS server hostname
+//        .timezone (optional, String) — source timezone override as an
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_bind {
     // @requires: workspace.bind.body       (required, String)
     // @requires: workspace.bind.pid        (optional, String)
@@ -173,6 +172,18 @@ def process parse_bind_query_record {
     )
 }
 
+// Process: bind_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.bind.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .src_endpoint.ip (optional, String)
+//        workspace.bind_query.*
+//        .qclass (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process bind_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Internet Systems Consortium" } }],

--- a/packaging/snippets/parsers/parse_cef.limpid
+++ b/packaging/snippets/parsers/parse_cef.limpid
@@ -1,23 +1,6 @@
-// Summary:     ArcSight CEF message (from a syslog body) → workspace.cef.*
-//              format fields (format-layer parser; interpreting the
-//              vendor dialect on top is the next stage's job).
-// Reads:       workspace.syslog.* (transport intake — populated by
-//              parse_syslog upstream)
-//                .msg (required, String) — syslog body carrying the
-//                     `CEF:...` message
-//                .hostname (optional, String) — originating host, retained
-//                     by cef_to_otlp as Resource `host.name`
-// Writes:      workspace.cef.{version, device_vendor, device_product,
-//              device_version, signature_id, name, severity} — the seven
-//              positional header fields — plus workspace.cef.extension_raw
-//              (raw Extension blob) and workspace.cef.extension.<key>
-//              (split key=value pairs, isolated in their own sub-object
-//              so data-driven extension keys can never shadow a
-//              positional header field). The CEF format namespace, not
-//              LSIS. cef_to_otlp writes
-//              source-owned OTLP Resource, Body, LogRecord attributes, and
-//              the shed severity slots mapped from the CEF 0-10 scale.
-// Category:    Transport
+// Facade: process parse_cef,
+//         process cef_to_otlp
+// Category: Transport
 // Test corpus: synthetic (sample wires in this header)
 //
 // Wire —    ArcSight CEF as carried in a syslog body —
@@ -55,6 +38,13 @@
 // belong to the per-vendor parsers (`parse_fortigate_cef`,
 // `parse_paloalto_cef`) stacked after this stage.
 
+// Process: parse_cef
+// Summary: ArcSight CEF message (from a syslog body) → workspace.cef.* format fields (format-layer parser; interpreting the vendor dialect on top is the next stage's job).
+// Reads: workspace.syslog.* (transport intake — populated by
+//        .msg (required, String) — syslog body carrying the
+//        .hostname (optional, String) — originating host, retained
+// Writes: workspace.cef.*
+//         .name (required, String)
 def process parse_cef {
     switch workspace.syslog.msg {
         null    { error "parse_cef: no syslog body to parse (workspace.syslog.msg is null)" }
@@ -145,6 +135,19 @@ def function cef_severity_number(sev) {
 //   * Timestamp extensions (rt / start / end) are not parsed here: CEF
 //     permits both epoch-milliseconds and several textual formats, so
 //     interpreting them needs vendor knowledge. Vendor parsers own time.
+
+// Process: cef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cef.*
+//        .device_vendor (optional, String)
+//        workspace.syslog.*
+//        .hostname (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.severity_number (optional, Int)
+//         .log_record.severity_text (optional, String)
+//         .log_record.attributes (optional, Array)
 def process cef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.cef.device_vendor != null {

--- a/packaging/snippets/parsers/parse_checkpoint_leef.limpid
+++ b/packaging/snippets/parsers/parse_checkpoint_leef.limpid
@@ -1,13 +1,6 @@
-// Summary:     Check Point LEEF 2.0 (log_exporter syslog) traffic events →
-//              LSIS Network Activity.
-// Reads:       workspace.checkpoint_leef.* (bridge — see Bridges below)
-//                .body (required, String) — full syslog wire
-//                .hostname (optional, String) — collector-side hostname override
-// Writes:      workspace.lsis.parsed.* — 4001 (Network Activity) for traffic EventIDs
-//              (Accept / Drop / Reject / Block); other LEEF events route to
-//              error_log; checkpoint_leef_to_otlp writes source-owned OTLP
-//              Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_checkpoint_leef,
+//         process checkpoint_leef_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (anonymised RFC 5737 sample wire in this header)
 //
 // Vendor notes — Check Point Software Technologies — VPN-1 / FireWall-1 /
@@ -86,6 +79,13 @@ def function parse_checkpoint_leef_kv(ext, name) {
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_checkpoint_leef
+// Summary: Check Point LEEF 2.0 (log_exporter syslog) traffic events → LSIS Network Activity.
+// Reads: workspace.checkpoint_leef.* (bridge — see Bridges below)
+//        .body (required, String) — full syslog wire
+//        .hostname (optional, String) — collector-side hostname override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_checkpoint_leef {
     // @requires: workspace.checkpoint_leef.body      (required, String)
     // @requires: workspace.checkpoint_leef.hostname  (optional, String)
@@ -185,6 +185,18 @@ def function checkpoint_leef_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: checkpoint_leef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cp_header.*
+//        .product (optional, String)
+//        workspace.checkpoint_leef.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process checkpoint_leef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Check Point" } }],

--- a/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
+++ b/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
@@ -1,13 +1,6 @@
-// Summary:     Check Point Syslog-Exporter records (RFC 5424 + Junos-style SD)
-//              → LSIS by action/product.
-// Reads:       workspace.checkpoint_syslog.* (bridge — see Bridges below)
-//                .body (required, String) — the full RFC 5424 wire
-//                .hostname (optional, String) — collector-side hostname override
-// Writes:      workspace.lsis.parsed.* — firewall actions → 4001, threat actions →
-//              2004, auth actions → 3002; unknown actions land in 4001 with
-//              the action preserved in unmapped. checkpoint_syslog_to_otlp
-//              writes source-owned OTLP Resource, Body, and attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_checkpoint_syslog,
+//         process checkpoint_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: public (elastic/integrations checkpoint corpus — ~80 events
 //              across 8 product types)
 //
@@ -386,6 +379,13 @@ def function checkpoint_syslog_source_host(wire_host, fallback_host) {
 // Main process — dispatch by class (decided heuristically from action / product)
 // ---------------------------------------------------------------------------
 
+// Process: parse_checkpoint_syslog
+// Summary: Check Point Syslog-Exporter records (RFC 5424 + Junos-style SD) → LSIS by action/product.
+// Reads: workspace.checkpoint_syslog.* (bridge — see Bridges below)
+//        .body (required, String) — the full RFC 5424 wire
+//        .hostname (optional, String) — collector-side hostname override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_checkpoint_syslog {
     // @requires: workspace.checkpoint_syslog.body      (required, String)
     // @requires: workspace.checkpoint_syslog.hostname  (optional, String)
@@ -511,6 +511,18 @@ def function checkpoint_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: checkpoint_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cp_syslog_class.*
+//        .sd (optional, Object)
+//        workspace.checkpoint_syslog.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process checkpoint_syslog_to_otlp {
     let sd = workspace.cp_syslog_class.sd
     let product = parse_checkpoint_syslog_kv_or_null(sd, "product")

--- a/packaging/snippets/parsers/parse_cloudtrail.limpid
+++ b/packaging/snippets/parsers/parse_cloudtrail.limpid
@@ -1,10 +1,6 @@
-// Summary:     AWS CloudTrail JSON events → LSIS API Activity.
-// Reads:       ingress (raw wire) — one CloudTrail event JSON object per
-//              ingress (unwrap {"Records":[...]} at the transport layer)
-// Writes:      workspace.lsis.parsed.* — 6003 (API Activity).
-//              cloudtrail_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-// Category:    Cloud audit (API control plane)
+// Facade: process parse_cloudtrail,
+//         process cloudtrail_to_otlp
+// Category: Cloud audit (API control plane)
 // Test corpus: public (FLAWS CloudTrail dataset, 1M events)
 //
 // Wire —    JSON — one CloudTrail event per `ingress`. CloudTrail's S3
@@ -134,6 +130,11 @@ def function cloudtrail_activity_id(name) {
 // One process: parse the JSON, then translate top-level CloudTrail
 // fields into OCSF API Activity (6003) on workspace.lsis.parsed.
 
+// Process: parse_cloudtrail
+// Summary: AWS CloudTrail JSON events → LSIS API Activity.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_cloudtrail {
     workspace.ct = parse_json(ingress)
 
@@ -230,6 +231,16 @@ def function cloudtrail_otlp_event_types(read_only) {
     }
 }
 
+// Process: cloudtrail_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.lsis.parsed.*
+//        .cloud.account.uid (optional, String)
+//        workspace.ct.*
+//        .readOnly (optional, Bool)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process cloudtrail_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "aws" } }],

--- a/packaging/snippets/parsers/parse_combined_log.limpid
+++ b/packaging/snippets/parsers/parse_combined_log.limpid
@@ -1,11 +1,6 @@
-// Summary:     Apache / Nginx combined log format → LSIS HTTP Activity.
-// Reads:       workspace.combined_log.* (bridge — see Bridges below)
-//                .body (required, String) — the CLF line
-//                .hostname (optional, String) — web server hostname
-// Writes:      workspace.lsis.parsed.* — 4002 (HTTP Activity);
-//              combined_log_to_otlp writes source-owned OTLP Resource, Body,
-//              and LogRecord attributes.
-// Category:    Web / proxy access
+// Facade: process parse_combined_log,
+//         process combined_log_to_otlp
+// Category: Web / proxy access
 // Test corpus: synthetic (sample CLF lines in this header)
 //
 // Vendor notes — Apache Software Foundation (Apache HTTP Server) — Nginx
@@ -86,6 +81,14 @@ def function combined_log_status_id(code) {
 
 // Top-level dispatcher: regex-match the line, route to the record
 // leaf on success or to error_log on a malformed line.
+
+// Process: parse_combined_log
+// Summary: Apache / Nginx combined log format → LSIS HTTP Activity.
+// Reads: workspace.combined_log.* (bridge — see Bridges below)
+//        .body (required, String) — the CLF line
+//        .hostname (optional, String) — web server hostname
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_combined_log {
     // @requires: workspace.combined_log.body      (required, String)
     // @requires: workspace.combined_log.hostname  (optional, String)
@@ -161,6 +164,16 @@ def function combined_log_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: combined_log_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.combined_log.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process combined_log_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.combined_log.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.combined_log.hostname } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -1,34 +1,6 @@
-// Summary:     Fortinet FortiGate CEF (FortiOS set format cef) → LSIS,
-//              dispatched by CEF cat subtype.
-// Reads:       workspace.cef.* (format intake — populated by
-//              parse_syslog | parse_cef upstream)
-//                .extension.cat (required, String) — FortiGate
-//                     `cat=<category>:<subtype>` extension, the dispatch key
-//                .severity (optional, Int) — CEF header priority
-//                     (FortiGate dialect 1-8)
-//                .device_vendor (optional, String) — CEF header vendor
-//                .device_product (optional, String) — CEF header product
-//                .device_version (optional, String) — CEF header version
-//                (plus the per-leaf standard / `FTNTFGT*` extension keys
-//                under workspace.cef.extension.*, documented on each
-//                subtype leaf below)
-//              workspace.syslog.* (transport intake)
-//                .timestamp (optional, String) — RFC 3164 wire timestamp
-//                .msg (optional, String) — syslog body, retained by
-//                     fortigate_cef_to_otlp as the OTLP Body
-//              workspace.fortigate_cef.timezone (optional, String) — source
-//              device timezone override as an IANA name or fixed offset; the
-//              RFC 3164 timestamp defaults to the limpid host's system timezone
-//              (FortiOS logs follow the configured device time zone, while
-//              the documented CEF wrapper omits the zone itself)
-//              https://docs.fortinet.com/document/fortigate/7.4.0/fortios-log-message-reference/949981/traffic-log-support-for-cef
-//              The default assumes FortiGate and limpid have the same correct
-//              system timezone. Correct either environment, override this
-//              slot, or use a custom parser when that assumption is false.
-// Writes:      workspace.lsis.parsed.* — class per subtype (traffic → 4001,
-//              IPS / virus → 2004, …); fortigate_cef_to_otlp writes
-//              source-owned OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_fortigate_cef,
+//         process fortigate_cef_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: real (anonymised FortiGate captures — the dialect-quirks
 //              block below was verified against them)
 //
@@ -189,6 +161,21 @@ def function fortigate_cef_metadata(vendor, product, version) {
 // because the CEF wrapper itself carries no timestamp; the per-leaf
 // validate process interprets it in the declared device timezone.
 
+// Process: parse_fortigate_cef
+// Summary: Fortinet FortiGate CEF (FortiOS set format cef) → LSIS, dispatched by CEF cat subtype.
+// Reads: workspace.cef.* (format intake — populated by
+//        .extension.cat (required, String) — FortiGate
+//        .severity (optional, Int) — CEF header priority
+//        .device_vendor (optional, String) — CEF header vendor
+//        .device_product (optional, String) — CEF header product
+//        .device_version (optional, String) — CEF header version
+//        workspace.syslog.* (transport intake)
+//        .timestamp (optional, String) — RFC 3164 wire timestamp
+//        .msg (optional, String) — syslog body, retained by
+//        workspace.fortigate_cef.*
+//        .timezone (optional, String) — source
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_fortigate_cef {
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.extension.cat {
@@ -990,6 +977,18 @@ def function fortigate_cef_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: fortigate_cef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cef.*
+//        .device_vendor (optional, String)
+//        workspace.syslog.*
+//        .msg (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process fortigate_cef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.cef.device_vendor != null {

--- a/packaging/snippets/parsers/parse_fortigate_syslog.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_syslog.limpid
@@ -1,17 +1,6 @@
-// Summary:     Fortinet FortiGate native key=value syslog (FortiOS
-//              "default" format) → same LSIS shape as parse_fortigate_cef.
-// Reads:       ingress (raw wire) — `<PRI>` + FortiGate KV body, NOT RFC 3164
-//              (no timestamp/hostname header between the priority and the
-//              body, so there is no meaningful `parse_syslog` stage to
-//              front this parser with; it strips the PRI itself)
-//              (`eventtime` is epoch seconds on older FortiOS and
-//              epoch nanoseconds on FortiOS 6.2.1+)
-// Writes:      workspace.lsis.parsed.* — same classes as parse_fortigate_cef
-//              (the LSIS contract is format-agnostic).
-//              fortigate_syslog_to_otlp additionally writes the
-//              source-specific workspace.lsis.shed.otlp Resource, Body,
-//              and LogRecord attributes consumed by compose_otlp.
-// Category:    Network firewall / IPS
+// Facade: process parse_fortigate_syslog,
+//         process fortigate_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (FortiOS "default"-format sample wires in this header)
 //
 // Wire —    syslog priority + KV body — `<priority>date=... time=... type=... ...`
@@ -153,6 +142,11 @@ def function fortigate_syslog_proto_name(num) {
 // switch site per format — mirrors the CEF parser shape (which dispatches
 // on `cat`, the CEF field that already carries `type:subtype`).
 
+// Process: parse_fortigate_syslog
+// Summary: Fortinet FortiGate native key=value syslog (FortiOS "default" format) → same LSIS shape as parse_fortigate_cef.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_fortigate_syslog {
     workspace.kv = parse_kv(syslog.strip_pri(ingress))
     let cat = workspace.kv.type + ":" + workspace.kv.subtype
@@ -314,6 +308,18 @@ def function fortigate_syslog_otlp_tls_version(version_text) {
     }
 }
 
+// Process: fortigate_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.kv.*
+//        .devid (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+//        workspace.fortigate_syslog.*
+//        .severity_number (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process fortigate_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Fortinet" } }],

--- a/packaging/snippets/parsers/parse_journald.limpid
+++ b/packaging/snippets/parsers/parse_journald.limpid
@@ -1,12 +1,6 @@
-// Summary:     journalctl -o json lines → workspace.journald.* transport
-//              fields (transport-layer parser).
-// Reads:       ingress (raw wire) — one journalctl -o json line (UTF-8
-//              JSON object) per ingress
-// Writes:      workspace.journald.* — all fields as journald exposes them;
-//              the transport namespace, not LSIS. journald_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes
-//              without promoting PRIORITY to canonical severity.
-// Category:    Transport
+// Facade: process parse_journald,
+//         process journald_to_otlp
+// Category: Transport
 // Test corpus: synthetic (journalctl -o json sample wire in this header)
 //
 // Typically the first process in a pipeline whose `input` is `type journal`.
@@ -52,10 +46,25 @@
 //   process parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress
 //   process parse_journald | parse_openssh | compose_ocsf | ocsf_to_egress
 
+// Process: parse_journald
+// Summary: journalctl -o json lines → workspace.journald.* transport fields (transport-layer parser).
+// Reads: ingress
+// Writes: workspace.journald.*
+//         .MESSAGE (optional, String)
 def process parse_journald {
     workspace.journald = parse_json(ingress)
 }
 
+// Process: journald_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.journald.*
+//        ._HOSTNAME (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .scope.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process journald_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.journald._HOSTNAME != null { true { [{ key: "host.name", value: { string_value: workspace.journald._HOSTNAME } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
@@ -1,13 +1,6 @@
-// Summary:     Juniper SRX sd-syslog (RFC 5424 + [junos@ SD block]) → LSIS by
-//              daemon / MSGID.
-// Reads:       workspace.juniper_srx_sd_syslog.* (bridge — see Bridges below)
-//                .body (required, String) — the full RFC 5424 wire INCLUDING the leading `<PRI>1`
-//                .hostname (optional, String) — collector-side override (parser prefers the wire's HOSTNAME field via classify)
-// Writes:      workspace.lsis.parsed.* — RT_FLOW / APPTRACK → 4001, RT_IDP / RT_IDS /
-//              RT_UTM (AV, antispam, content-filter) / RT_AAMW / RT_SECINTEL →
-//              2004, RT_UTM WEBFILTER_URL_* → 4002. juniper_srx_sd_syslog_to_otlp
-//              writes source-owned OTLP Resource, Body, and attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_juniper_srx_sd_syslog,
+//         process juniper_srx_sd_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: public (elastic/integrations juniper_srx fixtures — 88 events
 //              across RT_FLOW / APPTRACK / RT_IDP / RT_IDS / RT_UTM / RT_AAMW /
 //              RT_SECINTEL)
@@ -354,6 +347,13 @@ def process parse_juniper_srx_sd_syslog_normalize_time {
     }
 }
 
+// Process: parse_juniper_srx_sd_syslog
+// Summary: Juniper SRX sd-syslog (RFC 5424 + [junos@ SD block]) → LSIS by daemon / MSGID.
+// Reads: workspace.juniper_srx_sd_syslog.* (bridge — see Bridges below)
+//        .body (required, String) — the full RFC 5424 wire INCLUDING the leading `<PRI>1`
+//        .hostname (optional, String) — collector-side override (parser prefers the wire's HOSTNAME field via classify)
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_juniper_srx_sd_syslog {
     // @requires: workspace.juniper_srx_sd_syslog.body      (required, String)
     // @requires: workspace.juniper_srx_sd_syslog.hostname  (optional, String)
@@ -1004,6 +1004,18 @@ def function juniper_srx_sd_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: juniper_srx_sd_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.srx_sd_class.*
+//        .host (optional, String)
+//        workspace.juniper_srx_sd_syslog.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process juniper_srx_sd_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Juniper Networks" } }],

--- a/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
@@ -1,21 +1,6 @@
-// Summary:     Juniper SRX unstructured syslog mode (RFC 3164 + MSGID prefix)
-//              → LSIS Detection Finding.
-// Reads:       workspace.juniper_srx_syslog.* (bridge — see Bridges below)
-//                .body (required, String) — the syslog wire
-//                .hostname (optional, String) — collector-side hostname
-//                .timezone (optional, String) — source device timezone override
-//                  as an IANA name or fixed offset; defaults to the limpid
-//                  host's system timezone for RFC 3164 time
-//                  (Junos security logs may use the configured local zone)
-//                  https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/command/show-security-log.html
-//                  The default assumes Junos and limpid have the same correct
-//                  system timezone. Correct either environment, override this
-//                  slot, or use a custom parser when that assumption is false.
-// Writes:      workspace.lsis.parsed.* — RT_IDP IDP_ATTACK_LOG_EVENT → 2004 (Detection
-//              Finding); other daemons / subtypes route to error_log until
-//              their shapes are added. juniper_srx_syslog_to_otlp writes
-//              source-owned OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_juniper_srx_syslog,
+//         process juniper_srx_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: real (anonymised real-traffic samples, RFC 5737-rewritten, in
 //              this header)
 //
@@ -208,6 +193,14 @@ def process parse_juniper_srx_syslog_normalize_time {
     ))
 }
 
+// Process: parse_juniper_srx_syslog
+// Summary: Juniper SRX unstructured syslog mode (RFC 3164 + MSGID prefix) → LSIS Detection Finding.
+// Reads: workspace.juniper_srx_syslog.* (bridge — see Bridges below)
+//        .body (required, String) — the syslog wire
+//        .hostname (optional, String) — collector-side hostname
+//        .timezone (optional, String) — source device timezone override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_juniper_srx_syslog {
     // @requires: workspace.juniper_srx_syslog.body      (required, String)
     // @requires: workspace.juniper_srx_syslog.hostname  (optional, String)
@@ -290,6 +283,18 @@ def function juniper_srx_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: juniper_srx_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.srx_syslog_class.*
+//        .host (optional, String)
+//        workspace.juniper_srx_syslog.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .unmapped.action (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process juniper_srx_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Juniper Networks" } }],

--- a/packaging/snippets/parsers/parse_k8s_audit.limpid
+++ b/packaging/snippets/parsers/parse_k8s_audit.limpid
@@ -1,19 +1,12 @@
-// Kubernetes audit event JSON parser
-//
-// Summary:     Kubernetes audit Event JSON (audit.k8s.io/v1) → LSIS API
-//              Activity + Authentication.
-// Reads:       ingress (raw wire) — one audit Event object per ingress
-//              (no {"items":[...]} envelope)
-// Writes:      workspace.lsis.parsed.* — 6003 (API Activity) for resource requests,
-//              3002 (Authentication) for authentication.k8s.io objectRefs;
-//              unknown kinds route to error_log. k8s_audit_to_otlp additionally
-//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
-//              and LogRecord attributes.
-// Category:    Container / orchestration
+// Facade: process parse_k8s_audit,
+//         process k8s_audit_to_otlp
+// Category: Container / orchestration
 // Test corpus: spec-only (Kubernetes audit policy reference, kube-apiserver
 //              v1.29 audit.k8s.io/v1 schema; verb → activity_id per the OCSF
 //              6003 spec — verify against your apiserver's audit-policy
 //              output before production)
+//
+// Kubernetes audit event JSON parser
 //
 // Wire —        Kubernetes audit Event JSON — one event per `ingress`.
 //              kube-apiserver emits one JSON object per event (line-
@@ -131,6 +124,11 @@ def function k8s_audit_pick_src_ip(source_ips) {
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_k8s_audit
+// Summary: Kubernetes audit Event JSON (audit.k8s.io/v1) → LSIS API Activity + Authentication.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_k8s_audit {
     workspace.k8s = parse_json(ingress)
     workspace.k8s_class = k8s_audit_classify(workspace.k8s)
@@ -342,6 +340,16 @@ def function k8s_audit_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: k8s_audit_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.k8s.*
+//        .objectRef.apiGroup (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process k8s_audit_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Kubernetes" } }],

--- a/packaging/snippets/parsers/parse_nsp.limpid
+++ b/packaging/snippets/parsers/parse_nsp.limpid
@@ -1,21 +1,6 @@
-// Summary:     Trellix (McAfee) Network Security Platform standard-template KV
-//              alerts → LSIS Detection Finding.
-// Reads:       workspace.nsp.* (bridge — see Bridges below)
-//                .body (required, String) — the KV body
-//                .hostname (optional, String) — collector-side hostname
-//                .timezone (optional, String) — source timezone override as an
-//                  IANA name or fixed offset for attack_time values without
-//                  ` UTC`; defaults to the limpid host's system timezone
-//                  (the standard-template timestamp zone is not specified in
-//                  the available vendor documentation; explicit ` UTC` is
-//                  interpreted as UTC. The default assumes the Manager and
-//                  limpid share the same correct system timezone — the most
-//                  likely deployment when the zone is undocumented; override
-//                  it or use a custom parser when the source differs)
-// Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding);
-//              nsp_to_otlp writes source-owned OTLP Resource, Body, and
-//              LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_nsp,
+//         process nsp_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: real (Trellix NSP Manager capture — 56/56 alerts across HTTP /
 //              SSH / SSL / NETBIOS-SS / TELNET / NTP / BACKDOOR signature
 //              categories)
@@ -338,6 +323,14 @@ def process parse_nsp_normalize_time {
     }
 }
 
+// Process: parse_nsp
+// Summary: Trellix (McAfee) Network Security Platform standard-template KV alerts → LSIS Detection Finding.
+// Reads: workspace.nsp.* (bridge — see Bridges below)
+//        .body (required, String) — the KV body
+//        .hostname (optional, String) — collector-side hostname
+//        .timezone (optional, String) — source timezone override as an
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_nsp {
     // @requires: workspace.nsp.body      (required, String)
     // @requires: workspace.nsp.hostname  (optional, String)
@@ -376,6 +369,18 @@ def function nsp_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: nsp_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.nsp_kv.*
+//        .device_name (optional, String)
+//        workspace.nsp.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process nsp_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Trellix" } }],

--- a/packaging/snippets/parsers/parse_ocsf.limpid
+++ b/packaging/snippets/parsers/parse_ocsf.limpid
@@ -1,12 +1,5 @@
-// Summary:     Parses OCSF JSON into LSIS, normalizing root time to epoch
-//              nanoseconds and severity_id to OTel SeverityNumber.
-// Reads:       ingress (raw wire) — one OCSF class instance JSON object
-//              per ingress (class_uid at the root)
-// Writes:      workspace.lsis.parsed.* — same class and fields as the input,
-//              except root `.time` is normalized from ms to ns and
-//              `.severity_id` becomes canonical `.severity_number`, except
-//              OCSF Other (99), which remains in the legacy compatibility slot.
-// Category:    Vendor-neutral
+// Facade: process parse_ocsf
+// Category: Vendor-neutral
 // Test corpus: spec-only (OCSF 1.3.0 class instances; round-trips with
 //              compose_ocsf)
 //
@@ -44,6 +37,11 @@
 include "../functions/timestamp_converter.limpid"
 include "../functions/severity_converter.limpid"
 
+// Process: parse_ocsf
+// Summary: Parses OCSF JSON into LSIS, normalizing root time to epoch nanoseconds and severity_id to OTel SeverityNumber.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_ocsf {
     workspace.lsis.parsed = parse_json(ingress)
 

--- a/packaging/snippets/parsers/parse_okta_system.limpid
+++ b/packaging/snippets/parsers/parse_okta_system.limpid
@@ -1,19 +1,12 @@
-// Okta System Log parser
-//
-// Summary:     Okta System Log events JSON (System Log API v1) → LSIS
-//              identity classes, dispatched by eventType.
-// Reads:       ingress (raw wire) — one LogEvent object per ingress (unwrap
-//              Event Hooks data.events[] upstream)
-// Writes:      workspace.lsis.parsed.* — user.session/user.authentication → 3002,
-//              user.lifecycle → 3001, user.account → 3005, group.* → 3006;
-//              other eventTypes route to error_log. okta_system_to_otlp additionally
-//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
-//              and LogRecord attributes.
-// Category:    Identity / IdP
+// Facade: process parse_okta_system,
+//         process okta_system_to_otlp
+// Category: Identity / IdP
 // Test corpus: synthetic (synthesised from the Okta System Log API reference
 //              — eventType taxonomy and LogEvent schema; live-corpus
 //              parse-rate not yet measured, NOTE-flagged subtypes below
 //              unverified)
+//
+// Okta System Log parser
 //
 // Vendor notes — Okta Workforce Identity Cloud (Okta, Inc.) — System
 //              Log is the authoritative audit-event stream emitted
@@ -230,6 +223,11 @@ def process parse_okta_system_normalize_severity {
     }
 }
 
+// Process: parse_okta_system
+// Summary: Okta System Log events JSON (System Log API v1) → LSIS identity classes, dispatched by eventType.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_okta_system {
     // parse_json on malformed JSON bails to the DLQ via the standard
     // error-log policy, so no explicit null-check arm is needed here.
@@ -675,6 +673,14 @@ def function okta_otlp_event_outcome(result) {
     }
 }
 
+// Process: okta_system_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.okta.*
+//        .target (optional, Array)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process okta_system_to_otlp {
     let target_user = okta_first_target(workspace.okta.target, "User")
     let target_group = okta_first_target(workspace.okta.target, "UserGroup")

--- a/packaging/snippets/parsers/parse_openssh.limpid
+++ b/packaging/snippets/parsers/parse_openssh.limpid
@@ -1,14 +1,6 @@
-// Summary:     OpenSSH sshd application bodies (post-transport-unwrap) → LSIS
-//              Authentication.
-// Reads:       workspace.openssh.* (bridge — see Bridges below)
-//                .body (required, String) — sshd body
-//                .pid (optional, String) — process id as string
-//                .hostname (optional, String) — SSH server hostname
-//                .time (optional, Int) — epoch nanoseconds of the event
-// Writes:      workspace.lsis.parsed.* — 3002 (Authentication);
-//              openssh_to_otlp writes source-owned OTLP Resource,
-//              Body, and LogRecord attributes.
-// Category:    Endpoint / host audit (Unix)
+// Facade: process parse_openssh,
+//         process openssh_to_otlp
+// Category: Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sshd bodies in this header)
 //
 // Vendor notes — OpenSSH (the OpenBSD project's reference implementation of SSH —
@@ -146,6 +138,15 @@ def function openssh_auth_record(activity_id, status_id, user, ip, port_str, pid
 // route to the matching leaf.
 // ---------------------------------------------------------------------------
 
+// Process: parse_openssh
+// Summary: OpenSSH sshd application bodies (post-transport-unwrap) → LSIS Authentication.
+// Reads: workspace.openssh.* (bridge — see Bridges below)
+//        .body (required, String) — sshd body
+//        .pid (optional, String) — process id as string
+//        .hostname (optional, String) — SSH server hostname
+//        .time (optional, Int) — epoch nanoseconds of the event
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_openssh {
     // @requires: workspace.openssh.body       (required, String)
     // @requires: workspace.openssh.pid        (optional, String)
@@ -449,6 +450,18 @@ def function openssh_otlp_event_type(activity_id) {
     switch activity_id { 2 { "end" } default { "start" } }
 }
 
+// Process: openssh_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.openssh.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .activity_id (optional, Int)
+//        workspace.ssh.*
+//        .kind (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process openssh_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "OpenBSD" } }],

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -1,36 +1,6 @@
-// Summary:     Palo Alto Networks PAN-OS CEF → LSIS, dispatched by CEF
-//              name (TRAFFIC / THREAT / URL / …).
-// Reads:       workspace.cef.* (format intake — populated by
-//              parse_syslog | parse_cef upstream)
-//                .name (required, String) — CEF header Name, which PAN-OS
-//                     uses to encode the log type (the dispatch key)
-//                .severity (optional, Int) — CEF header severity
-//                     (PAN-OS dialect 1-5)
-//                .device_vendor (optional, String) — CEF header vendor
-//                .device_product (optional, String) — CEF header product
-//                .device_version (optional, String) — CEF header version
-//                (plus the per-leaf standard / `cs<n>` extension keys
-//                under workspace.cef.extension.*, documented on each
-//                subtype leaf below)
-//              workspace.syslog.* (transport intake)
-//                .timestamp (optional, String) — RFC 3164 wire timestamp
-//                .msg (optional, String) — syslog body, retained by
-//                     paloalto_cef_to_otlp as the OTLP Body
-//              workspace.paloalto_cef.timezone (optional, String) — source
-//              device timezone override as an IANA name or fixed offset; the
-//              legacy RFC 3164 wrapper defaults to the limpid host's system
-//              timezone (PAN-OS documents configurable device time zones but
-//              does not assign a zone to this legacy CEF wrapper timestamp)
-//              https://docs.paloaltonetworks.com/ngfw/help/10-1/device/device-setup-management
-//              The default assumes the firewall and limpid share the same
-//              correct system timezone — the most likely deployment when the
-//              zone is undocumented. Override this slot with an IANA name or
-//              fixed offset when the source zone is known to differ.
-// Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT / WILDFIRE → 2004,
-//              URL → 6004, GLOBALPROTECT / AUTHENTICATION → 3002; see the
-//              subtype leaves below. paloalto_cef_to_otlp writes source-owned
-//              OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_paloalto_cef,
+//         process paloalto_cef_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
 //
 // Typical pipeline —
@@ -170,6 +140,21 @@ include "../functions/proto_num.limpid"
 // because the CEF wrapper itself carries no timestamp; the per-leaf
 // normalize process interprets it in the declared device timezone.
 
+// Process: parse_paloalto_cef
+// Summary: Palo Alto Networks PAN-OS CEF → LSIS, dispatched by CEF name (TRAFFIC / THREAT / URL / …).
+// Reads: workspace.cef.* (format intake — populated by
+//        .name (required, String) — CEF header Name, which PAN-OS
+//        .severity (optional, Int) — CEF header severity
+//        .device_vendor (optional, String) — CEF header vendor
+//        .device_product (optional, String) — CEF header product
+//        .device_version (optional, String) — CEF header version
+//        workspace.syslog.* (transport intake)
+//        .timestamp (optional, String) — RFC 3164 wire timestamp
+//        .msg (optional, String) — syslog body, retained by
+//        workspace.paloalto_cef.*
+//        .timezone (optional, String) — source
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_paloalto_cef {
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.name {
@@ -571,6 +556,18 @@ def function paloalto_cef_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: paloalto_cef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cef.*
+//        .device_vendor (optional, String)
+//        workspace.syslog.*
+//        .msg (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process paloalto_cef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.cef.device_vendor != null {

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -1,24 +1,6 @@
-// Summary:     Palo Alto Networks PAN-OS native CSV syslog → LSIS,
-//              dispatched by the positional Type field.
-// Reads:       workspace.syslog.* (transport intake — populated by
-//              parse_syslog upstream)
-//                .msg (required, String) — syslog body carrying the positional
-//                     CSV row (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
-//              workspace.paloalto_syslog.timezone (optional, String) — source
-//              timezone override as an IANA name or fixed offset; legacy
-//              Receive/Generated Time defaults to the limpid host's system
-//              timezone (PAN-OS defines Receive/Generated Time meanings but
-//              gives a zone only for the separate high-resolution timestamp)
-//              https://docs.paloaltonetworks.com/ngfw/administration/monitoring/use-syslog-for-monitoring/syslog-field-descriptions/traffic-log-fields
-//              The default assumes the firewall and limpid share the same
-//              correct system timezone — the most likely deployment when the
-//              zone is undocumented. Override this slot with an IANA name or
-//              fixed offset when the source zone is known to differ.
-// Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT → 2004
-//              (url → 6004, wildfire → 2004), GLOBALPROTECT /
-//              AUTHENTICATION → 3002; paloalto_syslog_to_otlp writes
-//              source-owned OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_paloalto_syslog,
+//         process paloalto_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
 //
 // Typical pipeline —
@@ -162,6 +144,14 @@ include "../functions/proto_num.limpid"
 // ignored at this stage; the matched leaf re-parses the full row with
 // its own schema.
 
+// Process: parse_paloalto_syslog
+// Summary: Palo Alto Networks PAN-OS native CSV syslog → LSIS, dispatched by the positional Type field.
+// Reads: workspace.syslog.* (transport intake — populated by
+//        .msg (required, String) — syslog body carrying the positional
+//        workspace.paloalto_syslog.*
+//        .timezone (optional, String) — source
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_paloalto_syslog {
     workspace.pan_header = csv_parse(workspace.syslog.msg, ["", "", "", "Type", "Subtype"])
     switch workspace.pan_header.Type {
@@ -769,6 +759,18 @@ def function paloalto_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: paloalto_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.pan.*
+//        .Serial (optional, String)
+//        workspace.syslog.*
+//        .msg (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process paloalto_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Palo Alto Networks" } }],

--- a/packaging/snippets/parsers/parse_postfix.limpid
+++ b/packaging/snippets/parsers/parse_postfix.limpid
@@ -1,14 +1,6 @@
-// Summary:     Postfix mail-flow log bodies (postfix/<program>[pid]: tag
-//              included) → LSIS Email Activity.
-// Reads:       workspace.postfix.* (bridge — see Bridges below)
-//                .body (required, String) — the postfix-tagged body
-//                .hostname (optional, String) — host where the MTA ran
-//                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.parsed.* — 4009 (Email Activity) for mail-flow programs
-//              (smtp / smtpd / qmgr / bounce); daemon-control noise routes to
-//              error_log. postfix_to_otlp writes source-owned OTLP Resource,
-//              Body, and LogRecord attributes.
-// Category:    Mail (MTA)
+// Facade: process parse_postfix,
+//         process postfix_to_otlp
+// Category: Mail (MTA)
 // Test corpus: synthetic (sample postfix lines in this header)
 //
 // Vendor notes — The Postfix Project (Wietse Venema's MTA — covers Postfix
@@ -121,6 +113,14 @@ def function postfix_status_id(s) {
 // pipeline boundary thanks to the v0.7.0
 // process-call error-propagation fix.
 
+// Process: parse_postfix
+// Summary: Postfix mail-flow log bodies (postfix/<program>[pid]: tag included) → LSIS Email Activity.
+// Reads: workspace.postfix.* (bridge — see Bridges below)
+//        .body (required, String) — the postfix-tagged body
+//        .hostname (optional, String) — host where the MTA ran
+//        .time (optional, Int) — epoch nanoseconds
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_postfix {
     // @requires: workspace.postfix.body      (required, String) — postfix-tagged body
     // @requires: workspace.postfix.hostname  (optional, String)
@@ -374,6 +374,18 @@ def function postfix_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: postfix_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.pf.*
+//        .program (optional, String)
+//        workspace.postfix.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process postfix_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "service.name", value: { string_value: switch workspace.pf.program != null { true { "postfix/${workspace.pf.program}" } default { "postfix" } } } }],

--- a/packaging/snippets/parsers/parse_sudo.limpid
+++ b/packaging/snippets/parsers/parse_sudo.limpid
@@ -1,14 +1,6 @@
-// Summary:     sudo / sudoedit application bodies (post-transport-unwrap) →
-//              LSIS Authorize Session.
-// Reads:       workspace.sudo.* (bridge — see Bridges below)
-//                .body (required, String) — the sudo body
-//                .pid (optional, String) — process id as string
-//                .hostname (optional, String) — host where sudo ran
-//                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.parsed.* — 3003 (Authorize Session);
-//              sudo_to_otlp writes source-owned OTLP Resource, Body,
-//              and LogRecord attributes.
-// Category:    Endpoint / host audit (Unix)
+// Facade: process parse_sudo,
+//         process sudo_to_otlp
+// Category: Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sudo bodies in this header)
 //
 // Vendor notes — sudo (the Sudo Project — sudo/sudoedit; not pfexec, not
@@ -243,6 +235,15 @@ def function parse_sudo_message(msg) {
 // Top-level dispatcher
 // ---------------------------------------------------------------------------
 
+// Process: parse_sudo
+// Summary: sudo / sudoedit application bodies (post-transport-unwrap) → LSIS Authorize Session.
+// Reads: workspace.sudo.* (bridge — see Bridges below)
+//        .body (required, String) — the sudo body
+//        .pid (optional, String) — process id as string
+//        .hostname (optional, String) — host where sudo ran
+//        .time (optional, Int) — epoch nanoseconds
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_sudo {
     // @requires: workspace.sudo.body       (required, String)
     // @requires: workspace.sudo.pid        (optional, String)
@@ -488,6 +489,18 @@ def function sudo_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: sudo_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.sudo.*
+//        .hostname (optional, String)
+//        workspace.sudo_class.*
+//        .kind (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process sudo_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Sudo Project" } }],

--- a/packaging/snippets/parsers/parse_suricata.limpid
+++ b/packaging/snippets/parsers/parse_suricata.limpid
@@ -1,19 +1,11 @@
-// Suricata EVE JSON parser (vocabulary)
-//
-// Summary:     Suricata EVE JSON events → LSIS, dispatched by event_type.
-// Reads:       workspace.suricata.* (bridge — see Bridges below)
-//   .body (required, Object) — parsed EVE event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — alert → 2004, dns → 4003, http → 4002,
-//              tls / flow / fileinfo → 4001; stats dropped; other event_types
-//              route to error_log. suricata_to_otlp additionally writes
-//              source-specific workspace.lsis.shed.otlp Resource, Body, and
-//              LogRecord attributes.
-// Category:    OSS NDR
+// Facade: process parse_suricata,
+//         process suricata_to_otlp
+// Category: OSS NDR
 // Test corpus: public (elastic/integrations suricata corpus — 63 events
 //              across alert / dns / http / tls / flow / fileinfo / stats;
 //              Suricata 4.x-6.x EVE)
+//
+// Suricata EVE JSON parser (vocabulary)
 //
 // Vendor notes — OISF Suricata — open-source IDS / IPS / NSM that emits
 //           "Extensible Event Format" (EVE) as line-delimited JSON.
@@ -407,6 +399,14 @@ def function suricata_fileinfo_record(body, host, time_ns) {
 // Main process — dispatch by event_type
 // ---------------------------------------------------------------------------
 
+// Process: parse_suricata
+// Summary: Suricata EVE JSON events → LSIS, dispatched by event_type.
+// Reads: workspace.suricata.* (bridge — see Bridges below)
+//        .body (required, Object) — parsed EVE event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_suricata {
     // @requires: workspace.suricata.body      (required, Object — parsed EVE event)
     // @requires: workspace.suricata.hostname  (optional, String)
@@ -508,6 +508,16 @@ def function suricata_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: suricata_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.suricata.*
+//        .body (optional, Object)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process suricata_to_otlp {
     let body = workspace.suricata.body
     workspace.lsis.shed.otlp.resource.attributes = concat(

--- a/packaging/snippets/parsers/parse_syslog.limpid
+++ b/packaging/snippets/parsers/parse_syslog.limpid
@@ -1,15 +1,6 @@
-// Summary:     RFC 3164 / RFC 5424 syslog wire → workspace.syslog.*
-//              transport fields (transport-layer parser; bridging the body
-//              into a vocabulary intake is the caller's job).
-// Reads:       ingress (raw wire) — <PRI>-prefixed syslog line, RFC 3164
-//              BSD vs RFC 5424 auto-detected
-// Writes:      workspace.syslog.{pri, facility, severity, timestamp,
-//              hostname, appname, procid, msgid, msg} — the transport
-//              namespace, not LSIS. syslog_to_otlp writes source-owned OTLP
-//              Resource (APP-NAME as `service.name`), Body, and transport
-//              attributes without promoting PRI severity to canonical
-//              severity.
-// Category:    Transport
+// Facade: process parse_syslog,
+//         process syslog_to_otlp
+// Category: Transport
 // Test corpus: synthetic (RFC 3164 / RFC 5424 sample wires in this header)
 //
 // Typically the first process in a pipeline whose `input` is `syslog_tcp`
@@ -40,10 +31,23 @@
 // does not invent an ECS event.category or event.type.
 // https://www.rfc-editor.org/rfc/rfc3164#section-4.1.2
 
+// Process: parse_syslog
+// Summary: RFC 3164 / RFC 5424 syslog wire → workspace.syslog.* transport fields (transport-layer parser; bridging the body into a vocabulary intake is the caller's job).
+// Reads: ingress
+// Writes: workspace.syslog.*
+//         .msg (optional, String)
 def process parse_syslog {
     workspace.syslog = syslog.parse(ingress)
 }
 
+// Process: syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.syslog.*
+//        .hostname (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.syslog.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.syslog.hostname } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_sysmon.limpid
+++ b/packaging/snippets/parsers/parse_sysmon.limpid
@@ -1,17 +1,10 @@
-// Microsoft Sysmon parser (vocabulary)
-//
-// Summary:     Microsoft Sysmon Windows-event JSON (forwarder-shipped) → LSIS,
-//              dispatched by EventID.
-// Reads:       workspace.sysmon.* (bridge — see Bridges below)
-//   .body (required, Object) — parsed Sysmon event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-// Writes:      workspace.lsis.parsed.* — EventID 1 (ProcessCreate) → 1007,
-//              3 (NetworkConnect) → 4001, 11 (FileCreate) → 1001;
-//              unknown EventIDs route to error_log. sysmon_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    EDR
+// Facade: process parse_sysmon,
+//         process sysmon_to_otlp
+// Category: EDR
 // Test corpus: spec-only (Sysmon event schema reference; EventIDs 1 / 3 / 11
 //              only — the bulk of EDR/SOC consumption)
+//
+// Microsoft Sysmon parser (vocabulary)
 //
 // Vendor notes — Microsoft Sysinternals Sysmon (System Monitor) — the
 //           Windows kernel telemetry agent that produces detailed
@@ -78,6 +71,13 @@ include "../functions/proto_num.limpid"
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_sysmon
+// Summary: Microsoft Sysmon Windows-event JSON (forwarder-shipped) → LSIS, dispatched by EventID.
+// Reads: workspace.sysmon.* (bridge — see Bridges below)
+//        .body (required, Object) — parsed Sysmon event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_sysmon {
     // @requires: workspace.sysmon.body      (required, Object — already parse_json'd)
     // @requires: workspace.sysmon.hostname  (optional, String)
@@ -276,6 +276,17 @@ def function sysmon_otlp_event_type(class_uid) {
     switch class_uid { 1001 { "creation" } 1007 { "start" } default { "connection" } }
 }
 
+// Process: sysmon_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.lsis.parsed.*
+//        .process.name (optional, String)
+//        workspace.sysmon.*
+//        .body.Computer (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process sysmon_to_otlp {
     let process_name = coalesce(workspace.lsis.parsed.process.name, workspace.lsis.parsed.actor.process.name)
     let process_pid = coalesce(workspace.lsis.parsed.process.pid, workspace.lsis.parsed.actor.process.pid)

--- a/packaging/snippets/parsers/parse_winevent_json.limpid
+++ b/packaging/snippets/parsers/parse_winevent_json.limpid
@@ -1,12 +1,6 @@
-// Summary:     Windows Event Log JSON (NXLog field-naming shape;
-//              Security channel) → LSIS, dispatched by EventID.
-// Reads:       ingress (raw wire) — one Windows event record JSON object
-//              per ingress
-// Writes:      workspace.lsis.parsed.* — 3002 (logon/logoff), 1007 (process),
-//              3001 (account change), 3006 (group management), dispatched
-//              by EventID; unmapped IDs route to error_log. winevent_json_to_otlp
-//              writes source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    Endpoint / host audit (Windows)
+// Facade: process parse_winevent_json,
+//         process winevent_json_to_otlp
+// Category: Endpoint / host audit (Windows)
 // Test corpus: public (OTRF / Mordor dataset)
 //
 // Scope — Microsoft Windows Event Log channels (Security, System,
@@ -141,6 +135,11 @@ def process parse_winevent_json_normalize_severity {
     }
 }
 
+// Process: parse_winevent_json
+// Summary: Windows Event Log JSON (NXLog field-naming shape; Security channel) → LSIS, dispatched by EventID.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_winevent_json {
     // parse_json always returns a `Value::Object` (non-object JSON
     // is wrapped under a `_json` key per the primitive's contract);
@@ -486,6 +485,17 @@ def function winevent_json_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: winevent_json_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.winevent.*
+//        .Hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process winevent_json_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Microsoft" } }],

--- a/packaging/snippets/parsers/parse_zeek_default.limpid
+++ b/packaging/snippets/parsers/parse_zeek_default.limpid
@@ -1,18 +1,16 @@
-// Zeek (formerly Bro) JSON parser — default-enabled scripts (vocabulary)
-//
-// Summary:     Zeek default-enabled JSON streams (conn / dns / http / ssl /
-//              files / x509 / weird / notice) → LSIS, dispatched by _path.
-// Reads:       workspace.zeek.* (bridge — see Bridges below)
-//   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — conn / ssl / files / x509 → 4001,
-//              dns → 4003, http → 4002, weird / notice → 2004; other
-//              _paths route to error_log. zeek_default_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    OSS NDR
+// Facade: process parse_zeek_default,
+//         function zeek_time_ns,
+//         function zeek_endpoint,
+//         function zeek_default_hostname,
+//         function zeek_metadata,
+//         process parse_zeek_default_native,
+//         process parse_zeek_default_flat,
+//         process zeek_default_to_otlp
+// Category: OSS NDR
 // Test corpus: public (elastic/integrations zeek corpus — 61 events across
 //              the 8 default streams, pre-unflattened to native nested form)
+//
+// Zeek (formerly Bro) JSON parser — default-enabled scripts (vocabulary)
 //
 // Vendor notes — Zeek Project — open-source network monitoring framework
 //           that passively observes traffic and emits per-protocol
@@ -64,6 +62,10 @@ include "../functions/http_method_activity_id.limpid"
 // Zeek `ts` is a float Unix epoch in seconds with microsecond
 // precision. Convert to nanoseconds (OCSF `time` convention) without
 // losing sub-second resolution.
+
+// Function: zeek_time_ns
+// Summary: Resolve Zeek event time to epoch nanoseconds.
+// Signature: zeek_time_ns(Object, Int | Null) → Int | Null
 def function zeek_time_ns(body, override) {
     coalesce(
         switch true {
@@ -75,6 +77,10 @@ def function zeek_time_ns(body, override) {
 }
 
 // Build the canonical OCSF endpoint from Zeek's nested `id` object.
+
+// Function: zeek_endpoint
+// Summary: Build one canonical endpoint from a Zeek id tuple.
+// Signature: zeek_endpoint(Object | Null, String) → Object | Null
 def function zeek_endpoint(id_obj, side) {
     switch true {
         id_obj == null { null }
@@ -171,6 +177,10 @@ def function zeek_http_status_id(code) {
 //     emitted this" than the limpid host's own name. Use it
 //     directly (string-shape — operators can resolve to a real
 //     hostname downstream if they want).
+
+// Function: zeek_default_hostname
+// Summary: Resolve the source-backed hostname used by Zeek records.
+// Signature: zeek_default_hostname(String | Null, String | Null) → String | Null
 def function zeek_default_hostname(src_ip, local_name) {
     switch true {
         src_ip == "127.0.0.1" { local_name }
@@ -179,6 +189,10 @@ def function zeek_default_hostname(src_ip, local_name) {
 }
 
 // Constant metadata block stamped on every Zeek-derived record.
+
+// Function: zeek_metadata
+// Summary: Build the shared Zeek product metadata object.
+// Signature: zeek_metadata() → Object
 def function zeek_metadata() {
     {
         product: {
@@ -481,6 +495,13 @@ def function zeek_notice_record(body, host, time_ns) {
 //                 Runs `nest_dotted_keys` first to recover the native
 //                 nested shape before dispatch.
 
+// Process: parse_zeek_default_native
+// Summary: Bridge one native Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_default_native {
     workspace.zeek = {
         body:     parse_json(ingress),
@@ -490,6 +511,13 @@ def process parse_zeek_default_native {
     process parse_zeek_default
 }
 
+// Process: parse_zeek_default_flat
+// Summary: Bridge one flat Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_default_flat {
     workspace.zeek = {
         body:     nest_dotted_keys(parse_json(ingress)),
@@ -503,6 +531,14 @@ def process parse_zeek_default_flat {
 // Main process — dispatch by `_path`
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_default
+// Summary: Zeek default-enabled JSON streams (conn / dns / http / ssl / files / x509 / weird / notice) → LSIS, dispatched by _path.
+// Reads: workspace.zeek.* (bridge — see Bridges below)
+//        .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_default {
     // @requires: workspace.zeek.body      (required, Object — parsed Zeek event)
     // @requires: workspace.zeek.hostname  (optional, String)
@@ -591,6 +627,17 @@ def function zeek_default_otlp_event_category(class_uid) { switch class_uid { 20
 def function zeek_default_otlp_event_type(class_uid) { switch class_uid { 2004 { "info" } 4002 { "access" } default { "protocol" } } }
 def function zeek_default_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
+// Process: zeek_default_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.zeek.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process zeek_default_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Zeek Project" } }],

--- a/packaging/snippets/parsers/parse_zeek_full.limpid
+++ b/packaging/snippets/parsers/parse_zeek_full.limpid
@@ -1,20 +1,12 @@
-// Zeek full-scope parser (vocabulary)
-//
-// Summary:     Zeek full-scope extension — remaining protocol streams, drop
-//              arms for low-signal streams, and a catch-all that wraps
-//              unknown _paths into 4001/unmapped, on top of parse_zeek_soc.
-// Reads:       workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
-//   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — 14 protocol streams → 4001 (generic);
-//              stats / capture_loss / known_* / software dropped; catch-all
-//              wraps any other _path into 4001 with the raw body under
-//              unmapped. zeek_full_to_otlp writes source-owned OTLP Resource,
-//              Scope, Body, and LogRecord attributes.
-// Category:    OSS NDR
+// Facade: process parse_zeek_full,
+//         process parse_zeek_full_native,
+//         process parse_zeek_full_flat,
+//         process zeek_full_to_otlp
+// Category: OSS NDR
 // Test corpus: spec-only (Zeek script reference; catch-all and drop arms are
 //              shape-level, not corpus-verified)
+//
+// Zeek full-scope parser (vocabulary)
 //
 // Extends `parse_zeek_soc.limpid` with:
 //   - Specialised handlers for the rest of the Zeek default protocol
@@ -76,6 +68,13 @@ include "parse_zeek_soc.limpid"
 // Convenience entry points — see parse_zeek_default.limpid for rationale.
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_full_native
+// Summary: Bridge one native Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_full_native {
     workspace.zeek = {
         body:     parse_json(ingress),
@@ -85,6 +84,13 @@ def process parse_zeek_full_native {
     process parse_zeek_full
 }
 
+// Process: parse_zeek_full_flat
+// Summary: Bridge one flat Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_full_flat {
     workspace.zeek = {
         body:     nest_dotted_keys(parse_json(ingress)),
@@ -265,6 +271,14 @@ def function zeek_rfb_record(body, host, time_ns) {
 // catch-all.
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_full
+// Summary: Zeek full-scope extension — remaining protocol streams, drop arms for low-signal streams, and a catch-all that wraps unknown _paths into 4001/unmapped, on top of parse_zeek_soc.
+// Reads: workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
+//        .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_full {
     switch workspace.zeek.body._path {
         // High-signal full-extra
@@ -424,6 +438,17 @@ def function zeek_full_otlp_event_type(class_uid, activity_id) {
 }
 def function zeek_full_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
+// Process: zeek_full_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.zeek.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process zeek_full_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Zeek Project" } }],

--- a/packaging/snippets/parsers/parse_zeek_soc.limpid
+++ b/packaging/snippets/parsers/parse_zeek_soc.limpid
@@ -1,22 +1,13 @@
-// Zeek SOC-scope parser (vocabulary)
-//
-// Summary:     Zeek SOC-scope extension — auth / protocol streams (ssh, smtp,
-//              ftp, dhcp, kerberos, ntlm, radius, smb_*, dce_rpc, snmp, rdp)
-//              on top of parse_zeek_default.
-// Reads:       workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
-//   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — ssh → 4007, smtp → 4009, ftp → 4008,
-//              dhcp → 4004, kerberos / ntlm / radius → 3002,
-//              smb_mapping / smb_cmd / smb_files → 4006,
-//              dce_rpc / snmp → 4001, rdp → 4005; stock streams fall
-//              through to parse_zeek_default. zeek_soc_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    OSS NDR
+// Facade: process parse_zeek_soc,
+//         process parse_zeek_soc_native,
+//         process parse_zeek_soc_flat,
+//         process zeek_soc_to_otlp
+// Category: OSS NDR
 // Test corpus: spec-only (Zeek per-protocol log reference; SOC-extra streams
 //              not yet corpus-verified — the stock streams inherit
 //              parse_zeek_default's public-corpus verification)
+//
+// Zeek SOC-scope parser (vocabulary)
 //
 // Composition — this file transitively includes parse_zeek_default,
 // so operators picking the SOC scope only write a single include line
@@ -516,6 +507,13 @@ def function zeek_rdp_record(body, host, time_ns) {
 // rationale. Mirror naming: `_native` / `_flat`.
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_soc_native
+// Summary: Bridge one native Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_soc_native {
     workspace.zeek = {
         body:     parse_json(ingress),
@@ -525,6 +523,13 @@ def process parse_zeek_soc_native {
     process parse_zeek_soc
 }
 
+// Process: parse_zeek_soc_flat
+// Summary: Bridge one flat Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_soc_flat {
     workspace.zeek = {
         body:     nest_dotted_keys(parse_json(ingress)),
@@ -538,6 +543,14 @@ def process parse_zeek_soc_flat {
 // Main process — dispatch SOC-extra _paths, fall through to default
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_soc
+// Summary: Zeek SOC-scope extension — auth / protocol streams (ssh, smtp, ftp, dhcp, kerberos, ntlm, radius, smb_*, dce_rpc, snmp, rdp) on top of parse_zeek_default.
+// Reads: workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
+//        .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_soc {
     // @requires: workspace.zeek.body      (required, Object)
     // @requires: workspace.zeek.hostname  (optional, String)
@@ -651,6 +664,17 @@ def function zeek_soc_otlp_event_type(class_uid, activity_id) {
 }
 def function zeek_soc_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
+// Process: zeek_soc_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.zeek.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process zeek_soc_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Zeek Project" } }],


### PR DESCRIPTION
## Summary

Implements the two contract-schema decisions held out of #178, plus one
analyzer fix their strict-mode verification surfaced.

**`e2d467b` — Facade manifest + per-member headers.** A snippet file's
header previously carried one Reads/Writes set for the whole file, which
misrepresented multi-process files: `compose_rfc5424.limpid` declared only
the composer's shed intake while its journald bridge read
`workspace.journald.*` undeclared, and sibling-adapter Writes were spliced
into the primary sentence (the drift class fixed in #178).

The new schema separates the two concerns:

- **File level**: a `Facade:` line enumerating the externally-callable
  defs (`process X, function Y`), plus `Category:` / `Test corpus:` and
  free design prose. The facade line is the file's public-API manifest.
- **Per member**: each facade member carries its own block directly above
  its `def` — `Process:` blocks with Summary / Reads / Writes,
  `Function:` blocks with Summary / typed Signature. `Reads:` / `Writes:`
  now accept multiple `workspace.<ns>` roots, each validated against the
  dot-line grammar independently (the `compose_otlp` parsed+shed case the
  old linter silently skipped).
- **Internal defs** (dispatch leaves, file-local helpers) carry no
  contract block and are exempt from the lint.

The linter cross-checks in three directions: every facade entry must have
a member block adjacent to a matching `def` of the matching kind; every
member block must be in the facade (orphan detection); function
signatures are arity-checked against their `def`. All 42 snippets are
migrated; their non-comment executable lines are byte-identical to base.
Independent sweep: 589 defs — 90 public, 499 private, zero private
cross-file references.

**`02c28e5` — docs.** Design guide and snippet guide teach the new
schema; CHANGELOG entry.

**`5d891c3` — analyzer nullable-union narrowing.** Real-machine
verification of the combined #178 + this-branch state found the shipped
`compose_otlp` emitting 8 strict-warnings false positives introduced by
#178's honest nullable signatures: `len(coalesce(x, []))` inferred as
`Union(Int, Null)`, and `!= null` presence guards flagged always-same
after call-site specialization. Fixed in the analyzer, not by rewriting
correct snippet code:

- `coalesce` drops `Null` members from non-final arguments (runtime
  skips their nulls) and keeps only the final argument's nullability.
- `len` infers from its concrete input type (collections → `Int`,
  null/scalar → `Null`, unions member-wise).
- Equality against `null` is treated as a presence check, never an
  always-same warning; genuine type-mismatch equality warnings are
  regression-pinned.

## Test plan

- [x] `cargo test --workspace --locked` — 924 passed / 1 ignored
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check`, mdBook, snippet header lint (42/0),
      inventory in sync
- [x] Full snippet closure (42 snippets + root config = 43 files,
      323 processes, 6 pipelines) under
      `--check --ultra-strict --strict-warnings` — exit 0, 0 warnings
- [x] Executable-line comparison: 42/42 snippets unchanged vs base
- [x] Independent push-gate audits (uchgs, 9/9 scopes PASS at both the
      pre-fix and final tips)
- [x] End-to-end on Splunk Enterprise 10.4.1 (combined #178 + this
      branch): vendor chains (ASA / FortiGate CEF / PAN CEF / generic
      CEF 0..10 severity map), journald→RFC 5424 bridge frame fields,
      non-UTF-8 payload preserved ingress→egress byte-exact, CEF header
      escape recovery, scoped-wildcard extension reads, two-tier
      Resource/Scope placement — all green, DLQ 0