### PR TITLE
Release 0.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,17 @@ stages):
 | `parse_fortigate_cef \| ...` | `parse_syslog \| parse_cef \| parse_fortigate_cef \| ...` |
 | `parse_paloalto_cef \| ...` | `parse_syslog \| parse_cef \| parse_paloalto_cef \| ...` |
 
+### Added — block primitives iterate object entries
+
+`map`, `filter`, `find`, and `reduce` now accept Object values in addition to
+arrays. Object blocks bind each key as a String alongside its value, visit
+entries in insertion order without deduplicating repeated keys, and use
+type-specific arity checks so an array-shaped block cannot silently consume an
+object (or vice versa). `map` returns an array of block results, `filter`
+returns the retained object entries, `find` returns the first matching
+`[key, value]` pair, and `reduce` folds `|acc, key, value|` over the entries.
+Null inputs retain the existing array behavior.
+
 ### Changed — dependency dedupe
 
 Bumped `axum` to 0.8 and `webpki-roots` to 1.0 so the dependency graph no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — snippet headers declare file facades and member contracts
+
+Packaged snippets now separate file-level metadata from the contracts of each
+public process or function. A `Facade:` list names the externally callable
+members, and an adjacent `Process:` or `Function:` block documents each public
+member without forcing internal dispatch leaves into the public surface.
+`Reads:` and `Writes:` accept multiple independently validated workspace roots,
+so adapters and bridges can state their real cross-namespace boundaries. The
+header linter rejects missing, orphaned, misplaced, and signature-mismatched
+member blocks, and the generated inventory consumes the same facade metadata.
+
 ### Fixed — analyzer contracts match runtime value shapes
 
 Static checking now models ingress and egress as String-or-Bytes payloads,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — transport / format unwrapping separated from vocabulary parsing (breaking)
+
+Bundled vocabulary parsers no longer unwrap their transport or format
+layers internally: `parse_asa` / `parse_paloalto_syslog` stopped calling
+`syslog.parse(ingress)` and `parse_fortigate_cef` / `parse_paloalto_cef`
+additionally stopped calling `cef.parse(...)`. Each layer is its own
+pipeline stage — a new `parsers/parse_cef.limpid` (transport/format-style
+`parse_cef` + generic `cef_to_otlp` adapter for the vendor-independent
+ArcSight CEF surface) joins `parse_syslog`. The separation lets a
+pipeline inspect and drop events after each stage without paying the
+next stage's parse cost, and keeps the stages independently composable.
+`parse_fortigate_syslog` is deliberately unchanged: FortiGate's native
+`<PRI>date=...` wire is not RFC 3164, so there is no meaningful
+transport stage to split out (it keeps stripping the PRI itself).
+
+Out-of-tree pipelines using these four parsers must update their chains
+(extraction results are unchanged — the same primitives run at the new
+stages):
+
+| 0.7.14 chain | 0.7.15 chain |
+|---|---|
+| `parse_asa \| ...` | `parse_syslog \| parse_asa \| ...` |
+| `parse_paloalto_syslog \| ...` | `parse_syslog \| parse_paloalto_syslog \| ...` |
+| `parse_fortigate_cef \| ...` | `parse_syslog \| parse_cef \| parse_fortigate_cef \| ...` |
+| `parse_paloalto_cef \| ...` | `parse_syslog \| parse_cef \| parse_paloalto_cef \| ...` |
+
 ### Changed — dependency dedupe
 
 Bumped `axum` to 0.8 and `webpki-roots` to 1.0 so the dependency graph no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Fixed — cef.parse honors the header escapes `\|` and `\\`
+
+The header splitter treated every `|` as a field separator, so a
+spec-legal escaped pipe (`\|`) inside a header field shifted all
+subsequent fields — for `CEF:0|V|P|1.0|sig|deny\|drop|3|act=block` the
+name became `deny\`, the severity slot received the string `drop`, and
+the extension section received `3|act=block`, misclassifying telemetry
+severity downstream. The splitter now separates only on unescaped
+pipes and decodes the two generic structural escapes that participate
+in field splitting (`\|` → `|`, `\\` → `\`); sequences outside those
+two (`\x` etc.) are kept literally, and the spec's field-specific
+escaping for vulnerability spellings in deviceEventClassId / name is
+field-internal grammar the generic primitive passes through raw. The
+bug predates this release in the primitive itself; the new generic
+`parse_cef` / `cef_to_otlp` path widens its blast radius to every CEF
+pipeline, so it is fixed in 0.7.15. Extension-section escapes remain
+undecoded (unchanged, documented scope).
+
 ### Changed — cef.parse isolates Extension keys from the positional header (breaking)
 
 `cef.parse()` previously flattened the data-driven Extension key=value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Fixed — nullable expression inference follows runtime control flow
+
+The static analyzer now removes skipped `Null` members from non-final
+`coalesce` arguments while preserving the final argument's nullability, and
+infers `len` from its concrete input type. Equality checks against `null` are
+treated as presence guards rather than incompatible-type comparisons. These
+rules prevent reusable composers from producing strict-check false positives
+after a source adapter specializes an otherwise optional field.
+
 ### Changed — snippet headers declare file facades and member contracts
 
 Packaged snippets now separate file-level metadata from the contracts of each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,81 +8,7 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
-### Fixed — nullable expression inference follows runtime control flow
-
-The static analyzer now removes skipped `Null` members from non-final
-`coalesce` arguments while preserving the final argument's nullability, and
-infers `len` from its concrete input type. Equality checks against `null` are
-treated as presence guards rather than incompatible-type comparisons. These
-rules prevent reusable composers from producing strict-check false positives
-after a source adapter specializes an otherwise optional field.
-
-### Changed — snippet headers declare file facades and member contracts
-
-Packaged snippets now separate file-level metadata from the contracts of each
-public process or function. A `Facade:` list names the externally callable
-members, and an adjacent `Process:` or `Function:` block documents each public
-member without forcing internal dispatch leaves into the public surface.
-`Reads:` and `Writes:` accept multiple independently validated workspace roots,
-so adapters and bridges can state their real cross-namespace boundaries. The
-header linter rejects missing, orphaned, misplaced, and signature-mismatched
-member blocks, and the generated inventory consumes the same facade metadata.
-
-### Fixed — analyzer contracts match runtime value shapes
-
-Static checking now models ingress and egress as String-or-Bytes payloads,
-accepts both runtime input forms for `to_string` and the OTLP decoders, and
-preserves nullable returns for partial primitives instead of claiming a value
-is always present. `cef.parse` limits its data-driven workspace wildcard to
-`workspace.extension.*`, so unrelated workspace paths are no longer widened.
-User-defined function calls now report arity mismatches during `--check` with
-the same expected-versus-actual shape used by runtime diagnostics.
-
-The `strftime` and `strptime` timezone keywords `UTC` and `local` are now
-ASCII case-insensitive; IANA timezone names remain case-sensitive.
-
-### Fixed — cef.parse honors the header escapes `\|` and `\\`
-
-The header splitter treated every `|` as a field separator, so a
-spec-legal escaped pipe (`\|`) inside a header field shifted all
-subsequent fields — for `CEF:0|V|P|1.0|sig|deny\|drop|3|act=block` the
-name became `deny\`, the severity slot received the string `drop`, and
-the extension section received `3|act=block`, misclassifying telemetry
-severity downstream. The splitter now separates only on unescaped
-pipes and decodes the two generic structural escapes that participate
-in field splitting (`\|` → `|`, `\\` → `\`); sequences outside those
-two (`\x` etc.) are kept literally, and the spec's field-specific
-escaping for vulnerability spellings in deviceEventClassId / name is
-field-internal grammar the generic primitive passes through raw. The
-bug predates this release in the primitive itself; the new generic
-`parse_cef` / `cef_to_otlp` path widens its blast radius to every CEF
-pipeline, so it is fixed in 0.7.15. Extension-section escapes remain
-undecoded (unchanged, documented scope).
-
-### Changed — cef.parse isolates Extension keys from the positional header (breaking)
-
-`cef.parse()` previously flattened the data-driven Extension key=value
-pairs into the same object as the seven positionally-determined header
-fields. An extension named after a header field (`severity=`, `name=`
-— dialect quirk, buggy template, or log injection alike) was pushed as
-a duplicate sibling key: arena field reads resolved to the header
-(first-wins) but the persisted workspace snapshot resolved to the
-extension value (last-wins), so downstream processes saw the header
-silently replaced. Data of different trust levels must not share a
-plane, so the split pairs now land in a nested sub-object and the raw
-blob is renamed to avoid confusion with it:
-
-| 0.7.14 path | 0.7.15 path |
-|---|---|
-| `workspace.cef.<extension-key>` | `workspace.cef.extension.<extension-key>` |
-| `workspace.cef.ext` (raw blob) | `workspace.cef.extension_raw` |
-
-Header fields (`version` / `device_vendor` / `device_product` /
-`device_version` / `signature_id` / `name` / `severity`) are unchanged.
-Out-of-tree pipelines reading extension keys off `cef.parse()` output
-must add the `extension.` segment. The bundled CEF parsers
-(`parse_cef` / `parse_fortigate_cef` / `parse_paloalto_cef`) are
-updated accordingly.
+## [0.7.15] - 2026-07-20
 
 ### Changed — transport / format unwrapping separated from vocabulary parsing (breaking)
 
@@ -110,40 +36,30 @@ stages):
 | `parse_fortigate_cef \| ...` | `parse_syslog \| parse_cef \| parse_fortigate_cef \| ...` |
 | `parse_paloalto_cef \| ...` | `parse_syslog \| parse_cef \| parse_paloalto_cef \| ...` |
 
-### Added — block primitives iterate object entries
+### Changed — cef.parse isolates Extension keys from the positional header (breaking)
 
-`map`, `filter`, `find`, and `reduce` now accept Object values in addition to
-arrays. Object blocks bind each key as a String alongside its value, visit
-entries in insertion order without deduplicating repeated keys, and use
-type-specific arity checks so an array-shaped block cannot silently consume an
-object (or vice versa). `map` returns an array of block results, `filter`
-returns the retained object entries, `find` returns the first matching
-`[key, value]` pair, and `reduce` folds `|acc, key, value|` over the entries.
-Null inputs retain the existing array behavior.
+`cef.parse()` previously flattened the data-driven Extension key=value
+pairs into the same object as the seven positionally-determined header
+fields. An extension named after a header field (`severity=`, `name=`
+— dialect quirk, buggy template, or log injection alike) was pushed as
+a duplicate sibling key: arena field reads resolved to the header
+(first-wins) but the persisted workspace snapshot resolved to the
+extension value (last-wins), so downstream processes saw the header
+silently replaced. Data of different trust levels must not share a
+plane, so the split pairs now land in a nested sub-object and the raw
+blob is renamed to avoid confusion with it:
 
-### Changed — dependency dedupe
+| 0.7.14 path | 0.7.15 path |
+|---|---|
+| `workspace.cef.<extension-key>` | `workspace.cef.extension.<extension-key>` |
+| `workspace.cef.ext` (raw blob) | `workspace.cef.extension_raw` |
 
-Bumped `axum` to 0.8 and `webpki-roots` to 1.0 so the dependency graph no
-longer carries two major versions of `axum` / `axum-core` / `matchit` /
-`webpki-roots`. The remaining `getrandom` 0.2/0.3 split (ring vs rand 0.9)
-is an upstream limitation and is documented as version-scoped skips in
-`deny.toml`; the newest getrandom line (currently 0.4, dev-only via
-`tempfile`) is deliberately not skipped so any future additional split
-still warns.
-
-### Fixed — undocumented RFC 3164-family timezone default is host-local, not UTC
-
-Bundled parsers whose legacy timestamp format leaves the source zone
-undocumented (`parse_asa`, `parse_nsp`, `parse_paloalto_cef`,
-`parse_paloalto_syslog`) previously assumed UTC. No vendor specification
-documents UTC wall-clock for these formats, so the pack default now follows
-the ruling already applied to `parse_fortigate_cef` /
-`parse_juniper_srx_syslog`: a vendor-documented UTC format keeps UTC, and a
-documented device-local zone or a specification gap defaults to the limpid
-host's system timezone — the most likely assumption being that the device
-shares the host's zone. The `workspace.<parser>.timezone` override contract
-is unchanged: IANA names and fixed offsets are accepted, explicit `local`
-is still rejected.
+Header fields (`version` / `device_vendor` / `device_product` /
+`device_version` / `signature_id` / `name` / `severity`) are unchanged.
+Out-of-tree pipelines reading extension keys off `cef.parse()` output
+must add the `extension.` segment. The bundled CEF parsers
+(`parse_cef` / `parse_fortigate_cef` / `parse_paloalto_cef`) are
+updated accordingly.
 
 ### Fixed — OTLP Scope/Resource placement follows the spec's two-tier identity reading
 
@@ -161,6 +77,92 @@ Sysmon provider `Microsoft-Windows-Sysmon`, journald's
 event `Channel`, the Sysmon `Channel` when the forwarder ships it, Zeek's
 `_path`, and the static `journald` structuring layer. Sources that do not name
 themselves continue to leave both unset.
+
+### Fixed — undocumented RFC 3164-family timezone default is host-local, not UTC
+
+Bundled parsers whose legacy timestamp format leaves the source zone
+undocumented (`parse_asa`, `parse_nsp`, `parse_paloalto_cef`,
+`parse_paloalto_syslog`) previously assumed UTC. No vendor specification
+documents UTC wall-clock for these formats, so the pack default now follows
+the ruling already applied to `parse_fortigate_cef` /
+`parse_juniper_srx_syslog`: a vendor-documented UTC format keeps UTC, and a
+documented device-local zone or a specification gap defaults to the limpid
+host's system timezone — the most likely assumption being that the device
+shares the host's zone. The `workspace.<parser>.timezone` override contract
+is unchanged: IANA names and fixed offsets are accepted, explicit `local`
+is still rejected.
+
+### Fixed — cef.parse honors the header escapes `\|` and `\\`
+
+The header splitter treated every `|` as a field separator, so a
+spec-legal escaped pipe (`\|`) inside a header field shifted all
+subsequent fields — for `CEF:0|V|P|1.0|sig|deny\|drop|3|act=block` the
+name became `deny\`, the severity slot received the string `drop`, and
+the extension section received `3|act=block`, misclassifying telemetry
+severity downstream. The splitter now separates only on unescaped
+pipes and decodes the two generic structural escapes that participate
+in field splitting (`\|` → `|`, `\\` → `\`); sequences outside those
+two (`\x` etc.) are kept literally, and the spec's field-specific
+escaping for vulnerability spellings in deviceEventClassId / name is
+field-internal grammar the generic primitive passes through raw. The
+bug predates this release in the primitive itself; the new generic
+`parse_cef` / `cef_to_otlp` path widens its blast radius to every CEF
+pipeline, so it is fixed in 0.7.15. Extension-section escapes remain
+undecoded (unchanged, documented scope).
+
+### Added — block primitives iterate object entries
+
+`map`, `filter`, `find`, and `reduce` now accept Object values in addition to
+arrays. Object blocks bind each key as a String alongside its value, visit
+entries in insertion order without deduplicating repeated keys, and use
+type-specific arity checks so an array-shaped block cannot silently consume an
+object (or vice versa). `map` returns an array of block results, `filter`
+returns the retained object entries, `find` returns the first matching
+`[key, value]` pair, and `reduce` folds `|acc, key, value|` over the entries.
+Null inputs retain the existing array behavior.
+
+### Fixed — analyzer contracts match runtime value shapes
+
+Static checking now models ingress and egress as String-or-Bytes payloads,
+accepts both runtime input forms for `to_string` and the OTLP decoders, and
+preserves nullable returns for partial primitives instead of claiming a value
+is always present. `cef.parse` limits its data-driven workspace wildcard to
+`workspace.extension.*`, so unrelated workspace paths are no longer widened.
+User-defined function calls now report arity mismatches during `--check` with
+the same expected-versus-actual shape used by runtime diagnostics.
+
+The `strftime` and `strptime` timezone keywords `UTC` and `local` are now
+ASCII case-insensitive; IANA timezone names remain case-sensitive.
+
+### Fixed — nullable expression inference follows runtime control flow
+
+The static analyzer now removes skipped `Null` members from non-final
+`coalesce` arguments while preserving the final argument's nullability, and
+infers `len` from its concrete input type. Equality checks against `null` are
+treated as presence guards rather than incompatible-type comparisons. These
+rules prevent reusable composers from producing strict-check false positives
+after a source adapter specializes an otherwise optional field.
+
+### Changed — snippet headers declare file facades and member contracts
+
+Packaged snippets now separate file-level metadata from the contracts of each
+public process or function. A `Facade:` list names the externally callable
+members, and an adjacent `Process:` or `Function:` block documents each public
+member without forcing internal dispatch leaves into the public surface.
+`Reads:` and `Writes:` accept multiple independently validated workspace roots,
+so adapters and bridges can state their real cross-namespace boundaries. The
+header linter rejects missing, orphaned, misplaced, and signature-mismatched
+member blocks, and the generated inventory consumes the same facade metadata.
+
+### Changed — dependency dedupe
+
+Bumped `axum` to 0.8 and `webpki-roots` to 1.0 so the dependency graph no
+longer carries two major versions of `axum` / `axum-core` / `matchit` /
+`webpki-roots`. The remaining `getrandom` 0.2/0.3 split (ring vs rand 0.9)
+is an upstream limitation and is documented as version-scoped skips in
+`deny.toml`; the newest getrandom line (currently 0.4, dev-only via
+`tempfile`) is deliberately not skipped so any future additional split
+still warns.
 
 ## [0.7.14] - 2026-07-16
 
@@ -2274,7 +2276,8 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.7.14...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.7.15...HEAD
+[0.7.15]: https://github.com/naoto256/limpid/compare/v0.7.14...v0.7.15
 [0.7.14]: https://github.com/naoto256/limpid/compare/v0.7.13...v0.7.14
 [0.7.13]: https://github.com/naoto256/limpid/compare/v0.7.12...v0.7.13
 [0.7.12]: https://github.com/naoto256/limpid/compare/v0.7.11...v0.7.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ is an upstream limitation and is documented as version-scoped skips in
 `tempfile`) is deliberately not skipped so any future additional split
 still warns.
 
+### Fixed — OTLP Scope/Resource placement follows the spec's two-tier identity reading
+
+The bundled `<source>_to_otlp` adapters shipped in 0.7.14 placed program-level
+identity in the InstrumentationScope, inverting the OpenTelemetry Logs Data
+Model reading in which the program (process) that produced the record is
+Resource identity and only a logger / channel / stream *within* a program is
+Scope identity. Program names now land in Resource `service.name` — syslog
+APP-NAME, `sshd`, `sudo`, `auditd`, `named`, `suricata`, `kube-apiserver`,
+Juniper SRX daemon names, the full Postfix `postfix/<program>` spelling, the
+Sysmon provider `Microsoft-Windows-Sysmon`, journald's
+`SYSLOG_IDENTIFIER`/`_SYSTEMD_UNIT`, the Windows event `SourceName`, and Okta
+(`okta`, retiring the invented `okta.system_log` spelling) — while
+`scope.name` is reserved for genuine logger/channel identities: the Windows
+event `Channel`, the Sysmon `Channel` when the forwarder ships it, Zeek's
+`_path`, and the static `journald` structuring layer. Sources that do not name
+themselves continue to leave both unset.
+
 ## [0.7.14] - 2026-07-16
 
 > source-owned OTLP semantics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Fixed — analyzer contracts match runtime value shapes
+
+Static checking now models ingress and egress as String-or-Bytes payloads,
+accepts both runtime input forms for `to_string` and the OTLP decoders, and
+preserves nullable returns for partial primitives instead of claiming a value
+is always present. `cef.parse` limits its data-driven workspace wildcard to
+`workspace.extension.*`, so unrelated workspace paths are no longer widened.
+User-defined function calls now report arity mismatches during `--check` with
+the same expected-versus-actual shape used by runtime diagnostics.
+
+The `strftime` and `strptime` timezone keywords `UTC` and `local` are now
+ASCII case-insensitive; IANA timezone names remain case-sensitive.
+
 ### Fixed — cef.parse honors the header escapes `\|` and `\\`
 
 The header splitter treated every `|` as a field separator, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — dependency dedupe
+
+Bumped `axum` to 0.8 and `webpki-roots` to 1.0 so the dependency graph no
+longer carries two major versions of `axum` / `axum-core` / `matchit` /
+`webpki-roots`. The remaining `getrandom` 0.2/0.3 split (ring vs rand 0.9)
+is an upstream limitation and is documented as version-scoped skips in
+`deny.toml`; the newest getrandom line (currently 0.4, dev-only via
+`tempfile`) is deliberately not skipped so any future additional split
+still warns.
+
 ## [0.7.14] - 2026-07-16
 
 > source-owned OTLP semantics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ is an upstream limitation and is documented as version-scoped skips in
 `tempfile`) is deliberately not skipped so any future additional split
 still warns.
 
+### Fixed — undocumented RFC 3164-family timezone default is host-local, not UTC
+
+Bundled parsers whose legacy timestamp format leaves the source zone
+undocumented (`parse_asa`, `parse_nsp`, `parse_paloalto_cef`,
+`parse_paloalto_syslog`) previously assumed UTC. No vendor specification
+documents UTC wall-clock for these formats, so the pack default now follows
+the ruling already applied to `parse_fortigate_cef` /
+`parse_juniper_srx_syslog`: a vendor-documented UTC format keeps UTC, and a
+documented device-local zone or a specification gap defaults to the limpid
+host's system timezone — the most likely assumption being that the device
+shares the host's zone. The `workspace.<parser>.timezone` override contract
+is unchanged: IANA names and fixed offsets are accepted, explicit `local`
+is still rejected.
+
 ### Fixed — OTLP Scope/Resource placement follows the spec's two-tier identity reading
 
 The bundled `<source>_to_otlp` adapters shipped in 0.7.14 placed program-level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — cef.parse isolates Extension keys from the positional header (breaking)
+
+`cef.parse()` previously flattened the data-driven Extension key=value
+pairs into the same object as the seven positionally-determined header
+fields. An extension named after a header field (`severity=`, `name=`
+— dialect quirk, buggy template, or log injection alike) was pushed as
+a duplicate sibling key: arena field reads resolved to the header
+(first-wins) but the persisted workspace snapshot resolved to the
+extension value (last-wins), so downstream processes saw the header
+silently replaced. Data of different trust levels must not share a
+plane, so the split pairs now land in a nested sub-object and the raw
+blob is renamed to avoid confusion with it:
+
+| 0.7.14 path | 0.7.15 path |
+|---|---|
+| `workspace.cef.<extension-key>` | `workspace.cef.extension.<extension-key>` |
+| `workspace.cef.ext` (raw blob) | `workspace.cef.extension_raw` |
+
+Header fields (`version` / `device_vendor` / `device_product` /
+`device_version` / `signature_id` / `name` / `severity`) are unchanged.
+Out-of-tree pipelines reading extension keys off `cef.parse()` output
+must add the `extension.` segment. The bundled CEF parsers
+(`parse_cef` / `parse_fortigate_cef` / `parse_paloalto_cef`) are
+updated accordingly.
+
 ### Changed — transport / format unwrapping separated from vocabulary parsing (breaking)
 
 Bundled vocabulary parsers no longer unwrap their transport or format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -138,13 +138,13 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -152,65 +152,18 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core 0.5.6",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -232,6 +185,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -560,7 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -871,7 +825,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1146,7 +1100,7 @@ version = "0.7.14"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "axum-server",
  "base64",
  "bumpalo",
@@ -1186,7 +1140,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1262,12 +1216,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1334,7 +1282,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1457,7 +1405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1915,7 +1863,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1961,7 +1909,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2268,7 +2216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2336,7 +2284,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2511,7 +2459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "base64",
  "bytes",
  "h2",
@@ -2881,15 +2829,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ limpid is for you.
 
 It is a log pipeline daemon where most of the work is *picking which pieces to use*.
 
-Suppose you want to ship FortiGate firewall logs to a security data lake in OCSF format. With limpid, that is just chaining three things:
+Suppose you want to ship FortiGate firewall logs to a security data lake in OCSF format. With limpid, that is just chaining a handful of named pieces:
 
 ```limpid
 def pipeline fortigate_to_security_lake {
     input   fortigate_syslog
-    process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     output  security_lake
 }
 ```
 
-The flow is right there in the config. Bytes arrive on `fortigate_syslog`; `parse_fortigate_cef` extracts structured fields into `workspace.lsis.parsed.*` (the LSIS facts layer); `compose_ocsf` dispatches on `workspace.lsis.parsed.class_uid` and emits the matching OCSF JSON to `workspace.lsis.composed.ocsf`; the companion `ocsf_to_egress` hands that slot off to `egress` and the result leaves through `security_lake`. No hidden behavior. No plugin to install. No separate "transform" config.
+The flow is right there in the config. Bytes arrive on `fortigate_syslog`; `parse_syslog` unwraps the syslog transport into `workspace.syslog.*`; `parse_cef` decodes the CEF format from the syslog body into `workspace.cef.*`; `parse_fortigate_cef` interprets the FortiGate dialect and writes structured facts into `workspace.lsis.parsed.*` (the LSIS facts layer); `compose_ocsf` dispatches on `workspace.lsis.parsed.class_uid` and emits the matching OCSF JSON to `workspace.lsis.composed.ocsf`; the companion `ocsf_to_egress` hands that slot off to `egress` and the result leaves through `security_lake`. No hidden behavior. No plugin to install. No separate "transform" config.
 
 In limpid, anything you want to do to a log on its way from input to output is achieved by freely combining `process`es.
 
 ## So what is a `process`?
 
-A reusable chunk of pipeline logic — small, named, drop-in. You write them yourself, or you include them from the snippet library (a curated collection introduced in **v0.7.0** and expanded across the 0.7.x line: 31 parser files (29 source / vocabulary parsers plus 2 transport parsers), 30 sibling per-source OTLP adapters, the OCSF 1.3.0 27-class composer, an OTLP envelope composer, and shared helper functions; full list — machine-generated from snippet headers — in [Snippet Library](packaging/snippets/README.md)). Here is what an OCSF Detection Finding composer leaf looks like under the hood:
+A reusable chunk of pipeline logic — small, named, drop-in. You write them yourself, or you include them from the snippet library (a curated collection introduced in **v0.7.0** and expanded across the 0.7.x line: 32 parser files (29 source / vocabulary parsers plus 3 transport / format parsers), 31 sibling per-source OTLP adapters, the OCSF 1.3.0 27-class composer, an OTLP envelope composer, and shared helper functions; full list — machine-generated from snippet headers — in [Snippet Library](packaging/snippets/README.md)). Here is what an OCSF Detection Finding composer leaf looks like under the hood:
 
 ```limpid
 def process compose_ocsf_detection_finding {
@@ -66,7 +66,7 @@ The day you need to ship Cisco ASA logs to the same destination, you include the
 
 A few we have already covered:
 
-- **Composable pieces.** Pipelines are chains of small named processes — `parse_fortigate_cef | compose_ocsf | route_by_severity`. Each piece is one responsibility, swappable, and reusable across pipelines.
+- **Composable pieces.** Pipelines are chains of small named processes — `parse_cef | parse_fortigate_cef | compose_ocsf | route_by_severity`. Each piece is one responsibility, swappable, and reusable across pipelines.
 
 - **Durable recovery sink, built in.** `control { error_log "..." }` persists payloads that retry-exhaust or fail the shutdown flush — operators get the recovery guarantee without writing their own DLQ wiring. `--check --strict-warnings` enforces it on configs that need it.
 
@@ -147,9 +147,9 @@ See the [Getting Started guide](docs/src/getting-started.md) for installation, .
 
 Curated parser / composer / filter library, installed under `/usr/share/limpid/snippets/` and `include`-able by absolute path. Introduced in **v0.7.0**, with the transport layer split out as its own snippet category in **v0.7.1** and the vendor lineup expanded across the 0.7.x line:
 
-- **Transport parsers (2, v0.7.1)** — `parse_syslog` (RFC 3164 / 5424 syslog wire) · `parse_journald` (systemd journald JSON). These populate `workspace.<transport>.*` and feed any vocabulary parser downstream via an inline bridge.
+- **Transport / format parsers (3)** — `parse_syslog` (RFC 3164 / 5424 syslog wire, v0.7.1) · `parse_journald` (systemd journald JSON, v0.7.1) · `parse_cef` (ArcSight CEF format from a syslog body, with a generic `cef_to_otlp` adapter). These populate `workspace.<layer>.*` and feed any vocabulary parser downstream — vendor CEF parsers chain as `parse_syslog | parse_cef | parse_<vendor>_cef`.
 - **Source / vocabulary parsers (29)** — security devices / cloud audit: `parse_fortigate_cef` · `parse_fortigate_syslog` · `parse_paloalto_cef` · `parse_paloalto_syslog` · `parse_asa` · `parse_cloudtrail` · `parse_juniper_srx_sd_syslog` (Junos structured-data) · `parse_juniper_srx_syslog` (Junos unstructured RT_IDP) · `parse_checkpoint_leef` (LEEF 2.0 / QRadar) · `parse_checkpoint_syslog` (Check Point Syslog Exporter) · `parse_nsp` (Trellix Network Security Platform). OSS NDR: `parse_suricata` (EVE JSON) · `parse_zeek_default` / `parse_zeek_soc` / `parse_zeek_full` (Zeek 8 / 20 / 43 protocol scripts, nested-superset scopes, with `_native` / `_flat` convenience variants for raw Zeek vs Filebeat-flat upstream). Cloud (audit / data-plane / findings / identity / orchestration): `parse_aws_guardduty` · `parse_aws_vpc_flow` · `parse_azure_activity` · `parse_k8s_audit` · `parse_okta_system`. Server / host vocabulary: `parse_openssh` · `parse_sudo` · `parse_combined_log` (Apache / Nginx) · `parse_postfix` · `parse_winevent_json` · `parse_sysmon` · `parse_bind` · `parse_auditd` (7 LSIS classes). Vendor-neutral: `parse_ocsf`.
-- **Composers (4)** — `compose_ocsf` (OCSF 1.3.0 priority set, 27 classes, dispatched by `workspace.lsis.parsed.class_uid`) · `compose_rfc5424` (generic RFC 5424 record composer with a `journald_to_rfc5424` bridge for edge → syslog-relay use, v0.7.1) · `compose_replayable` (replay-shape capture) · `compose_otlp` (assembles OTLP 1.0.0 `ResourceLogs` proto bytes from 30 parser-owned source adapters, ten optional shed slots, and canonical parsed time/severity). Composers write to `workspace.lsis.composed.<slot>`; a companion `<slot>_to_egress` one-line process (shipped alongside each composer) moves the slot to `egress` under the egress single-writer invariant.
+- **Composers (4)** — `compose_ocsf` (OCSF 1.3.0 priority set, 27 classes, dispatched by `workspace.lsis.parsed.class_uid`) · `compose_rfc5424` (generic RFC 5424 record composer with a `journald_to_rfc5424` bridge for edge → syslog-relay use, v0.7.1) · `compose_replayable` (replay-shape capture) · `compose_otlp` (assembles OTLP 1.0.0 `ResourceLogs` proto bytes from 31 parser-owned source adapters, ten optional shed slots, and canonical parsed time/severity). Composers write to `workspace.lsis.composed.<slot>`; a companion `<slot>_to_egress` one-line process (shipped alongside each composer) moves the slot to `egress` under the egress single-writer invariant.
 - **Filters (1)** — `filter_openssh_journal` (drops PAM session double-count noise from journald sshd streams).
 
 Each parser writes facts to `workspace.lsis.parsed.*` (the LSIS facts layer — the Limpid Snippet Intermediate Schema, a three-layer gentleman's agreement documented in the [pack snippet README](packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema)); `compose_ocsf` reads from it and emits OCSF JSON to `workspace.lsis.composed.ocsf`, and the companion `ocsf_to_egress` hands the slot off to `egress`. Two `include` lines + a two-stage pipeline gets vendor logs into a SIEM / data lake in OCSF form. Full reference: [Snippet Library](packaging/snippets/README.md).

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.7.14"
+version = "0.7.15"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.7.14"
+version = "0.7.15"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -32,7 +32,7 @@ gethostname = "0.5"
 async-trait = "0.1"
 maxminddb = "0.27"
 tokio-rustls = "0.26"
-webpki-roots = "0.26"
+webpki-roots = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 flate2 = "1"
 sha2 = "0.10"
@@ -67,9 +67,9 @@ rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "sasl"], optiona
 opentelemetry-proto = { version = "0.32", features = ["logs", "gen-tonic", "with-serde"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-native-roots"] }
 prost = "0.14"
-axum = "0.7"
+axum = "0.8"
 # axum-server with rustls support for the otlp_http TLS / mTLS path.
-# axum 0.7's bundled `axum::serve` is hardcoded to `TcpListener`; switching
+# axum's bundled `axum::serve` is hardcoded to `TcpListener`; switching
 # to axum_server::bind / bind_rustls lets the same Router run on either
 # transport without rolling a manual hyper accept loop.
 axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }

--- a/crates/limpid/src/check/bindings.rs
+++ b/crates/limpid/src/check/bindings.rs
@@ -28,7 +28,7 @@
 //! [`super::outputs::check_pipeline_only_reference`] regardless of
 //! upstream binding status.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::dsl::field_schema::FieldType;
 
@@ -42,6 +42,9 @@ pub struct Bindings {
     /// analyzer can no longer tell which workspace keys exist, so any
     /// `workspace.*` read is admitted without flagging.
     wildcard: bool,
+    /// Data-driven subtrees admitted without widening unrelated workspace
+    /// paths, for example `workspace.extension.*` from `cef.parse`.
+    scoped_wildcards: HashSet<String>,
     /// Stack of `let` scopes; the innermost (top) scope wins on lookup.
     let_scopes: Vec<HashMap<String, FieldType>>,
 }
@@ -78,6 +81,20 @@ impl Bindings {
     /// (parse_json, parse_kv) ran without HashLit defaults.
     pub fn set_workspace_wildcard(&mut self) {
         self.wildcard = true;
+    }
+
+    pub fn set_workspace_scoped_wildcard(&mut self, path: &[String]) {
+        self.scoped_wildcards.insert(path.join("."));
+    }
+
+    pub fn is_workspace_path_wildcard(&self, path: &[String]) -> bool {
+        if self.wildcard {
+            return true;
+        }
+        let dotted = path.join(".");
+        self.scoped_wildcards
+            .iter()
+            .any(|scope| dotted == *scope || dotted.starts_with(&format!("{scope}.")))
     }
 
     #[allow(dead_code)] // currently consulted only from tests; kept on the
@@ -142,7 +159,19 @@ impl Bindings {
         self.workspace = merged;
         // Wildcard only survives if both sides wildcarded — otherwise
         // the precise side's known keys win.
-        self.wildcard = self.wildcard && other.wildcard;
+        let self_global = self.wildcard;
+        let other_global = other.wildcard;
+        self.wildcard = self_global && other_global;
+        self.scoped_wildcards = match (self_global, other_global) {
+            (true, true) => HashSet::new(),
+            (true, false) => other.scoped_wildcards.clone(),
+            (false, true) => self.scoped_wildcards.clone(),
+            (false, false) => self
+                .scoped_wildcards
+                .intersection(&other.scoped_wildcards)
+                .cloned()
+                .collect(),
+        };
     }
 }
 
@@ -235,5 +264,17 @@ mod tests {
         // so the precise side's `workspace.x` is dropped — paths must
         // be bound on *both* sides.
         assert!(a.get_workspace(&["workspace".into(), "x".into()]).is_none());
+    }
+
+    #[test]
+    fn scoped_wildcard_admits_only_its_subtree() {
+        let mut b = Bindings::new();
+        b.set_workspace_scoped_wildcard(&["workspace".into(), "extension".into()]);
+        assert!(b.is_workspace_path_wildcard(&[
+            "workspace".into(),
+            "extension".into(),
+            "src".into(),
+        ]));
+        assert!(!b.is_workspace_path_wildcard(&["workspace".into(), "unrelated".into(),]));
     }
 }

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -59,10 +59,24 @@ pub fn infer(expr: &Expr, bindings: &Bindings, registry: &FunctionRegistry) -> F
             args,
             block_arg: _,
         } => {
-            if namespace.is_none() && name == "filter" {
-                args.first()
-                    .map(|arg| filter_return_type(infer(arg, bindings, registry)))
-                    .unwrap_or(FieldType::Any)
+            if namespace.is_none() {
+                match name.as_str() {
+                    "filter" => args
+                        .first()
+                        .map(|arg| filter_return_type(infer(arg, bindings, registry)))
+                        .unwrap_or(FieldType::Any),
+                    "coalesce" => {
+                        coalesce_return_type(args.iter().map(|arg| infer(arg, bindings, registry)))
+                    }
+                    "len" => args
+                        .first()
+                        .map(|arg| len_return_type(infer(arg, bindings, registry)))
+                        .unwrap_or(FieldType::Any),
+                    _ => registry
+                        .signature(None, name)
+                        .map(|s| s.ret.clone())
+                        .unwrap_or(FieldType::Any),
+                }
             } else {
                 registry
                     .signature(namespace.as_deref(), name)
@@ -121,6 +135,67 @@ fn filter_return_type(input: FieldType) -> FieldType {
         // An unknown or invalid input stays unknown to avoid cascading
         // diagnostics after the call-site argument check.
         _ => FieldType::Any,
+    }
+}
+
+/// Infer the first non-null result of `coalesce` without losing the
+/// possibility that its final argument is null. Earlier arguments contribute
+/// only their non-null members because runtime evaluation skips their nulls.
+fn coalesce_return_type(types: impl IntoIterator<Item = FieldType>) -> FieldType {
+    let types: Vec<FieldType> = types.into_iter().collect();
+    let final_can_be_null = types.last().is_some_and(type_can_be_null);
+    let mut result = types
+        .into_iter()
+        .filter_map(type_without_null)
+        .reduce(FieldType::union);
+
+    if final_can_be_null {
+        result = Some(match result {
+            Some(non_null) => FieldType::union(non_null, FieldType::Null),
+            None => FieldType::Null,
+        });
+    }
+    result.unwrap_or(FieldType::Any)
+}
+
+fn type_can_be_null(ty: &FieldType) -> bool {
+    match ty {
+        FieldType::Null | FieldType::Any => true,
+        FieldType::Union(members) => members.iter().any(type_can_be_null),
+        _ => false,
+    }
+}
+
+fn type_without_null(ty: FieldType) -> Option<FieldType> {
+    match ty {
+        FieldType::Null => None,
+        FieldType::Union(members) => members
+            .into_iter()
+            .filter_map(type_without_null)
+            .reduce(FieldType::union),
+        other => Some(other),
+    }
+}
+
+/// `len` returns null exactly for null or non-collection scalar inputs. Keep
+/// the registered broad contract for `Any`, but preserve precise input types
+/// after expression-level narrowing.
+fn len_return_type(input: FieldType) -> FieldType {
+    match input {
+        FieldType::String | FieldType::Object | FieldType::Array | FieldType::Bytes => {
+            FieldType::Int
+        }
+        FieldType::Null
+        | FieldType::Bool
+        | FieldType::Int
+        | FieldType::Float
+        | FieldType::Timestamp => FieldType::Null,
+        FieldType::Union(members) => members
+            .into_iter()
+            .map(len_return_type)
+            .reduce(FieldType::union)
+            .unwrap_or(FieldType::Any),
+        FieldType::Any => FieldType::union(FieldType::Int, FieldType::Null),
     }
 }
 
@@ -501,7 +576,12 @@ fn check_binop(
 
     match op {
         BinOp::Eq | BinOp::Ne => {
-            if !type_compatible(&lt, &rt) && !type_compatible(&rt, &lt) {
+            // Equality against null is a presence check. A reusable process
+            // may receive a concrete call-site type in one pipeline and a
+            // nullable type in another, so call-site specialization must not
+            // turn its generic guard into an always-same warning.
+            let null_presence_check = lt == FieldType::Null || rt == FieldType::Null;
+            if !null_presence_check && !type_compatible(&lt, &rt) && !type_compatible(&rt, &lt) {
                 diagnostics.push(warning(
                     pipeline_name,
                     format!(
@@ -732,5 +812,57 @@ fn warning(pipeline: &str, message: String, span: Option<Span>) -> Diagnostic {
         message: format!("[pipeline {}] {}", pipeline, message),
         span,
         help: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalesce_removes_null_from_non_final_arguments() {
+        assert_eq!(
+            coalesce_return_type([
+                FieldType::union(FieldType::Array, FieldType::Null),
+                FieldType::Array,
+            ]),
+            FieldType::Array
+        );
+        assert_eq!(
+            coalesce_return_type([
+                FieldType::union(FieldType::String, FieldType::Null),
+                FieldType::Null,
+                FieldType::Int,
+            ]),
+            FieldType::union(FieldType::String, FieldType::Int)
+        );
+    }
+
+    #[test]
+    fn coalesce_preserves_null_only_from_the_final_argument() {
+        assert_eq!(
+            coalesce_return_type([
+                FieldType::String,
+                FieldType::union(FieldType::Int, FieldType::Null),
+            ]),
+            FieldType::union(
+                FieldType::union(FieldType::String, FieldType::Int),
+                FieldType::Null,
+            )
+        );
+        assert_eq!(
+            coalesce_return_type([FieldType::Null, FieldType::Null]),
+            FieldType::Null
+        );
+    }
+
+    #[test]
+    fn len_reflects_nullable_and_non_nullable_inputs() {
+        assert_eq!(len_return_type(FieldType::Array), FieldType::Int);
+        assert_eq!(len_return_type(FieldType::Null), FieldType::Null);
+        assert_eq!(
+            len_return_type(FieldType::union(FieldType::Array, FieldType::Null)),
+            FieldType::union(FieldType::Int, FieldType::Null)
+        );
     }
 }

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -128,7 +128,7 @@ fn filter_return_type(input: FieldType) -> FieldType {
 /// reserved-event-ident table.
 ///
 /// Reserved idents (always present, fixed type):
-/// - `ingress` / `egress` — String (raw bytes UTF-8-decoded)
+/// - `ingress` / `egress` — String or Bytes (transport payload)
 /// - `source` — Object `{ ip: String, port: Int }` (since v0.5.6;
 ///   pre-0.5.6 this was a flat String). `source.ip` and `source.port`
 ///   are the canonical accessors.
@@ -145,8 +145,12 @@ fn ident_type(parts: &[String], bindings: &Bindings) -> FieldType {
     }
     // Reserved event idents: always exist, fixed type.
     match parts.first().map(String::as_str) {
-        Some("ingress") if parts.len() == 1 => return FieldType::String,
-        Some("egress") if parts.len() == 1 => return FieldType::String,
+        Some("ingress") if parts.len() == 1 => {
+            return FieldType::union(FieldType::String, FieldType::Bytes);
+        }
+        Some("egress") if parts.len() == 1 => {
+            return FieldType::union(FieldType::String, FieldType::Bytes);
+        }
         Some("received_at") if parts.len() == 1 => return FieldType::Timestamp,
         Some("error") if parts.len() == 1 => return FieldType::String,
         // `source` is an Object since v0.5.6 — `source.ip` (String) and
@@ -163,6 +167,9 @@ fn ident_type(parts: &[String], bindings: &Bindings) -> FieldType {
             }
             if let Some(t) = bindings.get_workspace(parts) {
                 return t.clone();
+            }
+            if bindings.is_workspace_path_wildcard(parts) {
+                return FieldType::Any;
             }
             // Walk up looking for an ancestor binding (Object).
             for i in (2..parts.len()).rev() {
@@ -594,14 +601,26 @@ fn check_fn_call(
         return;
     };
     if !arity_in_range(sig, args.len()) {
-        // Wrong-arity calls are caught loudly at runtime; double-flagging
-        // is just noise. Skip.
+        if namespace.is_none() && registry.is_user_function(name) {
+            diagnostics.push(warning(
+                pipeline_name,
+                format!(
+                    "function `{}` expects {}, got {}",
+                    name,
+                    expected_arity(sig),
+                    args.len()
+                ),
+                span,
+            ));
+        }
         return;
     }
     for (i, actual) in args.iter().enumerate() {
         let expected = expected_arg_type(sig, i);
         let actual_ty = infer(actual, bindings, registry);
-        if !type_compatible(expected, &actual_ty) {
+        if !type_compatible(expected, &actual_ty)
+            && !reserved_payload_matches_text(expected, actual, &actual_ty)
+        {
             let display = qualified_name(namespace, name);
             // Prefer the tight per-argument span from the AST; fall
             // back to the call-level span only when the arg came from
@@ -618,6 +637,45 @@ fn check_fn_call(
                 ),
                 arg_span,
             ));
+        }
+    }
+}
+
+/// `ingress` and `egress` are event-dependent transport payloads: valid
+/// UTF-8 arrives as `String`, while invalid UTF-8 remains `Bytes`. A direct
+/// text consumer is therefore valid for the String arm and may reject the
+/// Bytes arm at runtime. Keep this exception local to the reserved payloads;
+/// ordinary unions still require every member to satisfy the argument type.
+fn reserved_payload_matches_text(
+    expected: &FieldType,
+    actual: &Expr,
+    actual_ty: &FieldType,
+) -> bool {
+    if expected != &FieldType::String
+        || actual_ty != &FieldType::union(FieldType::String, FieldType::Bytes)
+    {
+        return false;
+    }
+
+    matches!(
+        &actual.kind,
+        ExprKind::Ident(parts)
+            if parts.len() == 1 && matches!(parts[0].as_str(), "ingress" | "egress")
+    )
+}
+
+fn expected_arity(sig: &FunctionSig) -> String {
+    match sig.arity {
+        Arity::Fixed => match sig.args.len() {
+            1 => "1 argument".to_string(),
+            n => format!("{n} arguments"),
+        },
+        Arity::Optional { required } => {
+            format!("{} to {} arguments", required, sig.args.len())
+        }
+        Arity::Variadic { min } => {
+            let noun = if min == 1 { "argument" } else { "arguments" };
+            format!("at least {min} {noun}")
         }
     }
 }

--- a/crates/limpid/src/check/expr_types.rs
+++ b/crates/limpid/src/check/expr_types.rs
@@ -56,12 +56,20 @@ pub fn infer(expr: &Expr, bindings: &Bindings, registry: &FunctionRegistry) -> F
         ExprKind::FuncCall {
             namespace,
             name,
-            args: _,
+            args,
             block_arg: _,
-        } => registry
-            .signature(namespace.as_deref(), name)
-            .map(|s| s.ret.clone())
-            .unwrap_or(FieldType::Any),
+        } => {
+            if namespace.is_none() && name == "filter" {
+                args.first()
+                    .map(|arg| filter_return_type(infer(arg, bindings, registry)))
+                    .unwrap_or(FieldType::Any)
+            } else {
+                registry
+                    .signature(namespace.as_deref(), name)
+                    .map(|s| s.ret.clone())
+                    .unwrap_or(FieldType::Any)
+            }
+        }
         ExprKind::BinOp(_l, op, _r) => match op {
             BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge => {
                 FieldType::Bool
@@ -98,6 +106,21 @@ pub fn infer(expr: &Expr, bindings: &Bindings, registry: &FunctionRegistry) -> F
                 FieldType::union(result, FieldType::Null)
             }
         }
+    }
+}
+
+fn filter_return_type(input: FieldType) -> FieldType {
+    match input {
+        FieldType::Array | FieldType::Null => FieldType::Array,
+        FieldType::Object => FieldType::Object,
+        FieldType::Union(members) => members
+            .into_iter()
+            .map(filter_return_type)
+            .reduce(FieldType::union)
+            .unwrap_or(FieldType::Any),
+        // An unknown or invalid input stays unknown to avoid cascading
+        // diagnostics after the call-site argument check.
+        _ => FieldType::Any,
     }
 }
 
@@ -225,18 +248,48 @@ pub fn check_types(
             namespace,
             name,
             args,
-            block_arg: _,
+            block_arg,
         } => {
-            walk_children(expr, |child| {
+            for arg in args {
                 check_types(
-                    child,
+                    arg,
                     pipeline_name,
                     bindings,
                     registry,
                     fallback_span,
                     diagnostics,
-                )
-            });
+                );
+            }
+            if let Some(block) = block_arg {
+                let mut block_bindings = bindings.clone();
+                block_bindings.push_let_scope();
+                for (index, param) in block.params.iter().enumerate() {
+                    block_bindings.bind_let(
+                        param,
+                        block_parameter_type(name, args, index, bindings, registry),
+                    );
+                }
+                for local in &block.body.lets {
+                    check_types(
+                        &local.value,
+                        pipeline_name,
+                        &block_bindings,
+                        registry,
+                        fallback_span,
+                        diagnostics,
+                    );
+                    let ty = infer(&local.value, &block_bindings, registry);
+                    block_bindings.bind_let(&local.name, ty);
+                }
+                check_types(
+                    &block.body.ret,
+                    pipeline_name,
+                    &block_bindings,
+                    registry,
+                    fallback_span,
+                    diagnostics,
+                );
+            }
             // Function-call-level diagnostic (unknown function, arg
             // type mismatch) anchors to the call expression itself; the
             // per-argument diagnostic below prefers the individual arg
@@ -295,6 +348,28 @@ pub fn check_types(
                 diagnostics,
             )
         }),
+    }
+}
+
+fn block_parameter_type(
+    name: &str,
+    args: &[Expr],
+    index: usize,
+    bindings: &Bindings,
+    registry: &FunctionRegistry,
+) -> FieldType {
+    let collection = args
+        .first()
+        .map(|arg| infer(arg, bindings, registry))
+        .unwrap_or(FieldType::Any);
+    match (name, collection, index) {
+        ("map" | "filter" | "find", FieldType::Object, 0) => FieldType::String,
+        ("reduce", _, 0) => args
+            .get(1)
+            .map(|arg| infer(arg, bindings, registry))
+            .unwrap_or(FieldType::Any),
+        ("reduce", FieldType::Object, 1) => FieldType::String,
+        _ => FieldType::Any,
     }
 }
 

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -1599,9 +1599,7 @@ def pipeline p { input i; output o }
     fn function_call_site_resolves() {
         // Call sites referencing a user-defined function don't emit an
         // "unknown function" warning — `register_user_function` made
-        // the analyzer aware of it. (Arity mismatches are deferred to
-        // runtime by design; the analyzer skips wrong-arity warnings
-        // to avoid double-flagging.)
+        // the analyzer aware of it.
         let src = r#"
 def function takes_two(a, b) { a + b }
 def input i { type syslog_tcp bind "0.0.0.0:514" }
@@ -1618,6 +1616,83 @@ def pipeline p {
                 .iter()
                 .any(|w| w.message.contains("unknown function")),
             "user function should resolve at the call site, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn user_function_wrong_arity_is_reported() {
+        let src = r#"
+def function takes_two(a, b) { a + b }
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process { workspace.x = takes_two(1) }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            warnings(&diags).iter().any(|w| {
+                w.message
+                    .contains("function `takes_two` expects 2 arguments, got 1")
+            }),
+            "expected user-function arity warning, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn payload_consumers_accept_string_or_bytes_reserved_idents() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        workspace.parsed = parse_json(ingress)
+        workspace.syslog = syslog.parse(ingress)
+        workspace.text = to_string(ingress)
+        workspace.pb = otlp.decode_resourcelog_protobuf(ingress)
+        workspace.json = otlp.decode_resourcelog_json(egress)
+    }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            !warnings(&diags)
+                .iter()
+                .any(|w| w.message.contains("expects") && w.message.contains("got")),
+            "payload union should match the registered consumers: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn ordinary_string_bytes_union_remains_strict_for_text_consumers() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        if true { workspace.payload = "text" }
+        else { workspace.payload = to_bytes("binary") }
+        workspace.parsed = parse_json(workspace.payload)
+    }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            warnings(&diags).iter().any(|w| {
+                w.message
+                    .contains("function `parse_json` argument 1 expects String")
+                    && w.message.contains("Union(String | Bytes)")
+            }),
+            "ordinary unions must not inherit the reserved-payload exception: {:?}",
             diags
         );
     }

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -1100,6 +1100,72 @@ def pipeline p {
         );
     }
 
+    #[test]
+    fn coalesce_narrows_nullable_collection_before_len() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        if true { workspace.items = [] }
+        else { workspace.items = null }
+        workspace.has_items = len(coalesce(workspace.items, [])) > 0
+    }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(warnings(&diags).is_empty(), "got: {:?}", diags);
+    }
+
+    #[test]
+    fn null_presence_checks_do_not_warn_after_call_site_specialization() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def process guard_optional_fields {
+    if true { workspace.optional = "value" }
+    else { workspace.optional = null }
+    workspace.has_optional = workspace.optional != null
+    workspace.has_name = workspace.name != null
+    workspace.has_labels = workspace.labels != null
+}
+def pipeline p {
+    input i
+    process {
+        workspace.name = "source"
+        workspace.labels = []
+    }
+    process guard_optional_fields
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(warnings(&diags).is_empty(), "got: {:?}", diags);
+    }
+
+    #[test]
+    fn non_null_equality_type_mismatches_still_warn() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process { workspace.mismatch = "1" == 1 }
+    output o
+}
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            warnings(&diags)
+                .iter()
+                .any(|warning| warning.message.contains("always evaluates the same")),
+            "got: {:?}",
+            diags
+        );
+    }
+
     // ----- DiagKind tagging / promotion -----------------------------------
 
     #[test]

--- a/crates/limpid/src/check/parser_effects.rs
+++ b/crates/limpid/src/check/parser_effects.rs
@@ -32,6 +32,9 @@ pub(super) fn apply_parser_effects(
     for spec in &info.produces {
         bindings.bind_workspace(&spec.path, spec.ty.clone());
     }
+    for path in &info.scoped_wildcards {
+        bindings.set_workspace_scoped_wildcard(path);
+    }
 
     // Defaults arg (HashLit): every declared key becomes a workspace
     // binding too, with type inferred from the literal value. This is
@@ -218,5 +221,25 @@ mod tests {
         apply_parser_effects(None, "regex_parse", &args, &reg, &mut bindings);
         assert!(bindings.is_workspace_wildcard());
         assert!(bindings.get_workspace(&ws("user")).is_none());
+    }
+
+    #[test]
+    fn cef_parse_wildcards_only_the_extension_subtree() {
+        let reg = registry();
+        let mut bindings = Bindings::new();
+        apply_parser_effects(
+            Some("cef"),
+            "parse",
+            &[ident("ingress")],
+            &reg,
+            &mut bindings,
+        );
+        assert!(!bindings.is_workspace_wildcard());
+        assert!(bindings.is_workspace_path_wildcard(&[
+            "workspace".into(),
+            "extension".into(),
+            "src".into(),
+        ]));
+        assert!(!bindings.is_workspace_path_wildcard(&["workspace".into(), "unrelated".into(),]));
     }
 }

--- a/crates/limpid/src/dsl/eval.rs
+++ b/crates/limpid/src/dsl/eval.rs
@@ -237,16 +237,15 @@ pub fn eval_expr_with_scope<'bump>(
     }
 }
 
-/// Evaluate a primitive call that carries a trailing `{ |id| body }`
-/// block argument.
+/// Evaluate a primitive call that carries a trailing block argument.
 ///
 /// Only `map` / `filter` / `find` / `reduce` accept block-args (other
-/// names bail with a clear error). For each, the array argument is
-/// evaluated up-front (so type errors surface deterministically), then
-/// the block body is re-evaluated per element with the bound identifier
-/// pushed onto a child copy of the caller's [`LocalScope`]. Locals
-/// introduced inside the block body do not leak back to the caller —
-/// each iteration runs against a fresh clone.
+/// names bail with a clear error). Each primitive evaluates its collection
+/// argument up-front and dispatches on its runtime `Array` / `Object` type.
+/// The block body is then re-evaluated per element or entry with its
+/// arguments pushed onto a child copy of the caller's [`LocalScope`]. Locals
+/// introduced inside the block body do not leak back to the caller; each
+/// iteration runs against a fresh clone.
 #[allow(clippy::too_many_arguments)]
 fn eval_block_primitive<'bump>(
     namespace: Option<&str>,
@@ -306,31 +305,52 @@ fn eval_block_body<'bump>(
     eval_expr_with_scope(&block.body.ret, event, funcs, &scope, arena)
 }
 
-fn expect_one_arg_array<'bump>(
+fn expect_collection_arg<'bump>(
     name: &str,
     args: &[Expr],
+    expected_args: usize,
     event: &BorrowedEvent<'bump>,
     funcs: &FunctionRegistry,
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
-) -> Result<&'bump [Value<'bump>]> {
-    if args.len() != 1 {
+) -> Result<Value<'bump>> {
+    if args.len() != expected_args {
         bail!(
-            "{}() with a block expects 1 array argument, got {}",
+            "{}() with a block expects {} argument(s), got {}",
             name,
+            expected_args,
             args.len()
         );
     }
     let v = eval_expr_with_scope(&args[0], event, funcs, scope, arena)?;
     match v {
-        Value::Array(items) => Ok(items),
-        Value::Null => Ok(&[]),
+        Value::Array(_) | Value::Object(_) | Value::Null => Ok(v),
         other => bail!(
-            "{}() expects an array as its first argument, got {}",
+            "{}() expects an array or object as its first argument, got {}",
             name,
             other.type_name()
         ),
     }
+}
+
+fn expect_block_arity(
+    name: &str,
+    block: &BlockArg,
+    collection_type: &str,
+    expected: usize,
+    example: &str,
+) -> Result<()> {
+    if block.params.len() != expected {
+        bail!(
+            "{}() over an {} requires exactly {} block parameter(s) (`{}`); got {}",
+            name,
+            collection_type,
+            expected,
+            example,
+            block.params.len()
+        );
+    }
+    Ok(())
 }
 
 fn eval_map<'bump>(
@@ -341,19 +361,43 @@ fn eval_map<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 1 {
-        bail!(
-            "map block takes exactly 1 parameter (`{{ |x| ... }}`); got {}",
-            block.params.len()
-        );
+    match expect_collection_arg("map", args, 1, event, funcs, scope, arena)? {
+        Value::Array(items) => {
+            expect_block_arity("map", block, "array", 1, "{ |x| ... }")?;
+            let mut out = ArrayBuilder::with_capacity(arena, items.len());
+            for item in items {
+                out.push(eval_block_body(
+                    block,
+                    &[*item],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?);
+            }
+            Ok(out.finish())
+        }
+        Value::Object(entries) => {
+            expect_block_arity("map", block, "object", 2, "{ |key, value| ... }")?;
+            let mut out = ArrayBuilder::with_capacity(arena, entries.len());
+            for (key, value) in entries {
+                out.push(eval_block_body(
+                    block,
+                    &[Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?);
+            }
+            Ok(out.finish())
+        }
+        Value::Null => {
+            expect_block_arity("map", block, "array", 1, "{ |x| ... }")?;
+            Ok(ArrayBuilder::new(arena).finish())
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    let items = expect_one_arg_array("map", args, event, funcs, scope, arena)?;
-    let mut out = ArrayBuilder::with_capacity(arena, items.len());
-    for item in items {
-        let v = eval_block_body(block, &[*item], event, funcs, scope, arena)?;
-        out.push(v);
-    }
-    Ok(out.finish())
 }
 
 fn eval_filter<'bump>(
@@ -364,21 +408,42 @@ fn eval_filter<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 1 {
-        bail!(
-            "filter block takes exactly 1 parameter (`{{ |x| ... }}`); got {}",
-            block.params.len()
-        );
-    }
-    let items = expect_one_arg_array("filter", args, event, funcs, scope, arena)?;
-    let mut out = ArrayBuilder::new(arena);
-    for item in items {
-        let v = eval_block_body(block, &[*item], event, funcs, scope, arena)?;
-        if v.is_truthy() {
-            out.push(*item);
+    match expect_collection_arg("filter", args, 1, event, funcs, scope, arena)? {
+        Value::Array(items) => {
+            expect_block_arity("filter", block, "array", 1, "{ |x| ... }")?;
+            let mut out = ArrayBuilder::new(arena);
+            for item in items {
+                if eval_block_body(block, &[*item], event, funcs, scope, arena)?.is_truthy() {
+                    out.push(*item);
+                }
+            }
+            Ok(out.finish())
         }
+        Value::Object(entries) => {
+            expect_block_arity("filter", block, "object", 2, "{ |key, value| ... }")?;
+            let mut out = ObjectBuilder::with_capacity(arena, entries.len());
+            for (key, value) in entries {
+                if eval_block_body(
+                    block,
+                    &[Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?
+                .is_truthy()
+                {
+                    out.push(key, *value);
+                }
+            }
+            Ok(out.finish())
+        }
+        Value::Null => {
+            expect_block_arity("filter", block, "array", 1, "{ |x| ... }")?;
+            Ok(ArrayBuilder::new(arena).finish())
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    Ok(out.finish())
 }
 
 fn eval_find<'bump>(
@@ -389,20 +454,43 @@ fn eval_find<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 1 {
-        bail!(
-            "find block takes exactly 1 parameter (`{{ |x| ... }}`); got {}",
-            block.params.len()
-        );
-    }
-    let items = expect_one_arg_array("find", args, event, funcs, scope, arena)?;
-    for item in items {
-        let v = eval_block_body(block, &[*item], event, funcs, scope, arena)?;
-        if v.is_truthy() {
-            return Ok(*item);
+    match expect_collection_arg("find", args, 1, event, funcs, scope, arena)? {
+        Value::Array(items) => {
+            expect_block_arity("find", block, "array", 1, "{ |x| ... }")?;
+            for item in items {
+                if eval_block_body(block, &[*item], event, funcs, scope, arena)?.is_truthy() {
+                    return Ok(*item);
+                }
+            }
+            Ok(Value::Null)
         }
+        Value::Object(entries) => {
+            expect_block_arity("find", block, "object", 2, "{ |key, value| ... }")?;
+            for (key, value) in entries {
+                if eval_block_body(
+                    block,
+                    &[Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?
+                .is_truthy()
+                {
+                    let mut pair = ArrayBuilder::with_capacity(arena, 2);
+                    pair.push(Value::String(key));
+                    pair.push(*value);
+                    return Ok(pair.finish());
+                }
+            }
+            Ok(Value::Null)
+        }
+        Value::Null => {
+            expect_block_arity("find", block, "array", 1, "{ |x| ... }")?;
+            Ok(Value::Null)
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    Ok(Value::Null)
 }
 
 fn eval_reduce<'bump>(
@@ -413,30 +501,37 @@ fn eval_reduce<'bump>(
     scope: &LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<Value<'bump>> {
-    if block.params.len() != 2 {
-        bail!(
-            "reduce block takes exactly 2 parameters (`{{ |acc, x| ... }}`); got {}",
-            block.params.len()
-        );
+    let collection = expect_collection_arg("reduce", args, 2, event, funcs, scope, arena)?;
+    match collection {
+        Value::Array(_) | Value::Null => {
+            expect_block_arity("reduce", block, "array", 2, "{ |acc, x| ... }")?;
+        }
+        Value::Object(_) => {
+            expect_block_arity("reduce", block, "object", 3, "{ |acc, key, value| ... }")?;
+        }
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
-    if args.len() != 2 {
-        bail!(
-            "reduce() with a block expects 2 arguments (array, init), got {}",
-            args.len()
-        );
-    }
-    let arr_val = eval_expr_with_scope(&args[0], event, funcs, scope, arena)?;
-    let items: &[Value<'bump>] = match arr_val {
-        Value::Array(items) => items,
-        Value::Null => &[],
-        other => bail!(
-            "reduce() expects an array as its first argument, got {}",
-            other.type_name()
-        ),
-    };
     let mut acc = eval_expr_with_scope(&args[1], event, funcs, scope, arena)?;
-    for item in items {
-        acc = eval_block_body(block, &[acc, *item], event, funcs, scope, arena)?;
+    match collection {
+        Value::Array(items) => {
+            for item in items {
+                acc = eval_block_body(block, &[acc, *item], event, funcs, scope, arena)?;
+            }
+        }
+        Value::Object(entries) => {
+            for (key, value) in entries {
+                acc = eval_block_body(
+                    block,
+                    &[acc, Value::String(key), *value],
+                    event,
+                    funcs,
+                    scope,
+                    arena,
+                )?;
+            }
+        }
+        Value::Null => {}
+        _ => unreachable!("expect_collection_arg accepts only array, object, or null"),
     }
     Ok(acc)
 }

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -1003,6 +1003,38 @@ mod tests {
         })
     }
 
+    fn int_object(entries: &[(&str, i64)]) -> Expr {
+        e(ExprKind::HashLit(
+            entries
+                .iter()
+                .map(|(key, value)| ((*key).into(), e(ExprKind::IntLit(*value))))
+                .collect(),
+        ))
+    }
+
+    fn block_call_error(name: &str, collection: Expr, params: Vec<&str>) -> String {
+        let _bump = ::bumpalo::Bump::new();
+        let arena = crate::dsl::arena::EventArena::new(&_bump);
+        let event = make_event();
+        let bevent = event.view_in(&arena);
+        let mut args = vec![collection];
+        if name == "reduce" {
+            args.push(e(ExprKind::IntLit(0)));
+        }
+        let stmts = vec![ProcessStatement::Assign(
+            AssignTarget::Workspace(vec!["result".into()]),
+            block_call(name, args, params, e(ExprKind::BoolLit(true))),
+        )];
+        expect_exec_err(exec_process_body(
+            &stmts,
+            bevent,
+            &NoopRegistry,
+            &make_funcs(),
+            &arena,
+        ))
+        .to_string()
+    }
+
     #[test]
     fn test_exec_array_literal_into_workspace() {
         let _bump = ::bumpalo::Bump::new();
@@ -1232,6 +1264,245 @@ mod tests {
             }
             ExecResult::Dropped => panic!("unexpected drop"),
         }
+    }
+
+    #[test]
+    fn test_exec_block_object_primitives_preserve_entry_order_and_duplicates() {
+        let _bump = ::bumpalo::Bump::new();
+        let arena = crate::dsl::arena::EventArena::new(&_bump);
+        let event = make_event();
+        let bevent = event.view_in(&arena);
+        let entries = || e(ExprKind::Ident(vec!["workspace".into(), "entries".into()]));
+        let key = || e(ExprKind::Ident(vec!["key".into()]));
+        let value = || e(ExprKind::Ident(vec!["value".into()]));
+        let stmts = vec![
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["entries".into()]),
+                int_object(&[("a", 1), ("a", 2), ("b", 3)]),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["mapped".into()]),
+                block_call(
+                    "map",
+                    vec![entries()],
+                    vec!["key", "value"],
+                    e(ExprKind::ArrayLit(vec![key(), value()])),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["filtered".into()]),
+                block_call(
+                    "filter",
+                    vec![entries()],
+                    vec!["key", "value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["found".into()]),
+                block_call(
+                    "find",
+                    vec![entries()],
+                    vec!["key", "value"],
+                    e(ExprKind::BinOp(
+                        Box::new(value()),
+                        BinOp::Eq,
+                        Box::new(e(ExprKind::IntLit(2))),
+                    )),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["total".into()]),
+                block_call(
+                    "reduce",
+                    vec![entries(), e(ExprKind::IntLit(0))],
+                    vec!["acc", "key", "value"],
+                    e(ExprKind::BinOp(
+                        Box::new(e(ExprKind::Ident(vec!["acc".into()]))),
+                        BinOp::Add,
+                        Box::new(value()),
+                    )),
+                ),
+            ),
+        ];
+
+        match exec_process_body(&stmts, bevent, &NoopRegistry, &make_funcs(), &arena).unwrap() {
+            ExecResult::Continue(ev) => {
+                assert_eq!(
+                    ev.workspace_get("mapped").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![
+                        OwnedValue::Array(
+                            vec![OwnedValue::String("a".into()), OwnedValue::Int(1),]
+                        ),
+                        OwnedValue::Array(
+                            vec![OwnedValue::String("a".into()), OwnedValue::Int(2),]
+                        ),
+                        OwnedValue::Array(
+                            vec![OwnedValue::String("b".into()), OwnedValue::Int(3),]
+                        ),
+                    ])
+                );
+                let Some(Value::Object(filtered)) = ev.workspace_get("filtered") else {
+                    panic!("filter(object) did not return an object");
+                };
+                assert_eq!(
+                    filtered,
+                    &[
+                        ("a", Value::Int(1)),
+                        ("a", Value::Int(2)),
+                        ("b", Value::Int(3)),
+                    ]
+                );
+                assert_eq!(
+                    ev.workspace_get("found").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![OwnedValue::String("a".into()), OwnedValue::Int(2),])
+                );
+                assert_eq!(ev.workspace_get("total"), Some(Value::Int(6)));
+            }
+            ExecResult::Dropped => panic!("unexpected drop"),
+        }
+    }
+
+    #[test]
+    fn test_exec_block_object_primitives_handle_empty_and_null_collections() {
+        let _bump = ::bumpalo::Bump::new();
+        let arena = crate::dsl::arena::EventArena::new(&_bump);
+        let event = make_event();
+        let bevent = event.view_in(&arena);
+        let empty = || e(ExprKind::HashLit(vec![]));
+        let null = || e(ExprKind::Null);
+        let stmts = vec![
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["map_empty".into()]),
+                block_call(
+                    "map",
+                    vec![empty()],
+                    vec!["key", "value"],
+                    e(ExprKind::Null),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["filter_empty".into()]),
+                block_call(
+                    "filter",
+                    vec![empty()],
+                    vec!["key", "value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["find_empty".into()]),
+                block_call(
+                    "find",
+                    vec![empty()],
+                    vec!["key", "value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["reduce_empty".into()]),
+                block_call(
+                    "reduce",
+                    vec![empty(), e(ExprKind::IntLit(7))],
+                    vec!["acc", "key", "value"],
+                    e(ExprKind::Ident(vec!["acc".into()])),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["map_null".into()]),
+                block_call("map", vec![null()], vec!["value"], e(ExprKind::Null)),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["filter_null".into()]),
+                block_call(
+                    "filter",
+                    vec![null()],
+                    vec!["value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["find_null".into()]),
+                block_call(
+                    "find",
+                    vec![null()],
+                    vec!["value"],
+                    e(ExprKind::BoolLit(true)),
+                ),
+            ),
+            ProcessStatement::Assign(
+                AssignTarget::Workspace(vec!["reduce_null".into()]),
+                block_call(
+                    "reduce",
+                    vec![null(), e(ExprKind::IntLit(7))],
+                    vec!["acc", "value"],
+                    e(ExprKind::Ident(vec!["acc".into()])),
+                ),
+            ),
+        ];
+
+        match exec_process_body(&stmts, bevent, &NoopRegistry, &make_funcs(), &arena).unwrap() {
+            ExecResult::Continue(ev) => {
+                assert_eq!(
+                    ev.workspace_get("map_empty").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![])
+                );
+                assert!(matches!(
+                    ev.workspace_get("filter_empty"),
+                    Some(Value::Object(entries)) if entries.is_empty()
+                ));
+                assert_eq!(ev.workspace_get("find_empty"), Some(Value::Null));
+                assert_eq!(ev.workspace_get("reduce_empty"), Some(Value::Int(7)));
+                assert_eq!(
+                    ev.workspace_get("map_null").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![])
+                );
+                assert_eq!(
+                    ev.workspace_get("filter_null").unwrap().to_owned_value(),
+                    OwnedValue::Array(vec![])
+                );
+                assert_eq!(ev.workspace_get("find_null"), Some(Value::Null));
+                assert_eq!(ev.workspace_get("reduce_null"), Some(Value::Int(7)));
+            }
+            ExecResult::Dropped => panic!("unexpected drop"),
+        }
+    }
+
+    #[test]
+    fn test_exec_block_primitives_reject_collection_arity_mismatches() {
+        for name in ["map", "filter", "find"] {
+            let err = block_call_error(name, int_object(&[("a", 1)]), vec!["value"]);
+            assert!(
+                err.contains(&format!("{}() over an object requires exactly 2", name)),
+                "unexpected {name} object arity error: {err}"
+            );
+
+            let err = block_call_error(
+                name,
+                e(ExprKind::ArrayLit(vec![e(ExprKind::IntLit(1))])),
+                vec!["key", "value"],
+            );
+            assert!(
+                err.contains(&format!("{}() over an array requires exactly 1", name)),
+                "unexpected {name} array arity error: {err}"
+            );
+        }
+
+        let err = block_call_error("reduce", int_object(&[("a", 1)]), vec!["acc", "value"]);
+        assert!(
+            err.contains("reduce() over an object requires exactly 3"),
+            "unexpected reduce object arity error: {err}"
+        );
+
+        let err = block_call_error(
+            "reduce",
+            e(ExprKind::ArrayLit(vec![e(ExprKind::IntLit(1))])),
+            vec!["acc", "key", "value"],
+        );
+        assert!(
+            err.contains("reduce() over an array requires exactly 2"),
+            "unexpected reduce array arity error: {err}"
+        );
     }
 
     #[test]

--- a/crates/limpid/src/dsl/value.rs
+++ b/crates/limpid/src/dsl/value.rs
@@ -657,9 +657,9 @@ impl<'bump> ObjectBuilder<'bump> {
         }
     }
 
-    /// Push an entry. Insertion order is preserved by the underlying
-    /// arena vec; duplicate keys are NOT detected here (debug builds may
-    /// add a `debug_assert!` later — release stays linear-scan-fast).
+    /// Push an entry. Insertion order and duplicate keys are intentionally
+    /// preserved by the underlying arena vec; callers that iterate an Object
+    /// must observe every stored entry.
     pub fn push(&mut self, key: &'bump str, value: Value<'bump>) {
         self.entries.push((key, value));
     }

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -176,7 +176,8 @@ pub struct OwnedEvent {
     /// captured under a per-schema namespace
     /// (`workspace.syslog = syslog.parse(ingress)` then
     /// `workspace.syslog.timestamp`; CEF's `rt` extension surfaces as
-    /// `workspace.cef.rt` after `workspace.cef = cef.parse(...)`).
+    /// `workspace.cef.extension.rt` after
+    /// `workspace.cef = cef.parse(...)`).
     pub received_at: DateTime<Utc>,
     pub source: SocketAddr,
     pub ingress: Bytes,

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -79,28 +79,43 @@ fn parse_impl<'bump>(
         .strip_prefix("CEF:")
         .ok_or_else(|| anyhow::anyhow!("cef.parse(): input does not start with `CEF:`"))?;
 
+    // Of the escapes the CEF specification defines, two are generic
+    // structural escapes relevant to header field splitting: `\|`
+    // (literal pipe) and `\\` (literal backslash). Only an unescaped
+    // `|` is a field separator; a naive `find('|')` would split on the
+    // escaped form and shift every subsequent header field (name
+    // absorbs the fragment, severity receives the next field,
+    // extensions receive the severity). The spec's field-specific
+    // escaping (`=` / `%` / `#` when carrying vulnerability spellings
+    // in deviceEventClassId / name) is field-internal grammar this
+    // generic primitive does not interpret — those spellings pass
+    // through raw.
     let mut parts: [&str; 7] = [""; 7];
     let mut remaining = body;
     for slot in parts.iter_mut() {
-        if let Some(pos) = remaining.find('|') {
-            *slot = &remaining[..pos];
-            remaining = &remaining[pos + 1..];
+        if let Some((field, rest)) = split_unescaped_pipe(remaining) {
+            *slot = field;
+            remaining = rest;
         } else {
             bail!("cef.parse(): incomplete CEF header");
         }
     }
 
     let mut builder = ObjectBuilder::new(arena);
-    builder.push("version", Value::String(arena.alloc_str(parts[0])));
-    builder.push("device_vendor", Value::String(arena.alloc_str(parts[1])));
-    builder.push("device_product", Value::String(arena.alloc_str(parts[2])));
-    builder.push("device_version", Value::String(arena.alloc_str(parts[3])));
-    builder.push("signature_id", Value::String(arena.alloc_str(parts[4])));
-    builder.push("name", Value::String(arena.alloc_str(parts[5])));
-    let severity_value = parts[6]
+    builder.push("version", unescape_header_field(arena, parts[0]));
+    builder.push("device_vendor", unescape_header_field(arena, parts[1]));
+    builder.push("device_product", unescape_header_field(arena, parts[2]));
+    builder.push("device_version", unescape_header_field(arena, parts[3]));
+    builder.push("signature_id", unescape_header_field(arena, parts[4]));
+    builder.push("name", unescape_header_field(arena, parts[5]));
+    let severity_text = match unescape_header_field(arena, parts[6]) {
+        Value::String(s) => s,
+        _ => unreachable!("unescape_header_field always returns a String"),
+    };
+    let severity_value = severity_text
         .parse::<i64>()
         .map(Value::Int)
-        .unwrap_or_else(|_| Value::String(arena.alloc_str(parts[6])));
+        .unwrap_or(Value::String(severity_text));
     builder.push("severity", severity_value);
 
     // Emit the raw extension blob (omitted when empty, to mirror
@@ -129,6 +144,62 @@ fn parse_impl<'bump>(
     } else {
         Ok(parsed)
     }
+}
+
+/// Split the input at the first **unescaped** `|`, returning the raw
+/// (still-escaped) field and the rest after the separator.
+///
+/// A `\` consumes the following byte, so `\|` never separates and the
+/// pipe after `\\` (an escaped backslash) does — `a\\|b` splits into
+/// the field `a\\` and rest `b`. Scanning bytes is UTF-8-safe because
+/// `\` and `|` are ASCII and cannot occur inside a multi-byte sequence.
+fn split_unescaped_pipe(input: &str) -> Option<(&str, &str)> {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if i + 1 < bytes.len() => i += 2,
+            b'|' => return Some((&input[..i], &input[i + 1..])),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Decode the generic structural header escapes in a raw field:
+/// `\|` → `|` and `\\` → `\` — the two escapes that participate in
+/// field splitting. The spec's field-specific escaping (`=` / `%` /
+/// `#` for vulnerability spellings in deviceEventClassId / name) is
+/// field-internal grammar this generic primitive does not interpret;
+/// those spellings are preserved raw. Sequences outside the two
+/// structural escapes (`\x`, …) and a trailing lone `\` are kept
+/// literally — lenient by design, so a producer's stray backslash
+/// degrades to visible bytes instead of a parse error or silent data
+/// loss. Extension-section escapes are a separate scope and are
+/// deliberately not decoded here (see the `extension_raw` FieldSpec
+/// note).
+fn unescape_header_field<'bump>(arena: &'bump EventArena<'bump>, field: &str) -> Value<'bump> {
+    if !field.contains('\\') {
+        return Value::String(arena.alloc_str(field));
+    }
+    let mut out = String::with_capacity(field.len());
+    let mut chars = field.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('|') => out.push('|'),
+                Some('\\') => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    Value::String(arena.alloc_str(&out))
 }
 
 fn parse_cef_extensions<'bump>(
@@ -509,18 +580,14 @@ mod tests {
     }
 
     #[test]
-    fn header_with_escaped_pipe_keeps_literal() {
-        // CEF spec: `\|` inside a header field is a literal pipe, NOT
-        // a field separator. A regression that split on every `|`
-        // unconditionally would corrupt every CEF event with a piped
-        // value (common in proxy logs). Pin the current behaviour so
-        // a refactor of the header splitter can't silently drop the
-        // escape handling.
-        //
-        // NOTE: this test pins whatever behaviour parse_cef_header
-        // implements TODAY. If the parser doesn't currently handle
-        // `\|` as an escape it will assert on the byte-split result;
-        // either way the test guards against silent changes.
+    fn header_escaped_pipe_is_literal_not_separator() {
+        // CEF spec: `\|` inside a header field is a literal pipe, NOT a
+        // field separator. Splitting on it shifts every subsequent
+        // header field — name absorbed `deny\`, severity received
+        // `drop`, and the extension blob received `3|act=block`, so the
+        // positionally-determined severity was silently misclassified
+        // downstream. The splitter must honor the escape and the stored
+        // field must be unescaped.
         let bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let owned = dummy_event();
@@ -529,16 +596,154 @@ mod tests {
         // 7 fields; the `name` field contains an escaped pipe.
         let line = arena.alloc_str("CEF:0|V|P|1.0|sig|deny\\|drop|3|act=block");
         let v = parse_into(&reg, &bevent, &arena, line);
-        // Just verify parse succeeded and produced an Object — the
-        // exact name value depends on whether the parser unescapes.
-        // The regression we care about is "splitter doesn't blow up
-        // on escaped pipe AND the 7-field shape is preserved".
         let Value::Object(entries) = v else {
             panic!("expected Object on escaped-pipe input");
         };
-        // The trailing `act=block` is what tells us the 7-field
-        // count was respected (the 8th field is the extension blob).
+        assert_eq!(lookup(entries, "name"), Some(Value::String("deny|drop")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("act=block"))
+        );
         assert_eq!(ext_lookup(entries, "act"), Some(Value::String("block")));
+    }
+
+    #[test]
+    fn header_escaped_backslash_unescapes_to_single_backslash() {
+        // CEF spec: `\\` inside a header field is a literal backslash.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|A\\\\B|1.0|sig|name|3|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(
+            lookup(entries, "device_product"),
+            Some(Value::String("A\\B"))
+        );
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+    }
+
+    #[test]
+    fn header_pipe_after_escaped_backslash_separates() {
+        // `\\` consumes both backslashes, so the pipe that follows an
+        // escaped backslash IS a separator: the field `a\\` ends there
+        // and unescapes to `a\`.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|a\\\\|P|1.0|sig|name|3|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(lookup(entries, "device_vendor"), Some(Value::String("a\\")));
+        assert_eq!(lookup(entries, "device_product"), Some(Value::String("P")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+    }
+
+    #[test]
+    fn header_undefined_escape_is_preserved() {
+        // Only `\|` and `\\` are the generic structural escapes that
+        // participate in field splitting. A sequence outside those two
+        // (`\x`) is kept literally (lenient): a producer's stray
+        // backslash degrades to visible bytes rather than a parse
+        // error or silent loss.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|a\\xb|1.0|sig|tail\\|3|7|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        // `\x` is not a structural escape — both bytes survive.
+        assert_eq!(
+            lookup(entries, "device_product"),
+            Some(Value::String("a\\xb"))
+        );
+        // The `\|` inside `tail\|3` is consumed as an escape, so the
+        // name field runs through the literal pipe to the next
+        // unescaped separator — name `tail|3`, severity 7 from the
+        // following field.
+        assert_eq!(lookup(entries, "name"), Some(Value::String("tail|3")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(7)));
+    }
+
+    #[test]
+    fn header_unescape_preserves_trailing_backslash() {
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+
+        assert_eq!(
+            unescape_header_field(&arena, "tail\\"),
+            Value::String("tail\\")
+        );
+    }
+
+    #[test]
+    fn extension_raw_trailing_backslash_is_preserved() {
+        // A trailing lone `\` at the end of the *extension* section
+        // reaches `extension_raw` unmodified — the extension plane is
+        // not header-unescaped. (A complete header field ending in a
+        // lone `\` is structurally unobservable through the splitter:
+        // an odd backslash immediately before `|` always reads as the
+        // `\|` escape, so the header-side lone-backslash policy is
+        // exercised only via the unescape helper's terminal branch.)
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|P|1.0|sig|name|3|msg=x\\");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("msg=x\\"))
+        );
+    }
+
+    #[test]
+    fn header_escape_handles_utf8_and_odd_backslash_parity() {
+        // Pin two shapes the reviewer confirmed the splitter handles:
+        // multi-byte UTF-8 around an escaped pipe (the byte scan keys
+        // on ASCII `\` / `|`, which cannot occur inside a multi-byte
+        // sequence), and odd backslash parity before a pipe —
+        // `a\\\|b` is an escaped backslash followed by an escaped
+        // pipe, so nothing separates and the field unescapes to
+        // `a\|b`.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("CEF:0|V|日本\\|語|1.0|sig|a\\\\\\|b|3|act=block");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(
+            lookup(entries, "device_product"),
+            Some(Value::String("日本|語"))
+        );
+        assert_eq!(lookup(entries, "name"), Some(Value::String("a\\|b")));
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(3)));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("act=block"))
+        );
     }
 
     #[test]

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -8,6 +8,18 @@
 //!
 //! The input must start with `CEF:` — syslog wrapper handling is the
 //! caller's responsibility.
+//!
+//! The seven positionally-determined header fields land as direct keys
+//! of the result object; the data-driven Extension key=value pairs are
+//! isolated under the nested `extension` sub-object (raw blob under
+//! `extension_raw`). The two planes carry different trust: header
+//! values are fixed by position, extension keys are whatever the
+//! producer (or an injected payload) put on the wire, so they must not
+//! share a namespace. Before this split, an extension such as
+//! `severity=9` or `name=x` was pushed as a duplicate sibling of the
+//! header key — arena field reads resolved first-wins (header) but the
+//! owned workspace snapshot resolved last-wins, so downstream processes
+//! saw the header value silently replaced by the extension value.
 
 use crate::dsl::arena::EventArena;
 use crate::dsl::value::{ObjectBuilder, Value};
@@ -37,15 +49,19 @@ pub fn register(reg: &mut FunctionRegistry) {
                 FieldType::Union(vec![FieldType::Int, FieldType::String]),
             ),
             // Raw extension blob, as it appeared on the wire (before
-            // the `key=value` split that flattens individual fields
-            // into siblings of the header keys). Present only when the
-            // Extension section was non-empty; omitted otherwise to
-            // mirror `syslog.parse`'s treatment of `msg`. Useful for
+            // the `key=value` split). Present only when the Extension
+            // section was non-empty; omitted otherwise to mirror
+            // `syslog.parse`'s treatment of `msg`. Useful for
             // passthrough / re-emission, debugging the splitter, or
             // surfacing dialect-specific extension content that the
             // splitter doesn't decode (escape sequences, custom
             // separators).
-            FieldSpec::new(&["workspace", "ext"], FieldType::String),
+            FieldSpec::new(&["workspace", "extension_raw"], FieldType::String),
+            // Split extension key=value pairs, isolated in their own
+            // sub-object so data-driven keys can never collide with the
+            // positional header fields above. Individual keys are
+            // data-driven (wildcards).
+            FieldSpec::new(&["workspace", "extension"], FieldType::Object),
         ],
         wildcards: true,
         defaults_arg_indices: &[1],
@@ -88,15 +104,17 @@ fn parse_impl<'bump>(
     builder.push("severity", severity_value);
 
     // Emit the raw extension blob (omitted when empty, to mirror
-    // `syslog.parse`'s treatment of `msg`). This must come BEFORE the
-    // split so the raw form is captured before the splitter consumes
-    // its input; the split itself does not mutate `remaining`, but
-    // keeping the ordering explicit avoids future regressions.
+    // `syslog.parse`'s treatment of `msg`), then the split pairs in
+    // their own `extension` sub-object. The nesting is the collision
+    // barrier: extension keys named after header fields (`severity=`,
+    // `name=`, dialect quirks or log injection alike) stay in the
+    // extension plane and can never shadow a positional header value.
     if !remaining.is_empty() {
-        builder.push("ext", Value::String(arena.alloc_str(remaining)));
+        builder.push("extension_raw", Value::String(arena.alloc_str(remaining)));
+        let mut ext_builder = ObjectBuilder::new(arena);
+        parse_cef_extensions(arena, remaining, &mut ext_builder);
+        builder.push("extension", ext_builder.finish());
     }
-
-    parse_cef_extensions(arena, remaining, &mut builder);
 
     let parsed = builder.finish();
 
@@ -210,6 +228,17 @@ mod tests {
             .expect("parse should succeed")
     }
 
+    /// Look a key up inside the nested `extension` sub-object.
+    fn ext_lookup<'bump>(
+        entries: &'bump [(&'bump str, Value<'bump>)],
+        key: &str,
+    ) -> Option<Value<'bump>> {
+        let Some(Value::Object(ext)) = lookup(entries, "extension") else {
+            return None;
+        };
+        lookup(ext, key)
+    }
+
     #[test]
     fn header_fields_extracted() {
         let bump = ::bumpalo::Bump::new();
@@ -241,11 +270,11 @@ mod tests {
     }
 
     #[test]
-    fn extension_split_into_flat_keys_and_raw_ext() {
-        // Both forms must be present: the flat per-key form
-        // (`workspace.cef.src` etc., the documented authoring
-        // surface) AND the raw `ext` blob (the spec-bug fix —
-        // previously the raw form was lost).
+    fn extension_split_into_nested_keys_and_raw_blob() {
+        // Both forms must be present: the split per-key form under the
+        // nested `extension` sub-object (the documented authoring
+        // surface, isolated from the positional header plane) AND the
+        // raw `extension_raw` blob.
         let bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let owned = dummy_event();
@@ -258,24 +287,24 @@ mod tests {
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        // Flat per-key form
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
-        assert_eq!(lookup(entries, "dst"), Some(Value::String("10.0.0.2")));
-        assert_eq!(lookup(entries, "act"), Some(Value::String("accept")));
-        // Raw ext blob
+        // Split per-key form, isolated under `extension`
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "dst"), Some(Value::String("10.0.0.2")));
+        assert_eq!(ext_lookup(entries, "act"), Some(Value::String("accept")));
+        // Raw blob
         assert_eq!(
-            lookup(entries, "ext"),
+            lookup(entries, "extension_raw"),
             Some(Value::String("src=10.0.0.1 dst=10.0.0.2 act=accept"))
         );
     }
 
     #[test]
-    fn empty_extensions_omits_ext_field() {
-        // CEF allows an empty Extension section. When empty, `ext`
-        // must be omitted entirely (mirrors syslog.parse's treatment
-        // of empty `msg`), so callers can write `if workspace.cef.ext
-        // { ... }` against a presence test rather than against an
-        // empty-string test.
+    fn empty_extensions_omits_extension_fields() {
+        // CEF allows an empty Extension section. When empty, both
+        // `extension_raw` and the `extension` sub-object must be
+        // omitted entirely (mirrors syslog.parse's treatment of empty
+        // `msg`), so callers can write presence tests rather than
+        // empty-string tests.
         let bump = ::bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let owned = dummy_event();
@@ -289,10 +318,14 @@ mod tests {
         // Header still emitted.
         assert_eq!(lookup(entries, "version"), Some(Value::String("0")));
         assert_eq!(lookup(entries, "severity"), Some(Value::Int(5)));
-        // ext must be absent (not "" or null).
+        // Both extension planes must be absent (not "" or null).
         assert!(
-            lookup(entries, "ext").is_none(),
-            "ext key must be omitted when Extensions are empty"
+            lookup(entries, "extension_raw").is_none(),
+            "extension_raw must be omitted when Extensions are empty"
+        );
+        assert!(
+            lookup(entries, "extension").is_none(),
+            "extension sub-object must be omitted when Extensions are empty"
         );
     }
 
@@ -333,11 +366,11 @@ mod tests {
             panic!("expected Object");
         };
         assert_eq!(
-            lookup(entries, "msg"),
+            ext_lookup(entries, "msg"),
             Some(Value::String("Failed login attempt"))
         );
-        assert_eq!(lookup(entries, "user"), Some(Value::String("alice")));
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "user"), Some(Value::String("alice")));
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
     }
 
     #[test]
@@ -439,10 +472,10 @@ mod tests {
             panic!("expected Object");
         };
         assert_eq!(
-            lookup(entries, "request"),
+            ext_lookup(entries, "request"),
             Some(Value::String("https://x.example.com/a?b=1&c=2"))
         );
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
     }
 
     #[test]
@@ -464,12 +497,15 @@ mod tests {
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        assert_eq!(lookup(entries, "vendor_field"), Some(Value::String("v1")));
         assert_eq!(
-            lookup(entries, "cs1Label"),
+            ext_lookup(entries, "vendor_field"),
+            Some(Value::String("v1"))
+        );
+        assert_eq!(
+            ext_lookup(entries, "cs1Label"),
             Some(Value::String("Source IP"))
         );
-        assert_eq!(lookup(entries, "cs1"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "cs1"), Some(Value::String("10.0.0.1")));
     }
 
     #[test]
@@ -502,7 +538,7 @@ mod tests {
         };
         // The trailing `act=block` is what tells us the 7-field
         // count was respected (the 8th field is the extension blob).
-        assert_eq!(lookup(entries, "act"), Some(Value::String("block")));
+        assert_eq!(ext_lookup(entries, "act"), Some(Value::String("block")));
     }
 
     #[test]
@@ -510,8 +546,9 @@ mod tests {
         // Some vendors emit the same key twice (intentionally for
         // multi-value sources, accidentally for buggy templates).
         // `ObjectBuilder` does not deduplicate, so both `src` entries
-        // are emitted in source order; `lookup` returns the first
-        // match, making the observable semantics first-one-wins. Pin
+        // are emitted in source order inside the `extension`
+        // sub-object; `ext_lookup` returns the first match, making the
+        // observable semantics first-one-wins. Pin
         // it here so a future change to dedup or reverse insertion
         // order is a visible, intentional break instead of a silent
         // downstream-pipeline behaviour flip.
@@ -526,7 +563,50 @@ mod tests {
         let Value::Object(entries) = v else {
             panic!("expected Object");
         };
-        assert_eq!(lookup(entries, "src"), Some(Value::String("10.0.0.1")));
-        assert_eq!(lookup(entries, "dst"), Some(Value::String("8.8.8.8")));
+        assert_eq!(ext_lookup(entries, "src"), Some(Value::String("10.0.0.1")));
+        assert_eq!(ext_lookup(entries, "dst"), Some(Value::String("8.8.8.8")));
+    }
+
+    #[test]
+    fn header_named_extension_keys_cannot_shadow_header_fields() {
+        // Extensions named after header fields (`severity=`, `name=`,
+        // `ext=`) — dialect quirks, buggy templates, or log injection —
+        // must stay isolated in the `extension` sub-object. Before the
+        // split, `ObjectBuilder` pushed them as duplicate siblings of
+        // the header keys: arena field reads resolved first-wins (the
+        // header), but the owned workspace snapshot resolved last-wins,
+        // so a downstream process read `severity = "9"` in place of the
+        // positional header value 7. The nesting removes the duplicate
+        // keys entirely.
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena
+            .alloc_str("CEF:0|Vendor|Product|1.0|100|realname|7|severity=9 name=fakename ext=x");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        // Header plane untouched.
+        assert_eq!(lookup(entries, "severity"), Some(Value::Int(7)));
+        assert_eq!(lookup(entries, "name"), Some(Value::String("realname")));
+        // No duplicate top-level keys: each header key appears once.
+        for key in ["severity", "name"] {
+            assert_eq!(
+                entries.iter().filter(|(k, _)| *k == key).count(),
+                1,
+                "header key {key} must appear exactly once"
+            );
+        }
+        // Colliding extensions isolated in the extension plane.
+        assert_eq!(ext_lookup(entries, "severity"), Some(Value::String("9")));
+        assert_eq!(ext_lookup(entries, "name"), Some(Value::String("fakename")));
+        assert_eq!(ext_lookup(entries, "ext"), Some(Value::String("x")));
+        assert_eq!(
+            lookup(entries, "extension_raw"),
+            Some(Value::String("severity=9 name=fakename ext=x"))
+        );
     }
 }

--- a/crates/limpid/src/functions/cef/parse.rs
+++ b/crates/limpid/src/functions/cef/parse.rs
@@ -63,7 +63,8 @@ pub fn register(reg: &mut FunctionRegistry) {
             // data-driven (wildcards).
             FieldSpec::new(&["workspace", "extension"], FieldType::Object),
         ],
-        wildcards: true,
+        wildcards: false,
+        scoped_wildcards: vec![vec!["workspace".to_string(), "extension".to_string()]],
         defaults_arg_indices: &[1],
         defaults_arg_extractor: None,
     });

--- a/crates/limpid/src/functions/mod.rs
+++ b/crates/limpid/src/functions/mod.rs
@@ -145,9 +145,10 @@ pub type DefaultsArgExtractor =
 /// needs to know *which keys* a bare `parse_xxx(text)` call contributes
 /// to workspace, with *what types*, so downstream `workspace.*` references
 /// type-check. `produces` is the static answer; `wildcards = true` means
-/// the key set is data-driven (e.g. `parse_json`) and the analyzer should
-/// fall back to wildcard unless the caller pins a schema via the
-/// optional defaults HashLit argument.
+/// the whole key set is data-driven (e.g. `parse_json`) and the analyzer
+/// should fall back to wildcard unless the caller pins a schema via the
+/// optional defaults HashLit argument. `scoped_wildcards` handles parsers
+/// such as `cef.parse`, where only one nested subtree is data-driven.
 ///
 /// Parsers are registered alongside their implementation; the analyzer
 /// looks them up via [`FunctionRegistry::parser`].
@@ -183,10 +184,14 @@ pub struct ParserInfo {
     /// `(workspace key, type)` pairs the parser is known to emit. Empty
     /// when `wildcards = true` and there's no static structure.
     pub produces: Vec<FieldSpec>,
-    /// True when the output key set is determined by the input rather
-    /// than statically known (parse_json, parse_kv, parse_cef
-    /// extensions, etc.).
+    /// True when the entire output key set is determined by the input
+    /// rather than statically known (for example `parse_json` or
+    /// `parse_kv`).
     pub wildcards: bool,
+    /// Dynamic output subtrees whose keys are data-driven while the rest
+    /// of workspace remains statically described. Each path includes the
+    /// `workspace` root (for example `workspace.extension`).
+    pub scoped_wildcards: Vec<Vec<String>>,
     /// Positional indices where a `defaults` HashLit may appear. The
     /// analyzer scans these slots and uses the first HashLit found to
     /// pin precise workspace keys; if none match, wildcard parsers fall
@@ -389,6 +394,11 @@ impl FunctionRegistry {
     pub fn parser(&self, namespace: Option<&str>, name: &str) -> Option<&ParserInfo> {
         let key = (namespace.map(str::to_string), name.to_string());
         self.parsers.get(&key)
+    }
+
+    /// Whether `name` resolves to a user-defined flat function.
+    pub fn is_user_function(&self, name: &str) -> bool {
+        self.user_definitions.contains_key(name)
     }
 
     /// Dispatch a function call. `namespace = None` hits the flat
@@ -597,6 +607,27 @@ mod tests {
         )
     }
 
+    #[test]
+    fn partial_primitive_signatures_are_nullable() {
+        let reg = make_registry();
+        for (namespace, name, present) in [
+            (None, "regex_extract", FieldType::String),
+            (Some("syslog"), "extract_pri", FieldType::Int),
+            (None, "to_int", FieldType::Int),
+            (None, "len", FieldType::Int),
+            (None, "csv_parse", FieldType::Object),
+            (None, "append", FieldType::Array),
+            (None, "prepend", FieldType::Array),
+            (None, "hostname", FieldType::String),
+        ] {
+            assert_eq!(
+                reg.signature(namespace, name).unwrap().ret,
+                FieldType::union(present, FieldType::Null),
+                "{name} return contract"
+            );
+        }
+    }
+
     fn ts_value(s: &str) -> Value<'static> {
         Value::Timestamp(
             chrono::DateTime::parse_from_rfc3339(s)
@@ -663,13 +694,36 @@ mod tests {
                 &[
                     ts_value("2026-04-19T10:30:45+09:00"),
                     Value::String(arena.alloc_str("%Y-%m-%dT%H:%M:%S%z")),
-                    Value::String(arena.alloc_str("UTC")),
+                    Value::String(arena.alloc_str("uTc")),
                 ],
                 &bevent,
                 &arena,
             )
             .unwrap();
         assert_eq!(result, Value::String("2026-04-19T01:30:45+0000"));
+    }
+
+    #[test]
+    fn strftime_local_keyword_is_ascii_case_insensitive() {
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_owned();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let result = reg
+            .call(
+                None,
+                "strftime",
+                &[
+                    ts_value("2026-04-19T10:30:45+00:00"),
+                    Value::String(arena.alloc_str("%Y-%m-%d")),
+                    Value::String(arena.alloc_str("LoCaL")),
+                ],
+                &bevent,
+                &arena,
+            )
+            .unwrap();
+        assert!(matches!(result, Value::String(_)));
     }
 
     #[test]

--- a/crates/limpid/src/functions/otlp/encode.rs
+++ b/crates/limpid/src/functions/otlp/encode.rs
@@ -68,7 +68,10 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_in_with_sig(
         "otlp",
         "decode_resourcelog_protobuf",
-        FunctionSig::fixed(&[FieldType::Bytes], FieldType::Object),
+        FunctionSig::fixed(
+            &[FieldType::union(FieldType::String, FieldType::Bytes)],
+            FieldType::Object,
+        ),
         |arena, args, _event| {
             let bytes: &[u8] = match &args[0] {
                 Value::Bytes(b) => b,
@@ -97,7 +100,10 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_in_with_sig(
         "otlp",
         "decode_resourcelog_json",
-        FunctionSig::fixed(&[FieldType::String], FieldType::Object),
+        FunctionSig::fixed(
+            &[FieldType::union(FieldType::String, FieldType::Bytes)],
+            FieldType::Object,
+        ),
         |arena, args, _event| {
             let s: &str = match &args[0] {
                 Value::String(s) => s,

--- a/crates/limpid/src/functions/primitives/append.rs
+++ b/crates/limpid/src/functions/primitives/append.rs
@@ -9,7 +9,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "append",
-        FunctionSig::fixed(&[FieldType::Array, FieldType::Any], FieldType::Array),
+        FunctionSig::fixed(
+            &[FieldType::Array, FieldType::Any],
+            FieldType::union(FieldType::Array, FieldType::Null),
+        ),
         |arena, args, _event| Ok(push_back(arena, &args[0], &args[1])),
     );
 }

--- a/crates/limpid/src/functions/primitives/csv_parse.rs
+++ b/crates/limpid/src/functions/primitives/csv_parse.rs
@@ -24,7 +24,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "csv_parse",
-        FunctionSig::fixed(&[FieldType::String, FieldType::Any], FieldType::Object),
+        FunctionSig::fixed(
+            &[FieldType::String, FieldType::Any],
+            FieldType::union(FieldType::Object, FieldType::Null),
+        ),
         |arena, args, _event| Ok(parse(arena, &args[0], &args[1])),
     );
 }

--- a/crates/limpid/src/functions/primitives/filter.rs
+++ b/crates/limpid/src/functions/primitives/filter.rs
@@ -1,4 +1,11 @@
-//! `filter(arr) { |x| body }` — block-arg primitive.
+//! `filter(array) { |value| predicate }` /
+//! `filter(object) { |key, value| predicate }` — block-arg primitive.
+//!
+//! Arrays bind one block parameter and return an Array containing the
+//! truthy elements. Objects bind the entry key and value as two
+//! parameters and return an Object containing the truthy entries in
+//! insertion order. `Null` follows the empty-Array form, requires one
+//! block parameter, and returns an empty Array.
 //!
 //! See `map.rs` for the dispatch story (real evaluation in
 //! `eval::eval_block_primitive`; this stub installs the signature and
@@ -7,10 +14,15 @@ use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "filter",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Array),
+        FunctionSig::fixed(
+            &[block_collection_type()],
+            FieldType::Union(vec![FieldType::Array, FieldType::Object]),
+        ),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!(
                 "filter() requires a block argument: `filter(arr) {{ |x| <predicate> }}`"

--- a/crates/limpid/src/functions/primitives/find.rs
+++ b/crates/limpid/src/functions/primitives/find.rs
@@ -1,5 +1,11 @@
-//! `find(arr) { |x| body }` — return the first element where the block
-//! returns truthy, or `null`.
+//! `find(array) { |value| predicate }` /
+//! `find(object) { |key, value| predicate }` — find the first match.
+//!
+//! Arrays bind one block parameter and return the first matching
+//! element. Objects bind the entry key and value as two parameters and
+//! return the first match as a `[key, value]` Array. A miss returns
+//! `Null`; `Null` input follows the empty-Array form and requires one
+//! block parameter.
 //!
 //! Replaces the v0.7.3-and-earlier `find_by(arr, key, value)`. Real
 //! evaluation lives in `eval::eval_block_primitive`; this stub installs
@@ -10,10 +16,12 @@ use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "find",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Any),
+        FunctionSig::fixed(&[block_collection_type()], FieldType::Any),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!("find() requires a block argument: `find(arr) {{ |x| <predicate> }}`");
         },

--- a/crates/limpid/src/functions/primitives/hostname.rs
+++ b/crates/limpid/src/functions/primitives/hostname.rs
@@ -22,7 +22,7 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "hostname",
-        FunctionSig::fixed(&[], FieldType::String),
+        FunctionSig::fixed(&[], FieldType::union(FieldType::String, FieldType::Null)),
         |arena, _args, _event| {
             let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                 gethostname::gethostname().to_string_lossy().into_owned()

--- a/crates/limpid/src/functions/primitives/len.rs
+++ b/crates/limpid/src/functions/primitives/len.rs
@@ -15,7 +15,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "len",
-        FunctionSig::fixed(&[FieldType::Any], FieldType::Int),
+        FunctionSig::fixed(
+            &[FieldType::Any],
+            FieldType::union(FieldType::Int, FieldType::Null),
+        ),
         |_arena, args, _event| Ok(measure(&args[0])),
     );
 }

--- a/crates/limpid/src/functions/primitives/map.rs
+++ b/crates/limpid/src/functions/primitives/map.rs
@@ -1,7 +1,13 @@
-//! `map(arr) { |x| body }` — block-arg primitive.
+//! `map(array) { |value| body }` /
+//! `map(object) { |key, value| body }` — block-arg primitive.
+//!
+//! Arrays bind one block parameter per element. Objects bind the entry
+//! key and value as two parameters. Both forms collect block results
+//! into an Array in insertion order. `Null` follows the empty-Array
+//! form, requires one block parameter, and returns an empty Array.
 //!
 //! Real evaluation happens in [`crate::dsl::eval::eval_block_primitive`];
-//! call sites with a trailing `{ |x| body }` are intercepted at the
+//! call sites with a trailing block are intercepted at the
 //! `ExprKind::FuncCall` arm before ordinary primitive dispatch. The
 //! registration here exists so that:
 //!
@@ -9,16 +15,19 @@
 //! - a call site missing its block (e.g. `map(arr)`) routes through this
 //!   stub, which loud-fails with a clear error.
 //!
-//! Signature: `map(Array) -> Array`. The body's per-element return type
-//! is `Any` (block bodies are not pinned by FieldType today).
+//! Signature: `map(Array | Object | Null) -> Array`. The body's
+//! per-element return type is `Any` (block bodies are not pinned by
+//! FieldType today).
 use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "map",
-        FunctionSig::fixed(&[FieldType::Array], FieldType::Array),
+        FunctionSig::fixed(&[block_collection_type()], FieldType::Array),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!("map() requires a block argument: `map(arr) {{ |x| <body> }}`");
         },

--- a/crates/limpid/src/functions/primitives/mod.rs
+++ b/crates/limpid/src/functions/primitives/mod.rs
@@ -18,6 +18,8 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
+use crate::dsl::field_schema::FieldType;
+
 use super::FunctionRegistry;
 use super::table::TableStore;
 
@@ -119,6 +121,11 @@ pub fn register(reg: &mut FunctionRegistry, table_store: TableStore) {
 // ---------------------------------------------------------------------------
 // Shared helpers used by multiple primitive implementations.
 // ---------------------------------------------------------------------------
+
+/// Static input contract shared by block collection primitives.
+pub(super) fn block_collection_type() -> FieldType {
+    FieldType::Union(vec![FieldType::Array, FieldType::Object, FieldType::Null])
+}
 
 /// Coerce a value to a string the way DSL arithmetic / string
 /// primitives expect: string-through, null-as-empty, everything else via

--- a/crates/limpid/src/functions/primitives/parse_json.rs
+++ b/crates/limpid/src/functions/primitives/parse_json.rs
@@ -22,6 +22,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         name: "parse_json",
         produces: Vec::new(),
         wildcards: true,
+        scoped_wildcards: Vec::new(),
         defaults_arg_indices: &[1],
         defaults_arg_extractor: None,
     });

--- a/crates/limpid/src/functions/primitives/parse_kv.rs
+++ b/crates/limpid/src/functions/primitives/parse_kv.rs
@@ -34,6 +34,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         name: "parse_kv",
         produces: Vec::new(),
         wildcards: true,
+        scoped_wildcards: Vec::new(),
         // Retained for documentation; the extractor below takes over
         // the actual scan because parse_kv's defaults position depends
         // on the type of `args[1]`.

--- a/crates/limpid/src/functions/primitives/prepend.rs
+++ b/crates/limpid/src/functions/primitives/prepend.rs
@@ -9,7 +9,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "prepend",
-        FunctionSig::fixed(&[FieldType::Array, FieldType::Any], FieldType::Array),
+        FunctionSig::fixed(
+            &[FieldType::Array, FieldType::Any],
+            FieldType::union(FieldType::Array, FieldType::Null),
+        ),
         |arena, args, _event| Ok(push_front(arena, &args[0], &args[1])),
     );
 }

--- a/crates/limpid/src/functions/primitives/reduce.rs
+++ b/crates/limpid/src/functions/primitives/reduce.rs
@@ -1,16 +1,23 @@
-//! `reduce(arr, init) { |acc, x| body }` — left fold.
+//! `reduce(array, init) { |acc, value| step }` /
+//! `reduce(object, init) { |acc, key, value| step }` — left fold.
 //!
-//! Block takes two parameters: the running accumulator and the current
-//! element. Real evaluation lives in `eval::eval_block_primitive`; this
-//! stub installs the signature and the missing-block error.
+//! Arrays bind the accumulator and current element as two block
+//! parameters. Objects bind the accumulator, entry key, and entry value
+//! as three parameters. Both forms fold in insertion order and return
+//! the final accumulator. `Null` follows the empty-Array form, requires
+//! two block parameters, and returns `init` unchanged. Real evaluation
+//! lives in `eval::eval_block_primitive`; this stub installs the
+//! signature and the missing-block error.
 use crate::dsl::field_schema::FieldType;
 use crate::dsl::value::Value;
 use crate::functions::{FunctionRegistry, FunctionSig};
 
+use super::block_collection_type;
+
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "reduce",
-        FunctionSig::fixed(&[FieldType::Array, FieldType::Any], FieldType::Any),
+        FunctionSig::fixed(&[block_collection_type(), FieldType::Any], FieldType::Any),
         |_arena, _args, _event| -> anyhow::Result<Value<'_>> {
             anyhow::bail!(
                 "reduce() requires a block argument: `reduce(arr, init) {{ |acc, x| <step> }}`"

--- a/crates/limpid/src/functions/primitives/regex_extract.rs
+++ b/crates/limpid/src/functions/primitives/regex_extract.rs
@@ -15,7 +15,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "regex_extract",
-        FunctionSig::fixed(&[FieldType::String, FieldType::String], FieldType::String),
+        FunctionSig::fixed(
+            &[FieldType::String, FieldType::String],
+            FieldType::union(FieldType::String, FieldType::Null),
+        ),
         |arena, args, _event| {
             let target = val_to_str(&args[0])?;
             let pattern = val_to_str(&args[1])?;

--- a/crates/limpid/src/functions/primitives/regex_parse.rs
+++ b/crates/limpid/src/functions/primitives/regex_parse.rs
@@ -64,6 +64,7 @@ pub fn register(reg: &mut FunctionRegistry) {
         name: "regex_parse",
         produces: Vec::new(),
         wildcards: true,
+        scoped_wildcards: Vec::new(),
         defaults_arg_indices: &[],
         defaults_arg_extractor: None,
     });

--- a/crates/limpid/src/functions/primitives/strftime.rs
+++ b/crates/limpid/src/functions/primitives/strftime.rs
@@ -47,8 +47,10 @@ pub fn register(reg: &mut FunctionRegistry) {
 
             let formatted = match tz.as_deref() {
                 None => dt.format(&fmt).to_string(),
-                Some("local") => dt.with_timezone(&chrono::Local).format(&fmt).to_string(),
-                Some("UTC") | Some("utc") => {
+                Some(timezone) if timezone.eq_ignore_ascii_case("local") => {
+                    dt.with_timezone(&chrono::Local).format(&fmt).to_string()
+                }
+                Some(timezone) if timezone.eq_ignore_ascii_case("UTC") => {
                     dt.with_timezone(&chrono::Utc).format(&fmt).to_string()
                 }
                 Some(timezone) => {

--- a/crates/limpid/src/functions/primitives/strptime.rs
+++ b/crates/limpid/src/functions/primitives/strptime.rs
@@ -72,7 +72,7 @@ fn parse_with_tz(value: &str, fmt: &str, tz: Option<&str>) -> Result<DateTime<Fi
         )
     })?;
     match tz {
-        "local" => Ok(chrono::Local
+        timezone if timezone.eq_ignore_ascii_case("local") => Ok(chrono::Local
             .from_local_datetime(&naive)
             .single()
             .ok_or_else(|| {
@@ -82,7 +82,7 @@ fn parse_with_tz(value: &str, fmt: &str, tz: Option<&str>) -> Result<DateTime<Fi
                 )
             })?
             .fixed_offset()),
-        "UTC" | "utc" => {
+        timezone if timezone.eq_ignore_ascii_case("UTC") => {
             let offset = FixedOffset::east_opt(0).unwrap();
             Ok(offset.from_utc_datetime(&naive))
         }
@@ -142,5 +142,13 @@ mod tests {
                 .to_string()
                 .contains("ambiguous or invalid local time")
         );
+    }
+
+    #[test]
+    fn timezone_keywords_are_ascii_case_insensitive() {
+        let utc = parse_with_tz("2026-04-30 10:23:45", "%Y-%m-%d %H:%M:%S", Some("uTc")).unwrap();
+        assert_eq!(utc.offset().local_minus_utc(), 0);
+
+        parse_with_tz("2026-04-30 10:23:45", "%Y-%m-%d %H:%M:%S", Some("LoCaL")).unwrap();
     }
 }

--- a/crates/limpid/src/functions/primitives/to_int.rs
+++ b/crates/limpid/src/functions/primitives/to_int.rs
@@ -19,7 +19,10 @@ use crate::functions::{FunctionRegistry, FunctionSig};
 pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "to_int",
-        FunctionSig::fixed(&[FieldType::Any], FieldType::Int),
+        FunctionSig::fixed(
+            &[FieldType::Any],
+            FieldType::union(FieldType::Int, FieldType::Null),
+        ),
         |_arena, args, _event| coerce(&args[0]),
     );
 }

--- a/crates/limpid/src/functions/primitives/to_string.rs
+++ b/crates/limpid/src/functions/primitives/to_string.rs
@@ -12,7 +12,11 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_with_sig(
         "to_string",
         FunctionSig::optional(
-            &[FieldType::Bytes, FieldType::String, FieldType::Bool],
+            &[
+                FieldType::union(FieldType::String, FieldType::Bytes),
+                FieldType::String,
+                FieldType::Bool,
+            ],
             1,
             FieldType::String,
         ),

--- a/crates/limpid/src/functions/syslog/extract_pri.rs
+++ b/crates/limpid/src/functions/syslog/extract_pri.rs
@@ -12,7 +12,10 @@ pub fn register(reg: &mut FunctionRegistry) {
     reg.register_in_with_sig(
         "syslog",
         "extract_pri",
-        FunctionSig::fixed(&[FieldType::String], FieldType::Int),
+        FunctionSig::fixed(
+            &[FieldType::String],
+            FieldType::union(FieldType::Int, FieldType::Null),
+        ),
         |_arena, args, _event| {
             let input = val_to_str(&args[0])?;
             Ok(parse_leading_pri(&input)

--- a/crates/limpid/src/functions/syslog/parse.rs
+++ b/crates/limpid/src/functions/syslog/parse.rs
@@ -52,6 +52,7 @@ pub fn register(reg: &mut FunctionRegistry) {
             FieldSpec::new(&["workspace", "msg"], FieldType::String),
         ],
         wildcards: false,
+        scoped_wildcards: Vec::new(),
         defaults_arg_indices: &[1],
         defaults_arg_extractor: None,
     });

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -1472,6 +1472,7 @@ def pipeline p {
             "packaging/snippets/parsers/parse_azure_activity.limpid",
             "packaging/snippets/parsers/parse_bind.limpid",
             "packaging/snippets/parsers/parse_checkpoint_leef.limpid",
+            "packaging/snippets/parsers/parse_cef.limpid",
             "packaging/snippets/parsers/parse_checkpoint_syslog.limpid",
             "packaging/snippets/parsers/parse_cloudtrail.limpid",
             "packaging/snippets/parsers/parse_combined_log.limpid",
@@ -1577,7 +1578,13 @@ def pipeline suricata_otlp {
 
 def pipeline asa_otlp {
     input i
-    process parse_asa | asa_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_asa | asa_to_otlp | compose_otlp | otlp_to_egress
+    output o
+}
+
+def pipeline cef_otlp {
+    input i
+    process parse_syslog | parse_cef | cef_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
@@ -1595,7 +1602,7 @@ def pipeline checkpoint_syslog_otlp {
 
 def pipeline fortigate_cef_otlp {
     input i
-    process parse_fortigate_cef | fortigate_cef_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | fortigate_cef_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
@@ -1619,13 +1626,13 @@ def pipeline nsp_otlp {
 
 def pipeline paloalto_cef_otlp {
     input i
-    process parse_paloalto_cef | paloalto_cef_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_cef | parse_paloalto_cef | paloalto_cef_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
 def pipeline paloalto_native_otlp {
     input i
-    process parse_paloalto_syslog | paloalto_syslog_to_otlp | compose_otlp | otlp_to_egress
+    process parse_syslog | parse_paloalto_syslog | paloalto_syslog_to_otlp | compose_otlp | otlp_to_egress
     output o
 }
 
@@ -1712,7 +1719,7 @@ def pipeline zeek_full_otlp {
     }
 
     fn run_packaged_parser_pipeline(
-        parser: &str,
+        parsers: &[&str],
         setup: Option<&str>,
         process: &str,
         ingress: &[u8],
@@ -1728,7 +1735,10 @@ def pipeline zeek_full_otlp {
             .prefix(".limpid-parser-test-")
             .tempfile_in(&snippets)
             .expect("temporary packaged parser config");
-        writeln!(config_file, "include \"parsers/{parser}.limpid\"").expect("write parser include");
+        for parser in parsers {
+            writeln!(config_file, "include \"parsers/{parser}.limpid\"")
+                .expect("write parser include");
+        }
         writeln!(
             config_file,
             "def input i {{ type syslog_tcp bind \"127.0.0.1:5514\" }}\n\
@@ -1781,12 +1791,12 @@ def pipeline zeek_full_otlp {
     }
 
     fn run_packaged_parser_json(
-        parser: &str,
+        parsers: &[&str],
         setup: Option<&str>,
         process: &str,
         ingress: &[u8],
     ) -> serde_json::Value {
-        let result = run_packaged_parser_pipeline(parser, setup, process, ingress);
+        let result = run_packaged_parser_pipeline(parsers, setup, process, ingress);
         assert_eq!(
             result.termination,
             PipelineTermination::Finished,
@@ -1847,9 +1857,9 @@ def pipeline zeek_full_otlp {
             .expect("fixture fits i64");
 
         let asa = run_packaged_parser_json(
-            "parse_asa",
+            &["parse_syslog", "parse_asa"],
             Some("workspace.asa = { timezone: \"UTC\" }"),
-            "parse_asa",
+            "parse_syslog | parse_asa",
             format!(
                 "<165>{rfc3164_wire} fw-asa01 : %ASA-6-605005: Login permitted from 192.0.2.10/54321 to outside:198.51.100.5/SSH for user admin"
             )
@@ -1858,7 +1868,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(asa["time"], rfc3164_expected);
 
         let auditd = run_packaged_parser_json(
-            "parse_auditd",
+            &["parse_auditd"],
             Some("workspace.auditd = { body: ingress }"),
             "parse_auditd",
             b"type=USER_LOGIN msg=audit(1710000000.123:1): pid=42 uid=0 auid=1000 ses=1 res=success acct=alice addr=192.0.2.10 terminal=pts/0 exe=/usr/bin/login",
@@ -1866,7 +1876,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(auditd["time"], 1_710_000_000_123_000_000_i64);
 
         let bind = run_packaged_parser_json(
-            "parse_bind",
+            &["parse_bind"],
             Some(
                 "workspace.bind = { body: ingress, hostname: \"dns01\", timezone: \"Asia/Tokyo\" }",
             ),
@@ -1876,7 +1886,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(bind["time"], 1_777_512_225_123_000_000_i64);
 
         let checkpoint_leef = run_packaged_parser_json(
-            "parse_checkpoint_leef",
+            &["parse_checkpoint_leef"],
             Some("workspace.checkpoint_leef = { body: ingress }"),
             "parse_checkpoint_leef",
             b"<14>1 2026-04-30T01:23:45.123456789Z cpgw01 CheckPoint - - LEEF:2.0|Check Point|VPN-1 & FireWall-1|R81|Accept|src=192.0.2.10\tdst=198.51.100.5\tsrcPort=51234\tdstPort=443\tproto=tcp\taction=Accept",
@@ -1884,7 +1894,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(checkpoint_leef["time"], 1_777_512_225_123_456_789_i64);
 
         let checkpoint_syslog = run_packaged_parser_json(
-            "parse_checkpoint_syslog",
+            &["parse_checkpoint_syslog"],
             Some("workspace.checkpoint_syslog = { body: ingress }"),
             "parse_checkpoint_syslog",
             b"<14>1 2026-04-30T01:23:45.123456789Z cpgw01 CheckPoint - - [action:\"Accept\"; src:\"192.0.2.10\"; dst:\"198.51.100.5\"; service:\"443\"; proto:\"tcp\"; product:\"VPN-1 & FireWall-1\"; severity:\"Low\"]",
@@ -1892,9 +1902,9 @@ def pipeline zeek_full_otlp {
         assert_eq!(checkpoint_syslog["time"], 1_777_512_225_123_456_789_i64);
 
         let fortigate_cef = run_packaged_parser_json(
-            "parse_fortigate_cef",
+            &["parse_syslog", "parse_cef", "parse_fortigate_cef"],
             Some("workspace.fortigate_cef = { timezone: \"UTC\" }"),
-            "parse_fortigate_cef",
+            "parse_syslog | parse_cef | parse_fortigate_cef",
             format!(
                 "<129>{rfc3164_wire} fw01 CEF:0|Fortinet|Fortigate|v7.4.11|16384|utm:ips signature|7|cat=utm:ips src=192.0.2.10 dst=198.51.100.5 proto=6 act=detected FTNTFGTattack=test FTNTFGTattackid=42"
             )
@@ -1903,7 +1913,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(fortigate_cef["time"], rfc3164_expected);
 
         let fortigate_native = run_packaged_parser_json(
-            "parse_fortigate_syslog",
+            &["parse_fortigate_syslog"],
             None,
             "parse_fortigate_syslog",
             b"<134>eventtime=1777284000123456789 level=notice type=traffic subtype=forward srcip=192.0.2.10 dstip=198.51.100.5 proto=6 action=accept",
@@ -1911,7 +1921,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(fortigate_native["time"], 1_777_284_000_123_456_789_i64);
 
         let juniper_sd = run_packaged_parser_json(
-            "parse_juniper_srx_sd_syslog",
+            &["parse_juniper_srx_sd_syslog"],
             Some("workspace.juniper_srx_sd_syslog = { body: ingress }"),
             "parse_juniper_srx_sd_syslog",
             b"<14>1 2026-04-30T01:23:45.123456789Z srx01 RT_FLOW - RT_FLOW_SESSION_CREATE [junos@2636 source-address=\"192.0.2.10\" source-port=\"54321\" destination-address=\"198.51.100.5\" destination-port=\"443\" protocol-id=\"6\" policy-name=\"allow-web\"]",
@@ -1919,7 +1929,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(juniper_sd["time"], 1_777_512_225_123_456_789_i64);
 
         let juniper_legacy = run_packaged_parser_json(
-            "parse_juniper_srx_syslog",
+            &["parse_juniper_srx_syslog"],
             Some(
                 "workspace.juniper_srx_syslog = { body: ingress, timezone: \"UTC\" }",
             ),
@@ -1932,7 +1942,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(juniper_legacy["time"], rfc3164_expected);
 
         let nsp = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some(
                 "workspace.nsp = { body: ingress, hostname: \"nsp01\", timezone: \"+09:00\" }",
             ),
@@ -1948,9 +1958,9 @@ def pipeline zeek_full_otlp {
         assert_eq!(nsp["time"], nsp_expected);
 
         let paloalto_cef = run_packaged_parser_json(
-            "parse_paloalto_cef",
+            &["parse_syslog", "parse_cef", "parse_paloalto_cef"],
             Some("workspace.paloalto_cef = { timezone: \"UTC\" }"),
-            "parse_paloalto_cef",
+            "parse_syslog | parse_cef | parse_paloalto_cef",
             format!(
                 "<134>{rfc3164_wire} fw-pan01 CEF:0|Palo Alto Networks|PAN-OS|10.2.0|end|TRAFFIC|3|src=192.0.2.10 dst=198.51.100.5 proto=tcp act=allow"
             )
@@ -1960,15 +1970,15 @@ def pipeline zeek_full_otlp {
 
         let paloalto_native_wire = paloalto_traffic_wire("2026/04/30 10:23:45");
         let paloalto_native = run_packaged_parser_json(
-            "parse_paloalto_syslog",
+            &["parse_syslog", "parse_paloalto_syslog"],
             Some("workspace.paloalto_syslog = { timezone: \"Asia/Tokyo\" }"),
-            "parse_paloalto_syslog",
+            "parse_syslog | parse_paloalto_syslog",
             &paloalto_native_wire,
         );
         assert_eq!(paloalto_native["time"], 1_777_512_225_000_000_000_i64);
 
         let sysmon = run_packaged_parser_json(
-            "parse_sysmon",
+            &["parse_sysmon"],
             Some("workspace.sysmon = { body: parse_json(ingress) }"),
             "parse_sysmon",
             br#"{"EventID":11,"EventTime":"2026-04-30T01:23:45.123456789Z","Computer":"host01","EventData":{"TargetFilename":"C:\\Temp\\x.txt","User":"alice","Image":"C:\\Windows\\cmd.exe","ProcessId":"42"}}"#,
@@ -1976,7 +1986,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(sysmon["time"], 1_777_512_225_123_456_789_i64);
 
         let vpc = run_packaged_parser_json(
-            "parse_aws_vpc_flow",
+            &["parse_aws_vpc_flow"],
             None,
             "parse_aws_vpc_flow",
             b"2 123456789012 eni-0a1b2c3d4e5f6a7b8 192.0.2.10 198.51.100.5 54321 443 6 10 4000 1714000000 1714000060 ACCEPT OK",
@@ -2003,7 +2013,7 @@ def pipeline zeek_full_otlp {
         }
 
         let bind_default_timezone = run_packaged_parser_json(
-            "parse_bind",
+            &["parse_bind"],
             Some("workspace.bind = { body: ingress }"),
             "parse_bind",
             b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)",
@@ -2018,7 +2028,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(bind_default_timezone["time"], bind_default_expected);
 
         let bind_override = run_packaged_parser_json(
-            "parse_bind",
+            &["parse_bind"],
             Some("workspace.bind = { body: ingress, timezone: \"UTC\" }"),
             "parse_bind",
             b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)",
@@ -2034,7 +2044,7 @@ def pipeline zeek_full_otlp {
 
         let nsp_body = b"admin_domain=Default alert_id=12345 alert_type=Signature app_protocol=HTTP confidence=Tentative attack_count=1 attack_id=42 attack_name=Example severity=High alert_signature=SIG attack_time=2026-05-16 10:00:00 category=Exploit dest_ip=192.0.2.10 dest_name=web01 dest_port=80 device_name=nsp01 direction=Inbound confidence= file_name= file_hash= file_type= virus_name= action_status= error_status= protocol=TCP result=Blocked src_ip=198.51.100.5 src_name= src_port=54321";
         let nsp_default_timezone = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some("workspace.nsp = { body: ingress }"),
             "parse_nsp",
             nsp_body,
@@ -2054,7 +2064,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(nsp_default_timezone["time"], nsp_local_expected);
 
         let nsp_override = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some("workspace.nsp = { body: ingress, timezone: \"UTC\" }"),
             "parse_nsp",
             nsp_body,
@@ -2062,7 +2072,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(nsp_override["time"], nsp_utc_expected);
 
         let nsp_explicit_utc = run_packaged_parser_json(
-            "parse_nsp",
+            &["parse_nsp"],
             Some("workspace.nsp = { body: ingress }"),
             "parse_nsp",
             b"admin_domain=Default alert_id=12345 alert_type=Signature app_protocol=HTTP confidence=Tentative attack_count=1 attack_id=42 attack_name=Example severity=High alert_signature=SIG attack_time=2026-05-16 10:00:00 UTC category=Exploit dest_ip=192.0.2.10 dest_name=web01 dest_port=80 device_name=nsp01 direction=Inbound confidence= file_name= file_hash= file_type= virus_name= action_status= error_status= protocol=TCP result=Blocked src_ip=198.51.100.5 src_name= src_port=54321",
@@ -2071,9 +2081,9 @@ def pipeline zeek_full_otlp {
 
         let paloalto_wire = paloalto_traffic_wire("2026/04/30 10:23:45");
         let paloalto_default_timezone = run_packaged_parser_json(
-            "parse_paloalto_syslog",
+            &["parse_syslog", "parse_paloalto_syslog"],
             None,
-            "parse_paloalto_syslog",
+            "parse_syslog | parse_paloalto_syslog",
             &paloalto_wire,
         );
         let paloalto_local_expected = chrono_tz::America::New_York
@@ -2085,9 +2095,9 @@ def pipeline zeek_full_otlp {
         assert_eq!(paloalto_default_timezone["time"], paloalto_local_expected);
 
         let paloalto_override = run_packaged_parser_json(
-            "parse_paloalto_syslog",
+            &["parse_syslog", "parse_paloalto_syslog"],
             Some("workspace.paloalto_syslog = { timezone: \"UTC\" }"),
-            "parse_paloalto_syslog",
+            "parse_syslog | parse_paloalto_syslog",
             &paloalto_wire,
         );
         let paloalto_override_expected = chrono::Utc
@@ -2100,39 +2110,39 @@ def pipeline zeek_full_otlp {
 
         for (parser, setup, process, ingress) in [
             (
-                "parse_bind",
+                &["parse_bind"][..],
                 "workspace.bind = { body: ingress, timezone: \"Not/AZone\" }",
                 "parse_bind",
                 b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)".as_slice(),
             ),
             (
-                "parse_nsp",
+                &["parse_nsp"][..],
                 "workspace.nsp = { body: ingress, timezone: \"Not/AZone\" }",
                 "parse_nsp",
                 nsp_body.as_slice(),
             ),
             (
-                "parse_paloalto_syslog",
+                &["parse_syslog", "parse_paloalto_syslog"][..],
                 "workspace.paloalto_syslog = { timezone: \"Not/AZone\" }",
-                "parse_paloalto_syslog",
+                "parse_syslog | parse_paloalto_syslog",
                 paloalto_wire.as_slice(),
             ),
             (
-                "parse_bind",
+                &["parse_bind"][..],
                 "workspace.bind = { body: ingress, timezone: \"local\" }",
                 "parse_bind",
                 b"30-Apr-2026 10:23:45.123 client @0x1 192.0.2.10#54321 (example.com): query: example.com IN A +E(0) (198.51.100.53)".as_slice(),
             ),
             (
-                "parse_nsp",
+                &["parse_nsp"][..],
                 "workspace.nsp = { body: ingress, timezone: \"local\" }",
                 "parse_nsp",
                 nsp_body.as_slice(),
             ),
             (
-                "parse_paloalto_syslog",
+                &["parse_syslog", "parse_paloalto_syslog"][..],
                 "workspace.paloalto_syslog = { timezone: \"local\" }",
-                "parse_paloalto_syslog",
+                "parse_syslog | parse_paloalto_syslog",
                 paloalto_wire.as_slice(),
             ),
         ] {
@@ -2195,7 +2205,8 @@ def pipeline zeek_full_otlp {
 
         let cases = [
             (
-                "parse_asa",
+                &["parse_syslog", "parse_asa"][..],
+                "parse_syslog | parse_asa",
                 "workspace.asa = { timezone: \"UTC\" }",
                 "workspace.asa = { timezone: \"Not/AZone\" }",
                 "workspace.asa = { timezone: \"local\" }",
@@ -2205,7 +2216,8 @@ def pipeline zeek_full_otlp {
                 .into_bytes(),
             ),
             (
-                "parse_fortigate_cef",
+                &["parse_syslog", "parse_cef", "parse_fortigate_cef"][..],
+                "parse_syslog | parse_cef | parse_fortigate_cef",
                 "workspace.fortigate_cef = { timezone: \"UTC\" }",
                 "workspace.fortigate_cef = { timezone: \"Not/AZone\" }",
                 "workspace.fortigate_cef = { timezone: \"local\" }",
@@ -2215,6 +2227,7 @@ def pipeline zeek_full_otlp {
                 .into_bytes(),
             ),
             (
+                &["parse_juniper_srx_syslog"][..],
                 "parse_juniper_srx_syslog",
                 "workspace.juniper_srx_syslog = { body: ingress, timezone: \"UTC\" }",
                 "workspace.juniper_srx_syslog = { body: ingress, timezone: \"Not/AZone\" }",
@@ -2225,7 +2238,8 @@ def pipeline zeek_full_otlp {
                 .into_bytes(),
             ),
             (
-                "parse_paloalto_cef",
+                &["parse_syslog", "parse_cef", "parse_paloalto_cef"][..],
+                "parse_syslog | parse_cef | parse_paloalto_cef",
                 "workspace.paloalto_cef = { timezone: \"UTC\" }",
                 "workspace.paloalto_cef = { timezone: \"Not/AZone\" }",
                 "workspace.paloalto_cef = { timezone: \"local\" }",
@@ -2236,43 +2250,44 @@ def pipeline zeek_full_otlp {
             ),
         ];
 
-        for (parser, supplied_setup, invalid_setup, local_setup, ingress) in cases {
-            let supplied = run_packaged_parser_json(parser, Some(supplied_setup), parser, &ingress);
-            assert_eq!(supplied["time"], expected, "{parser} supplied timezone");
+        for (parsers, process, supplied_setup, invalid_setup, local_setup, ingress) in cases {
+            let supplied =
+                run_packaged_parser_json(parsers, Some(supplied_setup), process, &ingress);
+            assert_eq!(supplied["time"], expected, "{process} supplied timezone");
 
-            let default_setup = match parser {
+            let default_setup = match process {
                 "parse_juniper_srx_syslog" => {
                     Some("workspace.juniper_srx_syslog = { body: ingress }")
                 }
                 _ => None,
             };
-            let defaulted = run_packaged_parser_json(parser, default_setup, parser, &ingress);
+            let defaulted = run_packaged_parser_json(parsers, default_setup, process, &ingress);
             // All RFC 3164 parsers with an undocumented source zone default to
             // the limpid host's system timezone (host-local most-likely
             // assumption); only vendor-documented UTC formats default to UTC.
             let default_expected = local_expected;
             assert_eq!(
                 defaulted["time"], default_expected,
-                "{parser} default timezone"
+                "{process} default timezone"
             );
 
             for invalid_setup in [invalid_setup, local_setup] {
                 let invalid =
-                    run_packaged_parser_pipeline(parser, Some(invalid_setup), parser, &ingress);
+                    run_packaged_parser_pipeline(parsers, Some(invalid_setup), process, &ingress);
                 assert_eq!(
                     invalid.termination,
                     PipelineTermination::Errored,
-                    "{parser}"
+                    "{process}"
                 );
                 assert!(
                     invalid.outputs.is_empty(),
-                    "{parser} emitted invalid timezone"
+                    "{process} emitted invalid timezone"
                 );
                 let reason = match &invalid.errored[0] {
                     ErroredEventContext::Process { reason, .. } => reason,
                     other => panic!("expected process error, got {other:?}"),
                 };
-                assert!(reason.contains("timezone"), "{parser}: {reason}");
+                assert!(reason.contains("timezone"), "{process}: {reason}");
             }
         }
     }
@@ -2280,7 +2295,7 @@ def pipeline zeek_full_otlp {
     #[test]
     fn time_normalization_runs_at_public_leaf_boundaries() {
         let auditd = run_packaged_parser_json(
-            "parse_auditd",
+            &["parse_auditd"],
             Some(
                 "workspace.auditd = { body: ingress }; workspace.auditd_class = parse_auditd_classify(workspace.auditd.body)",
             ),
@@ -2290,7 +2305,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(auditd["time"], 1_710_000_000_123_000_000_i64);
 
         let juniper = run_packaged_parser_json(
-            "parse_juniper_srx_sd_syslog",
+            &["parse_juniper_srx_sd_syslog"],
             Some(
                 "workspace.juniper_srx_sd_syslog = { body: ingress }; workspace.srx_sd_class = parse_juniper_srx_sd_syslog_classify(workspace.juniper_srx_sd_syslog.body)",
             ),
@@ -2304,54 +2319,51 @@ def pipeline zeek_full_otlp {
     fn packaged_parser_public_leaves_reject_invalid_source_severity() {
         let cases = [
             (
-                "parse_asa",
+                &["parse_asa"][..],
                 "workspace.asa = { level: \"8\", body: \"Login permitted from 192.0.2.10/54321 to outside:198.51.100.5/SSH for user admin\" }",
                 "parse_asa_605005_login_permitted",
                 "invalid ASA payload severity level 8",
             ),
             (
-                "parse_aws_guardduty",
+                &["parse_aws_guardduty"][..],
                 "workspace.gd = { type: \"Recon:EC2/Test\", severity: 11 }; workspace.gd_type = aws_guardduty_split_type(workspace.gd.type); workspace.gd_tactic = \"Reconnaissance\"",
                 "parse_aws_guardduty_finding",
                 "invalid GuardDuty severity 11",
             ),
             (
-                "parse_azure_activity",
+                &["parse_azure_activity"][..],
                 "workspace.az = { level: \"TRACE\" }",
                 "parse_azure_activity_record",
                 "invalid Azure Activity Log level TRACE",
             ),
             (
-                "parse_fortigate_cef",
+                &["parse_fortigate_cef"][..],
                 "workspace.cef = { severity: 0 }",
                 "parse_fortigate_cef_traffic",
                 "invalid FortiGate CEF priority 0",
             ),
             (
-                "parse_okta_system",
+                &["parse_okta_system"][..],
                 "workspace.okta = { severity: \"TRACE\" }",
                 "parse_okta_user_authentication",
                 "invalid Okta System Log severity TRACE",
             ),
             (
-                "parse_winevent_json",
+                &["parse_winevent_json"][..],
                 "workspace.winevent = { EventType: \"TRACE\" }",
                 "parse_winevent_4624_logon_success",
                 "invalid NXLog Windows Event severity TRACE",
             ),
         ];
 
-        for (parser, setup, process, expected_error) in cases {
-            let result = run_packaged_parser_pipeline(parser, Some(setup), process, b"fixture");
+        for (parsers, setup, process, expected_error) in cases {
+            let result = run_packaged_parser_pipeline(parsers, Some(setup), process, b"fixture");
             assert_eq!(
                 result.termination,
                 PipelineTermination::Errored,
-                "{parser}:{process} unexpectedly succeeded"
+                "{process} unexpectedly succeeded"
             );
-            assert!(
-                result.outputs.is_empty(),
-                "{parser}:{process} emitted output"
-            );
+            assert!(result.outputs.is_empty(), "{process} emitted output");
             assert_eq!(result.errored.len(), 1);
             let reason = match &result.errored[0] {
                 ErroredEventContext::Process { reason, .. } => reason,
@@ -2359,7 +2371,7 @@ def pipeline zeek_full_otlp {
             };
             assert!(
                 reason.contains(expected_error),
-                "{parser}:{process} error was {reason:?}"
+                "{process} error was {reason:?}"
             );
         }
     }
@@ -2367,7 +2379,7 @@ def pipeline zeek_full_otlp {
     #[test]
     fn packaged_fortigate_dns_uses_rcode_not_error() {
         let with_rcode = run_packaged_parser_json(
-            "parse_fortigate_syslog",
+            &["parse_fortigate_syslog"],
             None,
             "parse_fortigate_syslog",
             b"<134>eventtime=1777284000123456789 level=notice type=utm subtype=dns action=blocked srcip=192.0.2.10 dstip=198.51.100.5 qname=example.test qtype=A rcode=NXDOMAIN error=SERVFAIL",
@@ -2375,7 +2387,7 @@ def pipeline zeek_full_otlp {
         assert_eq!(with_rcode["rcode_id"], 3);
 
         let without_rcode = run_packaged_parser_json(
-            "parse_fortigate_syslog",
+            &["parse_fortigate_syslog"],
             None,
             "parse_fortigate_syslog",
             b"<134>eventtime=1777284000123456789 level=notice type=utm subtype=dns action=blocked srcip=192.0.2.10 dstip=198.51.100.5 qname=example.test qtype=A error=NXDOMAIN",
@@ -2785,7 +2797,7 @@ def pipeline zeek_full_otlp {
         adapters.sort();
         assert_eq!(
             adapters.len(),
-            30,
+            31,
             "packaged source adapter inventory drift"
         );
 
@@ -2829,7 +2841,7 @@ def pipeline zeek_full_otlp {
     #[test]
     fn packaged_ocsf_severity_unknown_and_other_normalize_without_canonical_zero() {
         let unknown = run_packaged_parser_json(
-            "parse_ocsf",
+            &["parse_ocsf"],
             None,
             "parse_ocsf",
             br#"{"class_uid":4001,"severity_id":0}"#,
@@ -2838,7 +2850,7 @@ def pipeline zeek_full_otlp {
         assert!(unknown["severity_number"].is_null());
 
         let other = run_packaged_parser_json(
-            "parse_ocsf",
+            &["parse_ocsf"],
             None,
             "parse_ocsf",
             br#"{"class_uid":4001,"severity_id":99}"#,
@@ -2847,7 +2859,7 @@ def pipeline zeek_full_otlp {
         assert!(other["severity_number"].is_null());
 
         let error = run_packaged_parser_json(
-            "parse_ocsf",
+            &["parse_ocsf"],
             None,
             "parse_ocsf",
             br#"{"class_uid":4001,"severity_id":3}"#,
@@ -3871,7 +3883,98 @@ def pipeline zeek_full_otlp {
             Some("302013")
         );
 
-        let leef_wire = b"<14>1 2026-04-30T01:23:45Z cpgw01 CheckPoint - - LEEF:2.0|Check Point|VPN-1 & FireWall-1|R81|Accept|cat=Firewall\tsrc=192.0.2.10\tdst=198.51.100.5\tsrcPort=51234\tdstPort=443\tproto=tcp\trule=12\trule_name=Allow-Internet\taction=Accept\tservice=https\tusrName=alice";
+        // Generic transport/format chain: parse_syslog | parse_cef |
+        // cef_to_otlp with no vendor stage. CEF header severity 7 sits in
+        // the spec's High band (7-8) and must land on ERROR (17); the raw
+        // header fields surface as event.code / cef.* attributes.
+        let generic_cef_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|7|src=192.0.2.10 spt=51234 dst=198.51.100.5 dpt=443 act=blocked msg=Example alert";
+        let generic_cef = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_record = &generic_cef.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_record.severity_number, 17);
+        assert_eq!(generic_cef_record.severity_text, "7");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "event.code"),
+            Some("100")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "cef.name"),
+            Some("alert raised")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "event.action"),
+            Some("blocked")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_record.attributes, "source.ip"),
+            Some("192.0.2.10")
+        );
+        assert_eq!(
+            otlp_int_attribute(&generic_cef_record.attributes, "destination.port"),
+            Some(443)
+        );
+        assert_eq!(
+            otlp_string_attribute(
+                &generic_cef.resource.as_ref().expect("resource").attributes,
+                "observer.vendor"
+            ),
+            Some("ArcSight")
+        );
+        assert_eq!(
+            otlp_string_attribute(
+                &generic_cef.resource.as_ref().expect("resource").attributes,
+                "host.name"
+            ),
+            Some("host01")
+        );
+
+        // CEF also documents string Severity values (Unknown / Low /
+        // Medium / High / Very-High). A single band-wide value takes the
+        // band's smallest SeverityNumber: "High" → ERROR (17).
+        let generic_cef_string_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|High|src=192.0.2.10 act=blocked";
+        let generic_cef_string = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_string_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_string_record = &generic_cef_string.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_string_record.severity_number, 17);
+        assert_eq!(generic_cef_string_record.severity_text, "High");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_string_record.attributes, "cef.severity"),
+            Some("High")
+        );
+
+        // "Unknown" is spec-valid but makes no importance claim, so
+        // severity_number stays unset (proto default 0) while the raw
+        // value is preserved as severity_text / cef.severity.
+        let generic_cef_unknown_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|Unknown|src=192.0.2.10 act=blocked";
+        let generic_cef_unknown = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_unknown_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_unknown_record = &generic_cef_unknown.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_unknown_record.severity_number, 0);
+        assert_eq!(generic_cef_unknown_record.severity_text, "Unknown");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_unknown_record.attributes, "cef.severity"),
+            Some("Unknown")
+        );
+
+        let leef_wire =b"<14>1 2026-04-30T01:23:45Z cpgw01 CheckPoint - - LEEF:2.0|Check Point|VPN-1 & FireWall-1|R81|Accept|cat=Firewall\tsrc=192.0.2.10\tdst=198.51.100.5\tsrcPort=51234\tdstPort=443\tproto=tcp\trule=12\trule_name=Allow-Internet\taction=Accept\tservice=https\tusrName=alice";
         let checkpoint_leef = run_packaged_otlp_resource_logs_at(
             &cfg,
             &funcs,
@@ -4068,6 +4171,9 @@ def pipeline zeek_full_otlp {
 
         for resource_logs in [
             asa,
+            generic_cef,
+            generic_cef_string,
+            generic_cef_unknown,
             checkpoint_leef,
             checkpoint,
             fortigate_cef,

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -3934,6 +3934,36 @@ def pipeline zeek_full_otlp {
             Some("host01")
         );
 
+        // Collision isolation: extension keys named after header fields
+        // (`severity=`, `name=`, `ext=`) must not shadow the positional
+        // header values — cef.parse isolates them under the nested
+        // `extension` sub-object, so the record's severity still comes
+        // from the header (7 → ERROR 17), not the injected `severity=9`.
+        let generic_cef_collision_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|realname|7|severity=9 name=fakename ext=x src=192.0.2.10";
+        let generic_cef_collision = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_collision_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_collision_record = &generic_cef_collision.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_collision_record.severity_number, 17);
+        assert_eq!(generic_cef_collision_record.severity_text, "7");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_collision_record.attributes, "cef.severity"),
+            Some("7")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_collision_record.attributes, "cef.name"),
+            Some("realname")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_collision_record.attributes, "source.ip"),
+            Some("192.0.2.10")
+        );
+
         // CEF also documents string Severity values (Unknown / Low /
         // Medium / High / Very-High). A single band-wide value takes the
         // band's smallest SeverityNumber: "High" → ERROR (17).
@@ -4172,6 +4202,7 @@ def pipeline zeek_full_otlp {
         for resource_logs in [
             asa,
             generic_cef,
+            generic_cef_collision,
             generic_cef_string,
             generic_cef_unknown,
             checkpoint_leef,

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -2045,21 +2045,21 @@ def pipeline zeek_full_otlp {
             .unwrap()
             .timestamp_nanos_opt()
             .unwrap();
-        assert_eq!(nsp_default_timezone["time"], nsp_utc_expected);
-
-        let nsp_override = run_packaged_parser_json(
-            "parse_nsp",
-            Some("workspace.nsp = { body: ingress, timezone: \"America/New_York\" }"),
-            "parse_nsp",
-            nsp_body,
-        );
-        let nsp_override_expected = chrono_tz::America::New_York
+        let nsp_local_expected = chrono_tz::America::New_York
             .with_ymd_and_hms(2026, 5, 16, 10, 0, 0)
             .single()
             .unwrap()
             .timestamp_nanos_opt()
             .unwrap();
-        assert_eq!(nsp_override["time"], nsp_override_expected);
+        assert_eq!(nsp_default_timezone["time"], nsp_local_expected);
+
+        let nsp_override = run_packaged_parser_json(
+            "parse_nsp",
+            Some("workspace.nsp = { body: ingress, timezone: \"UTC\" }"),
+            "parse_nsp",
+            nsp_body,
+        );
+        assert_eq!(nsp_override["time"], nsp_utc_expected);
 
         let nsp_explicit_utc = run_packaged_parser_json(
             "parse_nsp",
@@ -2076,21 +2076,21 @@ def pipeline zeek_full_otlp {
             "parse_paloalto_syslog",
             &paloalto_wire,
         );
-        let paloalto_utc_expected = chrono::Utc
+        let paloalto_local_expected = chrono_tz::America::New_York
             .with_ymd_and_hms(2026, 4, 30, 10, 23, 45)
             .single()
             .unwrap()
             .timestamp_nanos_opt()
             .unwrap();
-        assert_eq!(paloalto_default_timezone["time"], paloalto_utc_expected);
+        assert_eq!(paloalto_default_timezone["time"], paloalto_local_expected);
 
         let paloalto_override = run_packaged_parser_json(
             "parse_paloalto_syslog",
-            Some("workspace.paloalto_syslog = { timezone: \"America/New_York\" }"),
+            Some("workspace.paloalto_syslog = { timezone: \"UTC\" }"),
             "parse_paloalto_syslog",
             &paloalto_wire,
         );
-        let paloalto_override_expected = chrono_tz::America::New_York
+        let paloalto_override_expected = chrono::Utc
             .with_ymd_and_hms(2026, 4, 30, 10, 23, 45)
             .single()
             .unwrap()
@@ -2247,11 +2247,10 @@ def pipeline zeek_full_otlp {
                 _ => None,
             };
             let defaulted = run_packaged_parser_json(parser, default_setup, parser, &ingress);
-            let default_expected = match parser {
-                "parse_fortigate_cef" | "parse_juniper_srx_syslog" => local_expected,
-                "parse_asa" | "parse_paloalto_cef" => expected,
-                _ => unreachable!(),
-            };
+            // All RFC 3164 parsers with an undocumented source zone default to
+            // the limpid host's system timezone (host-local most-likely
+            // assumption); only vendor-documented UTC formats default to UTC.
+            let default_expected = local_expected;
             assert_eq!(
                 defaulted["time"], default_expected,
                 "{parser} default timezone"

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -3763,11 +3763,12 @@ def pipeline zeek_full_otlp {
             json!({}),
             received_at,
         );
+        assert!(k8s.scope_logs[0].scope.is_none());
         assert_eq!(
-            k8s.scope_logs[0]
-                .scope
-                .as_ref()
-                .map(|scope| scope.name.as_str()),
+            otlp_string_attribute(
+                &k8s.resource.as_ref().expect("resource").attributes,
+                "service.name"
+            ),
             Some("kube-apiserver")
         );
         let k8s_record = &k8s.scope_logs[0].log_records[0];
@@ -4116,11 +4117,12 @@ def pipeline zeek_full_otlp {
             json!({"auditd": {"body": String::from_utf8_lossy(auditd_wire), "hostname": "host-1"}}),
             received_at,
         );
+        assert!(auditd.scope_logs[0].scope.is_none());
         assert_eq!(
-            auditd.scope_logs[0]
-                .scope
-                .as_ref()
-                .map(|scope| scope.name.as_str()),
+            otlp_string_attribute(
+                &auditd.resource.as_ref().expect("resource").attributes,
+                "service.name"
+            ),
             Some("auditd")
         );
 

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -3964,6 +3964,32 @@ def pipeline zeek_full_otlp {
             Some("192.0.2.10")
         );
 
+        // Header escape handling: `\|` inside a header field is a
+        // literal pipe per the CEF spec, not a separator. A split on it
+        // would shift severity into the extension blob and hand the
+        // name fragment to the severity slot — this wire must still
+        // classify from the real header severity 7 → ERROR (17).
+        let generic_cef_escape_wire = b"<134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|deny\\|drop|7|act=block src=192.0.2.10";
+        let generic_cef_escape = run_packaged_otlp_resource_logs_at(
+            &cfg,
+            &funcs,
+            "cef_otlp",
+            generic_cef_escape_wire,
+            json!({}),
+            received_at,
+        );
+        let generic_cef_escape_record = &generic_cef_escape.scope_logs[0].log_records[0];
+        assert_eq!(generic_cef_escape_record.severity_number, 17);
+        assert_eq!(generic_cef_escape_record.severity_text, "7");
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_escape_record.attributes, "cef.name"),
+            Some("deny|drop")
+        );
+        assert_eq!(
+            otlp_string_attribute(&generic_cef_escape_record.attributes, "event.action"),
+            Some("block")
+        );
+
         // CEF also documents string Severity values (Unknown / Low /
         // Medium / High / Very-High). A single band-wide value takes the
         // band's smallest SeverityNumber: "High" → ERROR (17).
@@ -4202,6 +4228,7 @@ def pipeline zeek_full_otlp {
         for resource_logs in [
             asa,
             generic_cef,
+            generic_cef_escape,
             generic_cef_collision,
             generic_cef_string,
             generic_cef_unknown,

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -497,6 +497,55 @@ def pipeline p {
     assert_eq!(out.status.code(), Some(2));
 }
 
+#[test]
+fn block_collection_overloads_pass_strict_static_checking() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("block_collections.conf");
+    fs::write(
+        &conf,
+        r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        let fields = {alpha: 1, beta: 2}
+        let mapped = map(fields) { |key, value| "${key}:${value}" }
+        let selected = filter(fields) { |key, value| value > 0 }
+        let found = find(fields) { |key, value| key == "alpha" }
+        let total = reduce(fields, 0) { |acc, key, value| acc + value }
+
+        let array_mapped = map([1, 2]) { |value| value + 1 }
+        let array_selected = filter([1, 2]) { |value| value > 0 }
+        let array_found = find([1, 2]) { |value| value == 2 }
+        let array_total = reduce([1, 2], 0) { |acc, value| acc + value }
+        let empty_mapped = map(null) { |value| value }
+        let empty_filtered = filter(null) { |value| value }
+        let empty_found = find(null) { |value| value != null }
+        let empty_total = reduce(null, 0) { |acc, value| acc + value }
+
+        workspace.object_shape = parse_kv("gamma=3", " ", selected)
+        workspace.array_shape = append(array_selected, 3)
+        workspace.results = [
+            mapped, found, total,
+            array_mapped, array_found, array_total,
+            empty_mapped, empty_filtered, empty_found, empty_total,
+        ]
+    }
+    output o
+}
+"#,
+    )
+    .unwrap();
+
+    let out = run_with_flags(&conf, &["--strict-warnings"]);
+    assert!(
+        out.status.success(),
+        "strict check failed: stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Global block schema (v0.7.2)
 // ---------------------------------------------------------------------------

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.7.14"
+version = "0.7.15"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/crates/xtask/src/header.rs
+++ b/crates/xtask/src/header.rs
@@ -1232,8 +1232,13 @@ def process example_to_otlp { }
     #[test]
     fn egress_write_is_valid_without_dot_declarations() {
         let source = clean_parser().replace(
-            "// Writes: workspace.lsis.shed.otlp.*\n//   .body (required, Object)",
+            "// Writes: workspace.lsis.shed.otlp.*\n//   .body (required, Bytes)",
             "// Writes: egress (OTLP protobuf bytes)",
+        );
+        assert_ne!(
+            source,
+            clean_parser(),
+            "egress fixture replacement must change the source"
         );
         assert!(
             lint(&parser(&source)).is_empty(),

--- a/crates/xtask/src/header.rs
+++ b/crates/xtask/src/header.rs
@@ -1,13 +1,10 @@
-//! Snippet-header schema (parse + lint) — 4 kinds, LSIS-era.
+//! Snippet-header schema (parse + lint) — file facade plus member contracts.
 //!
 //! The schema is documented in
 //! `packaging/snippets/README.md` § *Authoring conventions > Header
-//! schema*. Each snippet kind has its own canonical key set:
-//!
-//!   parser   (5 keys): Summary / Reads / Writes / Category / Test corpus
-//!   composer (4 keys): Summary / Reads / Writes / Test corpus
-//!   filter   (4 keys): Summary / Reads / Effect / Test corpus
-//!   function (3 keys): Summary / Signature / Test corpus
+//! schema*. File-level metadata declares `Facade`, `Category` (parser
+//! only), and `Test corpus`. Every facade process/function has a
+//! directly-adjacent member block carrying its authored contract.
 //!
 //! The kind is determined by the file's parent directory
 //! (`packaging/snippets/{parsers,composers,filters,functions}/`), not
@@ -21,9 +18,8 @@
 //! rather than authored, and why `Category:` on composers/filters
 //! (where it would duplicate Reads/Writes/Effect) is rejected.
 //!
-//! Unknown `// <Key>:` lines are tolerated with a warning — parsers
-//! historically carry vendor-specific prose blocks like `// FortiGate
-//! CEF dialect quirks:`.
+//! Top-level definitions omitted from `Facade` are private implementation
+//! details and do not need member blocks.
 
 use std::collections::BTreeMap;
 use std::error::Error;
@@ -98,30 +94,12 @@ impl SnippetKind {
         }
     }
 
-    /// Canonical required-key list in the order they must appear.
-    ///
-    /// Governing principle applied per kind:
-    /// - `Summary` and `Test corpus` are universal (all kinds).
-    /// - `Reads` is universal for stream kinds (parser/composer/filter).
-    /// - `Writes` (translator) / `Effect` (filter) split the stream
-    ///   kind by what happens to the payload.
-    /// - `Category` is parser-only — the composer and filter would-be
-    ///   category duplicates `Writes` / `Effect` / `Reads` and fails
-    ///   the authored-knowledge test.
-    /// - `Signature` is function-only.
+    /// Canonical file-level keys in source order.
     pub fn required_keys(&self) -> &'static [&'static str] {
         match self {
-            Self::Parser => &["Summary", "Reads", "Writes", "Category", "Test corpus"],
-            Self::Composer => &["Summary", "Reads", "Writes", "Test corpus"],
-            Self::Filter => &["Summary", "Reads", "Effect", "Test corpus"],
-            Self::Function => &["Summary", "Signature", "Test corpus"],
+            Self::Parser => &["Facade", "Category", "Test corpus"],
+            _ => &["Facade", "Test corpus"],
         }
-    }
-
-    /// True for kinds that flow events (have a `Reads:` key). The
-    /// universal Reads-dot-line grammar applies to all of these.
-    pub fn is_stream(&self) -> bool {
-        matches!(self, Self::Parser | Self::Composer | Self::Filter)
     }
 
     /// Allowed first-word prefixes for the `Test corpus:` value.
@@ -140,29 +118,88 @@ impl SnippetKind {
 // SnippetHeader — parsed key/value bag + kind + original content.
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MemberKind {
+    Process,
+    Function,
+}
+
+impl MemberKind {
+    fn keyword(self) -> &'static str {
+        match self {
+            Self::Process => "process",
+            Self::Function => "function",
+        }
+    }
+
+    fn heading(self) -> &'static str {
+        match self {
+            Self::Process => "Process",
+            Self::Function => "Function",
+        }
+    }
+
+    fn required_keys(self) -> &'static [&'static str] {
+        match self {
+            Self::Process => &["Process", "Summary", "Reads", "Writes"],
+            Self::Function => &["Function", "Summary", "Signature"],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FacadeMember {
+    pub kind: MemberKind,
+    pub name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct MemberHeader {
+    pub kind: MemberKind,
+    pub name: String,
+    pub keys: BTreeMap<String, String>,
+    pub observed_order: Vec<String>,
+    pub declaration: Option<FacadeMember>,
+    pub line: usize,
+}
+
+impl MemberHeader {
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.keys.get(key).map(String::as_str)
+    }
+}
+
 /// A parsed snippet header. Fields:
 /// - `file`: source file path (for diagnostics + inventory rendering).
 /// - `kind`: derived from the file's parent directory.
-/// - `keys`: insertion-collapsed key → value bag. Multi-line values
+/// - `keys`: file-level key → value bag. Multi-line values
 ///   are joined with `\n`. Stored as `BTreeMap` only for stable
 ///   iteration in tests; the observed-in-source order lives
 ///   separately in `observed_order` so the order-lint stays honest.
 /// - `observed_order`: keys in the order they appeared in the source.
-/// - `content`: full file content, kept for cross-checks that need to
-///   see the body (specifically: `Signature:` vs `def function`
-///   declaration for the Function kind).
+/// - `facade`: parsed public process/function declarations.
+/// - `members`: per-facade contract blocks found throughout the file.
+/// - `content`: full file content, retained for inventory caller scans.
 #[derive(Debug, Clone)]
 pub struct SnippetHeader {
     pub file: PathBuf,
     pub kind: SnippetKind,
     pub keys: BTreeMap<String, String>,
     pub observed_order: Vec<String>,
+    pub facade: Vec<FacadeMember>,
+    pub members: Vec<MemberHeader>,
     pub content: String,
 }
 
 impl SnippetHeader {
     pub fn get(&self, key: &str) -> Option<&str> {
         self.keys.get(key).map(String::as_str)
+    }
+
+    pub fn member(&self, kind: MemberKind, name: &str) -> Option<&MemberHeader> {
+        self.members
+            .iter()
+            .find(|member| member.kind == kind && member.name == name)
     }
 }
 
@@ -219,38 +256,48 @@ pub fn parse_str(
     kind: SnippetKind,
     content: &str,
 ) -> Result<SnippetHeader, Box<dyn Error>> {
-    let mut keys: BTreeMap<String, String> = BTreeMap::new();
-    let mut observed_order: Vec<String> = Vec::new();
-    let mut current_key: Option<String> = None;
+    let lines: Vec<&str> = content.lines().collect();
+    let file_block_end = lines
+        .iter()
+        .position(|line| !line.starts_with("//"))
+        .unwrap_or(lines.len());
+    let (keys, observed_order) = parse_comment_keys(&lines[..file_block_end]);
+    let facade = keys
+        .get("Facade")
+        .map(|value| parse_facade(value).0)
+        .unwrap_or_default();
 
-    for line in content.lines() {
-        let Some(after_slashes) = line.strip_prefix("//") else {
-            // first non-`//` line ends the header
-            break;
+    let mut members = Vec::new();
+    let mut index = 0usize;
+    while index < lines.len() {
+        if !lines[index].starts_with("//") {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        while index < lines.len() && lines[index].starts_with("//") {
+            index += 1;
+        }
+        let (member_keys, member_order) = parse_comment_keys(&lines[start..index]);
+        let process_name = member_keys.get("Process").map(|name| name.trim());
+        let function_name = member_keys.get("Function").map(|name| name.trim());
+        let heading = match (process_name, function_name) {
+            (Some(name), None) => Some((MemberKind::Process, name)),
+            (None, Some(name)) => Some((MemberKind::Function, name)),
+            (Some(name), Some(_)) => Some((MemberKind::Process, name)),
+            (None, None) => None,
         };
-
-        // A `// <Key>: <value>` line: detect key pattern.
-        if let Some((key, value)) = parse_key_line(after_slashes) {
-            keys.insert(key.clone(), value.to_string());
-            observed_order.push(key.clone());
-            current_key = Some(key);
-            continue;
-        }
-
-        // Otherwise it's either a blank `//` (= section divider,
-        // skip — does not end the header) or a continuation line.
-        let trimmed = after_slashes.trim();
-        if trimmed.is_empty() {
-            current_key = None;
-            continue;
-        }
-
-        // Continuation: only counts if there's a current key.
-        // Otherwise it's freeform prose (sample lines, intro).
-        if let Some(ref key) = current_key {
-            let value = keys.get_mut(key).expect("current_key must exist");
-            value.push('\n');
-            value.push_str(after_slashes.trim_start_matches(' '));
+        if let Some((member_kind, name)) = heading {
+            members.push(MemberHeader {
+                kind: member_kind,
+                name: name.to_string(),
+                keys: member_keys,
+                observed_order: member_order,
+                declaration: lines
+                    .get(index)
+                    .and_then(|line| parse_def_declaration(line)),
+                line: start + 1,
+            });
         }
     }
 
@@ -259,7 +306,86 @@ pub fn parse_str(
         kind,
         keys,
         observed_order,
+        facade,
+        members,
         content: content.to_string(),
+    })
+}
+
+fn parse_comment_keys(lines: &[&str]) -> (BTreeMap<String, String>, Vec<String>) {
+    let mut keys = BTreeMap::new();
+    let mut observed_order = Vec::new();
+    let mut current_key: Option<String> = None;
+
+    for line in lines {
+        let Some(after_slashes) = line.strip_prefix("//") else {
+            break;
+        };
+        if let Some((key, value)) = parse_key_line(after_slashes) {
+            keys.insert(key.clone(), value.to_string());
+            observed_order.push(key.clone());
+            current_key = Some(key);
+            continue;
+        }
+        let trimmed = after_slashes.trim();
+        if trimmed.is_empty() {
+            current_key = None;
+            continue;
+        }
+        if let Some(ref key) = current_key {
+            let value = keys.get_mut(key).expect("current_key must exist");
+            value.push('\n');
+            value.push_str(after_slashes.trim_start_matches(' '));
+        }
+    }
+    (keys, observed_order)
+}
+
+fn parse_facade(value: &str) -> (Vec<FacadeMember>, Vec<String>) {
+    let mut members = Vec::new();
+    let mut errors = Vec::new();
+    for raw_entry in value.split(',') {
+        let entry = raw_entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = entry.split_whitespace().collect();
+        let kind = match parts.first().copied() {
+            Some("process") => Some(MemberKind::Process),
+            Some("function") => Some(MemberKind::Function),
+            _ => None,
+        };
+        if parts.len() != 2
+            || kind.is_none()
+            || !is_ascii_ident(parts.get(1).copied().unwrap_or(""))
+        {
+            errors.push(format!(
+                "invalid `Facade:` entry {entry:?}; expected `process name` or `function name`"
+            ));
+            continue;
+        }
+        members.push(FacadeMember {
+            kind: kind.expect("checked above"),
+            name: parts[1].to_string(),
+        });
+    }
+    (members, errors)
+}
+
+fn parse_def_declaration(line: &str) -> Option<FacadeMember> {
+    let trimmed = line.trim_start();
+    let (kind, rest) = if let Some(rest) = trimmed.strip_prefix("def process ") {
+        (MemberKind::Process, rest)
+    } else {
+        (MemberKind::Function, trimmed.strip_prefix("def function ")?)
+    };
+    let name = rest
+        .split(|character: char| character == '(' || character == '{' || character.is_whitespace())
+        .next()
+        .unwrap_or("");
+    is_ascii_ident(name).then(|| FacadeMember {
+        kind,
+        name: name.to_string(),
     })
 }
 
@@ -297,55 +423,19 @@ fn parse_key_line(after_slashes: &str) -> Option<(String, &str)> {
 // Lint.
 // ---------------------------------------------------------------------------
 
-/// Lint a parsed header. Returns findings; empty means clean.
-///
-/// Rules (all enforced regardless of kind, dispatched per kind):
-///   1. all required keys present, in canonical order
-///   2. `Category:` is parser-only and its value is in the whitelist
-///   3. `Test corpus:` prefix is in the kind's allowed set
-///   4. `Reads:` dot-line grammar (universal for stream kinds)
-///   5. `Signature:` cross-check against `def function <name>(params)`
-///      in the same file (function only)
-///   6. Summary present (falls out of rule 1)
-///   7. Unknown keys → warning (not error), so vendor-specific prose
-///      blocks are tolerated but visible.
+/// Lint file-level facade metadata and every public member contract.
 pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
     let mut findings = Vec::new();
     let kind = header.kind;
 
-    // 1a. All required keys present.
-    for key in kind.required_keys() {
-        if !header.keys.contains_key(*key) {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!("missing required key `{key}:` for {} header", kind.label()),
-            });
-        }
-    }
-
-    // 1b. Required keys appear in canonical order.
-    let canonical: Vec<&str> = kind
-        .required_keys()
-        .iter()
-        .filter(|k| header.keys.contains_key(**k))
-        .copied()
-        .collect();
-    let observed_required: Vec<&str> = header
-        .observed_order
-        .iter()
-        .filter(|k| kind.required_keys().contains(&k.as_str()))
-        .map(String::as_str)
-        .collect();
-    if observed_required != canonical {
-        findings.push(Finding {
-            file: header.file.clone(),
-            severity: Severity::Error,
-            message: format!(
-                "required keys appear out of order: observed {observed_required:?}, expected {canonical:?}"
-            ),
-        });
-    }
+    lint_required_keys(
+        header,
+        "file",
+        &header.keys,
+        &header.observed_order,
+        kind.required_keys(),
+        &mut findings,
+    );
 
     // 2. Category: parser-only; value in whitelist.
     if let Some(cat) = header.get("Category") {
@@ -374,7 +464,7 @@ pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
         }
     }
 
-    // 3. Test corpus prefix.
+    // Test corpus stays file-level because all facade members share evidence.
     if let Some(tc) = header.get("Test corpus") {
         let first_word = tc.split_whitespace().next().unwrap_or("");
         let trimmed = first_word.trim_end_matches([':', ',', ';']);
@@ -391,21 +481,81 @@ pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
         }
     }
 
-    // 4. Reads dot-line grammar (universal for stream kinds).
-    if kind.is_stream()
-        && let Some(reads) = header.get("Reads")
-    {
-        findings.extend(lint_reads_grammar(header, reads));
+    let (parsed_facade, facade_errors) = header.get("Facade").map(parse_facade).unwrap_or_default();
+    for message in facade_errors {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message,
+        });
+    }
+    let mut facade_counts: BTreeMap<FacadeMember, usize> = BTreeMap::new();
+    for member in &parsed_facade {
+        *facade_counts.entry(member.clone()).or_default() += 1;
+    }
+    for (member, count) in &facade_counts {
+        if *count > 1 {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "duplicate `Facade:` entry `{} {}`",
+                    member.kind.keyword(),
+                    member.name
+                ),
+            });
+        }
     }
 
-    // 5. Signature cross-check (function only).
-    if kind == SnippetKind::Function
-        && let Some(sig) = header.get("Signature")
-    {
-        findings.extend(lint_signature(header, sig));
+    for facade_member in facade_counts.keys() {
+        let matching: Vec<&MemberHeader> = header
+            .members
+            .iter()
+            .filter(|member| member.kind == facade_member.kind && member.name == facade_member.name)
+            .collect();
+        match matching.as_slice() {
+            [] => findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "`Facade:` lists `{} {}` but no matching per-member block was found",
+                    facade_member.kind.keyword(),
+                    facade_member.name
+                ),
+            }),
+            [member] => findings.extend(lint_member(header, member)),
+            _ => findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "multiple per-member blocks found for `{} {}`",
+                    facade_member.kind.keyword(),
+                    facade_member.name
+                ),
+            }),
+        }
     }
 
-    // 7. Unknown keys → warning.
+    for member in &header.members {
+        if !facade_counts.contains_key(&FacadeMember {
+            kind: member.kind,
+            name: member.name.clone(),
+        }) {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "orphan `{}: {}` block at line {} is not listed in `Facade:`",
+                    member.kind.heading(),
+                    member.name,
+                    member.line
+                ),
+            });
+        }
+    }
+
+    // Unknown file-level keys remain warnings so authored design prose that
+    // looks like a key is visible without making migration brittle.
     for key in &header.observed_order {
         if !kind.required_keys().contains(&key.as_str()) {
             // Category on a non-parser is already an error above; don't
@@ -424,8 +574,122 @@ pub fn lint(header: &SnippetHeader) -> Vec<Finding> {
     findings
 }
 
+fn lint_required_keys(
+    header: &SnippetHeader,
+    context: &str,
+    keys: &BTreeMap<String, String>,
+    observed_order: &[String],
+    required: &[&str],
+    findings: &mut Vec<Finding>,
+) {
+    for key in required {
+        if !keys.contains_key(*key) {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!("missing required key `{key}:` for {context} header"),
+            });
+        }
+    }
+    let canonical: Vec<&str> = required
+        .iter()
+        .filter(|key| keys.contains_key(**key))
+        .copied()
+        .collect();
+    let observed: Vec<&str> = observed_order
+        .iter()
+        .filter(|key| required.contains(&key.as_str()))
+        .map(String::as_str)
+        .collect();
+    if observed != canonical {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "{context} required keys appear out of order: observed {observed:?}, expected {canonical:?}"
+            ),
+        });
+    }
+}
+
+fn lint_member(header: &SnippetHeader, member: &MemberHeader) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let context = format!("{} `{}`", member.kind.keyword(), member.name);
+    lint_required_keys(
+        header,
+        &context,
+        &member.keys,
+        &member.observed_order,
+        member.kind.required_keys(),
+        &mut findings,
+    );
+
+    match &member.declaration {
+        Some(declaration) if declaration.kind == member.kind && declaration.name == member.name => {
+        }
+        Some(declaration) => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`{}: {}` block at line {} is followed by `def {} {}`",
+                member.kind.heading(),
+                member.name,
+                member.line,
+                declaration.kind.keyword(),
+                declaration.name
+            ),
+        }),
+        None => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`{}: {}` block at line {} must be immediately followed by its definition",
+                member.kind.heading(),
+                member.name,
+                member.line
+            ),
+        }),
+    }
+
+    match member.kind {
+        MemberKind::Process => {
+            if let Some(reads) = member.get("Reads") {
+                findings.extend(lint_io_grammar(header, "Reads", reads, &["ingress"]));
+            }
+            if let Some(writes) = member.get("Writes") {
+                findings.extend(lint_io_grammar(
+                    header,
+                    "Writes",
+                    writes,
+                    &["ingress", "egress"],
+                ));
+            }
+        }
+        MemberKind::Function => {
+            if let Some(signature) = member.get("Signature") {
+                findings.extend(lint_signature(header, member, signature));
+            }
+        }
+    }
+
+    for key in &member.observed_order {
+        if !member.kind.required_keys().contains(&key.as_str()) {
+            findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Warning,
+                message: format!(
+                    "unknown key `{key}:` in {} `{}` block",
+                    member.kind.keyword(),
+                    member.name
+                ),
+            });
+        }
+    }
+    findings
+}
+
 // ---------------------------------------------------------------------------
-// Rule 4: Reads dot-line grammar.
+// Process Reads/Writes root grammar.
 // ---------------------------------------------------------------------------
 
 /// A parsed `.<name> (required|optional, <Type>)` intake row.
@@ -442,7 +706,7 @@ pub struct DotLineDecl {
     pub ty: String,
 }
 
-/// The 7 acceptable intake types on a dot-line. Kept in sync with the
+/// The 8 acceptable intake types on a dot-line. Kept in sync with the
 /// grammar documented in the packaging README's Authoring Conventions
 /// section. String-form so we can report unknowns verbatim.
 const INTAKE_TYPES: &[&str] = &[
@@ -453,121 +717,100 @@ const INTAKE_TYPES: &[&str] = &[
     "Object",
     "Array",
     "Timestamp",
+    "Bytes",
 ];
 
-/// Enforce the universal `Reads:` grammar across all stream kinds.
-///
-/// - First line's first token is `ingress` → dot-lines FORBIDDEN.
-/// - First line's first token matches `workspace.<ns>.*` → ≥1
-///   dot-line REQUIRED; each dot-line matches
-///   `^\.<ASCII_IDENT>\s+\((required|optional), <TYPE>\)`.
-/// - Non-dot continuation lines are prose (permissive) and ignored.
-fn lint_reads_grammar(header: &SnippetHeader, reads_value: &str) -> Vec<Finding> {
+/// Enforce reserved-value or one-or-more workspace-root contracts.
+/// Each workspace root owns the following dot declarations until the next
+/// root and must declare at least one field.
+fn lint_io_grammar(
+    header: &SnippetHeader,
+    key: &str,
+    value: &str,
+    reserved: &[&str],
+) -> Vec<Finding> {
     let mut findings = Vec::new();
+    let lines: Vec<&str> = value.lines().map(str::trim_start).collect();
+    let first = lines.first().copied().unwrap_or("");
+    let first_token = first.split_whitespace().next().unwrap_or("");
 
-    let (first_line, rest) = match reads_value.split_once('\n') {
-        Some((f, r)) => (f.trim(), Some(r)),
-        None => (reads_value.trim(), None),
-    };
-
-    let shape = classify_reads_first_line(first_line);
-
-    match shape {
-        ReadsShape::Ingress => {
-            // Any dot-shaped continuation is an error.
-            if let Some(rest) = rest {
-                for (idx, line) in rest.split('\n').enumerate() {
-                    let trimmed = line.trim_start();
-                    if trimmed.starts_with('.') {
-                        findings.push(Finding {
-                            file: header.file.clone(),
-                            severity: Severity::Error,
-                            message: format!(
-                                "`Reads:` first token is `ingress`, so dot-line intake rows \
-                                 are forbidden; found `{}` on continuation line {}",
-                                trimmed,
-                                idx + 2
-                            ),
-                        });
-                    }
-                }
-            }
-        }
-        ReadsShape::WorkspaceNamespace => {
-            // Require ≥1 dot line; each dot line must parse.
-            let mut dot_lines_seen = 0usize;
-            if let Some(rest) = rest {
-                for (idx, line) in rest.split('\n').enumerate() {
-                    let trimmed = line.trim_start();
-                    if !trimmed.starts_with('.') {
-                        continue; // prose line; permitted
-                    }
-                    match parse_dot_line(trimmed) {
-                        Some(_) => dot_lines_seen += 1,
-                        None => findings.push(Finding {
-                            file: header.file.clone(),
-                            severity: Severity::Error,
-                            message: format!(
-                                "`Reads:` dot-line at continuation line {} does not match the \
-                                 required grammar `^\\.<IDENT>\\s+\\((required|optional), \
-                                 <String|Int|Float|Bool|Object|Array|Timestamp>\\)`: {}",
-                                idx + 2,
-                                trimmed
-                            ),
-                        }),
-                    }
-                }
-            }
-            if dot_lines_seen == 0 {
+    if reserved.contains(&first_token) {
+        for (index, line) in lines.iter().enumerate().skip(1) {
+            if line.starts_with('.') || classify_workspace_root(line) {
                 findings.push(Finding {
                     file: header.file.clone(),
                     severity: Severity::Error,
                     message: format!(
-                        "`Reads:` first token is a workspace namespace (`{first_line}`), \
-                         so at least one dot-line intake row is required (e.g. \
-                         `.body (required, String) — sshd application body`)"
+                        "`{key}:` starts with reserved `{first_token}`, so workspace roots and dot declarations are forbidden; found `{line}` on line {}",
+                        index + 1
                     ),
                 });
             }
         }
-        ReadsShape::Unknown => findings.push(Finding {
+        return findings;
+    }
+
+    if !classify_workspace_root(first) {
+        findings.push(Finding {
             file: header.file.clone(),
             severity: Severity::Error,
             message: format!(
-                "`Reads:` first token must be `ingress` (raw wire) or `workspace.<ns>.*` \
-                 (bridge/reader); found: {first_line}"
+                "`{key}:` first token must be one of {reserved:?} or `workspace.<ns>.*`; found: {first}"
             ),
-        }),
+        });
+        return findings;
     }
 
+    let mut current_root = first_token.to_string();
+    let mut declarations = 0usize;
+    for (index, line) in lines.iter().enumerate().skip(1) {
+        if classify_workspace_root(line) {
+            if declarations == 0 {
+                findings.push(missing_root_declaration(header, key, &current_root));
+            }
+            current_root = line.split_whitespace().next().unwrap_or("").to_string();
+            declarations = 0;
+            continue;
+        }
+        if !line.starts_with('.') {
+            continue;
+        }
+        match parse_dot_line(line) {
+            Some(_) => declarations += 1,
+            None => findings.push(Finding {
+                file: header.file.clone(),
+                severity: Severity::Error,
+                message: format!(
+                    "`{key}:` dot-line {} does not match `.<IDENT> (required|optional, <TYPE>)`: {line}",
+                    index + 1
+                ),
+            }),
+        }
+    }
+    if declarations == 0 {
+        findings.push(missing_root_declaration(header, key, &current_root));
+    }
     findings
 }
 
-enum ReadsShape {
-    Ingress,
-    WorkspaceNamespace,
-    Unknown,
+fn missing_root_declaration(header: &SnippetHeader, key: &str, root: &str) -> Finding {
+    Finding {
+        file: header.file.clone(),
+        severity: Severity::Error,
+        message: format!("`{key}:` workspace root `{root}` requires at least one dot declaration"),
+    }
 }
 
-fn classify_reads_first_line(first_line: &str) -> ReadsShape {
-    let first_token = first_line.split_whitespace().next().unwrap_or("");
-    if first_token == "ingress" {
-        return ReadsShape::Ingress;
-    }
-    // workspace.<ident>[.<ident>]*.*  — a dot-separated path of ascii
-    // idents ending in `.*`. Multi-segment paths surface the LSIS
-    // strata (`workspace.lsis.parsed.*`, `workspace.lsis.shed.otlp.*`)
-    // and any future nested transport namespace; single-segment paths
-    // (`workspace.journald.*`, `workspace.cef.*`) still classify the
-    // same way.
+fn classify_workspace_root(line: &str) -> bool {
+    let first_token = line.split_whitespace().next().unwrap_or("");
     if let Some(after_workspace) = first_token.strip_prefix("workspace.")
         && let Some(path) = after_workspace.strip_suffix(".*")
         && !path.is_empty()
         && path.split('.').all(is_ascii_ident)
     {
-        return ReadsShape::WorkspaceNamespace;
+        return true;
     }
-    ReadsShape::Unknown
+    false
 }
 
 /// Parse a `.<name> (required|optional, <Type>)` line into a
@@ -639,113 +882,69 @@ fn is_ascii_ident(s: &str) -> bool {
 // Rule 5: Signature cross-check.
 // ---------------------------------------------------------------------------
 
-/// Cross-check the authored `Signature:` entries against every
-/// `def function <name>(<params>) { ... }` declaration in the same
-/// file. The return contract stays authored (the DSL has no
-/// return-type declaration to derive from), so we do not check it.
-fn lint_signature(header: &SnippetHeader, sig_value: &str) -> Vec<Finding> {
+/// Cross-check the authored typed `Signature:` against the adjacent
+/// definition's name and arity. Parameter and return types remain authored
+/// knowledge because the DSL declaration itself carries no type annotation.
+fn lint_signature(header: &SnippetHeader, member: &MemberHeader, sig_value: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
     let entries: Vec<&str> = signature_entries(sig_value).collect();
-    if entries.is_empty() {
+    if entries.len() != 1 {
         findings.push(Finding {
             file: header.file.clone(),
             severity: Severity::Error,
-            message: "`Signature:` must contain at least one non-blank entry".to_string(),
+            message: format!(
+                "`Function: {}` must have exactly one `Signature:` entry",
+                member.name
+            ),
         });
         return findings;
     }
 
-    let declarations = find_def_functions(&header.content);
-    let mut listed = Vec::new();
-    let mut listed_counts: BTreeMap<String, usize> = BTreeMap::new();
-
-    for entry in entries {
-        let Some((name, params)) = parse_signature(entry) else {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`Signature:` entry must have shape `name(param1, param2, ...) → ReturnType`; \
-                     could not parse: {entry:?}"
-                ),
-            });
-            continue;
-        };
-        *listed_counts.entry(name.clone()).or_default() += 1;
-        listed.push((name, params));
+    let entry = entries[0];
+    let Some((name, params)) = parse_signature(entry) else {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`Signature:` must have shape `name(Type1, Type2, ...) → ReturnType`; could not parse: {entry:?}"
+            ),
+        });
+        return findings;
+    };
+    if name != member.name {
+        findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!("`Function: {}` has `Signature:` for `{name}`", member.name),
+        });
+        return findings;
     }
-
-    for (name, count) in &listed_counts {
-        if *count > 1 {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "duplicate `Signature:` entry for `{name}`; each function must be listed exactly once"
-                ),
-            });
-        }
-    }
-
-    let mut declaration_counts: BTreeMap<String, usize> = BTreeMap::new();
-    for declaration in &declarations {
-        *declaration_counts
-            .entry(declaration.name.clone())
-            .or_default() += 1;
-    }
-    for (name, count) in &declaration_counts {
-        if *count > 1 {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "duplicate `def function {name}(...)` declaration; the `Signature:` contract requires one declaration per name"
-                ),
-            });
-        }
-    }
-
-    for (name, params) in &listed {
-        if listed_counts[name] != 1 {
-            continue;
-        }
-        let matching: Vec<&FunctionDecl> = declarations
-            .iter()
-            .filter(|declaration| declaration.name == *name)
-            .collect();
-        match matching.as_slice() {
-            [] => findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`Signature:` names `{name}` but no `def function {name}(...)` \
-                     declaration was found in the same file"
-                ),
-            }),
-            [declaration] if declaration.params != *params => findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`Signature:` parameter list {params:?} does not match the \
-                     `def function {name}` declaration's parameters {:?}",
-                    declaration.params
-                ),
-            }),
-            _ => {}
-        }
-    }
-
-    for name in declaration_counts.keys() {
-        if !listed_counts.contains_key(name) {
-            findings.push(Finding {
-                file: header.file.clone(),
-                severity: Severity::Error,
-                message: format!(
-                    "`def function {name}(...)` is declared in this file but missing from \
-                     the `Signature:` field; list every function the file defines"
-                ),
-            });
-        }
+    let declarations: Vec<FunctionDecl> = find_def_functions(&header.content)
+        .into_iter()
+        .filter(|declaration| declaration.name == member.name)
+        .collect();
+    match declarations.as_slice() {
+        [] => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!("no `def function {}(...)` declaration found", member.name),
+        }),
+        [declaration] if declaration.params.len() != params.len() => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!(
+                "`Signature:` declares {} parameter type(s), but `def function {}` has {} parameter(s)",
+                params.len(),
+                member.name,
+                declaration.params.len()
+            ),
+        }),
+        [_] => {}
+        _ => findings.push(Finding {
+            file: header.file.clone(),
+            severity: Severity::Error,
+            message: format!("duplicate `def function {}(...)` declarations", member.name),
+        }),
     }
 
     findings
@@ -756,15 +955,15 @@ pub(crate) fn signature_entries(value: &str) -> impl Iterator<Item = &str> {
     value.lines().map(str::trim).filter(|line| !line.is_empty())
 }
 
-/// Parse the header value of a `Signature:` key into (name, params).
+/// Parse the header value of a `Signature:` key into (name, parameter types).
 ///
-/// Accepts shapes like `proto_num(name) → Int | null`,
-/// `foo(a, b, c) → Object`. Whitespace within the paren list is
-/// tolerated. The return part (everything from `→` on) is discarded.
+/// Accepts shapes like `proto_num(String) → Int | Null` and
+/// `foo(Object, String | Null) → Object`. Both parameter and return type
+/// expressions are validated against the DSL value-type vocabulary.
 pub fn parse_signature(value: &str) -> Option<(String, Vec<String>)> {
     let value = value.trim();
     let (head, return_type) = value.split_once('→')?;
-    if return_type.trim().is_empty() || return_type.contains('→') {
+    if return_type.contains('→') || !is_type_expr(return_type) {
         return None;
     }
     let head = head.trim();
@@ -778,8 +977,37 @@ pub fn parse_signature(value: &str) -> Option<(String, Vec<String>)> {
     if !after[paren_close + 1..].trim().is_empty() {
         return None;
     }
-    let params = parse_params(&after[..paren_close])?;
+    let params = parse_signature_params(&after[..paren_close])?;
     Some((name, params))
+}
+
+const SIGNATURE_TYPES: &[&str] = &[
+    "Any",
+    "String",
+    "Int",
+    "Float",
+    "Bool",
+    "Object",
+    "Array",
+    "Timestamp",
+    "Bytes",
+    "Null",
+];
+
+fn is_type_expr(value: &str) -> bool {
+    let mut parts = value.split('|').map(str::trim).peekable();
+    parts.peek().is_some() && parts.all(|part| SIGNATURE_TYPES.contains(&part))
+}
+
+fn parse_signature_params(value: &str) -> Option<Vec<String>> {
+    if value.trim().is_empty() {
+        return Some(Vec::new());
+    }
+    value
+        .split(',')
+        .map(str::trim)
+        .map(|param| is_type_expr(param).then(|| param.to_string()))
+        .collect()
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -840,546 +1068,247 @@ fn parse_params(value: &str) -> Option<Vec<String>> {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
+mod facade_tests {
     use super::*;
 
-    fn parser(s: &str) -> SnippetHeader {
+    fn parser(source: &str) -> SnippetHeader {
         parse_str(
-            Path::new("packaging/snippets/parsers/x.limpid"),
+            Path::new("packaging/snippets/parsers/example.limpid"),
             SnippetKind::Parser,
-            s,
+            source,
         )
         .unwrap()
     }
-    fn composer(s: &str) -> SnippetHeader {
+
+    fn function(source: &str) -> SnippetHeader {
         parse_str(
-            Path::new("packaging/snippets/composers/x.limpid"),
-            SnippetKind::Composer,
-            s,
-        )
-        .unwrap()
-    }
-    fn filter(s: &str) -> SnippetHeader {
-        parse_str(
-            Path::new("packaging/snippets/filters/x.limpid"),
-            SnippetKind::Filter,
-            s,
-        )
-        .unwrap()
-    }
-    fn function(s: &str) -> SnippetHeader {
-        parse_str(
-            Path::new("packaging/snippets/functions/x.limpid"),
+            Path::new("packaging/snippets/functions/example.limpid"),
             SnippetKind::Function,
-            s,
+            source,
         )
         .unwrap()
     }
 
-    // --- Kind dispatch from path ---
-    #[test]
-    fn kind_from_path_walks_upward() {
-        assert_eq!(
-            SnippetKind::from_path(Path::new(
-                "/home/user/repo/packaging/snippets/parsers/parse_x.limpid"
-            )),
-            Some(SnippetKind::Parser)
-        );
-        assert_eq!(
-            SnippetKind::from_path(Path::new(
-                "/home/user/repo/packaging/snippets/functions/f.limpid"
-            )),
-            Some(SnippetKind::Function)
-        );
-        assert_eq!(
-            SnippetKind::from_path(Path::new("/tmp/unknown/loc.limpid")),
-            None
-        );
-    }
+    fn clean_parser() -> &'static str {
+        r#"// Facade: process parse_example, process example_to_otlp
+// Category: Transport
+// Test corpus: synthetic (unit fixtures)
 
-    // --- Rule 1: required keys + order ---
-    #[test]
-    fn parser_clean_canonical_header() {
-        let h = parser(
-            "\
-// Summary:     OpenSSH events → LSIS Authentication
-// Reads:       workspace.openssh.* (bridge from parse_syslog | parse_journald)
-//                .body     (required, String)  — sshd body
-//                .pid      (optional, String)  — pid
-// Writes:      workspace.lsis.* — class_uid 3002 (Authentication)
-// Category:    Endpoint / host audit (Unix)
-// Test corpus: real (OpenSSH sample)
+// Process: parse_example
+// Summary: parses an example event
+// Reads: ingress (raw wire)
+// Writes: workspace.lsis.parsed.*
+//   .class_uid (required, Int)
+def process parse_example { }
 
-def process foo {}
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
+def function private_helper(value) { value }
+
+// Process: example_to_otlp
+// Summary: places example facts in OTLP fields
+// Reads: workspace.lsis.parsed.*
+//   .class_uid (required, Int)
+//   workspace.example.*
+//   .source (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//   .body (required, Bytes)
+def process example_to_otlp { }
+"#
     }
 
     #[test]
-    fn parser_missing_summary_is_error() {
-        let h = parser(
-            "\
-// Reads:       ingress (raw wire) — X CEF wire
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("missing required key `Summary:`"))
-        );
+    fn canonical_facade_and_private_definition_are_clean() {
+        let header = parser(clean_parser());
+        assert_eq!(header.facade.len(), 2);
+        assert_eq!(header.members.len(), 2);
+        assert!(lint(&header).is_empty(), "{:?}", lint(&header));
     }
 
     #[test]
-    fn parser_order_violation_caught() {
-        let h = parser(
-            "\
-// Reads:       ingress (raw wire) — X
-// Summary:     X
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
+    fn facade_continuation_is_comma_separated() {
+        let source = clean_parser().replace(
+            "process parse_example, process example_to_otlp",
+            "process parse_example,\n//         process example_to_otlp",
         );
-        assert!(lint(&h).iter().any(|f| f.message.contains("out of order")));
-    }
-
-    // --- Rule 2: Category ---
-    #[test]
-    fn composer_with_category_is_error() {
-        let h = composer(
-            "\
-// Summary:     OCSF renderer
-// Reads:       workspace.lsis.* (LSIS)
-//                .class_uid (required, Int) — dispatch discriminator
-// Writes:      workspace.lsis.ocsf — OCSF 1.3.0 JSON string
-// Category:    OCSF 1.3.0
-// Test corpus: real (x)
-",
-        );
-        let findings = lint(&h);
-        assert!(
-            findings.iter().any(|f| f
-                .message
-                .contains("`Category:` is not permitted on composer")),
-            "findings: {findings:?}"
-        );
+        let header = parser(&source);
+        assert_eq!(header.facade.len(), 2);
+        assert!(lint(&header).is_empty(), "{:?}", lint(&header));
     }
 
     #[test]
-    fn parser_category_value_must_be_in_whitelist() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       ingress (raw wire) — X
-// Writes:      workspace.lsis.* — 4001
-// Category:    Made up category
-// Test corpus: real (x)
-",
+    fn malformed_and_duplicate_facade_entries_are_errors() {
+        let source = clean_parser().replace(
+            "process parse_example, process example_to_otlp",
+            "process parse_example, process parse_example, parser nope",
         );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("not in the allowed set"))
-        );
-    }
-
-    // --- Rule 3: Test corpus prefix ---
-    #[test]
-    fn function_needs_unit_prefix() {
-        let h = function(
-            "\
-// Summary:     IANA proto lookup
-// Signature:   proto_num(name) → Int | null
-// Test corpus: real (some corpus)
-
-def function proto_num(name) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("must start with"))
-        );
-    }
-
-    #[test]
-    fn parser_cannot_use_unit_prefix() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       ingress (raw wire) — X
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: unit (some source)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("must start with"))
-        );
-    }
-
-    // --- Rule 4: Reads dot-line grammar (universal) ---
-    #[test]
-    fn parser_bridge_needs_dot_lines() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       workspace.openssh.* (bridge from parse_syslog)
-// Writes:      workspace.lsis.* — 3002
-// Category:    Endpoint / host audit (Unix)
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("at least one dot-line"))
-        );
-    }
-
-    #[test]
-    fn parser_ingress_forbids_dot_lines() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       ingress (raw wire) — X CEF
-//                .body (required, String)
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("dot-line intake rows are forbidden"))
-        );
-    }
-
-    #[test]
-    fn composer_reads_grammar_applies() {
-        // Composer with the LSIS shape but zero dot lines → error.
-        let h = composer(
-            "\
-// Summary:     OCSF renderer
-// Reads:       workspace.lsis.* (LSIS)
-// Writes:      workspace.lsis.ocsf — OCSF 1.3.0 JSON string
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("at least one dot-line"))
-        );
-    }
-
-    #[test]
-    fn filter_reads_grammar_applies() {
-        let h = filter(
-            "\
-// Summary:     sshd journal noise drop
-// Reads:       workspace.journald.* (from parse_journald)
-//                .MESSAGE (required, String) — sshd body candidate
-// Effect:      drop pam_unix(sshd:session): ... / else pass-through
-// Test corpus: real (x)
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn dot_line_regex_accepts_leading_underscore() {
-        // journald's `_PID` / `__REALTIME_TIMESTAMP` are real intake fields.
-        let d = parse_dot_line("._PID (optional, String) — kernel-verified pid").unwrap();
-        assert_eq!(d.name, "_PID");
-        assert!(!d.required);
-        assert_eq!(d.ty, "String");
-        let d = parse_dot_line(".__REALTIME_TIMESTAMP (optional, Int) — µs").unwrap();
-        assert_eq!(d.name, "__REALTIME_TIMESTAMP");
-    }
-
-    #[test]
-    fn dot_line_regex_rejects_wrong_shape() {
-        assert!(parse_dot_line(".body (mandatory, String)").is_none());
-        assert!(parse_dot_line(".body (required, Blob)").is_none());
-        assert!(parse_dot_line(".body [required, String]").is_none());
-        assert!(parse_dot_line(".1body (required, String)").is_none());
-    }
-
-    #[test]
-    fn dot_line_regex_tolerates_trailing_prose() {
-        let d = parse_dot_line(".body (required, String)  — sshd body").unwrap();
-        assert_eq!(d.name, "body");
-        assert!(d.required);
-    }
-
-    #[test]
-    fn reads_multi_segment_workspace_namespace_accepted() {
-        // LSIS strata surface as multi-segment paths:
-        // workspace.lsis.parsed.*, workspace.lsis.shed.otlp.*, etc.
-        // Also dot-line intake names may be dotted (log_record.body).
-        let h = composer(
-            "\
-// Summary:     Composer reading a multi-segment shed sub-tree
-// Reads:       workspace.lsis.shed.otlp.* — per-slot intake
-//                .log_record.body       (required, String) — body
-//                .log_record.attributes (optional, Array)  — attrs
-// Writes:      workspace.lsis.composed.otlp — proto bytes
-// Test corpus: spec-only (OTLP proto shape)
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn reads_unknown_first_token_is_error() {
-        let h = parser(
-            "\
-// Summary:     X
-// Reads:       nothing sensible
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// Test corpus: real (x)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("first token must be"))
-        );
-    }
-
-    // --- Rule 5: Signature cross-check ---
-    #[test]
-    fn function_signature_matches_declaration() {
-        let h = function(
-            "\
-// Summary:     IANA proto lookup
-// Signature:   proto_num(name) → Int | null
-// Test corpus: unit (IANA proto registry, RFC 5237)
-
-def function proto_num(name) {
-    switch lower(name) {
-        \"tcp\" { 6 }
-        default { null }
-    }
-}
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn function_signature_name_mismatch_is_error() {
-        let h = function(
-            "\
-// Summary:     IANA proto lookup
-// Signature:   proto_num(name) → Int | null
-// Test corpus: unit (IANA proto registry)
-
-def function protonum(name) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("no `def function proto_num"))
-        );
-    }
-
-    #[test]
-    fn function_signature_param_mismatch_is_error() {
-        let h = function(
-            "\
-// Summary:     Two-arg thing
-// Signature:   foo(a, b) → Int
-// Test corpus: unit (docs)
-
-def function foo(a, b, c) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("parameter list"))
-        );
-    }
-
-    #[test]
-    fn function_family_signatures_match_all_declarations() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              timestamp_ns_to_ms(value) → Int
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-def function timestamp_ns_to_ms(value) {}
-",
-        );
-        assert!(lint(&h).is_empty(), "unexpected findings: {:?}", lint(&h));
-    }
-
-    #[test]
-    fn function_declaration_missing_from_signature_is_error() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-def function timestamp_ns_to_ms(value) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("timestamp_ns_to_ms") && f.message.contains("missing"))
-        );
-    }
-
-    #[test]
-    fn function_family_second_param_mismatch_is_error() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              timestamp_ns_to_ms(value, divisor) → Int
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-def function timestamp_ns_to_ms(value) {}
-",
-        );
-        let findings = lint(&h);
-        assert!(findings.iter().any(|f| {
-            f.message.contains("timestamp_ns_to_ms") && f.message.contains("parameter list")
-        }));
-    }
-
-    #[test]
-    fn malformed_signature_entry_is_error() {
-        let h = function(
-            "\
-// Summary:     Timestamp conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              not a signature
-// Test corpus: unit (timestamp boundaries)
-
-def function timestamp_ms_to_ns(value) {}
-",
-        );
-        assert!(lint(&h).iter().any(
-            |f| f.message.contains("could not parse") && f.message.contains("not a signature")
-        ));
-    }
-
-    #[test]
-    fn blank_signature_is_error() {
-        let h = function(
-            "\
-// Summary:     Empty family
-// Signature:
-// Test corpus: unit (header lint)
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("at least one non-blank entry"))
-        );
-    }
-
-    #[test]
-    fn duplicate_signature_name_is_error() {
-        let h = function(
-            "\
-// Summary:     Duplicate surface
-// Signature:   convert(value) → Int
-//              convert(other) → Int
-// Test corpus: unit (header lint)
-
-def function convert(value) {}
-",
-        );
-        assert!(lint(&h).iter().any(|f| {
-            f.message
-                .contains("duplicate `Signature:` entry for `convert`")
-        }));
-    }
-
-    #[test]
-    fn duplicate_function_declaration_is_error() {
-        let h = function(
-            "\
-// Summary:     Duplicate declaration
-// Signature:   convert(value) → Int
-// Test corpus: unit (header lint)
-
-def function convert(value) {}
-def function convert(value) {}
-",
-        );
-        assert!(
-            lint(&h)
-                .iter()
-                .any(|f| f.message.contains("duplicate `def function convert"))
-        );
-    }
-
-    // --- Rule 7: unknown key → warning ---
-    #[test]
-    fn unknown_key_is_warning_not_error() {
-        let h = parser(
-            "\
-// Summary:     FortiGate CEF
-// Reads:       ingress (raw wire) — FortiGate CEF
-// Writes:      workspace.lsis.* — 4001
-// Category:    Network firewall / IPS
-// FortiGate CEF dialect quirks: some prose
-// Test corpus: real (fortigate)
-",
-        );
-        let f = lint(&h);
-        let errors: Vec<_> = f.iter().filter(|x| x.severity == Severity::Error).collect();
-        let warnings: Vec<_> = f
-            .iter()
-            .filter(|x| x.severity == Severity::Warning)
+        let messages: Vec<String> = lint(&parser(&source))
+            .into_iter()
+            .map(|finding| finding.message)
             .collect();
-        assert!(errors.is_empty(), "errors: {errors:?}");
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].message.contains("FortiGate CEF dialect quirks"));
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("duplicate `Facade:`"))
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("invalid `Facade:`"))
+        );
     }
 
-    // --- Signature parser corner cases ---
+    #[test]
+    fn missing_and_orphan_member_blocks_are_errors() {
+        let missing = clean_parser().replace("// Process: example_to_otlp", "// Adapter contract");
+        assert!(
+            lint(&parser(&missing))
+                .iter()
+                .any(|finding| finding.message.contains("no matching per-member block"))
+        );
+
+        let orphan = clean_parser().replace(
+            "process parse_example, process example_to_otlp",
+            "process parse_example",
+        );
+        assert!(lint(&parser(&orphan)).iter().any(|finding| {
+            finding
+                .message
+                .contains("orphan `Process: example_to_otlp`")
+        }));
+    }
+
+    #[test]
+    fn member_block_must_be_immediately_followed_by_matching_def() {
+        let source = clean_parser().replace(
+            "def process parse_example { }",
+            "def process parse_other { }",
+        );
+        assert!(lint(&parser(&source)).iter().any(|finding| {
+            finding
+                .message
+                .contains("followed by `def process parse_other`")
+        }));
+    }
+
+    #[test]
+    fn process_member_requires_canonical_keys() {
+        let source = clean_parser().replace("// Summary: parses an example event\n", "");
+        assert!(
+            lint(&parser(&source))
+                .iter()
+                .any(|finding| finding.message.contains("missing required key `Summary:`"))
+        );
+    }
+
+    #[test]
+    fn multi_root_contract_validates_each_root() {
+        let clean = parser(clean_parser());
+        assert!(lint(&clean).is_empty(), "{:?}", lint(&clean));
+
+        let source = clean_parser().replace(
+            "//   workspace.example.*\n//   .source (optional, String)",
+            "//   workspace.example.*",
+        );
+        assert!(lint(&parser(&source)).iter().any(|finding| {
+            finding.message.contains("workspace.example.*")
+                && finding
+                    .message
+                    .contains("requires at least one dot declaration")
+        }));
+    }
+
+    #[test]
+    fn reserved_io_shapes_reject_field_declarations() {
+        let source = clean_parser().replace(
+            "// Reads: ingress (raw wire)",
+            "// Reads: ingress (raw wire)\n//   .body (required, String)",
+        );
+        assert!(lint(&parser(&source)).iter().any(|finding| {
+            finding
+                .message
+                .contains("workspace roots and dot declarations are forbidden")
+        }));
+    }
+
+    #[test]
+    fn egress_write_is_valid_without_dot_declarations() {
+        let source = clean_parser().replace(
+            "// Writes: workspace.lsis.shed.otlp.*\n//   .body (required, Object)",
+            "// Writes: egress (OTLP protobuf bytes)",
+        );
+        assert!(
+            lint(&parser(&source)).is_empty(),
+            "{:?}",
+            lint(&parser(&source))
+        );
+    }
+
+    #[test]
+    fn function_member_signature_matches_adjacent_definition() {
+        let source = r#"// Facade: function convert
+// Test corpus: unit (conversion table)
+
+// Function: convert
+// Summary: converts a value
+// Signature: convert(String) → Int | Null
+def function convert(value) { value }
+
+def function private_helper(value) { value }
+"#;
+        let header = function(source);
+        assert!(lint(&header).is_empty(), "{:?}", lint(&header));
+    }
+
+    #[test]
+    fn function_signature_name_and_parameters_are_checked() {
+        let source = r#"// Facade: function convert
+// Test corpus: unit (conversion table)
+
+// Function: convert
+// Summary: converts a value
+// Signature: other(Int, Int) → Int
+def function convert(value) { value }
+"#;
+        assert!(
+            lint(&function(source))
+                .iter()
+                .any(|finding| finding.message.contains("has `Signature:` for `other`"))
+        );
+    }
+
+    #[test]
+    fn file_metadata_order_category_and_corpus_are_checked() {
+        let source = clean_parser().replace(
+            "// Category: Transport\n// Test corpus: synthetic",
+            "// Test corpus: unit\n// Category: Unknown\n// Note: synthetic",
+        );
+        let findings = lint(&parser(&source));
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("out of order"))
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("allowed set"))
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("must start"))
+        );
+    }
+
     #[test]
     fn parse_signature_variants() {
         assert_eq!(
-            parse_signature("proto_num(name) → Int | null"),
-            Some(("proto_num".to_string(), vec!["name".to_string()]))
-        );
-        assert_eq!(
-            parse_signature("foo(a, b, c) → Object"),
+            parse_signature("convert(String, Object | Null) → Object | Null"),
             Some((
-                "foo".to_string(),
-                vec!["a".to_string(), "b".to_string(), "c".to_string()]
+                "convert".to_string(),
+                vec!["String".to_string(), "Object | Null".to_string()]
             ))
         );
-        assert_eq!(
-            parse_signature("nullary() → Bool"),
-            Some(("nullary".to_string(), vec![]))
-        );
-        assert_eq!(parse_signature("no parens"), None);
-        assert_eq!(parse_signature("no_return(value)"), None);
-        assert_eq!(parse_signature("empty_return(value) →"), None);
+        assert_eq!(parse_signature("missing return"), None);
+        assert_eq!(parse_signature("convert(value) → Object"), None);
     }
 }

--- a/crates/xtask/src/inventory.rs
+++ b/crates/xtask/src/inventory.rs
@@ -10,7 +10,7 @@
 //!   <!-- BEGIN: inventory:filters -->   ... <!-- END: inventory:filters -->
 //!   <!-- BEGIN: inventory:functions --> ... <!-- END: inventory:functions -->
 //!
-//! Governing principle: header values that are AUTHORED (Summary /
+//! Governing principle: facade-member values that are AUTHORED (Summary /
 //! Writes / Signature) are copied verbatim into the table cells.
 //! Derived values (function Used-by, composer Writes first token)
 //! are computed here from the shipped snippet bodies rather than
@@ -28,7 +28,7 @@
 
 use std::path::Path;
 
-use crate::header::{SnippetHeader, SnippetKind, parse_signature, signature_entries};
+use crate::header::{MemberKind, SnippetHeader, SnippetKind, parse_signature};
 
 /// Ordered, authoritative list of allowed parser categories.
 ///
@@ -164,7 +164,15 @@ pub fn render_functions_table(all_headers: &[SnippetHeader]) -> String {
         .iter()
         .filter(|h| h.kind == SnippetKind::Function)
     {
-        for sig in signature_entries(h.get("Signature").unwrap_or("")) {
+        for facade in h
+            .facade
+            .iter()
+            .filter(|member| member.kind == MemberKind::Function)
+        {
+            let sig = h
+                .member(MemberKind::Function, &facade.name)
+                .and_then(|member| member.get("Signature"))
+                .unwrap_or("");
             let name = parse_signature(sig).map(|(n, _)| n).unwrap_or_default();
             let callers = derive_used_by(&name, &h.file, all_headers);
             let callers_cell = if callers.is_empty() {
@@ -286,23 +294,50 @@ fn contains_call(line: &str, func_name: &str) -> bool {
 /// cell renders on a single row. Missing Summary → empty string
 /// (lint has already reported it as an error before we get here).
 fn summary_of(h: &SnippetHeader) -> String {
-    h.get("Summary")
+    h.facade
+        .first()
+        .and_then(|facade| h.member(facade.kind, &facade.name))
+        .and_then(|member| member.get("Summary"))
         .unwrap_or("")
         .replace('\n', " ")
         .trim()
         .to_string()
 }
 
-/// The first whitespace-separated token of the Writes value's first
-/// line (e.g. `workspace.lsis.ocsf`). Empty when Writes is missing.
+/// The concrete slot described by the first root and dot declaration in
+/// `Writes:` (e.g. `workspace.lsis.composed.*` + `.ocsf` becomes
+/// `workspace.lsis.composed.ocsf`). Reserved `egress` is returned as-is.
 fn writes_first_token(h: &SnippetHeader) -> String {
-    let writes = h.get("Writes").unwrap_or("");
-    let first_line = writes.split('\n').next().unwrap_or("");
-    first_line
-        .split_whitespace()
+    let writes = h
+        .facade
+        .iter()
+        .find(|facade| facade.kind == MemberKind::Process)
+        .and_then(|facade| h.member(MemberKind::Process, &facade.name))
+        .and_then(|member| member.get("Writes"))
+        .unwrap_or("");
+    let mut lines = writes.lines();
+    let root = lines
         .next()
         .unwrap_or("")
-        .to_string()
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    if root == "egress" || root == "ingress" {
+        return root.to_string();
+    }
+    let Some(prefix) = root.strip_suffix(".*") else {
+        return root.to_string();
+    };
+    let field = lines
+        .map(str::trim_start)
+        .find_map(|line| line.strip_prefix('.'))
+        .and_then(|line| line.split_whitespace().next())
+        .unwrap_or("");
+    if field.is_empty() {
+        root.to_string()
+    } else {
+        format!("{prefix}.{field}")
+    }
 }
 
 /// Escape characters that would break markdown table cells. Pipe is
@@ -388,7 +423,7 @@ mod tests {
         let def_file = "/repo/packaging/snippets/functions/proto_num.limpid";
         let def_content = "\
 // Summary:     IANA proto
-// Signature:   proto_num(name) → Int | null
+// Signature:   proto_num(String) → Int | Null
 // Test corpus: unit (registry)
 
 def function proto_num(name) {
@@ -469,7 +504,7 @@ def process z {
         // the guardrail should be surgical.
         let def_content = "\
 // Summary:     Self-caller
-// Signature:   selfy(x) → Int
+// Signature:   selfy(Int) → Int
 // Test corpus: unit (docs)
 
 def function selfy(x) {
@@ -491,12 +526,17 @@ def function selfy(x) {
             SnippetKind::Function,
             "/repo/packaging/snippets/functions/timestamp_converter.limpid",
             "\
-// Summary:     Timestamp unit conversions
-// Signature:   timestamp_ms_to_ns(value) → Int
-//              timestamp_ns_to_ms(value) → Int
+// Facade: function timestamp_ms_to_ns, function timestamp_ns_to_ms
 // Test corpus: unit (timestamp boundaries)
 
+// Function: timestamp_ms_to_ns
+// Summary: converts milliseconds to nanoseconds
+// Signature: timestamp_ms_to_ns(Int) → Int
 def function timestamp_ms_to_ns(value) {}
+
+// Function: timestamp_ns_to_ms
+// Summary: converts nanoseconds to milliseconds
+// Signature: timestamp_ns_to_ms(Int) → Int
 def function timestamp_ns_to_ms(value) {}
 ",
         );
@@ -532,13 +572,13 @@ def process compose_ms {
         );
 
         let out = render_functions_table(&[family, ms_caller, ns_caller]);
-        assert_eq!(out.matches("timestamp_ms_to_ns(value)").count(), 1);
-        assert_eq!(out.matches("timestamp_ns_to_ms(value)").count(), 1);
+        assert_eq!(out.matches("timestamp_ms_to_ns(Int)").count(), 1);
+        assert_eq!(out.matches("timestamp_ns_to_ms(Int)").count(), 1);
         assert!(out.contains(
-            "| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(value) → Int` | `parse_ms` |"
+            "| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(Int) → Int` | `parse_ms` |"
         ));
         assert!(out.contains(
-            "| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(value) → Int` | `compose_ms` |"
+            "| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(Int) → Int` | `compose_ms` |"
         ));
     }
 
@@ -581,15 +621,20 @@ def process compose_ms {
             SnippetKind::Composer,
             "/r/packaging/snippets/composers/compose_ocsf.limpid",
             "\
-// Summary:     Renders LSIS to OCSF 1.3.0
-// Reads:       workspace.lsis.* (LSIS)
-//                .class_uid (required, Int) — dispatch discriminator
-// Writes:      workspace.lsis.ocsf — OCSF 1.3.0 JSON string
+// Facade: process compose_ocsf
 // Test corpus: real (r)
+
+// Process: compose_ocsf
+// Summary: Renders LSIS to OCSF 1.3.0
+// Reads: workspace.lsis.parsed.*
+//                .class_uid (required, Int) — dispatch discriminator
+// Writes: workspace.lsis.composed.*
+//                .ocsf (required, Object)
+def process compose_ocsf {}
 ",
         );
         let out = render_composers_table(&[c]);
-        assert!(out.contains("`workspace.lsis.ocsf`"));
+        assert!(out.contains("`workspace.lsis.composed.ocsf`"));
         assert!(out.contains("Renders LSIS to OCSF 1.3.0"));
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -111,6 +111,20 @@ ignore = [
 multiple-versions = "warn"
 wildcards = "deny"
 
+# Duplicate-version exemptions. Each entry MUST carry a rationale comment
+# and the condition under which it can be removed.
+skip = [
+    # getrandom is split upstream: ring (used by the rustls stack) is
+    # pinned to getrandom 0.2, while rand 0.9 (pulled in by
+    # opentelemetry_sdk) requires getrandom 0.3. Unresolvable until ring
+    # migrates. Only these two lines are exempted; the newest line
+    # (currently 0.4, dev-only via tempfile) is left unskipped so a
+    # future additional split still warns. Remove these entries once
+    # `cargo tree -d` shows a single getrandom version.
+    { crate = "getrandom@0.2" },
+    { crate = "getrandom@0.3" },
+]
+
 [sources]
 # Only crates.io is accepted as a registry. git deps and unknown
 # registries are rejected — we want every dep to be reproducible via

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -19,7 +19,7 @@ It contains `include` directives and global blocks (`geoip`, `control`, `table`)
 ```
 include "inputs/*.limpid"          // glob
 include "outputs/ama.limpid"       // single file
-include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"   // shipped snippet
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"             // shipped snippet
 ```
 
 Rules:

--- a/docs/src/dsl-syntax.md
+++ b/docs/src/dsl-syntax.md
@@ -138,6 +138,7 @@ Evaluated values are coerced to strings:
 | Bool | `true` / `false` |
 | Null | empty string |
 | Timestamp | RFC3339 (`2026-04-19T10:30:45+00:00`) |
+| Bytes | `<bytes>` (use `to_string(...)` for an intentional text decoding) |
 | Object / Array | JSON |
 
 For full control over structured values, wrap them in `to_json(...)` yourself.

--- a/docs/src/dsl-syntax.md
+++ b/docs/src/dsl-syntax.md
@@ -262,7 +262,7 @@ The expression form has no side effects (no `workspace.x = …`, no `process foo
 
 The constructs not detailed above live on the page they semantically belong to:
 
-- **`try-catch`** — process-body only. See [User-defined Processes → Control flow](./processing/user-defined.md#control-flow) for the syntax and the `error` name binding inside `catch`. Iteration over arrays is *not* a control-flow construct in limpid: use the block-arg primitives (`map`, `filter`, `find`, `reduce`) instead — see [Arrays](./processing/user-defined.md#arrays).
+- **`try-catch`** — process-body only. See [User-defined Processes → Control flow](./processing/user-defined.md#control-flow) for the syntax and the `error` name binding inside `catch`. Iteration over arrays and objects is *not* a control-flow construct in limpid: use the block-arg primitives (`map`, `filter`, `find`, `reduce`) instead — see [Arrays](./processing/user-defined.md#arrays).
 - **`drop` / `finish` / `error`** — pipeline routing. `drop` terminates the event silently (intended discard, counted as `events_dropped`); `finish` ends the pipeline early without dropping (counted as `events_finished`); `error <expr?>` routes the event to the [error log](./operations/error-log.md) with an operator-readable reason (counted as `events_errored`, same as a runtime process failure). `drop` and `error` are also allowed inside a process body; `finish` is pipeline-only. See [Pipelines → drop, finish, and error](./pipelines/drop-finish-error.md) for when to choose which.
 
 ## Pipe operator
@@ -289,22 +289,24 @@ The right-hand side can be:
 - A bare identifier (zero-arg form): `arr |> first` ≡ `arr |> first()`.
 - A bare identifier with a trailing block argument: `arr |> map { |x| x.id }` ≡ `arr |> map() { |x| x.id }`.
 
-All three forms produce identical FuncCall AST after the parser splices the LHS as the first argument. The bare form is purely ergonomic — useful when the pipe is the only argument source and the function has no other positional inputs (`first` / `last` / `distinct` / `sum`) or only takes a block (`map` / `filter` / `find` over the pipe-fed array).
+All three forms produce identical FuncCall AST after the parser splices the LHS as the first argument. The bare form is purely ergonomic — useful when the pipe is the only argument source and the function has no other positional inputs (`first` / `last` / `distinct` / `sum`) or only takes a block (`map` / `filter` / `find` over the pipe-fed collection).
 
 ## Block argument
 
-The block-arg primitives — `map`, `filter`, `find`, `reduce` — accept a trailing block argument that binds one (or, for `reduce`, two) identifier per element and runs the body against it:
+The block-arg primitives — `map`, `filter`, `find`, `reduce` — accept a trailing block argument. Arrays bind one identifier per element (two for `reduce`); objects bind `key, value` per entry (three including the accumulator for `reduce`):
 
 ```limpid
 let evens = filter(workspace.nums) { |n| n % 2 == 0 }
 let doubled = map(workspace.nums) { |n| n * 2 }
 let user_alert = find(workspace.alerts) { |a| a.user == "alice" }
 let total = reduce(workspace.amounts, 0) { |acc, x| acc + x }
+let headers = map(workspace.headers) { |key, value| "${key}: ${value}" }
+let byte_total = reduce(workspace.fields, 0) { |acc, key, value| acc + value }
 ```
 
 The body has the same shape as a `def function` body: zero or more `let` bindings followed by a required trailing return expression. Locals introduced inside the body do not leak back to the caller — each iteration starts with a fresh child of the caller's scope.
 
-Only `map` / `filter` / `find` / `reduce` accept block-args today; attaching one to any other function is a clear error. See [Built-in Functions → Array operations](./functions/expression-functions.md) for the per-primitive details and edge cases.
+Only `map` / `filter` / `find` / `reduce` accept block-args today; attaching one to any other function, or using the wrong number of block parameters for the runtime collection type, is a clear error. See [Built-in Functions → Collection helpers](./functions/expression-functions.md#collection-helpers) for the per-primitive details and edge cases.
 
 ## Reserved identifiers
 

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -709,31 +709,37 @@ workspace.lsis.parsed.src_endpoint.port = to_int(workspace.cef.extension.spt)  /
 
 Motivation: CEF extension values and CSV column values arrive as strings even when carrying numeric content. OCSF schemas commonly require `Integer` for those same fields (ports, session IDs, byte counts). `to_int` is the schema-agnostic cast used by SIEM parser snippets.
 
-## Array helpers
+## Collection helpers
 
 Arrays in limpid are **ordered but index-hidden** — you construct them with `[a, b, c]` literals, but the DSL deliberately omits positional access (`arr[n]`) and positional writes (`arr[n] = v`). Element identity (or whole-array transforms) is the addressing model; see [User-defined Processes → Arrays](../processing/user-defined.md#arrays) for the rationale and the per-primitive references below.
 
-Four primitives — `map`, `filter`, `find`, `reduce` — take a **block argument** (`{ |x| ... }`) per element. Block syntax and the universal pipe operator `|>` are documented in [DSL Syntax Basics → Block argument](../dsl-syntax.md#block-argument).
+Four primitives — `map`, `filter`, `find`, `reduce` — take a **block argument** per array element or object entry. Array blocks bind `{ |x| ... }`; object blocks bind `{ |key, value| ... }`. Block syntax and the universal pipe operator `|>` are documented in [DSL Syntax Basics → Block argument](../dsl-syntax.md#block-argument).
 
-### map(array) { |x| body }
+### map(array) { |x| body } / map(object) { |key, value| body }
 
 Per-element transform; returns a new array of the same length, with each element replaced by the block's return value. Construction order is preserved. `Null` input → empty array.
 
+For an object, visits each entry in insertion order and returns an array containing each block result. Keys are bound as strings. Duplicate keys remain separate visits.
+
 ```limpid
 workspace.upper_users = map(workspace.events) { |e| upper(e.user) }
+workspace.headers = map(workspace.headers_by_name) { |key, value| "${key}: ${value}" }
 ```
 
-### filter(array) { |x| predicate }
+### filter(array) { |x| predicate } / filter(object) { |key, value| predicate }
 
 Keep elements where the block returns a truthy value. Order-preserving; non-truthy elements (`false`, `null`, `0`, `""`, empty containers) are dropped.
 
+For an object, returns an object containing the original entries whose block result is truthy. Entry order and duplicate keys are preserved. `Null` retains the established array behavior and returns an empty array.
+
 ```limpid
 workspace.alerts = filter(workspace.events) { |e| e.severity >= 7 }
+workspace.public = filter(workspace.fields) { |key, value| not starts_with(key, "_") }
 ```
 
 Equivalent to `compact` for null removal: `filter(arr) { |x| x != null }` drops `null` entries (no separate `compact` primitive ships — `null_omit` operates on objects, not arrays).
 
-### find(array) { |x| predicate }
+### find(array) { |x| predicate } / find(object) { |key, value| predicate }
 
 First element where the block returns truthy, or `null` if no match. An earlier `find_by(arr, key, value)` shape was removed in the 0.7.x cycle; the block-arg form composes for arbitrary predicates:
 
@@ -743,16 +749,23 @@ workspace.user    = find(workspace.evidence) { |e| e.entityType == "User" }
 workspace.recent  = find(workspace.events)   { |e| e.received_at > workspace.cutoff }
 ```
 
+For an object, returns the first matching entry as a two-element `[key, value]` array, or `null` when no entry matches.
+
 Non-object elements no longer have to be skipped silently — predicate logic decides what counts as a match.
 
-### reduce(array, init) { |acc, x| step }
+### reduce(array, init) { |acc, x| step } / reduce(object, init) { |acc, key, value| step }
 
 Left fold. The block takes two parameters: the running accumulator (`init` on the first iteration) and the current element. The block's return value becomes the new accumulator. Empty array → `init` unchanged.
+
+For an object, the block takes the accumulator, key, and value. Entries are folded in insertion order, including duplicate keys. Empty object → `init` unchanged. `Null` follows the array convention and also returns `init`.
 
 ```limpid
 let total = reduce(workspace.amounts, 0) { |acc, x| acc + x }
 let joined = reduce(workspace.tags, "") { |acc, t| acc + "," + t }
+let total_bytes = reduce(workspace.byte_fields, 0) { |acc, key, value| acc + value }
 ```
+
+Block arity is checked against the evaluated collection type. Array calls require one block parameter (`map` / `filter` / `find`) or two (`reduce`); object calls require two or three respectively. A mismatch is an error rather than an ignored binding.
 
 ### first(array) / last(array)
 
@@ -878,7 +891,7 @@ is_array(null)          // false
 is_array({a: 1})        // false (Object, not Array)
 ```
 
-Designed for snippet parsers that consume vendor JSON whose nominally-array fields may arrive as scalars when upstream is malformed. The pattern is **pre-validate intake shape, emit a parser-authored error on mismatch** — rather than fall through to `find()` / `map()` / `filter()` and surface a generic `<primitive>() expects an array` runtime error:
+Designed for snippet parsers that consume vendor JSON whose nominally-array fields may arrive as scalars when upstream is malformed. The pattern is **pre-validate intake shape, emit a parser-authored error on mismatch** — rather than fall through to `find()` / `map()` / `filter()` and surface a generic `<primitive>() expects an array or object` runtime error:
 
 ```limpid
 def process parse_okta_system {

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -6,7 +6,7 @@ Built-in functions are primitives implemented in Rust and shipped with the daemo
 def process parse_cef_line {
     workspace.syslog = syslog.parse(ingress)
     workspace.cef    = cef.parse(workspace.syslog.msg)
-    workspace.payload = parse_json(workspace.cef.msg)
+    workspace.payload = parse_json(workspace.cef.extension.msg)
 }
 ```
 
@@ -40,7 +40,7 @@ def process parse_fw_flat {
 ```limpid
 def process parse_fw_namespaced {
     workspace.syslog = syslog.parse(ingress)   // workspace.syslog.hostname, workspace.syslog.msg, ...
-    workspace.cef    = cef.parse(ingress)      // workspace.cef.version, workspace.cef.src, ...
+    workspace.cef    = cef.parse(ingress)      // workspace.cef.version, workspace.cef.extension.src, ...
 }
 ```
 
@@ -539,8 +539,8 @@ let event_time = coalesce(
 
 // Parser: pick first source IP that is populated
 workspace.lsis.parsed.src_endpoint.ip = coalesce(
-    workspace.cef.src,
-    workspace.cef.sourceTranslatedAddress,
+    workspace.cef.extension.src,
+    workspace.cef.extension.sourceTranslatedAddress,
     workspace.syslog.hostname
 )
 ```
@@ -573,11 +573,11 @@ it would hide the signal.
 
 ```limpid
 workspace.payload = {
-    src: workspace.cef.src,
-    dst: workspace.cef.dst,
-    user: workspace.cef.suser,        // may be null on machine-only events
+    src: workspace.cef.extension.src,
+    dst: workspace.cef.extension.dst,
+    user: workspace.cef.extension.suser,        // may be null on machine-only events
     evidences: [
-        { file: workspace.cef.fname, hash: workspace.cef.fhash }
+        { file: workspace.cef.extension.fname, hash: workspace.cef.extension.fhash }
     ]
 }
 egress = to_json(null_omit(workspace.payload))
@@ -694,7 +694,7 @@ Text-only primitives (`upper`, `regex_*`, `format`, `to_int`,
 Coerces a value to a 64-bit signed integer. Returns `null` on unparseable input, matching the partial-data policy of `regex_extract` and `table_lookup`.
 
 ```limpid
-workspace.lsis.parsed.src_endpoint.port = to_int(workspace.cef.spt)  // CEF ext: "54321" → 54321
+workspace.lsis.parsed.src_endpoint.port = to_int(workspace.cef.extension.spt)  // CEF ext: "54321" → 54321
 ```
 
 | Input | Result |

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1040,7 +1040,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.14"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.7.15"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -25,7 +25,7 @@ Errors raised by these primitives (a `parse_json` on malformed input, a `to_int`
 
 ### Bare statements vs assignments
 
-A parser function returns a `Value::Object` whose keys are taken from the parse — `hostname`, `appname`, `msg` for `syslog.parse`; `version`, `name`, `severity`, plus CEF extension keys (`src`, `dst`, `act`, …) for `cef.parse`; whatever the source JSON contains for `parse_json`. There are two ways to consume that object inside a process body.
+A parser function returns a `Value::Object` whose keys are taken from the parse — `hostname`, `appname`, `msg` for `syslog.parse`; `version`, `name`, `severity`, `extension_raw`, plus nested CEF extension keys (`extension.src`, `extension.dst`, `extension.act`, …) for `cef.parse`; whatever the source JSON contains for `parse_json`. There are two ways to consume that object inside a process body.
 
 **Bare statement** — the returned object's top-level keys are merged directly into `workspace`:
 
@@ -165,9 +165,10 @@ Returns a `Value::Object`:
 | `signature_id`   | String         | vendor-specific event id |
 | `name`           | String         | human-readable event name |
 | `severity`       | Int \| String  | vendor severity (0–10), or the raw string when the producer sent garbage |
-| `ext`            | String         | raw extension blob from the wire — present only when the Extension section was non-empty (mirrors `syslog.parse`'s treatment of `msg`) |
+| `extension_raw`  | String         | raw extension blob from the wire — present only when the Extension section was non-empty (mirrors `syslog.parse`'s treatment of `msg`) |
+| `extension`      | Object         | split Extension `key=value` pairs; keys are data-driven |
 
-Extension `key=value` pairs from the CEF tail (e.g. `src=10.0.0.1 dst=192.168.1.1 act=block`) are emitted **both** as the raw blob in `ext` **and** split into siblings of the header keys (`src`, `dst`, `act`, … — those names are part of CEF, not a limpid convention). The split form is what authors typically read from downstream; the raw `ext` is for passthrough / re-emission, debugging the splitter, or surfacing dialect-specific extension content the splitter doesn't decode (escape sequences, custom separators).
+Extension `key=value` pairs from the CEF tail (e.g. `src=10.0.0.1 dst=192.168.1.1 act=block`) are emitted both as the raw blob in `extension_raw` and under `extension.<key>` (`extension.src`, `extension.dst`, `extension.act`, …). Isolating the data-driven keys prevents them from shadowing positional header fields. The raw form is for passthrough / re-emission, debugging the splitter, or dialect-specific extension content the splitter does not decode.
 
 The optional `defaults` argument behaves the same as in `syslog.parse`.
 
@@ -231,9 +232,10 @@ Encode the HashLit as a `ResourceLogs` proto3 message and return
 the raw wire bytes. Pair with the [`otlp_http` output](../outputs/otlp_http.md) / [`otlp_grpc` output](../outputs/otlp_grpc.md)'s
 `http_protobuf` or `grpc` protocol.
 
-### otlp.decode_resourcelog_protobuf(bytes) → Object
+### otlp.decode_resourcelog_protobuf(bytes_or_string) → Object
 
-Inverse of `encode_resourcelog_protobuf`. Used by snippets that
+Inverse of `encode_resourcelog_protobuf`. Accepts `Bytes` or a `String`
+whose UTF-8 storage contains the protobuf octets. Used by snippets that
 need to inspect / transform an inbound OTLP record:
 
 ```limpid
@@ -256,7 +258,7 @@ manually through `output http` to a non-OTLP-aware HTTP receiver.
 > `http_json` / `http_protobuf` choice) should keep using
 > `otlp.encode_resourcelog_protobuf` for the egress bytes.
 
-### otlp.decode_resourcelog_json(s) → Object
+### otlp.decode_resourcelog_json(string_or_bytes) → Object
 
 Decode an OTLP/JSON-encoded `ResourceLogs` string (or UTF-8 bytes)
 back into the snake_case HashLit form.
@@ -455,7 +457,7 @@ strftime(received_at, "%H:%M", "+09:00")   // fixed offset
 |----------|-------------|
 | `timestamp` | a `Value::Timestamp` (from `received_at`, `timestamp()`, or `strptime`). Passing a string is a type error. |
 | `format` | `chrono` strftime format. |
-| `timezone` *(optional)* | `"local"`, `"UTC"` (case-insensitive), or `±HH:MM` / `±HHMM`. If omitted, the timestamp's own offset is used. |
+| `timezone` *(optional)* | `"local"` or `"UTC"` (case-insensitive), an IANA name such as `Asia/Tokyo` (case-sensitive), or `±HH:MM` / `±HHMM`. If omitted, output is UTC. |
 
 An invalid timezone specifier is a loud error — `strftime` never silently returns an empty string.
 
@@ -473,7 +475,7 @@ strptime("2026-04-15 10:30:00", "%Y-%m-%d %H:%M:%S", "local")  // naive + local
 |----------|-------------|
 | `value` | timestamp string |
 | `format` | `chrono` strftime format |
-| `timezone` *(required when format produces a naive datetime)* | `"local"`, `"UTC"`, or `±HH:MM` / `±HHMM` |
+| `timezone` *(required when format produces a naive datetime)* | `"local"` or `"UTC"` (case-insensitive), an IANA name such as `Asia/Tokyo` (case-sensitive), or `±HH:MM` / `±HHMM` |
 
 If the format includes an offset specifier (`%z`, `%:z`, `%#z`), the third argument is rejected as conflicting. If the format produces a naive datetime, the third argument is required — limpid never silently assumes UTC.
 
@@ -668,9 +670,10 @@ Errors on unknown encoding or malformed input (odd hex length,
 invalid hex digit, malformed base64). The default `utf8` form is
 lossless because Rust strings are always valid UTF-8.
 
-### to_string(b, encoding="utf8", strict=true)
+### to_string(string_or_bytes, encoding="utf8", strict=true)
 
-Convert raw bytes to a string. Counterpart of `to_bytes`.
+Interpret a raw `Bytes` value as text, or pass a `String` through the same
+encoding operation. Counterpart of `to_bytes`.
 
 | Encoding | `strict` | Behaviour |
 |----------|----------|-----------|
@@ -685,7 +688,7 @@ workspace.message = to_string(ingress, "utf8", false)        // lossy fallback
 workspace.signature_b64 = to_string(workspace.sig, "base64") // bytes → printable
 ```
 
-Text-only primitives (`upper`, `regex_*`, `format`, `to_int`,
+Text-only primitives (`upper`, `regex_*`, `strftime`, `to_int`,
 `contains`, etc.) reject `Bytes` to keep failure modes explicit;
 `to_string` is the way to opt into a textual interpretation.
 
@@ -780,7 +783,7 @@ Use these only when the order is itself the contract (chronology, "most recent",
 
 ### concat(a, b, ...)
 
-Variadic array concatenation; every argument must be an `Array`. Mixed input bails (no scalar auto-wrap — wrap explicitly if you want a single element: `concat(arr, [x])`).
+Variadic array concatenation with at least one argument; every argument must be an `Array`. Mixed input bails (no scalar auto-wrap — wrap explicitly if you want a single element: `concat(arr, [x])`).
 
 ```limpid
 workspace.all_tags = concat(workspace.host_tags, workspace.role_tags, ["pii"])
@@ -867,6 +870,7 @@ Cardinality primitive — works for every container-like type:
 |-------|--------|
 | `Array` | Number of elements |
 | `String` | Number of Unicode characters (not bytes) |
+| `Bytes` | Number of bytes |
 | `Object` | Number of top-level keys |
 | `Null` | `Null` |
 | Scalars (`Int` / `Float` / `Bool`) | `Null` |

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -19,8 +19,8 @@ Use one anywhere an expression goes:
 def process parse_fortigate_cef_traffic {
     workspace.lsis.parsed = {
         connection_info: {
-            protocol_num:  workspace.cef.proto,
-            protocol_name: normalize_proto(workspace.cef.proto)
+            protocol_num:  workspace.cef.extension.proto,
+            protocol_name: normalize_proto(workspace.cef.extension.proto)
         },
         // ... other canonical fields ...
     }
@@ -43,15 +43,15 @@ Anywhere an expression is evaluated — there's no callsite restriction on the f
   def output proto_udp { type file path "/var/log/limpid/udp/events.log" }
   def pipeline split {
       input syslog_udp
-      process parse_cef                                  // sets workspace.cef.proto
-      switch normalize_proto(workspace.cef.proto) {
+      process parse_cef                                  // sets workspace.cef.extension.proto
+      switch normalize_proto(workspace.cef.extension.proto) {
           "tcp" { output proto_tcp }
           "udp" { output proto_udp }
       }
   }
   ```
 - **HashLit values**: `workspace.lsis.parsed = { severity_number: severity_number_from_label(...), ... }`.
-- **Function arguments**: `lower(normalize_proto(workspace.cef.proto))`.
+- **Function arguments**: `lower(normalize_proto(workspace.cef.extension.proto))`.
 - **Binary operands**: `if double_score(s) > threshold { ... }`.
 
 The purity contract restricts the **body** of the function (no Event reads, no side effects). The call site is dispatch-wise unrestricted: it operates in the surrounding expression's evaluation context, which can read whatever that surface allows (full Event in process bodies / pipeline expressions; event-intrinsic only in output config templates) and pass concrete values into the function.

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -43,7 +43,7 @@ Anywhere an expression is evaluated — there's no callsite restriction on the f
   def output proto_udp { type file path "/var/log/limpid/udp/events.log" }
   def pipeline split {
       input syslog_udp
-      process parse_cef                                  // sets workspace.cef.extension.proto
+      process parse_syslog | parse_cef                   // unwrap transport, then parse CEF
       switch normalize_proto(workspace.cef.extension.proto) {
           "tcp" { output proto_tcp }
           "udp" { output proto_udp }

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -132,7 +132,7 @@ def function endpoint_label(host, port) {
 }
 ```
 
-Anything an expression can do (binary ops, primitive calls, hash literals, array literals, nested function calls) is fair game inside `let` RHS or the trailing expression. The block-arg primitives — `map`, `filter`, `find`, `reduce` — are pure expressions over arrays and compose freely inside a function body. What you cannot do is write a *statement* — no assignments to anything, no `drop` / `error` / `process foo` / `output foo`, no statement-form `if` / `switch` / `try-catch`. Use the expression-form alternatives.
+Anything an expression can do (binary ops, primitive calls, hash literals, array literals, nested function calls) is fair game inside `let` RHS or the trailing expression. The block-arg primitives — `map`, `filter`, `find`, `reduce` — are pure expressions over arrays or objects and compose freely inside a function body. Array blocks bind the element (plus the accumulator for `reduce`); object blocks bind key and value (plus the accumulator for `reduce`). What you cannot do is write a *statement* — no assignments to anything, no `drop` / `error` / `process foo` / `output foo`, no statement-form `if` / `switch` / `try-catch`. Use the expression-form alternatives.
 
 ## Restrictions (enforced at `--check` time)
 

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -374,8 +374,9 @@ time. A deployment that intentionally overrides event time does so in
 the adapter output before composition.
 
 Timezone interpretation follows the source contract. A vendor-defined
-zone wins. Device-local timestamps default to the limpid host's system
-timezone, while a documented specification gap defaults to UTC. Parsers
+zone wins. Device-local timestamps and timestamps whose specification
+leaves the zone undocumented both default to the limpid host's system
+timezone (the device most likely shares the host's zone). Parsers
 that accept local timestamps expose a source-specific timezone override;
 their headers document the exact default and accepted values.
 

--- a/docs/src/otlp.md
+++ b/docs/src/otlp.md
@@ -24,7 +24,7 @@ read that and explains the OTLP-specific reading on top.
 
 ## 1. Scope
 
-| Aspect | Current (0.7.14) |
+| Aspect | Current (0.7.15) |
 |---|---|
 | Signal | **logs** only — no traces, no metrics, no profiles |
 | Transports | HTTP/JSON, HTTP/protobuf, gRPC (all three; output side split into `output otlp_http` / `output otlp_grpc` introduced in 0.7.6; in 0.7.8 plaintext `http://` with `tls { ... }` is now rejected at parse time — see CHANGELOG 0.7.8) |

--- a/docs/src/pipelines/drop-finish-error.md
+++ b/docs/src/pipelines/drop-finish-error.md
@@ -35,7 +35,7 @@ Routes the event to the [error log](../operations/error-log.md) (DLQ) with an op
 
 ```
 def process parse_fortigate_cef {
-    workspace.cef = cef.parse(workspace.syslog.msg)
+    // workspace.cef.* was populated by `parse_syslog | parse_cef` upstream
     switch workspace.cef.name {
         "traffic" { process parse_fortigate_cef_traffic }
         "utm"     { process parse_fortigate_cef_utm }

--- a/docs/src/pipelines/examples.md
+++ b/docs/src/pipelines/examples.md
@@ -128,8 +128,8 @@ def pipeline siem {
     // Parse and enrich
     process {
         workspace.cef = cef.parse(ingress)
-        if workspace.cef.src != null {
-            workspace.geo = geoip(workspace.cef.src)
+        if workspace.cef.extension.src != null {
+            workspace.geo = geoip(workspace.cef.extension.src)
         }
         egress = to_json(workspace)
     }

--- a/docs/src/pipelines/multi-host.md
+++ b/docs/src/pipelines/multi-host.md
@@ -87,15 +87,15 @@ def output to_relay {
 
 def pipeline app_to_relay {
     input app_journal
-    process parse_journald | compose_rfc5424 | rfc5424_to_egress
+    process parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress
     output to_relay
 }
 ```
 
 Three design points worth calling out:
 
-- **PRI carries through the journald entry's own labels.** `app.service`'s `PRIORITY` / `SYSLOG_FACILITY` (set by libsystemd according to how the program writes — direct `sd_journal_send`, `printf` to stderr, syslog API) survive into the RFC 5424 frame. When the entry has neither, `compose_rfc5424` defaults to `<14>` (user.info) so the frame is always valid. Either way the edge does not invent routing; the relay still picks the final facility based on its own criteria.
-- **Parsing is mechanical, not vendor-specific.** `parse_journald` is `parse_json(ingress)` plus a docstring — the edge does not extract individual fields, it just hands the structured form to the composer. If the relay needs more (e.g. `parse_openssh | compose_ocsf | ocsf_to_egress`), it runs there, where the cycles can be amortised across many edge hosts. The edge's per-event work stays tiny.
+- **The bridge performs the field mapping.** `parse_journald` only exposes the journal record under `workspace.journald.*`. `journald_to_rfc5424` then selects the RFC 5424 PRI, timestamp, hostname, app name, process id, and message shed slots. `compose_rfc5424` serializes those slots; it does not read journal fields directly.
+- **Parsing is mechanical, not vendor-specific.** `parse_journald` parses the JSON record without promoting `PRIORITY` to LSIS severity. The named bridge is the explicit journald-to-RFC-5424 policy boundary. If the relay needs vocabulary parsing (for example `parse_openssh | compose_ocsf | ocsf_to_egress`), that runs after transport unwrap at the hop where the vocabulary is consumed.
 - **Disk queue on the edge.** Network to the relay can blip; we do not want the composer blocking the journal cursor. The queue lets the output layer absorb the blip without pushing backpressure into the pipeline.
 
 ## Central host: relay

--- a/docs/src/pipelines/routing.md
+++ b/docs/src/pipelines/routing.md
@@ -62,7 +62,7 @@ def pipeline main {
     // Parse and rewrite egress
     process {
         workspace.cef = cef.parse(ingress)
-        workspace.geo = geoip(workspace.cef.src)
+        workspace.geo = geoip(workspace.cef.extension.src)
         egress = to_json(workspace)
     }
 

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -28,7 +28,7 @@ Bad names give away the problem:
 
 If you catch yourself writing `and` in a process name, split it:
 
-```
+```limpid
 // Don't: one process doing three things — and parsing events you're
 // about to drop is wasted work.
 def process parse_and_enrich_fortigate {
@@ -76,7 +76,7 @@ When a file contains several leaves, put supplemental tags in the first comment
 block inside the leaf. One tag per line. Each tag names a field path in
 `workspace.*` (or, less commonly, `egress`).
 
-```
+```limpid
 def process compose_ocsf_authentication {
     // @requires: workspace.lsis.parsed.severity_number      (optional; normalized OTel SeverityNumber)
     // @requires: workspace.lsis.parsed.severity             (optional; exact source severity text)
@@ -152,7 +152,7 @@ If you need dedup, rate-limiting, or aggregation, use a primitive that limpid sh
 
 ### "God" processes with config-driven branches
 
-```
+```limpid
 // Don't — one body, many shapes, none of which is clearly the contract.
 def process fw_dispatch {
     if workspace.vendor == "Fortinet" {
@@ -170,7 +170,7 @@ def process fw_dispatch {
 
 Split these into `parse_fortigate`, `parse_paloalto`, `parse_cisco` and dispatch at the pipeline level with `switch`. The switch is load-bearing routing information — it deserves to be in the pipeline where routing lives, not hidden inside a process that reads like a parser.
 
-```
+```limpid
 def pipeline fw {
     input fw_syslog
     switch workspace.vendor {
@@ -239,7 +239,7 @@ Do not pack multiple unrelated schemas into a single file.
 
 Pick one canonical intermediate shape and have every parser write into it; have every composer read from it. limpid's library uses the namespace `workspace.lsis` for this — the Limpid Snippet Intermediate Schema (LSIS), stratified into `parsed` / `shed` / `composed` layers. See the [pack README](../../../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the layer contracts and slot registries; the summary that matters for this guide is the flow:
 
-```
+```text
 ingress
    │
    ▼
@@ -317,7 +317,7 @@ A vocabulary parser (or any snippet that consumes prior layer state in
 timestamp from. That binding is invisible from the dispatcher body, so
 state it explicitly in a header block at the top of the file:
 
-```
+```text
 // Vendor:   OpenSSH
 // Wire:     sshd application body (Accepted publickey for ... / Failed
 //           password for ... / Disconnected from ... etc.)

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -272,7 +272,7 @@ The two-sided rule of thumb for `workspace.lsis.parsed.*`:
 - **Parsers fill `workspace.lsis.parsed` in canonical LSIS shape — OCSF-vocabulary, not OCSF-bound.** Whenever a vendor field has a clean OCSF home, use the OCSF field name (`src_endpoint.ip`, `actor.user.name`). When it doesn't, carry it on `workspace.lsis.parsed` under a vendor-meaningful name; do not throw the data away just because OCSF has no slot.
 - **Composers may assume `workspace.lsis.parsed` follows canonical LSIS shape — but they must not assume strict OCSF compliance.** A composer reads the fields it needs and tolerates extras / absences. An OCSF composer renders `workspace.lsis.parsed.*` to OCSF JSON in the `workspace.lsis.composed.ocsf` slot; an ECS composer would translate the same facts into an ECS JSON slot, taking advantage of the OCSF-vocabulary overlap without depending on it.
 
-A parser must not write vendor-specific format names into the facts layer (`workspace.cef.src`, `workspace.fgt_session_id` left at top level); a composer must not read vendor-specific format names directly (`workspace.cef.src`). The contract between them is `workspace.lsis.parsed.*`, full stop. Each rename or pass-through layer beyond that is a drift risk.
+A parser must not write vendor-specific format names into the facts layer (`workspace.cef.extension.src`, `workspace.fgt_session_id` left at top level); a composer must not read vendor-specific format names directly (`workspace.cef.extension.src`). The contract between them is `workspace.lsis.parsed.*`, full stop. Each rename or pass-through layer beyond that is a drift risk.
 
 ### Keep composers pure
 

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -62,12 +62,13 @@ The split config is longer. It is also easier to test, easier to tap between ste
 
 Every process has an implicit contract with its neighbours in the pipeline: *what do I expect to be present when I run, and what do I leave behind for the next stage?*
 
-The shipped snippet pack declares its file-level contract in the canonical
-header schema (`Summary`, `Reads`, `Writes`, and kind-specific fields) described
+The shipped snippet pack declares its public surface in the canonical header
+schema: a file-level `Facade` plus adjacent per-member `Summary`, `Reads`,
+`Writes`, or `Signature` contracts described
 in the [pack README](../../../packaging/snippets/README.md#authoring-conventions).
-Inside a large file, leaf-local `@requires` / `@produces` comments may add useful
-detail, but they do not replace the canonical header and the analyzer does not
-consume them.
+Inside a large file, private leaf-local `@requires` / `@produces` comments may
+add useful detail, but they do not replace a facade member block and the
+analyzer does not consume them.
 
 ### The `@requires` / `@produces` tag convention
 
@@ -130,7 +131,8 @@ Requirement levels follow the OCSF / ECS convention:
 
 Free-form prose comments explaining "what this process does" are fine in
 addition to the tags. For shipped snippets, neither form substitutes for the
-canonical file header that header lint and inventory generation validate.
+canonical facade and member headers that header lint and inventory generation
+validate.
 
 ### Why make contracts explicit
 

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -62,18 +62,25 @@ The split config is longer. It is also easier to test, easier to tap between ste
 
 Every process has an implicit contract with its neighbours in the pipeline: *what do I expect to be present when I run, and what do I leave behind for the next stage?*
 
-Because the DSL does not check that contract today, you document it in comments using a small, machine-parseable convention. The grammar is parseable enough that a future static-analysis pass could promote these tags to a real check (warning when a pipeline links a composer to a parser that does not produce the required fields), but limpid does not commit to that — write them because they help the next reader, not because the analyzer will catch you. Pretending the contracts do not exist costs the first person who has to modify the snippet a year later.
+The shipped snippet pack declares its file-level contract in the canonical
+header schema (`Summary`, `Reads`, `Writes`, and kind-specific fields) described
+in the [pack README](../../../packaging/snippets/README.md#authoring-conventions).
+Inside a large file, leaf-local `@requires` / `@produces` comments may add useful
+detail, but they do not replace the canonical header and the analyzer does not
+consume them.
 
 ### The `@requires` / `@produces` tag convention
 
-Put tags in the first block of comments inside the process body. One tag per line. Each tag names a field path in `workspace.*` (or, less commonly, `egress`).
+When a file contains several leaves, put supplemental tags in the first comment
+block inside the leaf. One tag per line. Each tag names a field path in
+`workspace.*` (or, less commonly, `egress`).
 
 ```
 def process compose_ocsf_authentication {
     // @requires: workspace.lsis.parsed.severity_number      (optional; normalized OTel SeverityNumber)
     // @requires: workspace.lsis.parsed.severity             (optional; exact source severity text)
     // @requires: workspace.lsis.parsed.src_endpoint.ip      (recommended)
-    // @requires: workspace.lsis.parsed.actor.user.name      (recommended)
+    // @requires: workspace.lsis.parsed.user.name            (recommended)
     // @produces: workspace.lsis.composed.ocsf  (OCSF Authentication Activity, JSON string)
     //
     // Expects: the calling pipeline has run a vendor parser that
@@ -89,9 +96,27 @@ def process compose_ocsf_authentication {
     // single-writer invariant — see the [pack
     // README](../../../packaging/snippets/README.md#slot-registry--composed-layer).
 
-    workspace.lsis.parsed.class_uid   = 3002
-    workspace.lsis.parsed.activity_id = 1
-    workspace.lsis.composed.ocsf      = to_json(workspace.lsis.parsed)
+    process validate_ocsf_severity_number
+    let activity = workspace.lsis.parsed.activity_id
+    workspace.lsis.composed.ocsf = to_json(null_omit({
+        class_uid: 3002,
+        category_uid: 3,
+        activity_id: activity,
+        type_uid: 3002 * 100 + activity,
+        time: timestamp_ns_to_ms(coalesce(workspace.lsis.parsed.time, received_at)),
+        severity_id: compose_ocsf_severity_id(
+            workspace.lsis.parsed.severity_number,
+            workspace.lsis.parsed.severity_id,
+            workspace.lsis.parsed.severity
+        ),
+        severity: workspace.lsis.parsed.severity,
+        status_id: workspace.lsis.parsed.status_id,
+        user: workspace.lsis.parsed.user,
+        actor: workspace.lsis.parsed.actor,
+        src_endpoint: workspace.lsis.parsed.src_endpoint,
+        dst_endpoint: workspace.lsis.parsed.dst_endpoint,
+        metadata: workspace.lsis.parsed.metadata
+    }))
 }
 ```
 
@@ -103,7 +128,9 @@ Requirement levels follow the OCSF / ECS convention:
 | `recommended` | The process will run without it, but output quality degrades (lower fidelity, missing enrichment). |
 | `optional` | Nice to have. Documented so a future reader knows the field exists and is consumed. |
 
-Free-form prose comments explaining "what this process does" are fine *in addition to* the tags — but they are not a substitute. Prose drifts; structured tags survive review because tooling can check them.
+Free-form prose comments explaining "what this process does" are fine in
+addition to the tags. For shipped snippets, neither form substitutes for the
+canonical file header that header lint and inventory generation validate.
 
 ### Why make contracts explicit
 

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -132,7 +132,7 @@ Rule of thumb: if the catch block has nothing useful to do besides stamp `worksp
 
 ```limpid
 def process parse_asa {
-    workspace.syslog = syslog.parse(ingress)
+    // workspace.syslog.* was populated by `parse_syslog` upstream
     let mid = regex_extract(workspace.syslog.msg, "%ASA-\\d-(\\d+):")
     switch mid {
         "605004" { process parse_asa_auth_success }

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -10,11 +10,11 @@ You define a process with `def process <name> { ... }`. Inside the body you call
 def process enrich_fortigate {
     workspace.cef = cef.parse(workspace.syslog.msg)   // capture parser output
 
-    if workspace.cef.src != null {
-        workspace.geo = geoip(workspace.cef.src)
+    if workspace.cef.extension.src != null {
+        workspace.geo = geoip(workspace.cef.extension.src)
     }
 
-    egress = "${workspace.cef.device_product} ${workspace.cef.src} -> ${workspace.cef.dst} ${workspace.cef.act}"
+    egress = "${workspace.cef.device_product} ${workspace.cef.extension.src} -> ${workspace.cef.extension.dst} ${workspace.cef.extension.act}"
 }
 ```
 

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -2,7 +2,7 @@
 
 limpid ships a [Snippet Library](../snippets/README.md) of pre-built processes for common parsing / mapping work (introduced in v0.7.0, expanded across the 0.7.x line). Sooner or later you'll hit a situation the library doesn't cover — a vendor format we haven't shipped, a one-off enrichment, a dedup or rate-limit shape that's specific to your environment — and want to write your own. This page covers how.
 
-You define a process with `def process <name> { ... }`. Inside the body you call functions, assign to event slots and workspace, branch with `if` / `switch` / `try`, transform arrays with the block-arg primitives (`map`, `filter`, `find`, `reduce`), and call other processes by name.
+You define a process with `def process <name> { ... }`. Inside the body you call functions, assign to event slots and workspace, branch with `if` / `switch` / `try`, transform arrays and objects with the block-arg primitives (`map`, `filter`, `find`, `reduce`), and call other processes by name.
 
 ## Defining a process
 
@@ -182,6 +182,17 @@ The library steers toward identity-based access so snippets stay correct under u
 | Dynamic key access | `path(obj, "k1", "k2", ...)` (object only; integer keys rejected) |
 | Add to back / front | `append(arr, v)`, `prepend(arr, v)` |
 | Serialise to JSON | `to_json(arr)` |
+
+The same four block primitives iterate objects in insertion order with explicit key/value bindings:
+
+| Operation | Object form | Result |
+|-----------|-------------|--------|
+| Transform | `map(obj) { \|key, value\| <expr> }` | Array of block results |
+| Filter | `filter(obj) { \|key, value\| <bool> }` | Object containing the retained entries |
+| Pick | `find(obj) { \|key, value\| <bool> }` | First `[key, value]` pair or `null` |
+| Fold | `reduce(obj, init) { \|acc, key, value\| <step> }` | Final accumulator |
+
+Object iteration sees every stored entry as-is. Insertion order is preserved and duplicate keys are visited and retained; these primitives do not normalize an object into a unique-key map. A `null` collection follows the established array behavior: `map` / `filter` return an empty array, `find` returns `null`, and `reduce` returns `init`.
 
 Block-arg primitives (`map`, `filter`, `find`, `reduce`) and the pipe operator (`|>`) are documented in [DSL Syntax Basics → Block argument](../dsl-syntax.md#block-argument) and [Pipe operator](../dsl-syntax.md#pipe-operator).
 

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -120,8 +120,9 @@ contracts.
   applies the current-year + future-clamp policy after the calling
   parser resolves its vendor-specific timezone default or explicit
   override. A vendor-defined fixed zone wins; documented device-local
-  formats default to `local` (the limpid host's system timezone), and
-  formats with no authoritative timezone contract default to `UTC`.
+  formats and formats with no authoritative timezone contract both
+  default to `local` (the limpid host's system timezone — the device
+  most likely shares the host's zone).
   IANA names and fixed offsets are also accepted as explicit overrides.
   For RFC 5424 / OTLP / OCSF input use the built-in
   `parse_datetime_rfc3339` primitive directly.

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -102,7 +102,9 @@ before customising it; package upgrades replace files under
 See the [pack
 README](../../../packaging/snippets/README.md#slot-registry--composed-layer)
 for the full composed / shed slot registries and the LSIS layer
-contracts.
+contracts. The same README defines the authoring schema: each file declares a
+`Facade`, and every listed process or function has an adjacent contract block.
+Private dispatch leaves remain unlisted and need no public header.
 
 ### Filters
 
@@ -123,7 +125,7 @@ contracts.
   `severity` text rather than an invented OTel number.
 
 - `functions/parse_datetime_rfc3164.limpid` —
-  `parse_datetime_rfc3164(text, timezone) → Timestamp | null`. LPL
+  `parse_datetime_rfc3164(String, String) → Timestamp | Null`. LPL
   counterpart to the built-in `parse_datetime_rfc3339` primitive.
   RFC 3164 wire carries neither year nor timezone, so the helper
   applies the current-year + future-clamp policy after the calling
@@ -136,16 +138,17 @@ contracts.
   For RFC 5424 / OTLP / OCSF input use the built-in
   `parse_datetime_rfc3339` primitive directly.
 - `functions/timestamp_converter.limpid` — exact integer boundary helpers
-  `timestamp_ns_to_ms(value) → Int | null` and
-  `timestamp_ms_to_ns(value) → Int | null`. `compose_ocsf` uses the first;
+  `timestamp_ns_to_ms(Int | Timestamp | Null) → Int | Null` and
+  `timestamp_ms_to_ns(Int | Null) → Int | Null`.
+  `compose_ocsf` uses the first;
   `parse_ocsf` uses the second. Helpers shared by multiple source schemas
   live under `functions/`; source-local helpers stay beside their parser.
 - `functions/http_method_activity_id.limpid` —
-  `http_method_activity_id(method) → Int`. HTTP request method
+  `http_method_activity_id(String) → Int`. HTTP request method
   (`GET` / `POST` / `PUT` / `DELETE` / `HEAD` / `OPTIONS` /
   `CONNECT` / `TRACE`) → OCSF 4002 HTTP Activity `activity_id`,
   with `99` (Other) for anything outside the OCSF 1.3.0 enumeration.
-- `functions/proto_num.limpid` — `proto_num(name) → Int | null`.
+- `functions/proto_num.limpid` — `proto_num(String) → Int | Null`.
   Transport-layer protocol name (case-insensitive `tcp` / `udp` /
   `icmp` / …) → IANA protocol number for OCSF
   `connection_info.protocol_num`. Returns `null` rather than a

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -3,10 +3,12 @@
 A maintained set of vendor parsers and target-schema composers,
 shipped with the `limpid` package and installed under
 `/usr/share/limpid/snippets/`. Operators get vendor logs into a
-SIEM / data lake in OCSF form by adding a single `include` line to
-their config — no parser to write from scratch, no recompile when
-a vendor adds a field (the snippet is plain DSL: edit the file and
-SIGHUP).
+SIEM / data lake in OCSF form by including the parser, its declared
+helper dependencies, and the target composer. No parser has to be
+written from scratch, and changing DSL does not require recompiling
+the daemon. Copy an installed snippet into an operator-owned path
+before customising it; package upgrades replace files under
+`/usr/share/limpid/snippets/`.
 
 > **Status:** the snippet library was introduced in v0.7.0 and has
 > expanded across the 0.7.x line. It currently ships 32 parser files
@@ -25,7 +27,7 @@ SIGHUP).
 
 ### Parsers
 
-| Snippet | Source | OCSF class(es) emitted |
+| Snippet | Source | LSIS class facts produced |
 |---|---|---|
 | **Transport** | | |
 | `parsers/parse_syslog.limpid` | RFC 3164 / 5424 syslog wire (transport, populates `workspace.syslog.*`) | n/a |
@@ -37,7 +39,12 @@ SIGHUP).
 | `parsers/parse_paloalto_cef.limpid` | PAN-OS (CEF wrap; chain `parse_syslog \| parse_cef \|` upstream) | 4001 / 2004 / 6004 / 3002 |
 | `parsers/parse_paloalto_syslog.limpid` | PAN-OS (native CSV syslog; chain `parse_syslog \|` upstream) | (same as CEF) |
 | `parsers/parse_asa.limpid` | Cisco ASA / FTD-in-ASA-mode (syslog; chain `parse_syslog \|` upstream) | 3002 / 4001 |
+| `parsers/parse_aws_guardduty.limpid` | AWS GuardDuty findings (JSON) | 2004 Detection Finding |
+| `parsers/parse_aws_vpc_flow.limpid` | AWS VPC Flow Logs (text v2/v5) | 4001 Network Activity |
+| `parsers/parse_azure_activity.limpid` | Azure Activity Log (JSON) | 6003 API Activity |
 | `parsers/parse_cloudtrail.limpid` | AWS CloudTrail (JSON) | 6003 API Activity |
+| `parsers/parse_k8s_audit.limpid` | Kubernetes Audit API events (JSON) | 6003 / 3002 |
+| `parsers/parse_okta_system.limpid` | Okta System Log events (JSON) | 3001 / 3002 / 3005 / 3006 |
 | `parsers/parse_juniper_srx_sd_syslog.limpid` | Juniper SRX RT_FLOW (RFC 5424 + Junos SD, `set security log format sd-syslog` mode) | 4001 Network Activity |
 | `parsers/parse_juniper_srx_syslog.limpid` | Juniper SRX RT_IDP / IDP_ATTACK_LOG_EVENT (RFC 3164 unstructured, default `syslog` mode) | 2004 Detection Finding |
 | `parsers/parse_nsp.limpid` | Trellix / McAfee Network Security Platform IPS alerts (standard syslog KV template, real-traffic verified) | 2004 Detection Finding |
@@ -128,6 +135,11 @@ contracts.
   IANA names and fixed offsets are also accepted as explicit overrides.
   For RFC 5424 / OTLP / OCSF input use the built-in
   `parse_datetime_rfc3339` primitive directly.
+- `functions/timestamp_converter.limpid` — exact integer boundary helpers
+  `timestamp_ns_to_ms(value) → Int | null` and
+  `timestamp_ms_to_ns(value) → Int | null`. `compose_ocsf` uses the first;
+  `parse_ocsf` uses the second. Helpers shared by multiple source schemas
+  live under `functions/`; source-local helpers stay beside their parser.
 - `functions/http_method_activity_id.limpid` —
   `http_method_activity_id(method) → Int`. HTTP request method
   (`GET` / `POST` / `PUT` / `DELETE` / `HEAD` / `OPTIONS` /
@@ -268,11 +280,11 @@ systems below):
   attack-scenario dataset (Empire mimikatz logonpasswords trace,
   702 Security-channel events).
 
-The remaining classes for which `compose_ocsf` has a leaf but no
-parser yet emits to (most of category 2 Findings; some of category
-4 sub-protocols like DNS / DHCP / RDP / SMB / SSH / FTP /
-NetworkFile; some of category 6 like Datastore / Scan) are
-candidates for upcoming snippets in 0.7.x point releases.
+The remaining classes for which `compose_ocsf` has a leaf but no bundled
+parser currently produces facts are Registry Key Activity (1008), Registry
+Value Activity (1009), Compliance Finding (2003), Incident Finding (2005),
+Network File Activity (4010), Datastore Activity (6005), and Scan Activity
+(6007). These are candidates for future snippets.
 
 ## Authoring your own snippets
 
@@ -283,10 +295,13 @@ conventions are:
   (`parse_fortigate_cef` + `parse_fortigate_syslog`) because CEF and
   native KV are different wire shapes; OpenSSH is one file because
   sshd's wire is one shape across syslog and journald.
-- **File header** carries `// Vendor:` / `// Wire:` / `// Output:`
-  lines describing the source, plus per-shape sample lines anonymised
-  to RFC 5321 / 5737 forms (`example.com`, `192.0.2.x`,
-  `198.51.100.x`).
+- **Canonical file header** follows the per-kind schema documented in the
+  [pack README](../../../packaging/snippets/README.md#authoring-conventions):
+  parser files declare `Summary`, `Reads`, `Writes`, `Category`, and
+  `Test corpus`; composers and shared functions use their corresponding
+  schemas. The header is the source for generated inventory. Keep sample
+  wires in the header and anonymise them with documentation domains and
+  RFC 5737 addresses.
 - **Two-tier dispatch**: the top-level `def process parse_<vendor>`
   strips the wrapper and routes by header field (`switch
   workspace.<vendor>.<key>`); per-leaf `def process` re-parses the

--- a/docs/src/snippets/README.md
+++ b/docs/src/snippets/README.md
@@ -9,10 +9,11 @@ a vendor adds a field (the snippet is plain DSL: edit the file and
 SIGHUP).
 
 > **Status:** the snippet library was introduced in v0.7.0 and has
-> expanded across the 0.7.x line. It currently ships 31 parser files
+> expanded across the 0.7.x line. It currently ships 32 parser files
 > (source / vocabulary parsers — FortiGate / ASA / Checkpoint / Palo Alto /
 > Sysmon / CloudTrail / Zeek / Suricata / OCSF / Juniper SRX / ... — plus the
-> transport parsers `parse_syslog` and `parse_journald`), 30 sibling
+> transport / format parsers `parse_syslog`, `parse_journald`, and
+> `parse_cef`), 31 sibling
 > per-source OTLP adapters, the OCSF 1.3.0 27-class composer, the RFC 5424
 > and replay-shape composers, one filter, and several reusable functions.
 > The inbound `parse_ocsf` compatibility parser is the sole parser without
@@ -29,12 +30,13 @@ SIGHUP).
 | **Transport** | | |
 | `parsers/parse_syslog.limpid` | RFC 3164 / 5424 syslog wire (transport, populates `workspace.syslog.*`) | n/a |
 | `parsers/parse_journald.limpid` | systemd journald JSON (transport, populates `workspace.journald.*`) | n/a |
+| `parsers/parse_cef.limpid` | ArcSight CEF format from a syslog body (populates `workspace.cef.*`; chains as `parse_syslog \| parse_cef \| parse_<vendor>_cef`) | n/a |
 | **Security devices / cloud audit** | | |
-| `parsers/parse_fortigate_cef.limpid` | FortiGate (CEF wrap) | 4001 / 2004 / 3002 / 6002 |
+| `parsers/parse_fortigate_cef.limpid` | FortiGate (CEF wrap; chain `parse_syslog \| parse_cef \|` upstream) | 4001 / 2004 / 3002 / 6002 |
 | `parsers/parse_fortigate_syslog.limpid` | FortiGate (native KV syslog) | (same as CEF) |
-| `parsers/parse_paloalto_cef.limpid` | PAN-OS (CEF wrap) | 4001 / 2004 / 6004 / 3002 |
-| `parsers/parse_paloalto_syslog.limpid` | PAN-OS (native CSV syslog) | (same as CEF) |
-| `parsers/parse_asa.limpid` | Cisco ASA / FTD-in-ASA-mode (syslog) | 3002 / 4001 |
+| `parsers/parse_paloalto_cef.limpid` | PAN-OS (CEF wrap; chain `parse_syslog \| parse_cef \|` upstream) | 4001 / 2004 / 6004 / 3002 |
+| `parsers/parse_paloalto_syslog.limpid` | PAN-OS (native CSV syslog; chain `parse_syslog \|` upstream) | (same as CEF) |
+| `parsers/parse_asa.limpid` | Cisco ASA / FTD-in-ASA-mode (syslog; chain `parse_syslog \|` upstream) | 3002 / 4001 |
 | `parsers/parse_cloudtrail.limpid` | AWS CloudTrail (JSON) | 6003 API Activity |
 | `parsers/parse_juniper_srx_sd_syslog.limpid` | Juniper SRX RT_FLOW (RFC 5424 + Junos SD, `set security log format sd-syslog` mode) | 4001 Network Activity |
 | `parsers/parse_juniper_srx_syslog.limpid` | Juniper SRX RT_IDP / IDP_ATTACK_LOG_EVENT (RFC 3164 unstructured, default `syslog` mode) | 2004 Detection Finding |
@@ -139,9 +141,12 @@ contracts.
 
 ## Quick start
 
-The basic pattern is two `include` lines + a two-stage pipeline:
+The basic pattern is a few `include` lines + a staged pipeline
+(transport → format → vendor vocabulary → composer):
 
 ```limpid
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 include "/usr/share/limpid/snippets/composers/compose_ocsf.limpid"
 
@@ -156,12 +161,13 @@ def output security_lake {
 
 def pipeline fw_to_security_lake {
     input fw_syslog
-    process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     output security_lake
 }
 ```
 
-`parse_fortigate_cef` writes facts to `workspace.lsis.parsed.*`;
+`parse_syslog` unwraps the transport, `parse_cef` decodes the CEF
+format, and `parse_fortigate_cef` writes facts to `workspace.lsis.parsed.*`;
 `compose_ocsf` reads from there and writes the OCSF JSON record to
 `workspace.lsis.composed.ocsf`; the one-line `ocsf_to_egress`
 companion at the tail of the pipeline moves the slot to `egress`.
@@ -176,11 +182,11 @@ For mixed-vendor inputs, dispatch upstream of the parser:
 def pipeline mixed_in {
     input multi_vendor_syslog
     if contains(ingress, "CEF:0|Palo Alto Networks") {
-        process parse_paloalto_cef | compose_ocsf | ocsf_to_egress
+        process parse_syslog | parse_cef | parse_paloalto_cef | compose_ocsf | ocsf_to_egress
     } else if contains(ingress, "CEF:0|Fortinet") {
-        process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+        process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     } else {
-        process parse_paloalto_syslog | compose_ocsf | ocsf_to_egress
+        process parse_syslog | parse_paloalto_syslog | compose_ocsf | ocsf_to_egress
     }
     output security_lake
 }

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -67,7 +67,7 @@ After editing the config, reload the daemon to pick up the change — either `su
 
 FortiGate `traffic` events are too noisy to forward to AMA, but you still want them in the on-disk archive for after-the-fact investigation. So: archive everything, then drop FortiGate traffic, then forward what's left.
 
-To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The wire is layered — syslog transport around a CEF-formatted body around FortiGate's dialect — and the library ships one parser per layer: `parse_syslog` unwraps the transport into `workspace.syslog.*`, `parse_cef` decodes the CEF header / extensions into `workspace.cef.*`, and `parse_fortigate_cef` interprets the FortiGate dialect and fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract). In particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) after `parse_cef`, and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
+To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The wire is layered — syslog transport around a CEF-formatted body around FortiGate's dialect — and the library ships one parser per layer: `parse_syslog` unwraps the transport into `workspace.syslog.*`, `parse_cef` decodes the CEF header / extensions into `workspace.cef.*`, and `parse_fortigate_cef` interprets the FortiGate dialect and fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract). In particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.extension.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) after `parse_cef`, and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
 
 ```limpid
 // /etc/limpid/limpid.conf  — add at the top
@@ -95,7 +95,7 @@ def pipeline main {
     input fw_tcp
     output archive                                            // everything goes to disk
     process parse_syslog | parse_cef | parse_fortigate_cef    // transport | format | vendor vocabulary
-    if workspace.cef.cat == "traffic:forward" { drop }        // drop the noise
+    if workspace.cef.extension.cat == "traffic:forward" { drop }        // drop the noise
     output ama                                                // only the survivors reach AMA
 }
 ```
@@ -106,7 +106,7 @@ The first is the magic from Step 2. Even though the `process` and `if drop` afte
 
 The second is what the pipeline body actually contains: an `input`, two `output`s, a `process`, and an `if/drop`. There is no separate "filter" or "router" abstraction — routing decisions live in the pipeline as ordinary statements, in the order they execute. That mirrors how you'd describe the pipeline in words: "archive everything, parse it as FortiGate, drop traffic events, forward the rest to AMA."
 
-Worth one more note: `parse_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) and `parse_fortigate_cef` builds `workspace.lsis.parsed.*` from it; the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
+Worth one more note: `parse_cef` populates `workspace.cef.extension.cat` (from the FortiGate `cat=` extension) and `parse_fortigate_cef` builds `workspace.lsis.parsed.*` from it; the `if` reads from `workspace.cef.extension.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
 
 ## Step 4 — Confirm the drop is actually happening
 
@@ -212,7 +212,7 @@ def pipeline main {
     input fw_tcp
     output archive
     process parse_syslog | parse_cef | parse_fortigate_cef
-    if workspace.cef.cat == "traffic:forward" { drop }
+    if workspace.cef.extension.cat == "traffic:forward" { drop }
     output ama
 }
 ```
@@ -244,7 +244,7 @@ table {
 ```limpid
 // /etc/limpid/processes/dedup_fortigate_traffic.limpid
 def process dedup_fortigate_traffic {
-    if workspace.cef.cat == "traffic:forward" {
+    if workspace.cef.extension.cat == "traffic:forward" {
         let key = workspace.lsis.parsed.src_endpoint.ip + "|" + workspace.lsis.parsed.dst_endpoint.ip
         if table_lookup("traffic_seen", key) != null {
             drop

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -67,10 +67,12 @@ After editing the config, reload the daemon to pick up the change — either `su
 
 FortiGate `traffic` events are too noisy to forward to AMA, but you still want them in the on-disk archive for after-the-fact investigation. So: archive everything, then drop FortiGate traffic, then forward what's left.
 
-To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The FortiGate CEF parser is provided as `parsers/parse_fortigate_cef.limpid` and exposes a `parse_fortigate_cef` process that fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract) — from a FortiGate CEF event. Before it builds the canonical intermediate, the parser also leaves the raw CEF header / extensions in `workspace.cef.*`; in particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
+To recognise a FortiGate traffic event you need to parse the FortiGate event into a shape you can branch on. The `include` directive can pull in DSL parts from the shipped snippet library at `/usr/share/limpid/snippets/`. The wire is layered — syslog transport around a CEF-formatted body around FortiGate's dialect — and the library ships one parser per layer: `parse_syslog` unwraps the transport into `workspace.syslog.*`, `parse_cef` decodes the CEF header / extensions into `workspace.cef.*`, and `parse_fortigate_cef` interprets the FortiGate dialect and fills `workspace.lsis.parsed.*` — the facts layer of LSIS, the pack's shared naming convention for parser output (see the [pack snippet README](../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the full three-layer contract). In particular the FortiGate `cat=<category>:<subtype>` extension lands at `workspace.cef.cat` (e.g. `traffic:forward`, `utm:ips`, `event:system`) after `parse_cef`, and is the reliable key for routing. (The set of shipped snippets will grow over time — see [Snippet Library](./snippets/README.md) for what is available today.)
 
 ```limpid
 // /etc/limpid/limpid.conf  — add at the top
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 
 def input fw_tcp {
@@ -92,7 +94,7 @@ def output ama {
 def pipeline main {
     input fw_tcp
     output archive                                            // everything goes to disk
-    process parse_fortigate_cef                               // populate workspace.cef.* + workspace.lsis.parsed.*
+    process parse_syslog | parse_cef | parse_fortigate_cef    // transport | format | vendor vocabulary
     if workspace.cef.cat == "traffic:forward" { drop }        // drop the noise
     output ama                                                // only the survivors reach AMA
 }
@@ -104,7 +106,7 @@ The first is the magic from Step 2. Even though the `process` and `if drop` afte
 
 The second is what the pipeline body actually contains: an `input`, two `output`s, a `process`, and an `if/drop`. There is no separate "filter" or "router" abstraction — routing decisions live in the pipeline as ordinary statements, in the order they execute. That mirrors how you'd describe the pipeline in words: "archive everything, parse it as FortiGate, drop traffic events, forward the rest to AMA."
 
-Worth one more note: `parse_fortigate_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) on its way to building `workspace.lsis.parsed.*`, and the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
+Worth one more note: `parse_cef` populates `workspace.cef.cat` (from the FortiGate `cat=` extension) and `parse_fortigate_cef` builds `workspace.lsis.parsed.*` from it; the `if` reads from `workspace.cef.cat`. The daemon itself knows nothing about FortiGate — that knowledge lives entirely in the snippet, which maps the FortiGate event into limpid's canonical intermediate.
 
 ## Step 4 — Confirm the drop is actually happening
 
@@ -164,6 +166,8 @@ The config is growing. The conventional layout: one file per module under `input
 
 ```limpid
 // /etc/limpid/limpid.conf
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 
 include "inputs/*.limpid"
@@ -207,7 +211,7 @@ def output ama {
 def pipeline main {
     input fw_tcp
     output archive
-    process parse_fortigate_cef
+    process parse_syslog | parse_cef | parse_fortigate_cef
     if workspace.cef.cat == "traffic:forward" { drop }
     output ama
 }
@@ -255,14 +259,14 @@ def process dedup_fortigate_traffic {
 def pipeline main {
     input fw_tcp
     output archive
-    process parse_fortigate_cef | dedup_fortigate_trafic
+    process parse_syslog | parse_cef | parse_fortigate_cef | dedup_fortigate_trafic
     output ama
 }
 ```
 
 A few things to read:
 
-- `process A | B` chains processes left to right — the event flows through `parse_fortigate_cef` first, then `dedup_fortigate_traffic`. Equivalent to writing them on two `process` lines; the `|` form just reads more naturally when several processes line up.
+- `process A | B` chains processes left to right — the event flows through the three parser stages first, then `dedup_fortigate_traffic`. Equivalent to writing them on two `process` lines; the `|` form just reads more naturally when several processes line up.
 - `workspace.lsis.parsed.src_endpoint.ip` and `workspace.lsis.parsed.dst_endpoint.ip` exist because `parse_fortigate_cef` ran first. Pipeline order is real order — what comes earlier has populated the canonical intermediate by the time later steps run.
 - `let key = ...` is a process-local scratch variable — scoped to this process invocation, gone when the event leaves. The binding can hold any value type (scalar, Object, or Array); for an Object, `key.x` reads through the binding the same way `workspace.x.y` does. The binding *name* itself is a single identifier (`let foo.bar = ...` is a parse error — the `let` LHS is a single identifier in the grammar; write into `workspace.*` if you need a path target).
 - `table_upsert` resets the TTL on every call, so a flow that keeps appearing keeps being suppressed; the dedup window only opens up once a flow has been quiet for five minutes (`ttl 300` on the table).
@@ -280,8 +284,8 @@ $ limpid --check --config /etc/limpid/limpid.conf
 error: unknown process 'dedup_fortigate_trafic' referenced in pipeline 'main'
   --> /etc/limpid/pipelines/main.limpid:5:30
    |
- 5 |     process parse_fortigate_cef | dedup_fortigate_trafic
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^ no such process is defined
+ 5 |     process parse_syslog | parse_cef | parse_fortigate_cef | dedup_fortigate_trafic
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^ no such process is defined
    |
    = help: did you mean `dedup_fortigate_traffic`?
 ```

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -241,14 +241,13 @@ regions.
 
 | File | Signature | Used by |
 |---|---|---|
-| `functions/http_method_activity_id.limpid` | `http_method_activity_id(method) → Int` | `parse_combined_log`, `parse_suricata`, `parse_zeek_default` |
-| `functions/parse_datetime_rfc3164.limpid` | `parse_datetime_rfc3164(text, timezone) → Timestamp \| null;` | `parse_asa`, `parse_fortigate_cef`, `parse_juniper_srx_syslog`, `parse_paloalto_cef` |
-| `functions/parse_datetime_rfc3164.limpid` | `parse_datetime_rfc3164_in_timezone(text, timezone) → Timestamp` | `parse_datetime_rfc3164` |
-| `functions/proto_num.limpid` | `proto_num(name) → Int \| null` | `parse_checkpoint_leef`, `parse_checkpoint_syslog`, `parse_juniper_srx_sd_syslog`, `parse_juniper_srx_syslog`, `parse_paloalto_cef`, `parse_paloalto_syslog`, `parse_suricata`, `parse_sysmon`, `parse_zeek_default`, `parse_zeek_full` |
-| `functions/severity_converter.limpid` | `ocsf_severity_id_to_otel_severity_number(severity_id) → Int \| null` | `parse_ocsf` |
-| `functions/severity_converter.limpid` | `otel_severity_number_to_ocsf_severity_id(severity_number) → Int \| null` | `compose_ocsf` |
-| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(value) → Int \| null` | `compose_ocsf` |
-| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(value) → Int \| null` | `parse_ocsf` |
+| `functions/http_method_activity_id.limpid` | `http_method_activity_id(String) → Int` | `parse_combined_log`, `parse_suricata`, `parse_zeek_default` |
+| `functions/parse_datetime_rfc3164.limpid` | `parse_datetime_rfc3164(String, String) → Timestamp \| Null` | `parse_asa`, `parse_fortigate_cef`, `parse_juniper_srx_syslog`, `parse_paloalto_cef` |
+| `functions/proto_num.limpid` | `proto_num(String) → Int \| Null` | `parse_checkpoint_leef`, `parse_checkpoint_syslog`, `parse_juniper_srx_sd_syslog`, `parse_juniper_srx_syslog`, `parse_paloalto_cef`, `parse_paloalto_syslog`, `parse_suricata`, `parse_sysmon`, `parse_zeek_default`, `parse_zeek_full` |
+| `functions/severity_converter.limpid` | `ocsf_severity_id_to_otel_severity_number(Int \| Null) → Int \| Null` | `parse_ocsf` |
+| `functions/severity_converter.limpid` | `otel_severity_number_to_ocsf_severity_id(Int \| Null) → Int \| Null` | `compose_ocsf` |
+| `functions/timestamp_converter.limpid` | `timestamp_ns_to_ms(Int \| Timestamp \| Null) → Int \| Null` | `compose_ocsf` |
+| `functions/timestamp_converter.limpid` | `timestamp_ms_to_ns(Int \| Null) → Int \| Null` | `parse_ocsf` |
 <!-- END: inventory:functions -->
 
 Timestamp interpretation follows each source contract. A vendor-defined fixed
@@ -401,29 +400,54 @@ appropriate parser per branch.
 
 ## Authoring conventions
 
-Every snippet header carries a canonical key set determined by the
-file's parent directory:
+Every snippet has one file-level facade header followed by a contract block
+immediately above each public member. The file's parent directory still
+determines its inventory kind.
 
-| Kind | Directory | Required keys (canonical order) |
-|---|---|---|
-| parser | `parsers/` | `Summary`, `Reads`, `Writes`, `Category`, `Test corpus` |
-| composer | `composers/` | `Summary`, `Reads`, `Writes`, `Test corpus` |
-| filter | `filters/` | `Summary`, `Reads`, `Effect`, `Test corpus` |
-| function | `functions/` | `Summary`, `Signature`, `Test corpus` |
+| Scope | Required keys (canonical order) |
+|---|---|
+| parser file | `Facade`, `Category`, `Test corpus` |
+| composer / filter / function file | `Facade`, `Test corpus` |
+| facade process | `Process`, `Summary`, `Reads`, `Writes` |
+| facade function | `Function`, `Summary`, `Signature` |
+
+`Facade:` is a comma-separated list of `process <name>` and `function <name>`
+entries. A leading-space continuation line extends the list. Every listed
+member must have exactly one adjacent member block whose heading and following
+definition agree. A top-level definition omitted from `Facade:` is private to
+the file and has no member block; an unlisted member block is an error.
+
+```limpid
+// Facade: process parse_example, process example_to_otlp,
+//         function example_kind
+// Category: Vendor-neutral
+// Test corpus: synthetic (header examples)
+//
+// File-wide design prose follows here.
+
+// Process: parse_example
+// Summary: Normalize one example event into canonical facts.
+// Reads: workspace.example.*
+//        .body (required, Object)
+//        workspace.example_config.*
+//        .mode (optional, String)
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
+def process parse_example { ... }
+```
 
 **Governing principle.** A header holds only knowledge the author
 alone knows. Anything derivable from other keys, other files, or
 the body is banned from the header and surfaces in the generated
 inventory instead — that is why parsers carry `Category` but
 composers / filters do not (their axis would duplicate
-Reads/Writes/Effect), and why `Used by:` for a function is derived
+their process contracts), and why `Used by:` for a function is derived
 by the inventory generator rather than authored.
 
-### `Reads:` — universal stream-contract grammar
+### `Reads:` / `Writes:` — per-process contract grammar
 
-Every kind that flows events (parser / composer / filter) declares
-its input contract on the `Reads:` value. The first token of the
-first line names the stream source:
+Every facade process declares its input and output contracts. A contract is
+either a reserved event field or one or more workspace roots:
 
 - **Raw wire.** First token `ingress` — the snippet reads bytes off
   the wire. Dot-line intake rows are forbidden.
@@ -432,20 +456,20 @@ first line names the stream source:
   // Reads:       ingress (raw wire) — syslog-wrapped %ASA messages
   ```
 
-- **Bridge / reader.** First token `workspace.<ns>.*` — the snippet
-  reads a workspace namespace populated by an upstream process. At
-  least one dot-line intake row is required per intake field:
+- **Workspace roots.** A root is `workspace.<ns>.*`. Each root owns the
+  following dot-lines until the next root and requires at least one dot-line.
+  Multiple roots are permitted:
 
   ```
-  // Reads:       workspace.openssh.* (bridge — see Bridges below)
-  //                .body       (required, String)  — sshd body
-  //                .pid        (optional, String)  — process id
-  //                .hostname   (optional, String)  — SSH server host
-  //                .time       (optional, Int)     — epoch nanoseconds
+  // Reads: workspace.openssh.*
+  //        .body       (required, String)  — sshd body
+  //        .pid        (optional, String)  — process id
+  //        workspace.pipeline_options.*
+  //        .hostname   (optional, String)  — source-backed override
   ```
 
   Each dot-line matches the regex
-  `^\.<IDENT>\s+\((required|optional), <String|Int|Float|Bool|Object|Array|Timestamp>\)`.
+  `^\.<IDENT>\s+\((required|optional), <String|Int|Float|Bool|Object|Array|Timestamp|Bytes>\)`.
   Trailing prose after the closing paren is permitted. Leading
   underscores in the identifier are permitted (journald's `_PID` /
   `__REALTIME_TIMESTAMP` are real intake fields).
@@ -454,14 +478,11 @@ Ambient event metadata (`received_at`, `source`, `ingress` when
 passed through unchanged, `hostname()`) is not declared in `Reads:`
 — every process can read those unconditionally.
 
-### `Writes:` — LSIS-slot contract
-
-`Writes:` names the LSIS slot(s) the snippet produces. Parsers
-write facts to `workspace.lsis.parsed.*` and enumerate the LSIS
-`class_uid` facts their dispatcher produces (using OCSF class identifiers);
-composers write a single
-`workspace.lsis.composed.<slot>` from the composed-layer registry
-above.
+`Writes:` uses the same multi-root grammar. It additionally accepts the
+reserved `egress` and `ingress` forms. Parsers normally write canonical facts
+under `workspace.lsis.parsed.*`; transport and format parsers instead name
+their transport namespace. Composers write a composed-layer slot, while their
+terminal facade process writes `egress`.
 
 ### `Category:` — parser-only, closed vocabulary
 
@@ -470,9 +491,8 @@ Parsers pick a `Category:` value from the 17-entry whitelist in
 groups rows by this key. To add a category, extend the slice and
 document the addition here.
 
-Composers and filters have no `Category:` axis — the LSIS slot the
-composer writes and the drop / pass predicate the filter enforces
-are already visible on their `Writes:` / `Effect:` keys.
+Composers and filters have no `Category:` axis — their process contracts expose
+the relevant composition slot or pass/drop boundary.
 
 ### `Test corpus:` — provenance vocabulary
 

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -255,6 +255,9 @@ zone wins; documented device-local formats default to `local` (the limpid
 host's system timezone), and formats with no authoritative timezone contract
 default to `UTC`. Source-specific timezone slots override those defaults with
 an IANA name or fixed offset and reject invalid values loudly.
+Explicit `local` is not accepted in an override slot — `local` is a
+host-dependent internal default, not a source-device declaration; each
+parser's guard comment records the rationale.
 
 ### Filebeat-flat JSON: `nest_dotted_keys` primitive
 

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -139,7 +139,7 @@ RFC 5424 fields that the pack cannot synthesise on the caller's behalf).
 
 ## What's included
 
-The current pack contains 31 parser files. Thirty expose a sibling
+The current pack contains 32 parser files. Thirty-one expose a sibling
 `<source>_to_otlp` adapter; the inbound `parse_ocsf` compatibility parser is
 the sole exception.
 
@@ -157,6 +157,7 @@ regions.
 | File | Summary |
 |---|---|
 | **Transport** | |
+| `parsers/parse_cef.limpid` | ArcSight CEF message (from a syslog body) → workspace.cef.* format fields (format-layer parser; interpreting the vendor dialect on top is the next stage's job). |
 | `parsers/parse_journald.limpid` | journalctl -o json lines → workspace.journald.* transport fields (transport-layer parser). |
 | `parsers/parse_syslog.limpid` | RFC 3164 / RFC 5424 syslog wire → workspace.syslog.* transport fields (transport-layer parser; bridging the body into a vocabulary intake is the caller's job). |
 | **Network firewall / IPS** | |
@@ -288,6 +289,8 @@ process {
 Drop a snippet into your `/etc/limpid/limpid.conf`:
 
 ```limpid
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_fortigate_cef.limpid"
 include "/usr/share/limpid/snippets/composers/compose_ocsf.limpid"
 
@@ -302,12 +305,16 @@ def output ocsf_stdout {
 
 def pipeline fw_to_ocsf {
     input fw_syslog
-    process parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+    process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
     output ocsf_stdout
 }
 ```
 
-That's it. The parser writes facts to `workspace.lsis.parsed.*`;
+That's it. Each stage owns one layer: `parse_syslog` unwraps the
+transport, `parse_cef` decodes the CEF format, and the vendor parser
+interprets the dialect — so a pipeline can inspect and drop events
+between stages without paying the next parse. The vendor parser writes
+facts to `workspace.lsis.parsed.*`;
 `compose_ocsf` reads `workspace.lsis.parsed.*` and writes OCSF JSON
 to `workspace.lsis.composed.ocsf`; the one-line `ocsf_to_egress`
 step at the tail of the pipeline hands that slot off to `egress`.
@@ -356,17 +363,21 @@ The library follows four contracts:
 
 ## Pipeline shapes
 
-Schema wire form:
+Schema wire form (transport / format stages precede the vendor parser
+when the wire is layered — e.g. `parse_syslog | parse_asa`,
+`parse_syslog | parse_cef | parse_fortigate_cef`; single-layer wires
+such as FortiGate native KV or JSON-body sources go straight to the
+vendor parser):
 
 ```
-process <vendor_parser> | compose_ocsf | ocsf_to_egress
+process [<transport_parser> | [<format_parser> |]] <vendor_parser> | compose_ocsf | ocsf_to_egress
 ```
 
 Envelope-wrapped schema (OTLP wrapping the OCSF JSON as the log
 body):
 
 ```
-process <vendor_parser>
+process [<transport_parser> | [<format_parser> |]] <vendor_parser>
       | <vendor>_to_otlp
       | compose_ocsf
       | {

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -251,9 +251,10 @@ regions.
 <!-- END: inventory:functions -->
 
 Timestamp interpretation follows each source contract. A vendor-defined fixed
-zone wins; documented device-local formats default to `local` (the limpid
-host's system timezone), and formats with no authoritative timezone contract
-default to `UTC`. Source-specific timezone slots override those defaults with
+zone wins; documented device-local formats and formats with no authoritative
+timezone contract both default to `local` (the limpid host's system timezone —
+the most likely assumption is that the device shares the host's zone).
+Source-specific timezone slots override those defaults with
 an IANA name or fixed offset and reject invalid values loudly.
 Explicit `local` is not accepted in an override slot — `local` is a
 host-dependent internal default, not a source-device declaration; each

--- a/packaging/snippets/README.md
+++ b/packaging/snippets/README.md
@@ -457,8 +457,9 @@ passed through unchanged, `hostname()`) is not declared in `Reads:`
 ### `Writes:` — LSIS-slot contract
 
 `Writes:` names the LSIS slot(s) the snippet produces. Parsers
-write facts to `workspace.lsis.parsed.*` and enumerate the OCSF
-class(es) their dispatcher emits; composers write a single
+write facts to `workspace.lsis.parsed.*` and enumerate the LSIS
+`class_uid` facts their dispatcher produces (using OCSF class identifiers);
+composers write a single
 `workspace.lsis.composed.<slot>` from the composed-layer registry
 above.
 

--- a/packaging/snippets/composers/compose_ocsf.limpid
+++ b/packaging/snippets/composers/compose_ocsf.limpid
@@ -1,18 +1,5 @@
-// Summary:     Renders the LSIS intermediate to OCSF 1.3.0 JSON
-//              (27-class priority set), dispatched by class_uid.
-// Reads:       workspace.lsis.parsed.* (the canonical intermediate produced
-//              by vocabulary parsers)
-//                .class_uid (required, Int) — dispatch discriminator;
-//                            unknown values route to error_log
-//              Remaining fields are read per class by the
-//              `compose_ocsf_<class>` leaves (see class coverage
-//              below); root `time` is emitted in OCSF epoch milliseconds
-//              and falls back to `received_at` when LSIS has no event time.
-// Writes:      workspace.lsis.composed.ocsf — OCSF 1.3.0 JSON, one object per
-//              event (String). Pipe `| ocsf_to_egress` (defined at
-//              the foot of this file) to emit it as the wire form;
-//              a source adapter may be followed by a target-specific
-//              adjustment that selects this slot as an envelope body.
+// Facade: process compose_ocsf,
+//         process ocsf_to_egress
 // Test corpus: spec-only (OCSF 1.3.0 schema; per-class leaf shapes
 //              cross-checked against schema.ocsf.io class definitions)
 //
@@ -111,6 +98,12 @@ def function compose_ocsf_severity_id(severity_number, legacy_severity_id, sever
 // Top-level dispatcher
 // ---------------------------------------------------------------------------
 
+// Process: compose_ocsf
+// Summary: Renders the LSIS intermediate to OCSF 1.3.0 JSON (27-class priority set), dispatched by class_uid.
+// Reads: workspace.lsis.parsed.* (the canonical intermediate produced
+//        .class_uid (required, Int) — dispatch discriminator;
+// Writes: workspace.lsis.composed.*
+//         .ocsf (required, Object)
 def process compose_ocsf {
     switch workspace.lsis.parsed.class_uid {
         // System Activity (category 1)
@@ -949,6 +942,12 @@ def process compose_ocsf_scan_activity {
 // `compose_ocsf | ocsf_to_egress`. When wrapping into another
 // envelope (e.g. OTLP), skip this step and feed the slot directly
 // into the envelope's input.
+
+// Process: ocsf_to_egress
+// Summary: Emit the composed OCSF object as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .ocsf (required, Object)
+// Writes: egress
 def process ocsf_to_egress {
     egress = workspace.lsis.composed.ocsf
 }

--- a/packaging/snippets/composers/compose_otlp.limpid
+++ b/packaging/snippets/composers/compose_otlp.limpid
@@ -1,45 +1,5 @@
-// Summary:     Assembles one OTLP-1.0.0 ResourceLogs envelope from canonical
-//              LSIS scalars and source-adapter shed slots. Emits protobuf
-//              bytes for both otlp_http and otlp_grpc.
-// Reads:       workspace.lsis.parsed.* — canonical scalar facts:
-//                .time             (optional, Int) — event time in
-//                                  epoch nanoseconds.
-//                .severity_number  (optional, Int) — OTel SeverityNumber.
-//                .severity         (optional, String) — exact source text.
-//              workspace.lsis.shed.otlp.* — source-adapter output in OTLP
-//              vocabulary. Each slot is optional and replaces, rather than
-//              merges with, any lower-priority value:
-//                .resource.attributes (optional, Array) — OTLP KeyValue list.
-//                .scope.name (optional, String) — instrumentation scope name.
-//                .scope.version (optional, String) — instrumentation scope version.
-//                .scope.attributes (optional, Array) — OTLP KeyValue list.
-//                .log_record.time_unix_nano (optional, Int) — event-time override.
-//                .log_record.observed_time_unix_nano (optional, Int) — observation-time override.
-//                .log_record.severity_number (optional, Int) — severity override.
-//                .log_record.severity_text (optional, String) — severity-text override.
-//                .log_record.body (optional, Object) — tagged OTLP AnyValue.
-//                .log_record.attributes (optional, Array) — OTLP KeyValue list.
-//              `resource.attributes`, all scope slots, `body`, and LogRecord
-//              attributes are adapter-owned because their construction or
-//              placement is source-specific. Body is an OTLP AnyValue object;
-//              the adapter chooses its variant. Missing slots are omitted.
-//              Canonical scalar fallback chains are
-//                time             = coalesce(shed override, parsed.time)
-//                severity_number  = coalesce(shed override,
-//                                            parsed.severity_number)
-//                severity_text    = coalesce(shed override, parsed.severity)
-//                observed_time    = coalesce(shed override, received_at)
-//              Event time never falls back to `received_at`.
-//
-// Slots deliberately NOT exposed today — `log_record.trace_id`,
-// `log_record.span_id`, `log_record.event_name`, and the
-// `dropped_attributes_count` / `flags` housekeeping fields. These have
-// no implementation-driving caller in the pack today; they are added
-// on the same coalesce-with-default pattern above when a real caller
-// needs them.
-// Writes:      workspace.lsis.composed.otlp — ResourceLogs proto bytes
-//              (Bytes). Pipe `| otlp_to_egress` (foot of file) to emit
-//              for `output otlp_http` / `output otlp_grpc`.
+// Facade: process compose_otlp,
+//         process otlp_to_egress
 // Test corpus: spec-only (OTLP/1.0.0 proto shape;
 //              otlp.encode_resourcelog_protobuf reference in
 //              docs/src/functions/expression-functions.md)
@@ -56,6 +16,25 @@
 // canonical-scalar overrides. `compose_otlp` performs no source placement,
 // hostname synthesis, fixed scope naming, or Body coercion.
 
+// Process: compose_otlp
+// Summary: Assembles one OTLP-1.0.0 ResourceLogs envelope from canonical LSIS scalars and source-adapter shed slots. Emits protobuf bytes for both otlp_http and otlp_grpc.
+// Reads: workspace.lsis.parsed.* — canonical scalar facts:
+//        .time             (optional, Int) — event time in
+//        .severity_number  (optional, Int) — OTel SeverityNumber.
+//        .severity         (optional, String) — exact source text.
+//        workspace.lsis.shed.otlp.* — source-adapter output in OTLP
+//        .resource.attributes (optional, Array) — OTLP KeyValue list.
+//        .scope.name (optional, String) — instrumentation scope name.
+//        .scope.version (optional, String) — instrumentation scope version.
+//        .scope.attributes (optional, Array) — OTLP KeyValue list.
+//        .log_record.time_unix_nano (optional, Int) — event-time override.
+//        .log_record.observed_time_unix_nano (optional, Int) — observation-time override.
+//        .log_record.severity_number (optional, Int) — severity override.
+//        .log_record.severity_text (optional, String) — severity-text override.
+//        .log_record.body (optional, Object) — tagged OTLP AnyValue.
+//        .log_record.attributes (optional, Array) — OTLP KeyValue list.
+// Writes: workspace.lsis.composed.*
+//         .otlp (required, Bytes)
 def process compose_otlp {
     workspace.lsis.composed.otlp = otlp.encode_resourcelog_protobuf(null_omit({
         resource: switch len(coalesce(workspace.lsis.shed.otlp.resource.attributes, [])) > 0 {
@@ -108,6 +87,12 @@ def process compose_otlp {
 // Moves the OTLP ResourceLogs proto bytes from `workspace.lsis.composed.otlp`
 // to `egress`. Pipelines that emit OTLP as the wire form pipe
 // `compose_otlp | otlp_to_egress`.
+
+// Process: otlp_to_egress
+// Summary: Emit the composed OTLP protobuf bytes as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .otlp (required, Bytes)
+// Writes: egress
 def process otlp_to_egress {
     egress = workspace.lsis.composed.otlp
 }

--- a/packaging/snippets/composers/compose_replayable.limpid
+++ b/packaging/snippets/composers/compose_replayable.limpid
@@ -1,13 +1,5 @@
-// Summary:     Serialises the event into the minimal replay-record
-//              shape `{ received_at, source, ingress }` — the same
-//              three fields the error_log (DLQ) preserves and
-//              `inject --json` consumes.
-// Reads:       ingress (passed through verbatim) — plus the ambient
-//              event metadata `received_at` / `source`, which every
-//              process can read unconditionally.
-// Writes:      workspace.lsis.composed.replayable — replay record JSONL line
-//              (String). Pipe `| replayable_to_egress` (foot of
-//              file) to emit it as the capture stream.
+// Facade: process compose_replayable,
+//         process replayable_to_egress
 // Test corpus: spec-only (mirrors the error_log DLQ record shape;
 //              round-trips through `limpidctl inject --json`)
 //
@@ -42,6 +34,11 @@
 // captures *all* events. Both round-trip through `inject --json`
 // without preprocessing.
 
+// Process: compose_replayable
+// Summary: Serialises the event into the minimal replay-record shape `{ received_at, source, ingress }` — the same three fields the error_log (DLQ) preserves and `inject --json` consumes.
+// Reads: ingress
+// Writes: workspace.lsis.composed.*
+//         .replayable (required, String)
 def process compose_replayable {
     // Since v0.5.6 the DSL `source` ident is the canonical
     // `{ip, port}` object — same shape `inject --json` expects — so
@@ -61,6 +58,12 @@ def process compose_replayable {
 // Moves the replay record from `workspace.lsis.composed.replayable` to
 // `egress`. Pipelines that emit the capture stream as the wire form
 // pipe `compose_replayable | replayable_to_egress`.
+
+// Process: replayable_to_egress
+// Summary: Emit the composed replay record as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .replayable (required, String)
+// Writes: egress
 def process replayable_to_egress {
     egress = workspace.lsis.composed.replayable
 }

--- a/packaging/snippets/composers/compose_rfc5424.limpid
+++ b/packaging/snippets/composers/compose_rfc5424.limpid
@@ -1,28 +1,6 @@
-// Summary:     Assembles a single-line RFC 5424 syslog record from
-//              per-field shed slots
-//              (https://datatracker.ietf.org/doc/html/rfc5424).
-// Reads:       workspace.lsis.shed.rfc5424.* — per-field intake
-//              (RFC 5424 ABNF vocabulary):
-//                .pri        (optional, Int)    — default 14 (user.info)
-//                .timestamp  (optional, String) — default is `received_at`
-//                             formatted as RFC 3339 with microsecond UTC
-//                             precision. Callers supplying their own value
-//                             MUST also supply the RFC 5424 wire form.
-//                .hostname   (optional, String) — default hostname()
-//                .app_name   (optional, String) — default "-"
-//                .procid     (optional, String) — default "-"
-//                .msgid      (optional, String) — default "-"
-//                .sd         (optional, String) — default "-"
-//                .msg        (required, String) — the log body. If the slot
-//                             is absent the record still assembles with an
-//                             empty MSG, which is spec-compliant (RFC 5424
-//                             § 6 grammar makes MSG optional); required is
-//                             the intended contract from the composer's
-//                             point of view, and absence is a caller bug
-//                             to flag.
-// Writes:      workspace.lsis.composed.rfc5424 — single-line RFC 5424
-//              record (String). Pipe `| rfc5424_to_egress` (foot of file)
-//              to emit it as the wire form.
+// Facade: process compose_rfc5424,
+//         process journald_to_rfc5424,
+//         process rfc5424_to_egress
 // Test corpus: spec-only (RFC 5424 § 6 frame shape; field decisions
 //              documented below)
 //
@@ -97,6 +75,19 @@ def function rfc5424_pri_from(facility_str, severity_str) {
 // Generic RFC 5424 body composer — reads shed.rfc5424.*, writes composed.
 // ---------------------------------------------------------------------------
 
+// Process: compose_rfc5424
+// Summary: Assembles a single-line RFC 5424 syslog record from per-field shed slots (https://datatracker.ietf.org/doc/html/rfc5424).
+// Reads: workspace.lsis.shed.rfc5424.* — per-field intake
+//        .pri        (optional, Int)    — default 14 (user.info)
+//        .timestamp  (optional, String) — default is `received_at`
+//        .hostname   (optional, String) — default hostname()
+//        .app_name   (optional, String) — default "-"
+//        .procid     (optional, String) — default "-"
+//        .msgid      (optional, String) — default "-"
+//        .sd         (optional, String) — default "-"
+//        .msg        (required, String) — the log body. If the slot
+// Writes: workspace.lsis.composed.*
+//         .rfc5424 (required, String)
 def process compose_rfc5424 {
     let pri       = coalesce(workspace.lsis.shed.rfc5424.pri, 14)
     let ts        = coalesce(
@@ -158,6 +149,12 @@ def process compose_rfc5424 {
 //       output relay
 //   }
 
+// Process: journald_to_rfc5424
+// Summary: Bridge parsed journald transport fields into RFC 5424 shed slots.
+// Reads: workspace.journald.*
+//        .MESSAGE (required, String)
+// Writes: workspace.lsis.shed.rfc5424.*
+//         .msg (required, String)
 def process journald_to_rfc5424 {
     workspace.lsis.shed.rfc5424.pri      = rfc5424_pri_from(
                                               workspace.journald.SYSLOG_FACILITY,
@@ -183,6 +180,12 @@ def process journald_to_rfc5424 {
 // `egress`. Pipelines that emit RFC 5424 as the wire form pipe
 // `compose_rfc5424 | rfc5424_to_egress` (usually preceded by a bridge
 // or glue block that populates the shed slots).
+
+// Process: rfc5424_to_egress
+// Summary: Emit the composed RFC 5424 record as the event payload.
+// Reads: workspace.lsis.composed.*
+//        .rfc5424 (required, String)
+// Writes: egress
 def process rfc5424_to_egress {
     egress = workspace.lsis.composed.rfc5424
 }

--- a/packaging/snippets/filters/filter_openssh_journal.limpid
+++ b/packaging/snippets/filters/filter_openssh_journal.limpid
@@ -1,10 +1,4 @@
-// Summary:     Strip PAM-stack noise from a journal-sourced sshd
-//              stream ahead of parse_openssh.
-// Reads:       workspace.journald.* (from parse_journald)
-//                .MESSAGE (required, String) — sshd body candidate
-// Effect:      drop lines matching `^pam_unix(sshd:<module>):`
-//              (PAM lifecycle noise riding sshd's syslogtag); pass
-//              everything else through unchanged.
+// Facade: process filter_openssh_journal
 // Test corpus: synthetic (pam_unix / sshd sample bodies referenced
 //              in this header's drop/pass tables)
 //
@@ -51,6 +45,11 @@
 // string`, …). Those flow through unchanged for `parse_openssh` to
 // classify.
 
+// Process: filter_openssh_journal
+// Summary: Strip PAM-stack noise from a journal-sourced sshd stream ahead of parse_openssh.
+// Reads: workspace.journald.* (from parse_journald)
+//        .MESSAGE (required, String) — sshd body candidate
+// Writes: ingress
 def process filter_openssh_journal {
     let body = coalesce(workspace.journald.MESSAGE, "")
     if regex_match(body, "^pam_unix\\(sshd:[a-z]+\\):") {

--- a/packaging/snippets/functions/http_method_activity_id.limpid
+++ b/packaging/snippets/functions/http_method_activity_id.limpid
@@ -1,7 +1,4 @@
-// Summary:     HTTP request method → OCSF 4002 HTTP Activity
-//              `activity_id` (spec-standard enumeration,
-//              vendor-independent).
-// Signature:   http_method_activity_id(method) → Int
+// Facade: function http_method_activity_id
 // Test corpus: unit (OCSF 1.3.0 class 4002 activity_id enumeration)
 //
 // This mapping is OCSF spec standard (4002 class definition,
@@ -25,6 +22,9 @@
 // Lowercase / mixed-case method strings (rare, non-compliant) fall
 // through to 99.
 
+// Function: http_method_activity_id
+// Summary: HTTP request method → OCSF 4002 HTTP Activity `activity_id` (spec-standard enumeration, vendor-independent).
+// Signature: http_method_activity_id(String) → Int
 def function http_method_activity_id(method) {
     switch method {
         "CONNECT" { 1 }

--- a/packaging/snippets/functions/parse_datetime_rfc3164.limpid
+++ b/packaging/snippets/functions/parse_datetime_rfc3164.limpid
@@ -16,9 +16,15 @@
 //      Vector / Fluent Bit all converge on.
 //
 //   2. The wire carries no timezone. The caller resolves the vendor-specific
-//      default or an operator override before calling this helper. `local`
-//      means the limpid host's system timezone; `UTC`, IANA names, and fixed
-//      offsets are also accepted. An invalid timezone is a loud error.
+//      default or an operator override before calling this helper. This helper
+//      itself accepts `local` (the limpid host's system timezone), `UTC`, IANA
+//      names, and fixed offsets; invalid values are a loud error. Note that
+//      the pack's RFC 3164 parsers (parse_asa, parse_fortigate_cef,
+//      parse_juniper_srx_syslog, parse_paloalto_cef) additionally reject an
+//      explicit `local` in their `workspace.<parser>.timezone` override slot
+//      — a slot value is a source-device declaration, distinct from the
+//      internal device-local fallback used when the slot is unset. See each
+//      parser's guard comment for the full rationale.
 //
 // For modern senders (RFC 5424 syslog, OTLP, OCSF, AWS CloudTrail,
 // most cloud audit logs) use the built-in `parse_datetime_rfc3339`

--- a/packaging/snippets/functions/parse_datetime_rfc3164.limpid
+++ b/packaging/snippets/functions/parse_datetime_rfc3164.limpid
@@ -9,11 +9,12 @@
 // shipped as LPL rather than Rust because RFC 3164 timestamps
 // require policy decisions that should be operator-editable:
 //
-//   1. The wire carries no year. We assume current year, with a
-//      future-clamp: if the parsed datetime is more than 24 hours
-//      ahead of `timestamp()`, it actually refers to the previous
-//      year (year-end rollover). This is what rsyslog / syslog-ng /
-//      Vector / Fluent Bit all converge on.
+//   1. The wire carries no year. Major syslog implementations solve
+//      the same year-rollover problem with per-product heuristics
+//      (e.g. Vector uses a Dec/Jan calendar test); limpid assumes the
+//      current year with a 24-hour future-clamp: if the parsed
+//      datetime is more than 24 hours ahead of `timestamp()`, it
+//      actually refers to the previous year (year-end rollover).
 //
 //   2. The wire carries no timezone. The caller resolves the vendor-specific
 //      default or an operator override before calling this helper. This helper

--- a/packaging/snippets/functions/parse_datetime_rfc3164.limpid
+++ b/packaging/snippets/functions/parse_datetime_rfc3164.limpid
@@ -1,7 +1,4 @@
-// Summary:     RFC 3164 BSD syslog timestamp (`Apr 30 01:23:45`) plus
-//              a resolved source timezone → Timestamp, with year-rollover clamp.
-// Signature:   parse_datetime_rfc3164(text, timezone) → Timestamp | null;
-//              parse_datetime_rfc3164_in_timezone(text, timezone) → Timestamp
+// Facade: function parse_datetime_rfc3164
 // Test corpus: unit (RFC 3164 timestamp shapes; year-end rollover
 //              clamp cases)
 //
@@ -55,6 +52,9 @@ def function parse_datetime_rfc3164_in_timezone(text, timezone) {
     }
 }
 
+// Function: parse_datetime_rfc3164
+// Summary: RFC 3164 BSD syslog timestamp (`Apr 30 01:23:45`) plus a resolved source timezone → Timestamp, with year-rollover clamp.
+// Signature: parse_datetime_rfc3164(String, String) → Timestamp | Null
 def function parse_datetime_rfc3164(text, timezone) {
     switch timezone {
         null    { null }

--- a/packaging/snippets/functions/proto_num.limpid
+++ b/packaging/snippets/functions/proto_num.limpid
@@ -1,7 +1,4 @@
-// Summary:     IANA protocol number for a transport-layer protocol
-//              name — the universal mapping for filling
-//              `connection_info.protocol_num` on an LSIS record.
-// Signature:   proto_num(name) → Int | null
+// Facade: function proto_num
 // Test corpus: unit (IANA "Assigned Internet Protocol Numbers"
 //              registry, RFC 5237)
 //
@@ -30,6 +27,9 @@
 // Out of scope (return null): OSPF, IGMP, IPv4/IPv6 encapsulated,
 // EtherIP, PIM, etc. Add when a vendor parser surfaces them.
 
+// Function: proto_num
+// Summary: IANA protocol number for a transport-layer protocol name — the universal mapping for filling `connection_info.protocol_num` on an LSIS record.
+// Signature: proto_num(String) → Int | Null
 def function proto_num(name) {
     switch lower(name) {
         "tcp"    { 6 }

--- a/packaging/snippets/functions/severity_converter.limpid
+++ b/packaging/snippets/functions/severity_converter.limpid
@@ -1,8 +1,7 @@
-// Summary:     Converts severity values between OCSF 1.3.0 severity_id and
-//              OpenTelemetry SeverityNumber without guessing unknown values.
-// Signature:   ocsf_severity_id_to_otel_severity_number(severity_id) → Int | null
-//              otel_severity_number_to_ocsf_severity_id(severity_number) → Int | null
+// Facade: function ocsf_severity_id_to_otel_severity_number,
+//         function otel_severity_number_to_ocsf_severity_id
 // Test corpus: unit (OCSF 1.3.0 and OTel severity boundary tables)
+//
 
 // These partial functions encode only the published standard-to-standard
 // boundary. Null stays null. OCSF Unknown (0) maps to an unset canonical
@@ -12,6 +11,9 @@
 // processes compare the source and result and raise an operator-readable
 // error for invalid non-null input.
 
+// Function: ocsf_severity_id_to_otel_severity_number
+// Summary: Converts severity values between OCSF 1.3.0 severity_id and OpenTelemetry SeverityNumber without guessing unknown values.
+// Signature: ocsf_severity_id_to_otel_severity_number(Int | Null) → Int | Null
 def function ocsf_severity_id_to_otel_severity_number(severity_id) {
     switch severity_id {
         0       { null }
@@ -26,6 +28,9 @@ def function ocsf_severity_id_to_otel_severity_number(severity_id) {
     }
 }
 
+// Function: otel_severity_number_to_ocsf_severity_id
+// Summary: Converts severity values between OCSF 1.3.0 severity_id and OpenTelemetry SeverityNumber without guessing unknown values.
+// Signature: otel_severity_number_to_ocsf_severity_id(Int | Null) → Int | Null
 def function otel_severity_number_to_ocsf_severity_id(severity_number) {
     switch severity_number {
         1       { 1 }

--- a/packaging/snippets/functions/timestamp_converter.limpid
+++ b/packaging/snippets/functions/timestamp_converter.limpid
@@ -1,8 +1,7 @@
-// Summary:     Converts record-level Unix epoch timestamps between the LSIS
-//              nanosecond scale and the OCSF millisecond scale.
-// Signature:   timestamp_ns_to_ms(value) → Int | null
-//              timestamp_ms_to_ns(value) → Int | null
+// Facade: function timestamp_ns_to_ms,
+//         function timestamp_ms_to_ns
 // Test corpus: unit (exact epoch arithmetic and null passthrough)
+//
 
 // LSIS retains record-level timestamps as Unix epoch nanoseconds. OCSF
 // `timestamp_t` uses Unix epoch milliseconds. These helpers make that output
@@ -14,6 +13,9 @@
 // `compose_ocsf`; Int inputs remain exact. Null remains null, and arithmetic
 // errors such as an overflowing ms-to-ns conversion propagate to the caller.
 
+// Function: timestamp_ns_to_ms
+// Summary: Converts record-level Unix epoch timestamps between the LSIS nanosecond scale and the OCSF millisecond scale.
+// Signature: timestamp_ns_to_ms(Int | Timestamp | Null) → Int | Null
 def function timestamp_ns_to_ms(value) {
     switch value == null {
         true    { null }
@@ -21,6 +23,9 @@ def function timestamp_ns_to_ms(value) {
     }
 }
 
+// Function: timestamp_ms_to_ns
+// Summary: Converts record-level Unix epoch timestamps between the LSIS nanosecond scale and the OCSF millisecond scale.
+// Signature: timestamp_ms_to_ns(Int | Null) → Int | Null
 def function timestamp_ms_to_ns(value) {
     switch value == null {
         true    { null }

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -3,10 +3,11 @@
 // Reads:       ingress (raw wire) — syslog-wrapped %ASA-<level>-<msg_id> messages
 //              workspace.asa.timezone (optional, String) — source device
 //              timezone override as an IANA name or fixed offset; the legacy
-//              RFC 3164 timestamp defaults to UTC when this is absent
-//              (Cisco documents UTC only for RFC 5424; the accepted legacy
-//              RFC 3164 form has no documented zone, so UTC is the intentional
-//              pack default; override it when the device zone is known)
+//              RFC 3164 timestamp defaults to the limpid host's system
+//              timezone (Cisco documents UTC only for RFC 5424; the accepted
+//              legacy RFC 3164 form has no documented zone, so the pack
+//              assumes the device shares the host's zone — the most likely
+//              deployment; override it when the device zone is known)
 //              https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/I-R/asa-command-ref-I-R/m_log-lz.html
 // Writes:      workspace.lsis.parsed.* — 3002 (Authentication) and 4001 (Network
 //              asa_to_otlp additionally writes source-specific
@@ -117,7 +118,7 @@ def process validate_asa_severity_number {
         "local" { error "parse_asa: source timezone must be an IANA name or fixed offset, not local" }
     }
     workspace.asa.severity_number = asa_severity_number(to_int(workspace.asa.level))
-    let source_timezone = coalesce(workspace.asa.timezone, "UTC")
+    let source_timezone = coalesce(workspace.asa.timezone, "local")
     workspace.asa.time = switch workspace.asa.timestamp {
         null    { null }
         default { to_int(parse_datetime_rfc3164(workspace.asa.timestamp, source_timezone)) }

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -16,10 +16,10 @@
 //              deployment; override it when the device zone is known)
 //              https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/I-R/asa-command-ref-I-R/m_log-lz.html
 // Writes:      workspace.lsis.parsed.* — 3002 (Authentication) and 4001 (Network
-//              asa_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              Activity), dispatched by message ID; unmapped IDs route to
-//              error_log. Per-ID table below.
+//              error_log. Per-ID table below. asa_to_otlp additionally writes
+//              source-specific workspace.lsis.shed.otlp Resource, Body, and
+//              LogRecord attributes.
 // Category:    Network firewall / IPS
 // Test corpus: synthetic (sample wires in this header; several message-ID
 //              leaves are not yet exercised against live captures — see

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -110,6 +110,9 @@ def function asa_severity_number(level) {
 }
 
 def process validate_asa_severity_number {
+    // The timezone slot declares the source device's zone. Explicit "local"
+    // is rejected because it follows the limpid host's OS, does not identify
+    // the source, and can mask misconfiguration when host TZ happens to match.
     switch workspace.asa.timezone {
         "local" { error "parse_asa: source timezone must be an IANA name or fixed offset, not local" }
     }

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -1,6 +1,12 @@
 // Summary:     Cisco ASA / FTD (ASA-syslog-compatibility) %ASA syslog
 //              messages → LSIS Authentication + Network Activity.
-// Reads:       ingress (raw wire) — syslog-wrapped %ASA-<level>-<msg_id> messages
+// Reads:       workspace.syslog.* (transport intake — populated by
+//              parse_syslog upstream)
+//                .msg (required, String) — syslog body carrying the
+//                     `%ASA-<level>-<msg_id>` message
+//                .timestamp (optional, String) — RFC 3164 wire timestamp
+//                .hostname (optional, String) — originating device, retained
+//                     by asa_to_otlp as Resource `host.name`
 //              workspace.asa.timezone (optional, String) — source device
 //              timezone override as an IANA name or fixed offset; the legacy
 //              RFC 3164 timestamp defaults to the limpid host's system
@@ -23,6 +29,16 @@
 // Firepower Threat Defense (FTD) running in ASA-syslog-compatibility mode.
 // Pure FTD eStreamer / Snort-3 / FMC syslog has its own format and would
 // land in a separate parser file (`parse_firepower_*.limpid`).
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_asa | compose_ocsf | ocsf_to_egress
+//
+// The transport wrapper is unwrapped by `parse_syslog` upstream; this
+// parser consumes the syslog body (and transport timestamp / hostname)
+// from `workspace.syslog.*`. Separating the stages lets a pipeline
+// inspect and drop events after `parse_syslog` without paying the
+// vocabulary parse cost.
 //
 // Wire —    syslog-wrapped ASA messages —
 //          `<priority>timestamp host : %ASA-<level>-<msg_id>: <body>`
@@ -138,7 +154,6 @@ def process validate_asa_severity_number {
 
 def process parse_asa {
     let source_timezone = workspace.asa.timezone
-    workspace.syslog = syslog.parse(ingress)
     workspace.asa = regex_parse(
         workspace.syslog.msg,
         "^(?:[^:]*: )?%ASA-(?P<level>\\d)-(?P<msg_id>\\d+): (?P<body>.*)$"

--- a/packaging/snippets/parsers/parse_asa.limpid
+++ b/packaging/snippets/parsers/parse_asa.limpid
@@ -1,26 +1,6 @@
-// Summary:     Cisco ASA / FTD (ASA-syslog-compatibility) %ASA syslog
-//              messages → LSIS Authentication + Network Activity.
-// Reads:       workspace.syslog.* (transport intake — populated by
-//              parse_syslog upstream)
-//                .msg (required, String) — syslog body carrying the
-//                     `%ASA-<level>-<msg_id>` message
-//                .timestamp (optional, String) — RFC 3164 wire timestamp
-//                .hostname (optional, String) — originating device, retained
-//                     by asa_to_otlp as Resource `host.name`
-//              workspace.asa.timezone (optional, String) — source device
-//              timezone override as an IANA name or fixed offset; the legacy
-//              RFC 3164 timestamp defaults to the limpid host's system
-//              timezone (Cisco documents UTC only for RFC 5424; the accepted
-//              legacy RFC 3164 form has no documented zone, so the pack
-//              assumes the device shares the host's zone — the most likely
-//              deployment; override it when the device zone is known)
-//              https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/I-R/asa-command-ref-I-R/m_log-lz.html
-// Writes:      workspace.lsis.parsed.* — 3002 (Authentication) and 4001 (Network
-//              Activity), dispatched by message ID; unmapped IDs route to
-//              error_log. Per-ID table below. asa_to_otlp additionally writes
-//              source-specific workspace.lsis.shed.otlp Resource, Body, and
-//              LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_asa,
+//         process asa_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (sample wires in this header; several message-ID
 //              leaves are not yet exercised against live captures — see
 //              per-leaf NOTEs)
@@ -152,6 +132,16 @@ def process validate_asa_severity_number {
 // switch can dispatch by message ID. Each leaf re-parses the
 // remaining body text against its message-ID-specific shape.
 
+// Process: parse_asa
+// Summary: Cisco ASA / FTD (ASA-syslog-compatibility) %ASA syslog messages → LSIS Authentication + Network Activity.
+// Reads: workspace.syslog.* (transport intake — populated by
+//        .msg (required, String) — syslog body carrying the
+//        .timestamp (optional, String) — RFC 3164 wire timestamp
+//        .hostname (optional, String) — originating device, retained
+//        workspace.asa.*
+//        .timezone (optional, String) — source device
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_asa {
     let source_timezone = workspace.asa.timezone
     workspace.asa = regex_parse(
@@ -567,6 +557,18 @@ def function asa_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: asa_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.syslog.*
+//        .hostname (optional, String)
+//        workspace.asa.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process asa_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Cisco" } }],

--- a/packaging/snippets/parsers/parse_auditd.limpid
+++ b/packaging/snippets/parsers/parse_auditd.limpid
@@ -1,14 +1,6 @@
-// Summary:     Linux kernel audit records (auditd / audispd / auditbeat wire
-//              text) → LSIS, dispatched by record type.
-// Reads:       workspace.auditd.* (bridge — see Bridges below)
-//                .body (required, String) — the auditd record
-//                .hostname (optional, String) — host where audit ran
-// Writes:      workspace.lsis.parsed.* — 3002 (Authentication), 3001 (Account Change),
-//              1007 (Process Activity), 1001 (File System Activity), 2004
-//              (Detection Finding), dispatched by record type; unmapped types
-//              route to error_log. auditd_to_otlp writes source-owned OTLP
-//              Resource, Body, and LogRecord attributes.
-// Category:    Endpoint / host audit (Unix)
+// Facade: process parse_auditd,
+//         process auditd_to_otlp
+// Category: Endpoint / host audit (Unix)
 // Test corpus: public (elastic/integrations auditd corpus — 69 records across
 //              ~45 record types)
 //
@@ -413,6 +405,13 @@ def process parse_auditd_normalize_time {
     }
 }
 
+// Process: parse_auditd
+// Summary: Linux kernel audit records (auditd / audispd / auditbeat wire text) → LSIS, dispatched by record type.
+// Reads: workspace.auditd.* (bridge — see Bridges below)
+//        .body (required, String) — the auditd record
+//        .hostname (optional, String) — host where audit ran
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_auditd {
     // @requires: workspace.auditd.body      (required, String)
     // @requires: workspace.auditd.hostname  (optional, String)
@@ -908,6 +907,18 @@ def function auditd_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: auditd_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.auditd.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+//        workspace.auditd_class.*
+//        .type (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process auditd_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Linux" } }],

--- a/packaging/snippets/parsers/parse_auditd.limpid
+++ b/packaging/snippets/parsers/parse_auditd.limpid
@@ -7,7 +7,7 @@
 //              1007 (Process Activity), 1001 (File System Activity), 2004
 //              (Detection Finding), dispatched by record type; unmapped types
 //              route to error_log. auditd_to_otlp writes source-owned OTLP
-//              Resource, Scope, Body, and LogRecord attributes.
+//              Resource, Body, and LogRecord attributes.
 // Category:    Endpoint / host audit (Unix)
 // Test corpus: public (elastic/integrations auditd corpus — 69 records across
 //              ~45 record types)
@@ -914,10 +914,10 @@ def process auditd_to_otlp {
         [{ key: "observer.product", value: { string_value: "Linux Audit" } }],
         [{ key: "observer.type", value: { string_value: "host" } }],
         switch workspace.auditd.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.auditd.hostname } }] } default { [] } },
+        [{ key: "service.name", value: { string_value: "auditd" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "auditd"
     workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.auditd.body }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: auditd_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],

--- a/packaging/snippets/parsers/parse_aws_guardduty.limpid
+++ b/packaging/snippets/parsers/parse_aws_guardduty.limpid
@@ -4,9 +4,9 @@
 // Reads:       ingress (raw wire) — one GuardDuty finding object per ingress
 //              (identical across EventBridge / SNS / S3 delivery)
 // Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding), one finding → one
+//              record; unknown ThreatPurpose values route to error_log.
 //              aws_guardduty_to_otlp additionally writes source-specific
 //              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              record; unknown ThreatPurpose values route to error_log.
 // Category:    Cloud security findings
 // Test corpus: spec-only (AWS documentation per-finding-type sample bodies;
 //              cross-referenced against the CreateSampleFindings API shape —

--- a/packaging/snippets/parsers/parse_aws_guardduty.limpid
+++ b/packaging/snippets/parsers/parse_aws_guardduty.limpid
@@ -1,16 +1,11 @@
-// AWS GuardDuty finding JSON parser
-//
-// Summary:     AWS GuardDuty findings JSON → LSIS Detection Finding.
-// Reads:       ingress (raw wire) — one GuardDuty finding object per ingress
-//              (identical across EventBridge / SNS / S3 delivery)
-// Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding), one finding → one
-//              record; unknown ThreatPurpose values route to error_log.
-//              aws_guardduty_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-// Category:    Cloud security findings
+// Facade: process parse_aws_guardduty,
+//         process aws_guardduty_to_otlp
+// Category: Cloud security findings
 // Test corpus: spec-only (AWS documentation per-finding-type sample bodies;
 //              cross-referenced against the CreateSampleFindings API shape —
 //              verify against live findings before production rollout)
+//
+// AWS GuardDuty finding JSON parser
 //
 // Vendor notes — Amazon Web Services GuardDuty — the AWS-native threat
 //           detection service. Findings synthesise signals from
@@ -289,6 +284,11 @@ def function aws_guardduty_finding_record(body, type_parts, attack_tactic, sever
 // vocabulary (loud-fail-fast on a category AWS hasn't published
 // yet) and to populate the MITRE-aligned `attacks[].tactic.name`.
 
+// Process: parse_aws_guardduty
+// Summary: AWS GuardDuty findings JSON → LSIS Detection Finding.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_aws_guardduty {
     workspace.gd = parse_json(ingress)
     workspace.gd_type = aws_guardduty_split_type(workspace.gd.type)
@@ -435,6 +435,16 @@ def function aws_guardduty_otlp_tactic_name(category) {
     }
 }
 
+// Process: aws_guardduty_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.gd.*
+//        .accountId (optional, String)
+//        workspace.gd_type.*
+//        .category (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process aws_guardduty_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "aws" } }],

--- a/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
+++ b/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
@@ -5,9 +5,9 @@
 // Reads:       ingress (raw wire) — one space-separated flow-log record per
 //              line; dispatch by the leading version token
 // Writes:      workspace.lsis.parsed.* — 4001 (Network Activity); unknown version
-//              aws_vpc_flow_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              tokens route to error_log.
+//              tokens route to error_log. aws_vpc_flow_to_otlp additionally writes
+//              source-specific workspace.lsis.shed.otlp Resource, Body, and
+//              LogRecord attributes.
 // Category:    Cloud network (data plane)
 // Test corpus: spec-only (AWS VPC Flow Logs documentation column layouts;
 //              synthesised sample lines below cover ACCEPT / REJECT / NODATA /

--- a/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
+++ b/packaging/snippets/parsers/parse_aws_vpc_flow.limpid
@@ -1,18 +1,12 @@
-// AWS VPC Flow Logs parser
-//
-// Summary:     AWS VPC Flow Logs text records (v2 default + v5 custom
-//              formats) → LSIS Network Activity.
-// Reads:       ingress (raw wire) — one space-separated flow-log record per
-//              line; dispatch by the leading version token
-// Writes:      workspace.lsis.parsed.* — 4001 (Network Activity); unknown version
-//              tokens route to error_log. aws_vpc_flow_to_otlp additionally writes
-//              source-specific workspace.lsis.shed.otlp Resource, Body, and
-//              LogRecord attributes.
-// Category:    Cloud network (data plane)
+// Facade: process parse_aws_vpc_flow,
+//         process aws_vpc_flow_to_otlp
+// Category: Cloud network (data plane)
 // Test corpus: spec-only (AWS VPC Flow Logs documentation column layouts;
 //              synthesised sample lines below cover ACCEPT / REJECT / NODATA /
 //              SKIPDATA and IPv4 + IPv6 — verify the v5 leaf against live
 //              delivery before production)
+//
+// AWS VPC Flow Logs parser
 //
 // Vendor notes — Amazon Web Services VPC Flow Logs — flow-level network
 //              telemetry emitted per ENI / subnet / VPC. Both v2 (the
@@ -169,6 +163,11 @@ def function aws_vpc_flow_epoch_seconds_to_nanos(s) {
 // re-parses the line against its own column count and writes a 4001
 // record. Unknown versions → error.
 
+// Process: parse_aws_vpc_flow
+// Summary: AWS VPC Flow Logs text records (v2 default + v5 custom formats) → LSIS Network Activity.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_aws_vpc_flow {
     let version = regex_parse(ingress, "^(?P<v>\\S+)")
     switch true {
@@ -369,6 +368,14 @@ def function aws_vpc_flow_otlp_event_types(status_id) {
     }
 }
 
+// Process: aws_vpc_flow_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.lsis.parsed.*
+//        .cloud.account.uid (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process aws_vpc_flow_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "aws" } }],

--- a/packaging/snippets/parsers/parse_azure_activity.limpid
+++ b/packaging/snippets/parsers/parse_azure_activity.limpid
@@ -4,10 +4,9 @@
 // Reads:       ingress (raw wire) — one Activity Log event per ingress (flat
 //              per-record form; unwrap Event Hub batches upstream)
 // Writes:      workspace.lsis.parsed.* — 6003 (API Activity), dispatched over the
+//              8 documented categories; unknown categories route to error_log.
 //              azure_activity_to_otlp additionally writes source-specific
 //              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              8 documented categories; unknown categories route to
-//              error_log.
 // Category:    Cloud audit (API control plane)
 // Test corpus: spec-only (Microsoft Learn Azure Activity Log schema reference
 //              + documentation samples for the 8 categories; no live capture)

--- a/packaging/snippets/parsers/parse_azure_activity.limpid
+++ b/packaging/snippets/parsers/parse_azure_activity.limpid
@@ -1,15 +1,10 @@
-// Azure Activity Log JSON parser
-//
-// Summary:     Azure Activity Log events JSON → LSIS API Activity.
-// Reads:       ingress (raw wire) — one Activity Log event per ingress (flat
-//              per-record form; unwrap Event Hub batches upstream)
-// Writes:      workspace.lsis.parsed.* — 6003 (API Activity), dispatched over the
-//              8 documented categories; unknown categories route to error_log.
-//              azure_activity_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-// Category:    Cloud audit (API control plane)
+// Facade: process parse_azure_activity,
+//         process azure_activity_to_otlp
+// Category: Cloud audit (API control plane)
 // Test corpus: spec-only (Microsoft Learn Azure Activity Log schema reference
 //              + documentation samples for the 8 categories; no live capture)
+//
+// Azure Activity Log JSON parser
 //
 // Wire —        JSON — one Activity Log event per `ingress`. Azure emits
 //              Activity Log records in two delivery shapes (event hub
@@ -263,6 +258,11 @@ def process parse_azure_activity_record {
 // `error` so a future Azure RP addition surfaces in the DLQ on day
 // one rather than silently zero-mapping.
 
+// Process: parse_azure_activity
+// Summary: Azure Activity Log events JSON → LSIS API Activity.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_azure_activity {
     workspace.az = parse_json(ingress)
 
@@ -338,6 +338,16 @@ def function azure_activity_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: azure_activity_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.az.*
+//        .subscriptionId (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process azure_activity_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "azure" } }],

--- a/packaging/snippets/parsers/parse_bind.limpid
+++ b/packaging/snippets/parsers/parse_bind.limpid
@@ -1,16 +1,6 @@
-// Summary:     ISC BIND 9 querylog lines → LSIS DNS Activity.
-// Reads:       workspace.bind.* (bridge — see Bridges below)
-//                .body (required, String) — the query log line
-//                .pid (optional, String) — named pid
-//                .hostname (optional, String) — DNS server hostname
-//                .timezone (optional, String) — source timezone override as an
-//                  IANA name or fixed offset; defaults to the limpid host's
-//                  system timezone for BIND's local wall time
-//                  https://bind9.readthedocs.io/en/v9.18.13/reference.html#namedconf-statement-print-time
-// Writes:      workspace.lsis.parsed.* — 4003 (DNS Activity). Only the queries
-//              channel; bind_to_otlp writes source-owned OTLP Resource,
-//              Body, and LogRecord attributes.
-// Category:    DNS server
+// Facade: process parse_bind,
+//         process bind_to_otlp
+// Category: DNS server
 // Test corpus: synthetic (sample querylog lines in this header)
 //
 // Vendor notes — ISC BIND 9 (Internet Systems Consortium) — the dominant
@@ -139,6 +129,15 @@ def function bind_dns_record(client_ip, client_port_str, qname, qclass, qtype, s
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_bind
+// Summary: ISC BIND 9 querylog lines → LSIS DNS Activity.
+// Reads: workspace.bind.* (bridge — see Bridges below)
+//        .body (required, String) — the query log line
+//        .pid (optional, String) — named pid
+//        .hostname (optional, String) — DNS server hostname
+//        .timezone (optional, String) — source timezone override as an
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_bind {
     // @requires: workspace.bind.body       (required, String)
     // @requires: workspace.bind.pid        (optional, String)
@@ -173,6 +172,18 @@ def process parse_bind_query_record {
     )
 }
 
+// Process: bind_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.bind.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .src_endpoint.ip (optional, String)
+//        workspace.bind_query.*
+//        .qclass (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process bind_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Internet Systems Consortium" } }],

--- a/packaging/snippets/parsers/parse_bind.limpid
+++ b/packaging/snippets/parsers/parse_bind.limpid
@@ -9,7 +9,7 @@
 //                  https://bind9.readthedocs.io/en/v9.18.13/reference.html#namedconf-statement-print-time
 // Writes:      workspace.lsis.parsed.* — 4003 (DNS Activity). Only the queries
 //              channel; bind_to_otlp writes source-owned OTLP Resource,
-//              Scope, Body, and LogRecord attributes.
+//              Body, and LogRecord attributes.
 // Category:    DNS server
 // Test corpus: synthetic (sample querylog lines in this header)
 //
@@ -179,10 +179,10 @@ def process bind_to_otlp {
         [{ key: "observer.product", value: { string_value: "BIND" } }],
         [{ key: "observer.type", value: { string_value: "dns" } }],
         switch workspace.bind.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.bind.hostname } }] } default { [] } },
+        [{ key: "service.name", value: { string_value: "named" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "named"
     workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.bind.body }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],

--- a/packaging/snippets/parsers/parse_cef.limpid
+++ b/packaging/snippets/parsers/parse_cef.limpid
@@ -8,8 +8,13 @@
 //                .hostname (optional, String) — originating host, retained
 //                     by cef_to_otlp as Resource `host.name`
 // Writes:      workspace.cef.{version, device_vendor, device_product,
-//              device_version, signature_id, name, severity, ext, <ext-key>…}
-//              — the CEF format namespace, not LSIS. cef_to_otlp writes
+//              device_version, signature_id, name, severity} — the seven
+//              positional header fields — plus workspace.cef.extension_raw
+//              (raw Extension blob) and workspace.cef.extension.<key>
+//              (split key=value pairs, isolated in their own sub-object
+//              so data-driven extension keys can never shadow a
+//              positional header field). The CEF format namespace, not
+//              LSIS. cef_to_otlp writes
 //              source-owned OTLP Resource, Body, LogRecord attributes, and
 //              the shed severity slots mapped from the CEF 0-10 scale.
 // Category:    Transport
@@ -128,10 +133,12 @@ def function cef_severity_number(sev) {
 //     ("alert raised", "utm:ips signature"), which does NOT meet OTel
 //     semconv `event.name`'s low-cardinality identifier contract — so it
 //     stays in the CEF namespace as `cef.name`.
-//   * Standard extension keys whose semconv equivalent is self-evident
-//     are placed under the semconv name (src → source.ip, request →
-//     url.full, …). Spec-defined keys without a self-evident semconv
-//     home are passed through under `cef.<key>`. The DSL has no
+//   * Standard extension keys (read from `workspace.cef.extension.*` —
+//     the data-driven plane, isolated from the positional header) whose
+//     semconv equivalent is self-evident are placed under the semconv
+//     name (src → source.ip, request → url.full, …). Spec-defined keys
+//     without a self-evident semconv home are passed through under
+//     `cef.<key>`. The DSL has no
 //     object-key iteration, so the passthrough is a curated table of
 //     the spec dictionary's common keys rather than a wildcard; nothing
 //     is lost — the Body carries the complete original CEF message.
@@ -171,80 +178,80 @@ def process cef_to_otlp {
             true { [{ key: "event.code", value: { string_value: workspace.cef.signature_id } }] }
             default { [] }
         },
-        switch workspace.cef.act != null {
-            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+        switch workspace.cef.extension.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.extension.act } }] }
             default { [] }
         },
-        switch workspace.cef.msg != null {
-            true { [{ key: "message", value: { string_value: workspace.cef.msg } }] }
+        switch workspace.cef.extension.msg != null {
+            true { [{ key: "message", value: { string_value: workspace.cef.extension.msg } }] }
             default { [] }
         },
-        switch workspace.cef.src != null {
-            true { [{ key: "source.ip", value: { string_value: workspace.cef.src } }] }
+        switch workspace.cef.extension.src != null {
+            true { [{ key: "source.ip", value: { string_value: workspace.cef.extension.src } }] }
             default { [] }
         },
-        switch workspace.cef.spt != null {
-            true { [{ key: "source.port", value: { int_value: to_int(workspace.cef.spt) } }] }
+        switch workspace.cef.extension.spt != null {
+            true { [{ key: "source.port", value: { int_value: to_int(workspace.cef.extension.spt) } }] }
             default { [] }
         },
-        switch workspace.cef.smac != null {
-            true { [{ key: "source.mac", value: { string_value: workspace.cef.smac } }] }
+        switch workspace.cef.extension.smac != null {
+            true { [{ key: "source.mac", value: { string_value: workspace.cef.extension.smac } }] }
             default { [] }
         },
-        switch workspace.cef.shost != null {
-            true { [{ key: "source.domain", value: { string_value: workspace.cef.shost } }] }
+        switch workspace.cef.extension.shost != null {
+            true { [{ key: "source.domain", value: { string_value: workspace.cef.extension.shost } }] }
             default { [] }
         },
-        switch workspace.cef.in != null {
-            true { [{ key: "source.bytes", value: { int_value: to_int(workspace.cef.in) } }] }
+        switch workspace.cef.extension.in != null {
+            true { [{ key: "source.bytes", value: { int_value: to_int(workspace.cef.extension.in) } }] }
             default { [] }
         },
-        switch workspace.cef.dst != null {
-            true { [{ key: "destination.ip", value: { string_value: workspace.cef.dst } }] }
+        switch workspace.cef.extension.dst != null {
+            true { [{ key: "destination.ip", value: { string_value: workspace.cef.extension.dst } }] }
             default { [] }
         },
-        switch workspace.cef.dpt != null {
-            true { [{ key: "destination.port", value: { int_value: to_int(workspace.cef.dpt) } }] }
+        switch workspace.cef.extension.dpt != null {
+            true { [{ key: "destination.port", value: { int_value: to_int(workspace.cef.extension.dpt) } }] }
             default { [] }
         },
-        switch workspace.cef.dmac != null {
-            true { [{ key: "destination.mac", value: { string_value: workspace.cef.dmac } }] }
+        switch workspace.cef.extension.dmac != null {
+            true { [{ key: "destination.mac", value: { string_value: workspace.cef.extension.dmac } }] }
             default { [] }
         },
-        switch workspace.cef.dhost != null {
-            true { [{ key: "destination.domain", value: { string_value: workspace.cef.dhost } }] }
+        switch workspace.cef.extension.dhost != null {
+            true { [{ key: "destination.domain", value: { string_value: workspace.cef.extension.dhost } }] }
             default { [] }
         },
-        switch workspace.cef.out != null {
-            true { [{ key: "destination.bytes", value: { int_value: to_int(workspace.cef.out) } }] }
+        switch workspace.cef.extension.out != null {
+            true { [{ key: "destination.bytes", value: { int_value: to_int(workspace.cef.extension.out) } }] }
             default { [] }
         },
-        switch workspace.cef.suser != null {
-            true { [{ key: "user.name", value: { string_value: workspace.cef.suser } }] }
+        switch workspace.cef.extension.suser != null {
+            true { [{ key: "user.name", value: { string_value: workspace.cef.extension.suser } }] }
             default { [] }
         },
-        switch workspace.cef.duser != null {
-            true { [{ key: "destination.user.name", value: { string_value: workspace.cef.duser } }] }
+        switch workspace.cef.extension.duser != null {
+            true { [{ key: "destination.user.name", value: { string_value: workspace.cef.extension.duser } }] }
             default { [] }
         },
-        switch workspace.cef.proto != null {
-            true { [{ key: "network.transport", value: { string_value: lower(workspace.cef.proto) } }] }
+        switch workspace.cef.extension.proto != null {
+            true { [{ key: "network.transport", value: { string_value: lower(workspace.cef.extension.proto) } }] }
             default { [] }
         },
-        switch workspace.cef.app != null {
-            true { [{ key: "network.application", value: { string_value: workspace.cef.app } }] }
+        switch workspace.cef.extension.app != null {
+            true { [{ key: "network.application", value: { string_value: workspace.cef.extension.app } }] }
             default { [] }
         },
-        switch workspace.cef.request != null {
-            true { [{ key: "url.full", value: { string_value: workspace.cef.request } }] }
+        switch workspace.cef.extension.request != null {
+            true { [{ key: "url.full", value: { string_value: workspace.cef.extension.request } }] }
             default { [] }
         },
-        switch workspace.cef.requestMethod != null {
-            true { [{ key: "http.request.method", value: { string_value: workspace.cef.requestMethod } }] }
+        switch workspace.cef.extension.requestMethod != null {
+            true { [{ key: "http.request.method", value: { string_value: workspace.cef.extension.requestMethod } }] }
             default { [] }
         },
-        switch workspace.cef.fname != null {
-            true { [{ key: "file.name", value: { string_value: workspace.cef.fname } }] }
+        switch workspace.cef.extension.fname != null {
+            true { [{ key: "file.name", value: { string_value: workspace.cef.extension.fname } }] }
             default { [] }
         },
         // CEF namespace — header fields and spec keys without a
@@ -261,32 +268,32 @@ def process cef_to_otlp {
             true { [{ key: "cef.severity", value: { string_value: "${workspace.cef.severity}" } }] }
             default { [] }
         },
-        switch workspace.cef.cat != null {
-            true { [{ key: "cef.cat", value: { string_value: workspace.cef.cat } }] }
+        switch workspace.cef.extension.cat != null {
+            true { [{ key: "cef.cat", value: { string_value: workspace.cef.extension.cat } }] }
             default { [] }
         },
-        switch workspace.cef.outcome != null {
-            true { [{ key: "cef.outcome", value: { string_value: workspace.cef.outcome } }] }
+        switch workspace.cef.extension.outcome != null {
+            true { [{ key: "cef.outcome", value: { string_value: workspace.cef.extension.outcome } }] }
             default { [] }
         },
-        switch workspace.cef.reason != null {
-            true { [{ key: "cef.reason", value: { string_value: workspace.cef.reason } }] }
+        switch workspace.cef.extension.reason != null {
+            true { [{ key: "cef.reason", value: { string_value: workspace.cef.extension.reason } }] }
             default { [] }
         },
-        switch workspace.cef.externalId != null {
-            true { [{ key: "cef.externalId", value: { string_value: workspace.cef.externalId } }] }
+        switch workspace.cef.extension.externalId != null {
+            true { [{ key: "cef.externalId", value: { string_value: workspace.cef.extension.externalId } }] }
             default { [] }
         },
-        switch workspace.cef.deviceExternalId != null {
-            true { [{ key: "cef.deviceExternalId", value: { string_value: workspace.cef.deviceExternalId } }] }
+        switch workspace.cef.extension.deviceExternalId != null {
+            true { [{ key: "cef.deviceExternalId", value: { string_value: workspace.cef.extension.deviceExternalId } }] }
             default { [] }
         },
-        switch workspace.cef.fileHash != null {
-            true { [{ key: "cef.fileHash", value: { string_value: workspace.cef.fileHash } }] }
+        switch workspace.cef.extension.fileHash != null {
+            true { [{ key: "cef.fileHash", value: { string_value: workspace.cef.extension.fileHash } }] }
             default { [] }
         },
-        switch workspace.cef.cnt != null {
-            true { [{ key: "cef.cnt", value: { int_value: to_int(workspace.cef.cnt) } }] }
+        switch workspace.cef.extension.cnt != null {
+            true { [{ key: "cef.cnt", value: { int_value: to_int(workspace.cef.extension.cnt) } }] }
             default { [] }
         }
     )

--- a/packaging/snippets/parsers/parse_cef.limpid
+++ b/packaging/snippets/parsers/parse_cef.limpid
@@ -1,0 +1,293 @@
+// Summary:     ArcSight CEF message (from a syslog body) → workspace.cef.*
+//              format fields (format-layer parser; interpreting the
+//              vendor dialect on top is the next stage's job).
+// Reads:       workspace.syslog.* (transport intake — populated by
+//              parse_syslog upstream)
+//                .msg (required, String) — syslog body carrying the
+//                     `CEF:...` message
+//                .hostname (optional, String) — originating host, retained
+//                     by cef_to_otlp as Resource `host.name`
+// Writes:      workspace.cef.{version, device_vendor, device_product,
+//              device_version, signature_id, name, severity, ext, <ext-key>…}
+//              — the CEF format namespace, not LSIS. cef_to_otlp writes
+//              source-owned OTLP Resource, Body, LogRecord attributes, and
+//              the shed severity slots mapped from the CEF 0-10 scale.
+// Category:    Transport
+// Test corpus: synthetic (sample wires in this header)
+//
+// Wire —    ArcSight CEF as carried in a syslog body —
+//          `CEF:Version|Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|Extensions`
+//          The outer syslog wrapper (`<PRI>`, timestamp, hostname) is
+//          transport, unwrapped by `parse_syslog` upstream; this parser
+//          consumes the body only.
+//
+// Thin wrapper around the `cef.parse()` primitive, mirroring
+// parse_syslog's role one layer up the stack. Exists so a pipeline can
+// express format stacking explicitly:
+//
+//   process parse_syslog | parse_cef | parse_<vendor>_cef | compose_<target>
+//
+// rather than having every vendor CEF parser inline
+// `cef.parse(workspace.syslog.msg)` itself. The separation buys two
+// things: a pipeline can inspect `workspace.syslog.*` / `workspace.cef.*`
+// and drop or route events *before* paying the next stage's parse cost,
+// and each stage stays independently composable (a non-syslog CEF
+// carrier only needs a different bridge into `workspace.syslog.msg` —
+// the CEF stage is unchanged).
+//
+// Non-CEF or absent bodies are loud errors (DLQ), matching the pack's
+// loud-fail-fast policy: `cef.parse` itself rejects input that does not
+// start with `CEF:` or lacks the 7 header fields.
+//
+// Sample input (RFC 3164 wrapper, generic ArcSight example):
+//   <134>Apr 27 10:00:00 host01 CEF:0|ArcSight|Console|6.9|100|alert raised|7|src=192.0.2.10 spt=51234 dst=198.51.100.5 dpt=443 act=blocked msg=Example alert
+//
+// Sample input (RFC 5424 wrapper):
+//   <134>1 2026-04-30T01:23:45Z host01 - - - - CEF:0|Vendor|Product|1.0|100|name|5|src=192.0.2.10 dst=198.51.100.5
+//
+// Vendor dialects (FortiGate `cat=` routing, PAN-OS `name`-encoded log
+// types, `FTNTFGT*` extension prefixes, …) are out of scope here — they
+// belong to the per-vendor parsers (`parse_fortigate_cef`,
+// `parse_paloalto_cef`) stacked after this stage.
+
+def process parse_cef {
+    switch workspace.syslog.msg {
+        null    { error "parse_cef: no syslog body to parse (workspace.syslog.msg is null)" }
+        default { workspace.cef = cef.parse(workspace.syslog.msg) }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generic OTLP source adapter
+// ---------------------------------------------------------------------------
+//
+// The CEF header and the standard extension dictionary are defined by the
+// ArcSight CEF specification independent of any vendor, so a generic
+// adapter is legitimate here — unlike the vendor severity dialects
+// (FortiGate's 1-8, PAN-OS's 1-5) that need their own adapters.
+//
+// Severity — the CEF specification defines header Severity with two
+// valid notations: an integer 0-10 reflecting event importance, grouped
+// as 0-3 Low / 4-6 Medium / 7-8 High / 9-10 Very-High, and the string
+// values Unknown / Low / Medium / High / Very-High naming those groups
+// directly. The OTel Logs Data Model defines SeverityNumber bands
+// INFO 9-12 / WARN 13-16 / ERROR 17-20 / FATAL 21-24, with unspecified
+// band-internal steps available for finer source scales. The Data Model
+// appendix carries no official CEF mapping example, so this table
+// follows the Data Model body's mapping principles — place each source
+// band on a target band, order finer values inside the band, and give a
+// single band-wide value the band's smallest number:
+//
+//   CEF band            CEF value → SeverityNumber
+//   Low       (0-3)     0 → 9   1 → 10   2 → 11   3 → 12   (INFO..INFO4)
+//   Medium    (4-6)     4 → 13  5 → 14   6 → 15            (WARN..WARN3)
+//   High      (7-8)     7 → 17  8 → 18                     (ERROR..ERROR2)
+//   Very-High (9-10)    9 → 21  10 → 22                    (FATAL..FATAL2)
+//
+//   CEF string          "Low" → 9   "Medium" → 13   "High" → 17
+//                       "Very-High" → 21   (band minimum each)
+//                       "Unknown" → unset (no importance claim to map)
+//
+// Low maps to INFO (not TRACE/DEBUG — CEF 0 is a least-important event,
+// not diagnostic verbosity), Very-High to FATAL; consecutive CEF values
+// take consecutive numbers from each band floor, so the integer mapping
+// is order-preserving and injective — distinct source severities remain
+// distinguishable after conversion. String values are matched exactly
+// in the specification's capitalized spelling (the CEF guide documents
+// no case-insensitive allowance). True out-of-domain values (integers
+// outside 0-10, strings other than the five documented words) leave
+// severity_number unset; the raw value is retained as severity_text and
+// the `cef.severity` attribute either way.
+def function cef_severity_number(sev) {
+    switch sev {
+        0           { 9 }
+        1           { 10 }
+        2           { 11 }
+        3           { 12 }
+        4           { 13 }
+        5           { 14 }
+        6           { 15 }
+        7           { 17 }
+        8           { 18 }
+        9           { 21 }
+        10          { 22 }
+        "Low"       { 9 }
+        "Medium"    { 13 }
+        "High"      { 17 }
+        "Very-High" { 21 }
+        "Unknown"   { null }
+        default     { null }
+    }
+}
+
+// Attribute placement notes —
+//
+//   * `event.code` ← Signature ID: the CEF header's unique per-event-type
+//     identifier, which is exactly ECS `event.code`'s contract.
+//   * The CEF header Name is a free-form human-readable description
+//     ("alert raised", "utm:ips signature"), which does NOT meet OTel
+//     semconv `event.name`'s low-cardinality identifier contract — so it
+//     stays in the CEF namespace as `cef.name`.
+//   * Standard extension keys whose semconv equivalent is self-evident
+//     are placed under the semconv name (src → source.ip, request →
+//     url.full, …). Spec-defined keys without a self-evident semconv
+//     home are passed through under `cef.<key>`. The DSL has no
+//     object-key iteration, so the passthrough is a curated table of
+//     the spec dictionary's common keys rather than a wildcard; nothing
+//     is lost — the Body carries the complete original CEF message.
+//   * Timestamp extensions (rt / start / end) are not parsed here: CEF
+//     permits both epoch-milliseconds and several textual formats, so
+//     interpreting them needs vendor knowledge. Vendor parsers own time.
+def process cef_to_otlp {
+    workspace.lsis.shed.otlp.resource.attributes = concat(
+        switch workspace.cef.device_vendor != null {
+            true { [{ key: "observer.vendor", value: { string_value: workspace.cef.device_vendor } }] }
+            default { [] }
+        },
+        switch workspace.cef.device_product != null {
+            true { [{ key: "observer.product", value: { string_value: workspace.cef.device_product } }] }
+            default { [] }
+        },
+        switch workspace.cef.device_version != null {
+            true { [{ key: "observer.version", value: { string_value: workspace.cef.device_version } }] }
+            default { [] }
+        },
+        switch workspace.syslog.hostname != null {
+            true { [{ key: "host.name", value: { string_value: workspace.syslog.hostname } }] }
+            default { [] }
+        },
+        [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
+        [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
+    )
+    workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.syslog.msg }
+    workspace.lsis.shed.otlp.log_record.severity_number = cef_severity_number(workspace.cef.severity)
+    workspace.lsis.shed.otlp.log_record.severity_text = switch workspace.cef.severity {
+        null    { null }
+        default { "${workspace.cef.severity}" }
+    }
+    workspace.lsis.shed.otlp.log_record.attributes = concat(
+        [{ key: "event.kind", value: { string_value: "event" } }],
+        switch workspace.cef.signature_id != null {
+            true { [{ key: "event.code", value: { string_value: workspace.cef.signature_id } }] }
+            default { [] }
+        },
+        switch workspace.cef.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+            default { [] }
+        },
+        switch workspace.cef.msg != null {
+            true { [{ key: "message", value: { string_value: workspace.cef.msg } }] }
+            default { [] }
+        },
+        switch workspace.cef.src != null {
+            true { [{ key: "source.ip", value: { string_value: workspace.cef.src } }] }
+            default { [] }
+        },
+        switch workspace.cef.spt != null {
+            true { [{ key: "source.port", value: { int_value: to_int(workspace.cef.spt) } }] }
+            default { [] }
+        },
+        switch workspace.cef.smac != null {
+            true { [{ key: "source.mac", value: { string_value: workspace.cef.smac } }] }
+            default { [] }
+        },
+        switch workspace.cef.shost != null {
+            true { [{ key: "source.domain", value: { string_value: workspace.cef.shost } }] }
+            default { [] }
+        },
+        switch workspace.cef.in != null {
+            true { [{ key: "source.bytes", value: { int_value: to_int(workspace.cef.in) } }] }
+            default { [] }
+        },
+        switch workspace.cef.dst != null {
+            true { [{ key: "destination.ip", value: { string_value: workspace.cef.dst } }] }
+            default { [] }
+        },
+        switch workspace.cef.dpt != null {
+            true { [{ key: "destination.port", value: { int_value: to_int(workspace.cef.dpt) } }] }
+            default { [] }
+        },
+        switch workspace.cef.dmac != null {
+            true { [{ key: "destination.mac", value: { string_value: workspace.cef.dmac } }] }
+            default { [] }
+        },
+        switch workspace.cef.dhost != null {
+            true { [{ key: "destination.domain", value: { string_value: workspace.cef.dhost } }] }
+            default { [] }
+        },
+        switch workspace.cef.out != null {
+            true { [{ key: "destination.bytes", value: { int_value: to_int(workspace.cef.out) } }] }
+            default { [] }
+        },
+        switch workspace.cef.suser != null {
+            true { [{ key: "user.name", value: { string_value: workspace.cef.suser } }] }
+            default { [] }
+        },
+        switch workspace.cef.duser != null {
+            true { [{ key: "destination.user.name", value: { string_value: workspace.cef.duser } }] }
+            default { [] }
+        },
+        switch workspace.cef.proto != null {
+            true { [{ key: "network.transport", value: { string_value: lower(workspace.cef.proto) } }] }
+            default { [] }
+        },
+        switch workspace.cef.app != null {
+            true { [{ key: "network.application", value: { string_value: workspace.cef.app } }] }
+            default { [] }
+        },
+        switch workspace.cef.request != null {
+            true { [{ key: "url.full", value: { string_value: workspace.cef.request } }] }
+            default { [] }
+        },
+        switch workspace.cef.requestMethod != null {
+            true { [{ key: "http.request.method", value: { string_value: workspace.cef.requestMethod } }] }
+            default { [] }
+        },
+        switch workspace.cef.fname != null {
+            true { [{ key: "file.name", value: { string_value: workspace.cef.fname } }] }
+            default { [] }
+        },
+        // CEF namespace — header fields and spec keys without a
+        // self-evident semconv home.
+        switch workspace.cef.version != null {
+            true { [{ key: "cef.version", value: { string_value: workspace.cef.version } }] }
+            default { [] }
+        },
+        switch workspace.cef.name != null {
+            true { [{ key: "cef.name", value: { string_value: workspace.cef.name } }] }
+            default { [] }
+        },
+        switch workspace.cef.severity != null {
+            true { [{ key: "cef.severity", value: { string_value: "${workspace.cef.severity}" } }] }
+            default { [] }
+        },
+        switch workspace.cef.cat != null {
+            true { [{ key: "cef.cat", value: { string_value: workspace.cef.cat } }] }
+            default { [] }
+        },
+        switch workspace.cef.outcome != null {
+            true { [{ key: "cef.outcome", value: { string_value: workspace.cef.outcome } }] }
+            default { [] }
+        },
+        switch workspace.cef.reason != null {
+            true { [{ key: "cef.reason", value: { string_value: workspace.cef.reason } }] }
+            default { [] }
+        },
+        switch workspace.cef.externalId != null {
+            true { [{ key: "cef.externalId", value: { string_value: workspace.cef.externalId } }] }
+            default { [] }
+        },
+        switch workspace.cef.deviceExternalId != null {
+            true { [{ key: "cef.deviceExternalId", value: { string_value: workspace.cef.deviceExternalId } }] }
+            default { [] }
+        },
+        switch workspace.cef.fileHash != null {
+            true { [{ key: "cef.fileHash", value: { string_value: workspace.cef.fileHash } }] }
+            default { [] }
+        },
+        switch workspace.cef.cnt != null {
+            true { [{ key: "cef.cnt", value: { int_value: to_int(workspace.cef.cnt) } }] }
+            default { [] }
+        }
+    )
+}

--- a/packaging/snippets/parsers/parse_cef.limpid
+++ b/packaging/snippets/parsers/parse_cef.limpid
@@ -1,23 +1,6 @@
-// Summary:     ArcSight CEF message (from a syslog body) → workspace.cef.*
-//              format fields (format-layer parser; interpreting the
-//              vendor dialect on top is the next stage's job).
-// Reads:       workspace.syslog.* (transport intake — populated by
-//              parse_syslog upstream)
-//                .msg (required, String) — syslog body carrying the
-//                     `CEF:...` message
-//                .hostname (optional, String) — originating host, retained
-//                     by cef_to_otlp as Resource `host.name`
-// Writes:      workspace.cef.{version, device_vendor, device_product,
-//              device_version, signature_id, name, severity} — the seven
-//              positional header fields — plus workspace.cef.extension_raw
-//              (raw Extension blob) and workspace.cef.extension.<key>
-//              (split key=value pairs, isolated in their own sub-object
-//              so data-driven extension keys can never shadow a
-//              positional header field). The CEF format namespace, not
-//              LSIS. cef_to_otlp writes
-//              source-owned OTLP Resource, Body, LogRecord attributes, and
-//              the shed severity slots mapped from the CEF 0-10 scale.
-// Category:    Transport
+// Facade: process parse_cef,
+//         process cef_to_otlp
+// Category: Transport
 // Test corpus: synthetic (sample wires in this header)
 //
 // Wire —    ArcSight CEF as carried in a syslog body —
@@ -55,6 +38,13 @@
 // belong to the per-vendor parsers (`parse_fortigate_cef`,
 // `parse_paloalto_cef`) stacked after this stage.
 
+// Process: parse_cef
+// Summary: ArcSight CEF message (from a syslog body) → workspace.cef.* format fields (format-layer parser; interpreting the vendor dialect on top is the next stage's job).
+// Reads: workspace.syslog.* (transport intake — populated by
+//        .msg (required, String) — syslog body carrying the
+//        .hostname (optional, String) — originating host, retained
+// Writes: workspace.cef.*
+//         .name (required, String)
 def process parse_cef {
     switch workspace.syslog.msg {
         null    { error "parse_cef: no syslog body to parse (workspace.syslog.msg is null)" }
@@ -145,6 +135,19 @@ def function cef_severity_number(sev) {
 //   * Timestamp extensions (rt / start / end) are not parsed here: CEF
 //     permits both epoch-milliseconds and several textual formats, so
 //     interpreting them needs vendor knowledge. Vendor parsers own time.
+
+// Process: cef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cef.*
+//        .device_vendor (optional, String)
+//        workspace.syslog.*
+//        .hostname (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.severity_number (optional, Int)
+//         .log_record.severity_text (optional, String)
+//         .log_record.attributes (optional, Array)
 def process cef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.cef.device_vendor != null {

--- a/packaging/snippets/parsers/parse_checkpoint_leef.limpid
+++ b/packaging/snippets/parsers/parse_checkpoint_leef.limpid
@@ -1,13 +1,6 @@
-// Summary:     Check Point LEEF 2.0 (log_exporter syslog) traffic events →
-//              LSIS Network Activity.
-// Reads:       workspace.checkpoint_leef.* (bridge — see Bridges below)
-//                .body (required, String) — full syslog wire
-//                .hostname (optional, String) — collector-side hostname override
-// Writes:      workspace.lsis.parsed.* — 4001 (Network Activity) for traffic EventIDs
-//              (Accept / Drop / Reject / Block); other LEEF events route to
-//              error_log; checkpoint_leef_to_otlp writes source-owned OTLP
-//              Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_checkpoint_leef,
+//         process checkpoint_leef_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (anonymised RFC 5737 sample wire in this header)
 //
 // Vendor notes — Check Point Software Technologies — VPN-1 / FireWall-1 /
@@ -86,6 +79,13 @@ def function parse_checkpoint_leef_kv(ext, name) {
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_checkpoint_leef
+// Summary: Check Point LEEF 2.0 (log_exporter syslog) traffic events → LSIS Network Activity.
+// Reads: workspace.checkpoint_leef.* (bridge — see Bridges below)
+//        .body (required, String) — full syslog wire
+//        .hostname (optional, String) — collector-side hostname override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_checkpoint_leef {
     // @requires: workspace.checkpoint_leef.body      (required, String)
     // @requires: workspace.checkpoint_leef.hostname  (optional, String)
@@ -185,6 +185,18 @@ def function checkpoint_leef_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: checkpoint_leef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cp_header.*
+//        .product (optional, String)
+//        workspace.checkpoint_leef.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process checkpoint_leef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Check Point" } }],

--- a/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
+++ b/packaging/snippets/parsers/parse_checkpoint_syslog.limpid
@@ -1,13 +1,6 @@
-// Summary:     Check Point Syslog-Exporter records (RFC 5424 + Junos-style SD)
-//              → LSIS by action/product.
-// Reads:       workspace.checkpoint_syslog.* (bridge — see Bridges below)
-//                .body (required, String) — the full RFC 5424 wire
-//                .hostname (optional, String) — collector-side hostname override
-// Writes:      workspace.lsis.parsed.* — firewall actions → 4001, threat actions →
-//              2004, auth actions → 3002; unknown actions land in 4001 with
-//              the action preserved in unmapped. checkpoint_syslog_to_otlp
-//              writes source-owned OTLP Resource, Body, and attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_checkpoint_syslog,
+//         process checkpoint_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: public (elastic/integrations checkpoint corpus — ~80 events
 //              across 8 product types)
 //
@@ -386,6 +379,13 @@ def function checkpoint_syslog_source_host(wire_host, fallback_host) {
 // Main process — dispatch by class (decided heuristically from action / product)
 // ---------------------------------------------------------------------------
 
+// Process: parse_checkpoint_syslog
+// Summary: Check Point Syslog-Exporter records (RFC 5424 + Junos-style SD) → LSIS by action/product.
+// Reads: workspace.checkpoint_syslog.* (bridge — see Bridges below)
+//        .body (required, String) — the full RFC 5424 wire
+//        .hostname (optional, String) — collector-side hostname override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_checkpoint_syslog {
     // @requires: workspace.checkpoint_syslog.body      (required, String)
     // @requires: workspace.checkpoint_syslog.hostname  (optional, String)
@@ -511,6 +511,18 @@ def function checkpoint_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: checkpoint_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cp_syslog_class.*
+//        .sd (optional, Object)
+//        workspace.checkpoint_syslog.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process checkpoint_syslog_to_otlp {
     let sd = workspace.cp_syslog_class.sd
     let product = parse_checkpoint_syslog_kv_or_null(sd, "product")

--- a/packaging/snippets/parsers/parse_cloudtrail.limpid
+++ b/packaging/snippets/parsers/parse_cloudtrail.limpid
@@ -1,10 +1,6 @@
-// Summary:     AWS CloudTrail JSON events → LSIS API Activity.
-// Reads:       ingress (raw wire) — one CloudTrail event JSON object per
-//              ingress (unwrap {"Records":[...]} at the transport layer)
-// Writes:      workspace.lsis.parsed.* — 6003 (API Activity).
-//              cloudtrail_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-// Category:    Cloud audit (API control plane)
+// Facade: process parse_cloudtrail,
+//         process cloudtrail_to_otlp
+// Category: Cloud audit (API control plane)
 // Test corpus: public (FLAWS CloudTrail dataset, 1M events)
 //
 // Wire —    JSON — one CloudTrail event per `ingress`. CloudTrail's S3
@@ -134,6 +130,11 @@ def function cloudtrail_activity_id(name) {
 // One process: parse the JSON, then translate top-level CloudTrail
 // fields into OCSF API Activity (6003) on workspace.lsis.parsed.
 
+// Process: parse_cloudtrail
+// Summary: AWS CloudTrail JSON events → LSIS API Activity.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_cloudtrail {
     workspace.ct = parse_json(ingress)
 
@@ -230,6 +231,16 @@ def function cloudtrail_otlp_event_types(read_only) {
     }
 }
 
+// Process: cloudtrail_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.lsis.parsed.*
+//        .cloud.account.uid (optional, String)
+//        workspace.ct.*
+//        .readOnly (optional, Bool)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process cloudtrail_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "aws" } }],

--- a/packaging/snippets/parsers/parse_combined_log.limpid
+++ b/packaging/snippets/parsers/parse_combined_log.limpid
@@ -1,11 +1,6 @@
-// Summary:     Apache / Nginx combined log format → LSIS HTTP Activity.
-// Reads:       workspace.combined_log.* (bridge — see Bridges below)
-//                .body (required, String) — the CLF line
-//                .hostname (optional, String) — web server hostname
-// Writes:      workspace.lsis.parsed.* — 4002 (HTTP Activity);
-//              combined_log_to_otlp writes source-owned OTLP Resource, Body,
-//              and LogRecord attributes.
-// Category:    Web / proxy access
+// Facade: process parse_combined_log,
+//         process combined_log_to_otlp
+// Category: Web / proxy access
 // Test corpus: synthetic (sample CLF lines in this header)
 //
 // Vendor notes — Apache Software Foundation (Apache HTTP Server) — Nginx
@@ -86,6 +81,14 @@ def function combined_log_status_id(code) {
 
 // Top-level dispatcher: regex-match the line, route to the record
 // leaf on success or to error_log on a malformed line.
+
+// Process: parse_combined_log
+// Summary: Apache / Nginx combined log format → LSIS HTTP Activity.
+// Reads: workspace.combined_log.* (bridge — see Bridges below)
+//        .body (required, String) — the CLF line
+//        .hostname (optional, String) — web server hostname
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_combined_log {
     // @requires: workspace.combined_log.body      (required, String)
     // @requires: workspace.combined_log.hostname  (optional, String)
@@ -161,6 +164,16 @@ def function combined_log_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: combined_log_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.combined_log.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process combined_log_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.combined_log.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.combined_log.hostname } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -2,15 +2,16 @@
 //              dispatched by CEF cat subtype.
 // Reads:       workspace.cef.* (format intake — populated by
 //              parse_syslog | parse_cef upstream)
-//                .cat (required, String) — FortiGate `cat=<category>:<subtype>`
-//                     extension, the dispatch key
+//                .extension.cat (required, String) — FortiGate
+//                     `cat=<category>:<subtype>` extension, the dispatch key
 //                .severity (optional, Int) — CEF header priority
 //                     (FortiGate dialect 1-8)
 //                .device_vendor (optional, String) — CEF header vendor
 //                .device_product (optional, String) — CEF header product
 //                .device_version (optional, String) — CEF header version
 //                (plus the per-leaf standard / `FTNTFGT*` extension keys
-//                documented on each subtype leaf below)
+//                under workspace.cef.extension.*, documented on each
+//                subtype leaf below)
 //              workspace.syslog.* (transport intake)
 //                .timestamp (optional, String) — RFC 3164 wire timestamp
 //                .msg (optional, String) — syslog body, retained by
@@ -190,7 +191,7 @@ def function fortigate_cef_metadata(vendor, product, version) {
 
 def process parse_fortigate_cef {
     workspace.cef.timestamp = workspace.syslog.timestamp
-    switch workspace.cef.cat {
+    switch workspace.cef.extension.cat {
         // Traffic logs (Network Activity 4001)
         "traffic:forward"    { process parse_fortigate_cef_traffic }
         "traffic:local"      { process parse_fortigate_cef_traffic }
@@ -216,7 +217,7 @@ def process parse_fortigate_cef {
         "event:system"           { process parse_fortigate_cef_event_system }
         "event:wireless"         { process parse_fortigate_cef_event_wireless }
         "event:security-rating"  { process parse_fortigate_cef_event_security_rating }
-        default { error "parse_fortigate_cef: unsupported FortiGate CEF cat: ${workspace.cef.cat}" }
+        default { error "parse_fortigate_cef: unsupported FortiGate CEF cat: ${workspace.cef.extension.cat}" }
     }
 }
 
@@ -228,30 +229,30 @@ def process parse_fortigate_cef {
 //   src / spt / dst / dpt / proto / act / app / in / out / msg
 def process parse_fortigate_cef_traffic {
     process validate_fortigate_cef_severity_number
-    let proto_num = to_int(workspace.cef.proto)
+    let proto_num = to_int(workspace.cef.extension.proto)
     workspace.lsis.parsed = {
         class_uid:    4001,
         category_uid: 4,
-        activity_id:  fortigate_cef_action_to_activity_id(workspace.cef.act),
+        activity_id:  fortigate_cef_action_to_activity_id(workspace.cef.extension.act),
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         connection_info: {
             protocol_num:  proto_num,
             protocol_name: fortigate_cef_proto_name(proto_num)
         },
         traffic: {
-            bytes_in:  to_int(workspace.cef.in),
-            bytes_out: to_int(workspace.cef.out)
+            bytes_in:  to_int(workspace.cef.extension.in),
+            bytes_out: to_int(workspace.cef.extension.out)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -277,25 +278,25 @@ def process parse_fortigate_cef_utm_ips {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTattack,
-            uid:   workspace.cef.FTNTFGTattackid,
+            title: workspace.cef.extension.FTNTFGTattack,
+            uid:   workspace.cef.extension.FTNTFGTattackid,
             types: ["IDS/IPS"],
-            src_url: { url_string: workspace.cef.FTNTFGTref }
+            src_url: { url_string: workspace.cef.extension.FTNTFGTref }
         },
         attack: {
-            technique: { name: workspace.cef.FTNTFGTattack }
+            technique: { name: workspace.cef.extension.FTNTFGTattack }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -317,7 +318,7 @@ def process parse_fortigate_cef_utm_ips {
 //   suser                  — authenticated username (standard CEF)
 def process parse_fortigate_cef_utm_webfilter {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "blocked"     { 2 }
         "block"       { 2 }
         "passthrough" { 1 }
@@ -333,27 +334,27 @@ def process parse_fortigate_cef_utm_webfilter {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         http_request: {
-            url:        { url_string: workspace.cef.request },
-            http_method: workspace.cef.requestMethod
+            url:        { url_string: workspace.cef.extension.request },
+            http_method: workspace.cef.extension.requestMethod
         },
         web_resources: [
             {
-                url:      { url_string: workspace.cef.request },
-                category: workspace.cef.FTNTFGTcatdesc
+                url:      { url_string: workspace.cef.extension.request },
+                category: workspace.cef.extension.FTNTFGTcatdesc
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -379,16 +380,16 @@ def process parse_fortigate_cef_utm_antivirus {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title:   workspace.cef.FTNTFGTvirus,
-            uid:     workspace.cef.FTNTFGTvirusid,
+            title:   workspace.cef.extension.FTNTFGTvirus,
+            uid:     workspace.cef.extension.FTNTFGTvirusid,
             types:   ["Malware"],
-            src_url: { url_string: workspace.cef.FTNTFGTref }
+            src_url: { url_string: workspace.cef.extension.FTNTFGTref }
         },
         malware: [
             {
-                name:               workspace.cef.FTNTFGTvirus,
+                name:               workspace.cef.extension.FTNTFGTvirus,
                 classification_ids: [1]
             }
         ],
@@ -399,21 +400,21 @@ def process parse_fortigate_cef_utm_antivirus {
         evidences: [
             {
                 file: {
-                    name:   workspace.cef.fname,
-                    hashes: [{ value: workspace.cef.FTNTFGTanalyticscksum }]
+                    name:   workspace.cef.extension.fname,
+                    hashes: [{ value: workspace.cef.extension.FTNTFGTanalyticscksum }]
                 },
-                url: { url_string: workspace.cef.request }
+                url: { url_string: workspace.cef.extension.request }
             }
         ],
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -433,32 +434,32 @@ def process parse_fortigate_cef_utm_dlp {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTfiltername,
-            uid:   workspace.cef.FTNTFGTfilteridx,
+            title: workspace.cef.extension.FTNTFGTfiltername,
+            uid:   workspace.cef.extension.FTNTFGTfilteridx,
             types: ["Data Loss"]
         },
         evidences: [
             {
                 file: {
-                    name: workspace.cef.FTNTFGTfilename,
-                    size: to_int(workspace.cef.FTNTFGTfilesize)
+                    name: workspace.cef.extension.FTNTFGTfilename,
+                    size: to_int(workspace.cef.extension.FTNTFGTfilesize)
                 }
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -480,27 +481,27 @@ def process parse_fortigate_cef_utm_appctrl {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.app,
-            uid:   workspace.cef.FTNTFGTappid,
+            title: workspace.cef.extension.app,
+            uid:   workspace.cef.extension.FTNTFGTappid,
             types: ["Application"]
         },
         evidences: [
-            { process: { name: workspace.cef.app } }
+            { process: { name: workspace.cef.extension.app } }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -516,13 +517,13 @@ def process parse_fortigate_cef_utm_appctrl {
 // FortiGate DNS filter — qname / qtype / response code / verdict.
 def process parse_fortigate_cef_utm_dns {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "blocked"     { 1 }
         "redirected"  { 1 }
         "passthrough" { 6 }
         default       { 6 }
     }
-    let rcode = switch workspace.cef.FTNTFGTerror {
+    let rcode = switch workspace.cef.extension.FTNTFGTerror {
         "NOERROR"  { 0 }
         "FORMERR"  { 1 }
         "SERVFAIL" { 2 }
@@ -538,13 +539,13 @@ def process parse_fortigate_cef_utm_dns {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         rcode_id:     rcode,
-        src_endpoint: { ip: workspace.cef.src },
-        dst_endpoint: { ip: workspace.cef.dst },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        dst_endpoint: { ip: workspace.cef.extension.dst },
         query: {
-            hostname: workspace.cef.FTNTFGTqname,
-            type:     workspace.cef.FTNTFGTqtype
+            hostname: workspace.cef.extension.FTNTFGTqname,
+            type:     workspace.cef.extension.FTNTFGTqtype
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -560,7 +561,7 @@ def process parse_fortigate_cef_utm_dns {
 // FortiGate email filter — sender / recipient / subject / message-id.
 def process parse_fortigate_cef_utm_emailfilter {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "blocked"     { 6 }
         "quarantined" { 6 }
         "passthrough" { 6 }
@@ -573,15 +574,15 @@ def process parse_fortigate_cef_utm_emailfilter {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         direction_id: 0,
-        src_endpoint: { ip: workspace.cef.src },
-        dst_endpoint: { ip: workspace.cef.dst },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        dst_endpoint: { ip: workspace.cef.extension.dst },
         email: {
-            from:        workspace.cef.suser,
-            to:          [workspace.cef.duser],
-            subject:     workspace.cef.FTNTFGTsubject,
-            message_uid: workspace.cef.FTNTFGTmsgid
+            from:        workspace.cef.extension.suser,
+            to:          [workspace.cef.extension.duser],
+            subject:     workspace.cef.extension.FTNTFGTsubject,
+            message_uid: workspace.cef.extension.FTNTFGTmsgid
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -603,35 +604,35 @@ def process parse_fortigate_cef_utm_waf {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTsignature,
-            uid:   workspace.cef.FTNTFGTsignatureid,
+            title: workspace.cef.extension.FTNTFGTsignature,
+            uid:   workspace.cef.extension.FTNTFGTsignatureid,
             types: ["WAF"]
         },
         attack: {
-            technique: { name: workspace.cef.FTNTFGTsignature }
+            technique: { name: workspace.cef.extension.FTNTFGTsignature }
         },
         evidences: [
             {
                 http_request: {
-                    url:         { url_string: workspace.cef.request },
-                    http_method: workspace.cef.requestMethod
+                    url:         { url_string: workspace.cef.extension.request },
+                    http_method: workspace.cef.extension.requestMethod
                 }
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -664,26 +665,26 @@ def process parse_fortigate_cef_utm_ssl {
         activity_id:    1,
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
-        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.act),
+        disposition_id: fortigate_cef_utm_disposition_id(workspace.cef.extension.act),
         finding_info: {
-            title: workspace.cef.FTNTFGTeventsubtype,
-            desc:  workspace.cef.msg,
+            title: workspace.cef.extension.FTNTFGTeventsubtype,
+            desc:  workspace.cef.extension.msg,
             types: ["TLS Anomaly"]
         },
         tls: {
-            version: workspace.cef.FTNTFGTtlsver,
-            sni:     workspace.cef.FTNTFGTsni
+            version: workspace.cef.extension.FTNTFGTtlsver,
+            sni:     workspace.cef.extension.FTNTFGTsni
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:       workspace.cef.dst,
-            port:     to_int(workspace.cef.dpt),
-            hostname: workspace.cef.dhost
+            ip:       workspace.cef.extension.dst,
+            port:     to_int(workspace.cef.extension.dpt),
+            hostname: workspace.cef.extension.dhost
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -713,7 +714,7 @@ def process parse_fortigate_cef_utm_ssl {
 //   proto              — IP proto (17 UDP / 6 TCP)
 def process parse_fortigate_cef_utm_voip {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.outcome {
+    let activity = switch workspace.cef.extension.outcome {
         "start"  { 1 }
         "end"    { 2 }
         default  { 6 }
@@ -725,19 +726,19 @@ def process parse_fortigate_cef_utm_voip {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         connection_info: {
-            protocol_num:  to_int(workspace.cef.proto),
-            protocol_name: fortigate_cef_proto_name(to_int(workspace.cef.proto))
+            protocol_num:  to_int(workspace.cef.extension.proto),
+            protocol_name: fortigate_cef_proto_name(to_int(workspace.cef.extension.proto))
         },
-        app_name: workspace.cef.FTNTFGTvoip_proto,
-        message:  "VoIP " + workspace.cef.FTNTFGTkind + " " + workspace.cef.suser + " -> " + workspace.cef.duser + " (call_id=" + workspace.cef.FTNTFGTcall_id + ")",
+        app_name: workspace.cef.extension.FTNTFGTvoip_proto,
+        message:  "VoIP " + workspace.cef.extension.FTNTFGTkind + " " + workspace.cef.extension.suser + " -> " + workspace.cef.extension.duser + " (call_id=" + workspace.cef.extension.FTNTFGTcall_id + ")",
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -751,7 +752,7 @@ def process parse_fortigate_cef_utm_voip {
 // ---------------------------------------------------------------------------
 def process parse_fortigate_cef_event_user {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "login"           { 1 }
         "logon"           { 1 }
         "auth-logon"      { 1 }
@@ -763,7 +764,7 @@ def process parse_fortigate_cef_event_user {
         "login-failed"    { 1 }
         default           { 0 }
     }
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "auth-fail"       { 2 }
         "failed-login"    { 2 }
         "login-failed"    { 2 }
@@ -777,12 +778,12 @@ def process parse_fortigate_cef_event_user {
         time:            workspace.cef.time,
         status_id:    status,
         user: {
-            name: workspace.cef.suser
+            name: workspace.cef.extension.suser
         },
         src_endpoint: {
-            ip: workspace.cef.src
+            ip: workspace.cef.extension.src
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -796,7 +797,7 @@ def process parse_fortigate_cef_event_user {
 // ---------------------------------------------------------------------------
 def process parse_fortigate_cef_event_vpn {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "tunnel-up"       { 1 }
         "ssl-login-fail"  { 1 }
         "ssl-new-con"     { 1 }
@@ -804,7 +805,7 @@ def process parse_fortigate_cef_event_vpn {
         "ssl-disconnect"  { 2 }
         default           { 0 }
     }
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "ssl-login-fail"  { 2 }
         default           { 1 }
     }
@@ -816,12 +817,12 @@ def process parse_fortigate_cef_event_vpn {
         time:            workspace.cef.time,
         status_id:    status,
         user: {
-            name: workspace.cef.suser
+            name: workspace.cef.extension.suser
         },
         src_endpoint: {
-            ip: workspace.cef.src
+            ip: workspace.cef.extension.src
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -847,14 +848,14 @@ def process parse_fortigate_cef_event_system {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         finding_info: {
-            title: workspace.cef.act,
-            desc:  workspace.cef.FTNTFGTlogdesc,
+            title: workspace.cef.extension.act,
+            desc:  workspace.cef.extension.FTNTFGTlogdesc,
             types: ["System Event"]
         },
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -868,7 +869,7 @@ def process parse_fortigate_cef_event_system {
 // ---------------------------------------------------------------------------
 def process parse_fortigate_cef_event_wireless {
     process validate_fortigate_cef_severity_number
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "client-connect"    { 1 }
         "client-associate"  { 1 }
         "client-disconnect" { 2 }
@@ -882,14 +883,14 @@ def process parse_fortigate_cef_event_wireless {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         src_endpoint: {
-            ip:  workspace.cef.src,
-            mac: workspace.cef.FTNTFGTsrcmac
+            ip:  workspace.cef.extension.src,
+            mac: workspace.cef.extension.FTNTFGTsrcmac
         },
         dst_endpoint: {
-            ip:  workspace.cef.dst,
-            mac: workspace.cef.FTNTFGTapmac
+            ip:  workspace.cef.extension.dst,
+            mac: workspace.cef.extension.FTNTFGTapmac
         },
-        message:  workspace.cef.msg,
+        message:  workspace.cef.extension.msg,
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
             workspace.cef.device_product,
@@ -925,18 +926,18 @@ def process parse_fortigate_cef_event_security_rating {
         severity_number: workspace.cef.severity_number,
         time:            workspace.cef.time,
         finding_info: {
-            title: "Security Rating " + workspace.cef.FTNTFGTauditreporttype,
-            uid:   workspace.cef.FTNTFGTauditid,
-            desc:  workspace.cef.FTNTFGTlogdesc,
+            title: "Security Rating " + workspace.cef.extension.FTNTFGTauditreporttype,
+            uid:   workspace.cef.extension.FTNTFGTauditid,
+            desc:  workspace.cef.extension.FTNTFGTlogdesc,
             types: ["Security Audit"]
         },
         unmapped: {
-            audit_score:    workspace.cef.FTNTFGTauditscore,
-            critical_count: to_int(workspace.cef.FTNTFGTcriticalcount),
-            high_count:     to_int(workspace.cef.FTNTFGThighcount),
-            medium_count:   to_int(workspace.cef.FTNTFGTmediumcount),
-            low_count:      to_int(workspace.cef.FTNTFGTlowcount),
-            passed_count:   to_int(workspace.cef.FTNTFGTpassedcount)
+            audit_score:    workspace.cef.extension.FTNTFGTauditscore,
+            critical_count: to_int(workspace.cef.extension.FTNTFGTcriticalcount),
+            high_count:     to_int(workspace.cef.extension.FTNTFGThighcount),
+            medium_count:   to_int(workspace.cef.extension.FTNTFGTmediumcount),
+            low_count:      to_int(workspace.cef.extension.FTNTFGTlowcount),
+            passed_count:   to_int(workspace.cef.extension.FTNTFGTpassedcount)
         },
         metadata: fortigate_cef_metadata(
             workspace.cef.device_vendor,
@@ -1012,8 +1013,8 @@ def process fortigate_cef_to_otlp {
         [{ key: "event.kind", value: { string_value: fortigate_cef_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],
         [{ key: "event.category", value: { array_value: { values: [{ string_value: fortigate_cef_otlp_event_category(workspace.lsis.parsed.class_uid) }] } } }],
         [{ key: "event.type", value: { array_value: { values: [{ string_value: fortigate_cef_otlp_event_type(workspace.lsis.parsed.class_uid) }] } } }],
-        switch workspace.cef.act != null {
-            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+        switch workspace.cef.extension.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.extension.act } }] }
             default { [] }
         },
         switch fortigate_cef_otlp_event_outcome(workspace.lsis.parsed.status_id) != null {

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -1,6 +1,20 @@
 // Summary:     Fortinet FortiGate CEF (FortiOS set format cef) → LSIS,
 //              dispatched by CEF cat subtype.
-// Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Fortinet|Fortigate|...)
+// Reads:       workspace.cef.* (format intake — populated by
+//              parse_syslog | parse_cef upstream)
+//                .cat (required, String) — FortiGate `cat=<category>:<subtype>`
+//                     extension, the dispatch key
+//                .severity (optional, Int) — CEF header priority
+//                     (FortiGate dialect 1-8)
+//                .device_vendor (optional, String) — CEF header vendor
+//                .device_product (optional, String) — CEF header product
+//                .device_version (optional, String) — CEF header version
+//                (plus the per-leaf standard / `FTNTFGT*` extension keys
+//                documented on each subtype leaf below)
+//              workspace.syslog.* (transport intake)
+//                .timestamp (optional, String) — RFC 3164 wire timestamp
+//                .msg (optional, String) — syslog body, retained by
+//                     fortigate_cef_to_otlp as the OTLP Body
 //              workspace.fortigate_cef.timezone (optional, String) — source
 //              device timezone override as an IANA name or fixed offset; the
 //              RFC 3164 timestamp defaults to the limpid host's system timezone
@@ -16,6 +30,16 @@
 // Category:    Network firewall / IPS
 // Test corpus: real (anonymised FortiGate captures — the dialect-quirks
 //              block below was verified against them)
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_cef | parse_fortigate_cef | compose_ocsf | ocsf_to_egress
+//
+// Transport (`parse_syslog`) and format (`parse_cef`) are separate
+// upstream stages; this parser interprets the FortiGate dialect on the
+// already-parsed `workspace.cef.*`. Separating the stages lets a
+// pipeline inspect and drop events after each stage without paying the
+// next stage's parse cost.
 //
 // Wire —    syslog-wrapped CEF — `<PRI>Mmm DD HH:MM:SS host CEF:0|Fortinet|Fortigate|...`
 //          ArcSight CEF header + FortiGate-specific extension keys
@@ -151,7 +175,7 @@ def function fortigate_cef_metadata(vendor, product, version) {
 }
 
 // ---------------------------------------------------------------------------
-// Top-level dispatcher: parse syslog wrapper + CEF body, dispatch on `cat`
+// Top-level dispatcher: read the parsed CEF intake, dispatch on `cat`
 // ---------------------------------------------------------------------------
 //
 // The CEF `cat` extension carries the canonical `<category>:<subtype>`
@@ -159,10 +183,12 @@ def function fortigate_cef_metadata(vendor, product, version) {
 // dispatchers (the previous `name=utm` then `subtype=ips` form fails on
 // real FortiGate output where `name=utm:ips signature` and
 // `cat=utm:ips`).
+//
+// The RFC 3164 wrapper timestamp is copied into the CEF namespace here
+// because the CEF wrapper itself carries no timestamp; the per-leaf
+// validate process interprets it in the declared device timezone.
 
 def process parse_fortigate_cef {
-    workspace.syslog = syslog.parse(ingress)
-    workspace.cef    = cef.parse(workspace.syslog.msg)
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.cat {
         // Traffic logs (Network Activity 4001)

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -1,34 +1,6 @@
-// Summary:     Fortinet FortiGate CEF (FortiOS set format cef) → LSIS,
-//              dispatched by CEF cat subtype.
-// Reads:       workspace.cef.* (format intake — populated by
-//              parse_syslog | parse_cef upstream)
-//                .extension.cat (required, String) — FortiGate
-//                     `cat=<category>:<subtype>` extension, the dispatch key
-//                .severity (optional, Int) — CEF header priority
-//                     (FortiGate dialect 1-8)
-//                .device_vendor (optional, String) — CEF header vendor
-//                .device_product (optional, String) — CEF header product
-//                .device_version (optional, String) — CEF header version
-//                (plus the per-leaf standard / `FTNTFGT*` extension keys
-//                under workspace.cef.extension.*, documented on each
-//                subtype leaf below)
-//              workspace.syslog.* (transport intake)
-//                .timestamp (optional, String) — RFC 3164 wire timestamp
-//                .msg (optional, String) — syslog body, retained by
-//                     fortigate_cef_to_otlp as the OTLP Body
-//              workspace.fortigate_cef.timezone (optional, String) — source
-//              device timezone override as an IANA name or fixed offset; the
-//              RFC 3164 timestamp defaults to the limpid host's system timezone
-//              (FortiOS logs follow the configured device time zone, while
-//              the documented CEF wrapper omits the zone itself)
-//              https://docs.fortinet.com/document/fortigate/7.4.0/fortios-log-message-reference/949981/traffic-log-support-for-cef
-//              The default assumes FortiGate and limpid have the same correct
-//              system timezone. Correct either environment, override this
-//              slot, or use a custom parser when that assumption is false.
-// Writes:      workspace.lsis.parsed.* — class per subtype (traffic → 4001,
-//              IPS / virus → 2004, …); fortigate_cef_to_otlp writes
-//              source-owned OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_fortigate_cef,
+//         process fortigate_cef_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: real (anonymised FortiGate captures — the dialect-quirks
 //              block below was verified against them)
 //
@@ -189,6 +161,21 @@ def function fortigate_cef_metadata(vendor, product, version) {
 // because the CEF wrapper itself carries no timestamp; the per-leaf
 // validate process interprets it in the declared device timezone.
 
+// Process: parse_fortigate_cef
+// Summary: Fortinet FortiGate CEF (FortiOS set format cef) → LSIS, dispatched by CEF cat subtype.
+// Reads: workspace.cef.* (format intake — populated by
+//        .extension.cat (required, String) — FortiGate
+//        .severity (optional, Int) — CEF header priority
+//        .device_vendor (optional, String) — CEF header vendor
+//        .device_product (optional, String) — CEF header product
+//        .device_version (optional, String) — CEF header version
+//        workspace.syslog.* (transport intake)
+//        .timestamp (optional, String) — RFC 3164 wire timestamp
+//        .msg (optional, String) — syslog body, retained by
+//        workspace.fortigate_cef.*
+//        .timezone (optional, String) — source
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_fortigate_cef {
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.extension.cat {
@@ -990,6 +977,18 @@ def function fortigate_cef_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: fortigate_cef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cef.*
+//        .device_vendor (optional, String)
+//        workspace.syslog.*
+//        .msg (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process fortigate_cef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.cef.device_vendor != null {

--- a/packaging/snippets/parsers/parse_fortigate_cef.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_cef.limpid
@@ -64,6 +64,11 @@ def function fortigate_cef_severity_number(sev) {
 }
 
 def process validate_fortigate_cef_severity_number {
+    // The timezone slot declares the source device's zone. Explicit "local"
+    // is rejected because it follows the limpid host's OS, does not identify
+    // the source, and can mask misconfiguration when host TZ happens to match.
+    // (An unset slot still falls back to "local" internally per the FortiGate
+    // device-local default below; that default is not equivalent to declaring it.)
     switch workspace.fortigate_cef.timezone {
         "local" { error "parse_fortigate_cef: source timezone must be an IANA name or fixed offset, not local" }
     }

--- a/packaging/snippets/parsers/parse_fortigate_syslog.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_syslog.limpid
@@ -1,6 +1,9 @@
 // Summary:     Fortinet FortiGate native key=value syslog (FortiOS
 //              "default" format) → same LSIS shape as parse_fortigate_cef.
-// Reads:       ingress (raw wire) — syslog priority + KV body
+// Reads:       ingress (raw wire) — `<PRI>` + FortiGate KV body, NOT RFC 3164
+//              (no timestamp/hostname header between the priority and the
+//              body, so there is no meaningful `parse_syslog` stage to
+//              front this parser with; it strips the PRI itself)
 //              (`eventtime` is epoch seconds on older FortiOS and
 //              epoch nanoseconds on FortiOS 6.2.1+)
 // Writes:      workspace.lsis.parsed.* — same classes as parse_fortigate_cef

--- a/packaging/snippets/parsers/parse_fortigate_syslog.limpid
+++ b/packaging/snippets/parsers/parse_fortigate_syslog.limpid
@@ -1,17 +1,6 @@
-// Summary:     Fortinet FortiGate native key=value syslog (FortiOS
-//              "default" format) → same LSIS shape as parse_fortigate_cef.
-// Reads:       ingress (raw wire) — `<PRI>` + FortiGate KV body, NOT RFC 3164
-//              (no timestamp/hostname header between the priority and the
-//              body, so there is no meaningful `parse_syslog` stage to
-//              front this parser with; it strips the PRI itself)
-//              (`eventtime` is epoch seconds on older FortiOS and
-//              epoch nanoseconds on FortiOS 6.2.1+)
-// Writes:      workspace.lsis.parsed.* — same classes as parse_fortigate_cef
-//              (the LSIS contract is format-agnostic).
-//              fortigate_syslog_to_otlp additionally writes the
-//              source-specific workspace.lsis.shed.otlp Resource, Body,
-//              and LogRecord attributes consumed by compose_otlp.
-// Category:    Network firewall / IPS
+// Facade: process parse_fortigate_syslog,
+//         process fortigate_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (FortiOS "default"-format sample wires in this header)
 //
 // Wire —    syslog priority + KV body — `<priority>date=... time=... type=... ...`
@@ -153,6 +142,11 @@ def function fortigate_syslog_proto_name(num) {
 // switch site per format — mirrors the CEF parser shape (which dispatches
 // on `cat`, the CEF field that already carries `type:subtype`).
 
+// Process: parse_fortigate_syslog
+// Summary: Fortinet FortiGate native key=value syslog (FortiOS "default" format) → same LSIS shape as parse_fortigate_cef.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_fortigate_syslog {
     workspace.kv = parse_kv(syslog.strip_pri(ingress))
     let cat = workspace.kv.type + ":" + workspace.kv.subtype
@@ -314,6 +308,18 @@ def function fortigate_syslog_otlp_tls_version(version_text) {
     }
 }
 
+// Process: fortigate_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.kv.*
+//        .devid (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+//        workspace.fortigate_syslog.*
+//        .severity_number (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process fortigate_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Fortinet" } }],

--- a/packaging/snippets/parsers/parse_journald.limpid
+++ b/packaging/snippets/parsers/parse_journald.limpid
@@ -1,12 +1,6 @@
-// Summary:     journalctl -o json lines → workspace.journald.* transport
-//              fields (transport-layer parser).
-// Reads:       ingress (raw wire) — one journalctl -o json line (UTF-8
-//              JSON object) per ingress
-// Writes:      workspace.journald.* — all fields as journald exposes them;
-//              the transport namespace, not LSIS. journald_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes
-//              without promoting PRIORITY to canonical severity.
-// Category:    Transport
+// Facade: process parse_journald,
+//         process journald_to_otlp
+// Category: Transport
 // Test corpus: synthetic (journalctl -o json sample wire in this header)
 //
 // Typically the first process in a pipeline whose `input` is `type journal`.
@@ -52,10 +46,25 @@
 //   process parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress
 //   process parse_journald | parse_openssh | compose_ocsf | ocsf_to_egress
 
+// Process: parse_journald
+// Summary: journalctl -o json lines → workspace.journald.* transport fields (transport-layer parser).
+// Reads: ingress
+// Writes: workspace.journald.*
+//         .MESSAGE (optional, String)
 def process parse_journald {
     workspace.journald = parse_json(ingress)
 }
 
+// Process: journald_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.journald.*
+//        ._HOSTNAME (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .scope.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process journald_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.journald._HOSTNAME != null { true { [{ key: "host.name", value: { string_value: workspace.journald._HOSTNAME } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_journald.limpid
+++ b/packaging/snippets/parsers/parse_journald.limpid
@@ -60,10 +60,11 @@ def process parse_journald {
 def process journald_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.journald._HOSTNAME != null { true { [{ key: "host.name", value: { string_value: workspace.journald._HOSTNAME } }] } default { [] } },
+        switch coalesce(workspace.journald.SYSLOG_IDENTIFIER, workspace.journald._SYSTEMD_UNIT) != null { true { [{ key: "service.name", value: { string_value: coalesce(workspace.journald.SYSLOG_IDENTIFIER, workspace.journald._SYSTEMD_UNIT) } }] } default { [] } },
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = coalesce(workspace.journald.SYSLOG_IDENTIFIER, workspace.journald._SYSTEMD_UNIT)
+    workspace.lsis.shed.otlp.scope.name = "journald"
     workspace.lsis.shed.otlp.scope.attributes = concat(
         switch workspace.journald._SYSTEMD_UNIT != null { true { [{ key: "systemd.unit", value: { string_value: workspace.journald._SYSTEMD_UNIT } }] } default { [] } },
         switch workspace.journald._TRANSPORT != null { true { [{ key: "systemd.transport", value: { string_value: workspace.journald._TRANSPORT } }] } default { [] } }

--- a/packaging/snippets/parsers/parse_journald.limpid
+++ b/packaging/snippets/parsers/parse_journald.limpid
@@ -14,9 +14,8 @@
 // `parse_journald` is a thin LOTL wrapper: limpid's `input journal`
 // emits ingress as `journalctl -o json`-byte-identical JSON, and this
 // snippet just hands it to `parse_json`. No vendor-specific decoding
-// happens here — field names stay journald-canonical so downstream
-// composers (e.g. `compose_rfc5424`) can read them by their original
-// name.
+// happens here — field names stay journald-canonical. Target-specific
+// adapters or named bridges read that namespace; generic composers do not.
 //
 // Field naming notes —
 //   PRIORITY               — syslog severity (0-7), JSON string ("6")
@@ -50,7 +49,7 @@
 //    "MESSAGE":"Accepted publickey for alice from 192.0.2.10 port 51234 ssh2"}
 //
 // Typical pipeline —
-//   process parse_journald | compose_rfc5424 | rfc5424_to_egress
+//   process parse_journald | journald_to_rfc5424 | compose_rfc5424 | rfc5424_to_egress
 //   process parse_journald | parse_openssh | compose_ocsf | ocsf_to_egress
 
 def process parse_journald {

--- a/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
@@ -1,13 +1,6 @@
-// Summary:     Juniper SRX sd-syslog (RFC 5424 + [junos@ SD block]) → LSIS by
-//              daemon / MSGID.
-// Reads:       workspace.juniper_srx_sd_syslog.* (bridge — see Bridges below)
-//                .body (required, String) — the full RFC 5424 wire INCLUDING the leading `<PRI>1`
-//                .hostname (optional, String) — collector-side override (parser prefers the wire's HOSTNAME field via classify)
-// Writes:      workspace.lsis.parsed.* — RT_FLOW / APPTRACK → 4001, RT_IDP / RT_IDS /
-//              RT_UTM (AV, antispam, content-filter) / RT_AAMW / RT_SECINTEL →
-//              2004, RT_UTM WEBFILTER_URL_* → 4002. juniper_srx_sd_syslog_to_otlp
-//              writes source-owned OTLP Resource, Body, and attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_juniper_srx_sd_syslog,
+//         process juniper_srx_sd_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: public (elastic/integrations juniper_srx fixtures — 88 events
 //              across RT_FLOW / APPTRACK / RT_IDP / RT_IDS / RT_UTM / RT_AAMW /
 //              RT_SECINTEL)
@@ -354,6 +347,13 @@ def process parse_juniper_srx_sd_syslog_normalize_time {
     }
 }
 
+// Process: parse_juniper_srx_sd_syslog
+// Summary: Juniper SRX sd-syslog (RFC 5424 + [junos@ SD block]) → LSIS by daemon / MSGID.
+// Reads: workspace.juniper_srx_sd_syslog.* (bridge — see Bridges below)
+//        .body (required, String) — the full RFC 5424 wire INCLUDING the leading `<PRI>1`
+//        .hostname (optional, String) — collector-side override (parser prefers the wire's HOSTNAME field via classify)
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_juniper_srx_sd_syslog {
     // @requires: workspace.juniper_srx_sd_syslog.body      (required, String)
     // @requires: workspace.juniper_srx_sd_syslog.hostname  (optional, String)
@@ -1004,6 +1004,18 @@ def function juniper_srx_sd_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: juniper_srx_sd_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.srx_sd_class.*
+//        .host (optional, String)
+//        workspace.juniper_srx_sd_syslog.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process juniper_srx_sd_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Juniper Networks" } }],

--- a/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_sd_syslog.limpid
@@ -6,7 +6,7 @@
 // Writes:      workspace.lsis.parsed.* — RT_FLOW / APPTRACK → 4001, RT_IDP / RT_IDS /
 //              RT_UTM (AV, antispam, content-filter) / RT_AAMW / RT_SECINTEL →
 //              2004, RT_UTM WEBFILTER_URL_* → 4002. juniper_srx_sd_syslog_to_otlp
-//              writes source-owned OTLP Resource, Scope, Body, and attributes.
+//              writes source-owned OTLP Resource, Body, and attributes.
 // Category:    Network firewall / IPS
 // Test corpus: public (elastic/integrations juniper_srx fixtures — 88 events
 //              across RT_FLOW / APPTRACK / RT_IDP / RT_IDS / RT_UTM / RT_AAMW /
@@ -1013,13 +1013,13 @@ def process juniper_srx_sd_syslog_to_otlp {
             true { [{ key: "host.name", value: { string_value: workspace.srx_sd_class.host } }] }
             default { [] }
         },
+        switch workspace.srx_sd_class.daemon != null {
+            true { [{ key: "service.name", value: { string_value: "RT_${workspace.srx_sd_class.daemon}" } }] }
+            default { [] }
+        },
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = switch workspace.srx_sd_class.daemon != null {
-        true    { "RT_${workspace.srx_sd_class.daemon}" }
-        default { null }
-    }
     workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.juniper_srx_sd_syslog.body }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: juniper_srx_sd_syslog_otlp_event_kind(workspace.lsis.parsed.class_uid) } }],

--- a/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
@@ -193,6 +193,11 @@ def function juniper_srx_syslog_idp_finding_record(src_ip, src_port_str, dst_ip,
 // ---------------------------------------------------------------------------
 
 def process parse_juniper_srx_syslog_normalize_time {
+    // The timezone slot declares the source device's zone. Explicit "local"
+    // is rejected because it follows the limpid host's OS, does not identify
+    // the source, and can mask misconfiguration when host TZ happens to match.
+    // (An unset slot still falls back to "local" internally per the SRX
+    // device-local default below; that default is not equivalent to declaring it.)
     switch workspace.juniper_srx_syslog.timezone {
         "local" { error "parse_juniper_srx_syslog: source timezone must be an IANA name or fixed offset, not local" }
     }

--- a/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
@@ -299,13 +299,13 @@ def process juniper_srx_syslog_to_otlp {
             true { [{ key: "host.name", value: { string_value: workspace.srx_syslog_class.host } }] }
             default { [] }
         },
+        switch workspace.srx_syslog_class.daemon != null {
+            true { [{ key: "service.name", value: { string_value: "RT_${workspace.srx_syslog_class.daemon}" } }] }
+            default { [] }
+        },
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = switch workspace.srx_syslog_class.daemon != null {
-        true    { "RT_${workspace.srx_syslog_class.daemon}" }
-        default { null }
-    }
     workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.juniper_srx_syslog.body }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "alert" } }],

--- a/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
@@ -1,21 +1,6 @@
-// Summary:     Juniper SRX unstructured syslog mode (RFC 3164 + MSGID prefix)
-//              → LSIS Detection Finding.
-// Reads:       workspace.juniper_srx_syslog.* (bridge — see Bridges below)
-//                .body (required, String) — the syslog wire
-//                .hostname (optional, String) — collector-side hostname
-//                .timezone (optional, String) — source device timezone override
-//                  as an IANA name or fixed offset; defaults to the limpid
-//                  host's system timezone for RFC 3164 time
-//                  (Junos security logs may use the configured local zone)
-//                  https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/command/show-security-log.html
-//                  The default assumes Junos and limpid have the same correct
-//                  system timezone. Correct either environment, override this
-//                  slot, or use a custom parser when that assumption is false.
-// Writes:      workspace.lsis.parsed.* — RT_IDP IDP_ATTACK_LOG_EVENT → 2004 (Detection
-//              Finding); other daemons / subtypes route to error_log until
-//              their shapes are added. juniper_srx_syslog_to_otlp writes
-//              source-owned OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_juniper_srx_syslog,
+//         process juniper_srx_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: real (anonymised real-traffic samples, RFC 5737-rewritten, in
 //              this header)
 //
@@ -208,6 +193,14 @@ def process parse_juniper_srx_syslog_normalize_time {
     ))
 }
 
+// Process: parse_juniper_srx_syslog
+// Summary: Juniper SRX unstructured syslog mode (RFC 3164 + MSGID prefix) → LSIS Detection Finding.
+// Reads: workspace.juniper_srx_syslog.* (bridge — see Bridges below)
+//        .body (required, String) — the syslog wire
+//        .hostname (optional, String) — collector-side hostname
+//        .timezone (optional, String) — source device timezone override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_juniper_srx_syslog {
     // @requires: workspace.juniper_srx_syslog.body      (required, String)
     // @requires: workspace.juniper_srx_syslog.hostname  (optional, String)
@@ -290,6 +283,18 @@ def function juniper_srx_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: juniper_srx_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.srx_syslog_class.*
+//        .host (optional, String)
+//        workspace.juniper_srx_syslog.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .unmapped.action (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process juniper_srx_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Juniper Networks" } }],

--- a/packaging/snippets/parsers/parse_k8s_audit.limpid
+++ b/packaging/snippets/parsers/parse_k8s_audit.limpid
@@ -5,10 +5,10 @@
 // Reads:       ingress (raw wire) — one audit Event object per ingress
 //              (no {"items":[...]} envelope)
 // Writes:      workspace.lsis.parsed.* — 6003 (API Activity) for resource requests,
-//              k8s_audit_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              3002 (Authentication) for authentication.k8s.io objectRefs;
-//              unknown kinds route to error_log.
+//              unknown kinds route to error_log. k8s_audit_to_otlp additionally
+//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
+//              and LogRecord attributes.
 // Category:    Container / orchestration
 // Test corpus: spec-only (Kubernetes audit policy reference, kube-apiserver
 //              v1.29 audit.k8s.io/v1 schema; verb → activity_id per the OCSF

--- a/packaging/snippets/parsers/parse_k8s_audit.limpid
+++ b/packaging/snippets/parsers/parse_k8s_audit.limpid
@@ -1,19 +1,12 @@
-// Kubernetes audit event JSON parser
-//
-// Summary:     Kubernetes audit Event JSON (audit.k8s.io/v1) → LSIS API
-//              Activity + Authentication.
-// Reads:       ingress (raw wire) — one audit Event object per ingress
-//              (no {"items":[...]} envelope)
-// Writes:      workspace.lsis.parsed.* — 6003 (API Activity) for resource requests,
-//              3002 (Authentication) for authentication.k8s.io objectRefs;
-//              unknown kinds route to error_log. k8s_audit_to_otlp additionally
-//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
-//              and LogRecord attributes.
-// Category:    Container / orchestration
+// Facade: process parse_k8s_audit,
+//         process k8s_audit_to_otlp
+// Category: Container / orchestration
 // Test corpus: spec-only (Kubernetes audit policy reference, kube-apiserver
 //              v1.29 audit.k8s.io/v1 schema; verb → activity_id per the OCSF
 //              6003 spec — verify against your apiserver's audit-policy
 //              output before production)
+//
+// Kubernetes audit event JSON parser
 //
 // Wire —        Kubernetes audit Event JSON — one event per `ingress`.
 //              kube-apiserver emits one JSON object per event (line-
@@ -131,6 +124,11 @@ def function k8s_audit_pick_src_ip(source_ips) {
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_k8s_audit
+// Summary: Kubernetes audit Event JSON (audit.k8s.io/v1) → LSIS API Activity + Authentication.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_k8s_audit {
     workspace.k8s = parse_json(ingress)
     workspace.k8s_class = k8s_audit_classify(workspace.k8s)
@@ -342,6 +340,16 @@ def function k8s_audit_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: k8s_audit_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.k8s.*
+//        .objectRef.apiGroup (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process k8s_audit_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Kubernetes" } }],

--- a/packaging/snippets/parsers/parse_k8s_audit.limpid
+++ b/packaging/snippets/parsers/parse_k8s_audit.limpid
@@ -6,7 +6,7 @@
 //              (no {"items":[...]} envelope)
 // Writes:      workspace.lsis.parsed.* — 6003 (API Activity) for resource requests,
 //              k8s_audit_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Scope, Body, and LogRecord attributes.
+//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              3002 (Authentication) for authentication.k8s.io objectRefs;
 //              unknown kinds route to error_log.
 // Category:    Container / orchestration
@@ -347,10 +347,10 @@ def process k8s_audit_to_otlp {
         [{ key: "observer.vendor", value: { string_value: "Kubernetes" } }],
         [{ key: "observer.product", value: { string_value: "kube-apiserver" } }],
         [{ key: "observer.type", value: { string_value: "audit" } }],
+        [{ key: "service.name", value: { string_value: "kube-apiserver" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "kube-apiserver"
     workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],

--- a/packaging/snippets/parsers/parse_nsp.limpid
+++ b/packaging/snippets/parsers/parse_nsp.limpid
@@ -1,21 +1,6 @@
-// Summary:     Trellix (McAfee) Network Security Platform standard-template KV
-//              alerts → LSIS Detection Finding.
-// Reads:       workspace.nsp.* (bridge — see Bridges below)
-//                .body (required, String) — the KV body
-//                .hostname (optional, String) — collector-side hostname
-//                .timezone (optional, String) — source timezone override as an
-//                  IANA name or fixed offset for attack_time values without
-//                  ` UTC`; defaults to the limpid host's system timezone
-//                  (the standard-template timestamp zone is not specified in
-//                  the available vendor documentation; explicit ` UTC` is
-//                  interpreted as UTC. The default assumes the Manager and
-//                  limpid share the same correct system timezone — the most
-//                  likely deployment when the zone is undocumented; override
-//                  it or use a custom parser when the source differs)
-// Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding);
-//              nsp_to_otlp writes source-owned OTLP Resource, Body, and
-//              LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_nsp,
+//         process nsp_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: real (Trellix NSP Manager capture — 56/56 alerts across HTTP /
 //              SSH / SSL / NETBIOS-SS / TELNET / NTP / BACKDOOR signature
 //              categories)
@@ -338,6 +323,14 @@ def process parse_nsp_normalize_time {
     }
 }
 
+// Process: parse_nsp
+// Summary: Trellix (McAfee) Network Security Platform standard-template KV alerts → LSIS Detection Finding.
+// Reads: workspace.nsp.* (bridge — see Bridges below)
+//        .body (required, String) — the KV body
+//        .hostname (optional, String) — collector-side hostname
+//        .timezone (optional, String) — source timezone override as an
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_nsp {
     // @requires: workspace.nsp.body      (required, String)
     // @requires: workspace.nsp.hostname  (optional, String)
@@ -376,6 +369,18 @@ def function nsp_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: nsp_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.nsp_kv.*
+//        .device_name (optional, String)
+//        workspace.nsp.*
+//        .body (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process nsp_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Trellix" } }],

--- a/packaging/snippets/parsers/parse_nsp.limpid
+++ b/packaging/snippets/parsers/parse_nsp.limpid
@@ -5,11 +5,13 @@
 //                .hostname (optional, String) — collector-side hostname
 //                .timezone (optional, String) — source timezone override as an
 //                  IANA name or fixed offset for attack_time values without
-//                  ` UTC`; defaults to UTC when absent
+//                  ` UTC`; defaults to the limpid host's system timezone
 //                  (the standard-template timestamp zone is not specified in
 //                  the available vendor documentation; explicit ` UTC` is
-//                  interpreted as UTC. UTC is the intentional pack default;
-//                  override it or use a custom parser when the source differs)
+//                  interpreted as UTC. The default assumes the Manager and
+//                  limpid share the same correct system timezone — the most
+//                  likely deployment when the zone is undocumented; override
+//                  it or use a custom parser when the source differs)
 // Writes:      workspace.lsis.parsed.* — 2004 (Detection Finding);
 //              nsp_to_otlp writes source-owned OTLP Resource, Body, and
 //              LogRecord attributes.
@@ -314,7 +316,7 @@ def process parse_nsp_normalize_time {
     switch workspace.nsp.timezone {
         "local" { error "parse_nsp: source timezone must be an IANA name or fixed offset, not local" }
     }
-    let source_timezone = coalesce(workspace.nsp.timezone, "UTC")
+    let source_timezone = coalesce(workspace.nsp.timezone, "local")
     workspace.nsp.timezone_probe = strptime(
         "2000-01-15 12:00:00",
         "%Y-%m-%d %H:%M:%S",

--- a/packaging/snippets/parsers/parse_ocsf.limpid
+++ b/packaging/snippets/parsers/parse_ocsf.limpid
@@ -1,12 +1,5 @@
-// Summary:     Parses OCSF JSON into LSIS, normalizing root time to epoch
-//              nanoseconds and severity_id to OTel SeverityNumber.
-// Reads:       ingress (raw wire) — one OCSF class instance JSON object
-//              per ingress (class_uid at the root)
-// Writes:      workspace.lsis.parsed.* — same class and fields as the input,
-//              except root `.time` is normalized from ms to ns and
-//              `.severity_id` becomes canonical `.severity_number`, except
-//              OCSF Other (99), which remains in the legacy compatibility slot.
-// Category:    Vendor-neutral
+// Facade: process parse_ocsf
+// Category: Vendor-neutral
 // Test corpus: spec-only (OCSF 1.3.0 class instances; round-trips with
 //              compose_ocsf)
 //
@@ -44,6 +37,11 @@
 include "../functions/timestamp_converter.limpid"
 include "../functions/severity_converter.limpid"
 
+// Process: parse_ocsf
+// Summary: Parses OCSF JSON into LSIS, normalizing root time to epoch nanoseconds and severity_id to OTel SeverityNumber.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_ocsf {
     workspace.lsis.parsed = parse_json(ingress)
 

--- a/packaging/snippets/parsers/parse_okta_system.limpid
+++ b/packaging/snippets/parsers/parse_okta_system.limpid
@@ -1,19 +1,12 @@
-// Okta System Log parser
-//
-// Summary:     Okta System Log events JSON (System Log API v1) → LSIS
-//              identity classes, dispatched by eventType.
-// Reads:       ingress (raw wire) — one LogEvent object per ingress (unwrap
-//              Event Hooks data.events[] upstream)
-// Writes:      workspace.lsis.parsed.* — user.session/user.authentication → 3002,
-//              user.lifecycle → 3001, user.account → 3005, group.* → 3006;
-//              other eventTypes route to error_log. okta_system_to_otlp additionally
-//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
-//              and LogRecord attributes.
-// Category:    Identity / IdP
+// Facade: process parse_okta_system,
+//         process okta_system_to_otlp
+// Category: Identity / IdP
 // Test corpus: synthetic (synthesised from the Okta System Log API reference
 //              — eventType taxonomy and LogEvent schema; live-corpus
 //              parse-rate not yet measured, NOTE-flagged subtypes below
 //              unverified)
+//
+// Okta System Log parser
 //
 // Vendor notes — Okta Workforce Identity Cloud (Okta, Inc.) — System
 //              Log is the authoritative audit-event stream emitted
@@ -230,6 +223,11 @@ def process parse_okta_system_normalize_severity {
     }
 }
 
+// Process: parse_okta_system
+// Summary: Okta System Log events JSON (System Log API v1) → LSIS identity classes, dispatched by eventType.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_okta_system {
     // parse_json on malformed JSON bails to the DLQ via the standard
     // error-log policy, so no explicit null-check arm is needed here.
@@ -675,6 +673,14 @@ def function okta_otlp_event_outcome(result) {
     }
 }
 
+// Process: okta_system_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.okta.*
+//        .target (optional, Array)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process okta_system_to_otlp {
     let target_user = okta_first_target(workspace.okta.target, "User")
     let target_group = okta_first_target(workspace.okta.target, "UserGroup")

--- a/packaging/snippets/parsers/parse_okta_system.limpid
+++ b/packaging/snippets/parsers/parse_okta_system.limpid
@@ -6,7 +6,7 @@
 //              Event Hooks data.events[] upstream)
 // Writes:      workspace.lsis.parsed.* — user.session/user.authentication → 3002,
 //              okta_system_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Scope, Body, and LogRecord attributes.
+//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              user.lifecycle → 3001, user.account → 3005, group.* → 3006;
 //              other eventTypes route to error_log.
 // Category:    Identity / IdP
@@ -680,11 +680,10 @@ def process okta_system_to_otlp {
     let target_group = okta_first_target(workspace.okta.target, "UserGroup")
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "cloud.provider", value: { string_value: "okta" } }],
-        [{ key: "service.name", value: { string_value: "Okta System Log" } }],
+        [{ key: "service.name", value: { string_value: "okta" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "okta.system_log"
     workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],

--- a/packaging/snippets/parsers/parse_okta_system.limpid
+++ b/packaging/snippets/parsers/parse_okta_system.limpid
@@ -5,10 +5,10 @@
 // Reads:       ingress (raw wire) — one LogEvent object per ingress (unwrap
 //              Event Hooks data.events[] upstream)
 // Writes:      workspace.lsis.parsed.* — user.session/user.authentication → 3002,
-//              okta_system_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              user.lifecycle → 3001, user.account → 3005, group.* → 3006;
-//              other eventTypes route to error_log.
+//              other eventTypes route to error_log. okta_system_to_otlp additionally
+//              writes source-specific workspace.lsis.shed.otlp Resource, Body,
+//              and LogRecord attributes.
 // Category:    Identity / IdP
 // Test corpus: synthetic (synthesised from the Okta System Log API reference
 //              — eventType taxonomy and LogEvent schema; live-corpus

--- a/packaging/snippets/parsers/parse_openssh.limpid
+++ b/packaging/snippets/parsers/parse_openssh.limpid
@@ -6,7 +6,7 @@
 //                .hostname (optional, String) — SSH server hostname
 //                .time (optional, Int) — epoch nanoseconds of the event
 // Writes:      workspace.lsis.parsed.* — 3002 (Authentication);
-//              openssh_to_otlp writes source-owned OTLP Resource, Scope,
+//              openssh_to_otlp writes source-owned OTLP Resource,
 //              Body, and LogRecord attributes.
 // Category:    Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sshd bodies in this header)
@@ -455,10 +455,10 @@ def process openssh_to_otlp {
         [{ key: "observer.product", value: { string_value: "OpenSSH" } }],
         [{ key: "observer.type", value: { string_value: "host" } }],
         switch workspace.openssh.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.openssh.hostname } }] } default { [] } },
+        [{ key: "service.name", value: { string_value: "sshd" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "sshd"
     workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.openssh.body }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],

--- a/packaging/snippets/parsers/parse_openssh.limpid
+++ b/packaging/snippets/parsers/parse_openssh.limpid
@@ -1,14 +1,6 @@
-// Summary:     OpenSSH sshd application bodies (post-transport-unwrap) → LSIS
-//              Authentication.
-// Reads:       workspace.openssh.* (bridge — see Bridges below)
-//                .body (required, String) — sshd body
-//                .pid (optional, String) — process id as string
-//                .hostname (optional, String) — SSH server hostname
-//                .time (optional, Int) — epoch nanoseconds of the event
-// Writes:      workspace.lsis.parsed.* — 3002 (Authentication);
-//              openssh_to_otlp writes source-owned OTLP Resource,
-//              Body, and LogRecord attributes.
-// Category:    Endpoint / host audit (Unix)
+// Facade: process parse_openssh,
+//         process openssh_to_otlp
+// Category: Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sshd bodies in this header)
 //
 // Vendor notes — OpenSSH (the OpenBSD project's reference implementation of SSH —
@@ -146,6 +138,15 @@ def function openssh_auth_record(activity_id, status_id, user, ip, port_str, pid
 // route to the matching leaf.
 // ---------------------------------------------------------------------------
 
+// Process: parse_openssh
+// Summary: OpenSSH sshd application bodies (post-transport-unwrap) → LSIS Authentication.
+// Reads: workspace.openssh.* (bridge — see Bridges below)
+//        .body (required, String) — sshd body
+//        .pid (optional, String) — process id as string
+//        .hostname (optional, String) — SSH server hostname
+//        .time (optional, Int) — epoch nanoseconds of the event
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_openssh {
     // @requires: workspace.openssh.body       (required, String)
     // @requires: workspace.openssh.pid        (optional, String)
@@ -449,6 +450,18 @@ def function openssh_otlp_event_type(activity_id) {
     switch activity_id { 2 { "end" } default { "start" } }
 }
 
+// Process: openssh_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.openssh.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .activity_id (optional, Int)
+//        workspace.ssh.*
+//        .kind (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process openssh_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "OpenBSD" } }],

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -3,12 +3,14 @@
 // Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Palo Alto Networks|PAN-OS|...)
 //              workspace.paloalto_cef.timezone (optional, String) — source
 //              device timezone override as an IANA name or fixed offset; the
-//              legacy RFC 3164 wrapper defaults to UTC when this is absent
-//              (PAN-OS documents configurable device time zones but does not
-//              assign a zone to this legacy CEF wrapper timestamp)
+//              legacy RFC 3164 wrapper defaults to the limpid host's system
+//              timezone (PAN-OS documents configurable device time zones but
+//              does not assign a zone to this legacy CEF wrapper timestamp)
 //              https://docs.paloaltonetworks.com/ngfw/help/10-1/device/device-setup-management
-//              UTC is the intentional pack default; override this slot or use
-//              a custom parser when the source zone is known to differ.
+//              The default assumes the firewall and limpid share the same
+//              correct system timezone — the most likely deployment when the
+//              zone is undocumented. Override this slot with an IANA name or
+//              fixed offset when the source zone is known to differ.
 // Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT / WILDFIRE → 2004,
 //              URL → 6004, GLOBALPROTECT / AUTHENTICATION → 3002; see the
 //              subtype leaves below. paloalto_cef_to_otlp writes source-owned
@@ -76,7 +78,7 @@ def process parse_paloalto_cef_normalize_severity {
         "local" { error "parse_paloalto_cef: source timezone must be an IANA name or fixed offset, not local" }
     }
     let severity_number = paloalto_cef_severity_number(workspace.cef.severity)
-    let source_timezone = coalesce(workspace.paloalto_cef.timezone, "UTC")
+    let source_timezone = coalesce(workspace.paloalto_cef.timezone, "local")
     workspace.paloalto_cef.time = switch true {
         workspace.cef.timestamp == null { null }
         default                         { to_int(parse_datetime_rfc3164(workspace.cef.timestamp, source_timezone)) }

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -1,36 +1,6 @@
-// Summary:     Palo Alto Networks PAN-OS CEF → LSIS, dispatched by CEF
-//              name (TRAFFIC / THREAT / URL / …).
-// Reads:       workspace.cef.* (format intake — populated by
-//              parse_syslog | parse_cef upstream)
-//                .name (required, String) — CEF header Name, which PAN-OS
-//                     uses to encode the log type (the dispatch key)
-//                .severity (optional, Int) — CEF header severity
-//                     (PAN-OS dialect 1-5)
-//                .device_vendor (optional, String) — CEF header vendor
-//                .device_product (optional, String) — CEF header product
-//                .device_version (optional, String) — CEF header version
-//                (plus the per-leaf standard / `cs<n>` extension keys
-//                under workspace.cef.extension.*, documented on each
-//                subtype leaf below)
-//              workspace.syslog.* (transport intake)
-//                .timestamp (optional, String) — RFC 3164 wire timestamp
-//                .msg (optional, String) — syslog body, retained by
-//                     paloalto_cef_to_otlp as the OTLP Body
-//              workspace.paloalto_cef.timezone (optional, String) — source
-//              device timezone override as an IANA name or fixed offset; the
-//              legacy RFC 3164 wrapper defaults to the limpid host's system
-//              timezone (PAN-OS documents configurable device time zones but
-//              does not assign a zone to this legacy CEF wrapper timestamp)
-//              https://docs.paloaltonetworks.com/ngfw/help/10-1/device/device-setup-management
-//              The default assumes the firewall and limpid share the same
-//              correct system timezone — the most likely deployment when the
-//              zone is undocumented. Override this slot with an IANA name or
-//              fixed offset when the source zone is known to differ.
-// Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT / WILDFIRE → 2004,
-//              URL → 6004, GLOBALPROTECT / AUTHENTICATION → 3002; see the
-//              subtype leaves below. paloalto_cef_to_otlp writes source-owned
-//              OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_paloalto_cef,
+//         process paloalto_cef_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
 //
 // Typical pipeline —
@@ -170,6 +140,21 @@ include "../functions/proto_num.limpid"
 // because the CEF wrapper itself carries no timestamp; the per-leaf
 // normalize process interprets it in the declared device timezone.
 
+// Process: parse_paloalto_cef
+// Summary: Palo Alto Networks PAN-OS CEF → LSIS, dispatched by CEF name (TRAFFIC / THREAT / URL / …).
+// Reads: workspace.cef.* (format intake — populated by
+//        .name (required, String) — CEF header Name, which PAN-OS
+//        .severity (optional, Int) — CEF header severity
+//        .device_vendor (optional, String) — CEF header vendor
+//        .device_product (optional, String) — CEF header product
+//        .device_version (optional, String) — CEF header version
+//        workspace.syslog.* (transport intake)
+//        .timestamp (optional, String) — RFC 3164 wire timestamp
+//        .msg (optional, String) — syslog body, retained by
+//        workspace.paloalto_cef.*
+//        .timezone (optional, String) — source
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_paloalto_cef {
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.name {
@@ -571,6 +556,18 @@ def function paloalto_cef_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: paloalto_cef_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.cef.*
+//        .device_vendor (optional, String)
+//        workspace.syslog.*
+//        .msg (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process paloalto_cef_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.cef.device_vendor != null {

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -10,7 +10,8 @@
 //                .device_product (optional, String) — CEF header product
 //                .device_version (optional, String) — CEF header version
 //                (plus the per-leaf standard / `cs<n>` extension keys
-//                documented on each subtype leaf below)
+//                under workspace.cef.extension.*, documented on each
+//                subtype leaf below)
 //              workspace.syslog.* (transport intake)
 //                .timestamp (optional, String) — RFC 3164 wire timestamp
 //                .msg (optional, String) — syslog body, retained by
@@ -207,28 +208,28 @@ def process parse_paloalto_cef_traffic {
     workspace.lsis.parsed = {
         class_uid:       4001,
         category_uid:    4,
-        activity_id:     paloalto_cef_traffic_action_to_activity_id(workspace.cef.act),
+        activity_id:     paloalto_cef_traffic_action_to_activity_id(workspace.cef.extension.act),
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         connection_info: {
-            protocol_num:  proto_num(workspace.cef.proto),
-            protocol_name: lower(workspace.cef.proto)
+            protocol_num:  proto_num(workspace.cef.extension.proto),
+            protocol_name: lower(workspace.cef.extension.proto)
         },
         traffic: {
-            bytes_in:  to_int(workspace.cef.in),
-            bytes_out: to_int(workspace.cef.out)
+            bytes_in:  to_int(workspace.cef.extension.in),
+            bytes_out: to_int(workspace.cef.extension.out)
         },
-        app_name: workspace.cef.app,
+        app_name: workspace.cef.extension.app,
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         unmapped: {
             cef_severity: workspace.cef.severity
@@ -274,7 +275,7 @@ def process parse_paloalto_cef_threat {
         activity_id:     1,
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
-        disposition_id: paloalto_cef_threat_disposition_id(workspace.cef.act),
+        disposition_id: paloalto_cef_threat_disposition_id(workspace.cef.extension.act),
         finding_info: {
             title: workspace.cef.signature_id,
             types: ["Threat"]
@@ -283,15 +284,15 @@ def process parse_paloalto_cef_threat {
             technique: { name: workspace.cef.signature_id }
         },
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         unmapped: {
             cef_severity: workspace.cef.severity
@@ -326,7 +327,7 @@ def process parse_paloalto_cef_threat {
 //   app                     — application context
 def process parse_paloalto_cef_url {
     process parse_paloalto_cef_normalize_severity
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "block-url" { 2 }
         "block"     { 2 }
         "deny"      { 2 }
@@ -344,25 +345,25 @@ def process parse_paloalto_cef_url {
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         src_endpoint: {
-            ip:   workspace.cef.src,
-            port: to_int(workspace.cef.spt)
+            ip:   workspace.cef.extension.src,
+            port: to_int(workspace.cef.extension.spt)
         },
         dst_endpoint: {
-            ip:   workspace.cef.dst,
-            port: to_int(workspace.cef.dpt)
+            ip:   workspace.cef.extension.dst,
+            port: to_int(workspace.cef.extension.dpt)
         },
         http_request: {
-            url:         { url_string: workspace.cef.request },
-            http_method: workspace.cef.requestMethod
+            url:         { url_string: workspace.cef.extension.request },
+            http_method: workspace.cef.extension.requestMethod
         },
         web_resources: [
             {
-                url:      { url_string: workspace.cef.request },
-                category: workspace.cef.cs2
+                url:      { url_string: workspace.cef.extension.request },
+                category: workspace.cef.extension.cs2
             }
         ],
         actor: {
-            user: { name: workspace.cef.suser }
+            user: { name: workspace.cef.extension.suser }
         },
         unmapped: {
             cef_severity: workspace.cef.severity
@@ -396,7 +397,7 @@ def process parse_paloalto_cef_url {
 //   request                — fetch URL when HTTP-delivered
 def process parse_paloalto_cef_wildfire {
     process parse_paloalto_cef_normalize_severity
-    let disposition = switch workspace.cef.cs1 {
+    let disposition = switch workspace.cef.extension.cs1 {
         "malicious" { 2 }
         "phishing"  { 2 }
         "grayware"  { 6 }
@@ -411,26 +412,26 @@ def process parse_paloalto_cef_wildfire {
         time:            workspace.paloalto_cef.time,
         disposition_id: disposition,
         finding_info: {
-            title: workspace.cef.cs1,
-            uid:   workspace.cef.cs2,
+            title: workspace.cef.extension.cs1,
+            uid:   workspace.cef.extension.cs2,
             types: ["Malware"]
         },
         malware: [
             {
-                name:               workspace.cef.cs1,
+                name:               workspace.cef.extension.cs1,
                 classification_ids: [1]
             }
         ],
         evidences: [
             {
                 file: {
-                    name:   workspace.cef.fname,
-                    hashes: [{ value: workspace.cef.fileHash }]
+                    name:   workspace.cef.extension.fname,
+                    hashes: [{ value: workspace.cef.extension.fileHash }]
                 }
             }
         ],
-        src_endpoint: { ip: workspace.cef.src },
-        dst_endpoint: { ip: workspace.cef.dst },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        dst_endpoint: { ip: workspace.cef.extension.dst },
         unmapped: {
             cef_severity: workspace.cef.severity
         },
@@ -458,7 +459,7 @@ def process parse_paloalto_cef_wildfire {
 //   reason           — failure reason (when applicable)
 def process parse_paloalto_cef_globalprotect {
     process parse_paloalto_cef_normalize_severity
-    let activity = switch workspace.cef.act {
+    let activity = switch workspace.cef.extension.act {
         "login"        { 1 }
         "connected"    { 1 }
         "logout"       { 2 }
@@ -466,7 +467,7 @@ def process parse_paloalto_cef_globalprotect {
         "failed"       { 1 }
         default        { 0 }
     }
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "failed" { 2 }
         default  { 1 }
     }
@@ -477,9 +478,9 @@ def process parse_paloalto_cef_globalprotect {
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         status_id:       status,
-        user: { name: workspace.cef.suser },
-        src_endpoint: { ip: workspace.cef.src },
-        message:      workspace.cef.reason,
+        user: { name: workspace.cef.extension.suser },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        message:      workspace.cef.extension.reason,
         unmapped: {
             cef_severity: workspace.cef.severity
         },
@@ -506,7 +507,7 @@ def process parse_paloalto_cef_globalprotect {
 //   reason  — failure reason
 def process parse_paloalto_cef_authentication {
     process parse_paloalto_cef_normalize_severity
-    let status = switch workspace.cef.act {
+    let status = switch workspace.cef.extension.act {
         "success" { 1 }
         "failure" { 2 }
         default   { 0 }
@@ -518,9 +519,9 @@ def process parse_paloalto_cef_authentication {
         severity_number: workspace.paloalto_cef.severity_number,
         time:            workspace.paloalto_cef.time,
         status_id:       status,
-        user:         { name: workspace.cef.suser },
-        src_endpoint: { ip: workspace.cef.src },
-        message:      workspace.cef.reason,
+        user:         { name: workspace.cef.extension.suser },
+        src_endpoint: { ip: workspace.cef.extension.src },
+        message:      workspace.cef.extension.reason,
         unmapped: {
             cef_severity: workspace.cef.severity
         },
@@ -597,8 +598,8 @@ def process paloalto_cef_to_otlp {
             true { [{ key: "event.code", value: { string_value: workspace.cef.name } }] }
             default { [] }
         },
-        switch workspace.cef.act != null {
-            true { [{ key: "event.action", value: { string_value: workspace.cef.act } }] }
+        switch workspace.cef.extension.act != null {
+            true { [{ key: "event.action", value: { string_value: workspace.cef.extension.act } }] }
             default { [] }
         },
         switch paloalto_cef_otlp_event_outcome(workspace.lsis.parsed.status_id) != null {

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -1,6 +1,20 @@
 // Summary:     Palo Alto Networks PAN-OS CEF → LSIS, dispatched by CEF
 //              name (TRAFFIC / THREAT / URL / …).
-// Reads:       ingress (raw wire) — syslog-wrapped CEF (CEF:0|Palo Alto Networks|PAN-OS|...)
+// Reads:       workspace.cef.* (format intake — populated by
+//              parse_syslog | parse_cef upstream)
+//                .name (required, String) — CEF header Name, which PAN-OS
+//                     uses to encode the log type (the dispatch key)
+//                .severity (optional, Int) — CEF header severity
+//                     (PAN-OS dialect 1-5)
+//                .device_vendor (optional, String) — CEF header vendor
+//                .device_product (optional, String) — CEF header product
+//                .device_version (optional, String) — CEF header version
+//                (plus the per-leaf standard / `cs<n>` extension keys
+//                documented on each subtype leaf below)
+//              workspace.syslog.* (transport intake)
+//                .timestamp (optional, String) — RFC 3164 wire timestamp
+//                .msg (optional, String) — syslog body, retained by
+//                     paloalto_cef_to_otlp as the OTLP Body
 //              workspace.paloalto_cef.timezone (optional, String) — source
 //              device timezone override as an IANA name or fixed offset; the
 //              legacy RFC 3164 wrapper defaults to the limpid host's system
@@ -17,6 +31,16 @@
 //              OTLP Resource, Body, and LogRecord attributes.
 // Category:    Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_cef | parse_paloalto_cef | compose_ocsf | ocsf_to_egress
+//
+// Transport (`parse_syslog`) and format (`parse_cef`) are separate
+// upstream stages; this parser interprets the PAN-OS dialect on the
+// already-parsed `workspace.cef.*`. Separating the stages lets a
+// pipeline inspect and drop events after each stage without paying the
+// next stage's parse cost.
 //
 // Wire —    syslog-wrapped CEF — `<priority>timestamp host CEF:0|Palo Alto Networks|PAN-OS|...`
 //          ArcSight CEF header + PAN-OS-specific extension keys
@@ -37,10 +61,11 @@
 // Sample input (RFC 3164 syslog wrapper around CEF, TRAFFIC subtype):
 //   <134>Apr 27 10:00:00 fw-pan01 CEF:0|Palo Alto Networks|PAN-OS|10.2.0|end|TRAFFIC|3|src=192.0.2.10 spt=54321 dst=198.51.100.5 dpt=443 proto=tcp act=allow in=2048 out=1024 app=ssl suser=alice
 //
-// Direct call (skip syslog wrapper, supply raw CEF in `ingress`):
+// Direct call (no syslog wrapper, raw CEF in `ingress` — bridge the body
+// into the transport intake so the shared `parse_cef` stage applies):
 //   def pipeline x {
 //     input bare_cef
-//     process { workspace.cef = cef.parse(ingress) } | parse_paloalto_cef_traffic | compose_ocsf | ocsf_to_egress
+//     process { workspace.syslog = { msg: ingress } } | parse_cef | parse_paloalto_cef_traffic | compose_ocsf | ocsf_to_egress
 //     output ...
 //   }
 
@@ -137,12 +162,14 @@ def function paloalto_cef_threat_disposition_id(act) {
 include "../functions/proto_num.limpid"
 
 // ---------------------------------------------------------------------------
-// Dispatcher: parse syslog wrapper + CEF body, dispatch by cef.name
+// Dispatcher: read the parsed CEF intake, dispatch by cef.name
 // ---------------------------------------------------------------------------
+//
+// The RFC 3164 wrapper timestamp is copied into the CEF namespace here
+// because the CEF wrapper itself carries no timestamp; the per-leaf
+// normalize process interprets it in the declared device timezone.
 
 def process parse_paloalto_cef {
-    workspace.syslog = syslog.parse(ingress)
-    workspace.cef    = cef.parse(workspace.syslog.msg)
     workspace.cef.timestamp = workspace.syslog.timestamp
     switch workspace.cef.name {
         "TRAFFIC"        { process parse_paloalto_cef_traffic }

--- a/packaging/snippets/parsers/parse_paloalto_cef.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_cef.limpid
@@ -69,6 +69,9 @@ def function paloalto_cef_severity_number(sev) {
 }
 
 def process parse_paloalto_cef_normalize_severity {
+    // The timezone slot declares the source device's zone. Explicit "local"
+    // is rejected because it follows the limpid host's OS, does not identify
+    // the source, and can mask misconfiguration when host TZ happens to match.
     switch workspace.paloalto_cef.timezone {
         "local" { error "parse_paloalto_cef: source timezone must be an IANA name or fixed offset, not local" }
     }

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -1,7 +1,9 @@
 // Summary:     Palo Alto Networks PAN-OS native CSV syslog → LSIS,
 //              dispatched by the positional Type field.
-// Reads:       ingress (raw wire) — syslog-wrapped positional CSV
-//              (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
+// Reads:       workspace.syslog.* (transport intake — populated by
+//              parse_syslog upstream)
+//                .msg (required, String) — syslog body carrying the positional
+//                     CSV row (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
 //              workspace.paloalto_syslog.timezone (optional, String) — source
 //              timezone override as an IANA name or fixed offset; legacy
 //              Receive/Generated Time defaults to the limpid host's system
@@ -18,6 +20,15 @@
 //              source-owned OTLP Resource, Body, and LogRecord attributes.
 // Category:    Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
+//
+// Typical pipeline —
+//
+//   process parse_syslog | parse_paloalto_syslog | compose_ocsf | ocsf_to_egress
+//
+// The syslog wrapper is unwrapped by `parse_syslog` upstream; this
+// parser consumes the CSV row from `workspace.syslog.msg`. Separating
+// the stages lets a pipeline inspect and drop events after
+// `parse_syslog` without paying the vocabulary parse cost.
 //
 // Wire —    syslog-wrapped CSV — `<priority>timestamp host FUTURE_USE,RecvTime,Serial,Type,Subtype,...`
 //          PAN-OS native CSV log format (positional, ~60-117 fields per
@@ -152,7 +163,6 @@ include "../functions/proto_num.limpid"
 // its own schema.
 
 def process parse_paloalto_syslog {
-    workspace.syslog = syslog.parse(ingress)
     workspace.pan_header = csv_parse(workspace.syslog.msg, ["", "", "", "Type", "Subtype"])
     switch workspace.pan_header.Type {
         "TRAFFIC"        { process parse_paloalto_syslog_traffic }

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -1,24 +1,6 @@
-// Summary:     Palo Alto Networks PAN-OS native CSV syslog → LSIS,
-//              dispatched by the positional Type field.
-// Reads:       workspace.syslog.* (transport intake — populated by
-//              parse_syslog upstream)
-//                .msg (required, String) — syslog body carrying the positional
-//                     CSV row (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
-//              workspace.paloalto_syslog.timezone (optional, String) — source
-//              timezone override as an IANA name or fixed offset; legacy
-//              Receive/Generated Time defaults to the limpid host's system
-//              timezone (PAN-OS defines Receive/Generated Time meanings but
-//              gives a zone only for the separate high-resolution timestamp)
-//              https://docs.paloaltonetworks.com/ngfw/administration/monitoring/use-syslog-for-monitoring/syslog-field-descriptions/traffic-log-fields
-//              The default assumes the firewall and limpid share the same
-//              correct system timezone — the most likely deployment when the
-//              zone is undocumented. Override this slot with an IANA name or
-//              fixed offset when the source zone is known to differ.
-// Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT → 2004
-//              (url → 6004, wildfire → 2004), GLOBALPROTECT /
-//              AUTHENTICATION → 3002; paloalto_syslog_to_otlp writes
-//              source-owned OTLP Resource, Body, and LogRecord attributes.
-// Category:    Network firewall / IPS
+// Facade: process parse_paloalto_syslog,
+//         process paloalto_syslog_to_otlp
+// Category: Network firewall / IPS
 // Test corpus: synthetic (documentation-derived sample wires in this header)
 //
 // Typical pipeline —
@@ -162,6 +144,14 @@ include "../functions/proto_num.limpid"
 // ignored at this stage; the matched leaf re-parses the full row with
 // its own schema.
 
+// Process: parse_paloalto_syslog
+// Summary: Palo Alto Networks PAN-OS native CSV syslog → LSIS, dispatched by the positional Type field.
+// Reads: workspace.syslog.* (transport intake — populated by
+//        .msg (required, String) — syslog body carrying the positional
+//        workspace.paloalto_syslog.*
+//        .timezone (optional, String) — source
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_paloalto_syslog {
     workspace.pan_header = csv_parse(workspace.syslog.msg, ["", "", "", "Type", "Subtype"])
     switch workspace.pan_header.Type {
@@ -769,6 +759,18 @@ def function paloalto_syslog_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: paloalto_syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.pan.*
+//        .Serial (optional, String)
+//        workspace.syslog.*
+//        .msg (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process paloalto_syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Palo Alto Networks" } }],

--- a/packaging/snippets/parsers/parse_paloalto_syslog.limpid
+++ b/packaging/snippets/parsers/parse_paloalto_syslog.limpid
@@ -4,12 +4,14 @@
 //              (FUTURE_USE,RecvTime,Serial,Type,Subtype,...)
 //              workspace.paloalto_syslog.timezone (optional, String) — source
 //              timezone override as an IANA name or fixed offset; legacy
-//              Receive/Generated Time defaults to UTC when absent
-//              (PAN-OS defines Receive/Generated Time meanings but gives a
-//              zone only for the separate high-resolution timestamp)
+//              Receive/Generated Time defaults to the limpid host's system
+//              timezone (PAN-OS defines Receive/Generated Time meanings but
+//              gives a zone only for the separate high-resolution timestamp)
 //              https://docs.paloaltonetworks.com/ngfw/administration/monitoring/use-syslog-for-monitoring/syslog-field-descriptions/traffic-log-fields
-//              UTC is the intentional pack default; override this slot or use
-//              a custom parser when the source zone is known to differ.
+//              The default assumes the firewall and limpid share the same
+//              correct system timezone — the most likely deployment when the
+//              zone is undocumented. Override this slot with an IANA name or
+//              fixed offset when the source zone is known to differ.
 // Writes:      workspace.lsis.parsed.* — TRAFFIC → 4001, THREAT → 2004
 //              (url → 6004, wildfire → 2004), GLOBALPROTECT /
 //              AUTHENTICATION → 3002; paloalto_syslog_to_otlp writes
@@ -88,7 +90,7 @@ def process parse_paloalto_syslog_normalize_time {
     switch workspace.paloalto_syslog.timezone {
         "local" { error "parse_paloalto_syslog: source timezone must be an IANA name or fixed offset, not local" }
     }
-    let source_timezone = coalesce(workspace.paloalto_syslog.timezone, "UTC")
+    let source_timezone = coalesce(workspace.paloalto_syslog.timezone, "local")
     workspace.paloalto_syslog.time = switch true {
         workspace.pan.GenerateTime == null { null }
         workspace.pan.GenerateTime == ""   { null }

--- a/packaging/snippets/parsers/parse_postfix.limpid
+++ b/packaging/snippets/parsers/parse_postfix.limpid
@@ -1,14 +1,6 @@
-// Summary:     Postfix mail-flow log bodies (postfix/<program>[pid]: tag
-//              included) → LSIS Email Activity.
-// Reads:       workspace.postfix.* (bridge — see Bridges below)
-//                .body (required, String) — the postfix-tagged body
-//                .hostname (optional, String) — host where the MTA ran
-//                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.parsed.* — 4009 (Email Activity) for mail-flow programs
-//              (smtp / smtpd / qmgr / bounce); daemon-control noise routes to
-//              error_log. postfix_to_otlp writes source-owned OTLP Resource,
-//              Body, and LogRecord attributes.
-// Category:    Mail (MTA)
+// Facade: process parse_postfix,
+//         process postfix_to_otlp
+// Category: Mail (MTA)
 // Test corpus: synthetic (sample postfix lines in this header)
 //
 // Vendor notes — The Postfix Project (Wietse Venema's MTA — covers Postfix
@@ -121,6 +113,14 @@ def function postfix_status_id(s) {
 // pipeline boundary thanks to the v0.7.0
 // process-call error-propagation fix.
 
+// Process: parse_postfix
+// Summary: Postfix mail-flow log bodies (postfix/<program>[pid]: tag included) → LSIS Email Activity.
+// Reads: workspace.postfix.* (bridge — see Bridges below)
+//        .body (required, String) — the postfix-tagged body
+//        .hostname (optional, String) — host where the MTA ran
+//        .time (optional, Int) — epoch nanoseconds
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_postfix {
     // @requires: workspace.postfix.body      (required, String) — postfix-tagged body
     // @requires: workspace.postfix.hostname  (optional, String)
@@ -374,6 +374,18 @@ def function postfix_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: postfix_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.pf.*
+//        .program (optional, String)
+//        workspace.postfix.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process postfix_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "service.name", value: { string_value: switch workspace.pf.program != null { true { "postfix/${workspace.pf.program}" } default { "postfix" } } } }],

--- a/packaging/snippets/parsers/parse_postfix.limpid
+++ b/packaging/snippets/parsers/parse_postfix.limpid
@@ -7,7 +7,7 @@
 // Writes:      workspace.lsis.parsed.* — 4009 (Email Activity) for mail-flow programs
 //              (smtp / smtpd / qmgr / bounce); daemon-control noise routes to
 //              error_log. postfix_to_otlp writes source-owned OTLP Resource,
-//              Scope, Body, and LogRecord attributes.
+//              Body, and LogRecord attributes.
 // Category:    Mail (MTA)
 // Test corpus: synthetic (sample postfix lines in this header)
 //
@@ -376,12 +376,11 @@ def function postfix_otlp_event_outcome(status_id) {
 
 def process postfix_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
-        [{ key: "service.name", value: { string_value: "postfix" } }],
+        [{ key: "service.name", value: { string_value: switch workspace.pf.program != null { true { "postfix/${workspace.pf.program}" } default { "postfix" } } } }],
         switch workspace.postfix.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.postfix.hostname } }] } default { [] } },
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = switch workspace.pf.program != null { true { "postfix/${workspace.pf.program}" } default { "postfix" } }
     workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.postfix.body }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],

--- a/packaging/snippets/parsers/parse_sudo.limpid
+++ b/packaging/snippets/parsers/parse_sudo.limpid
@@ -1,14 +1,6 @@
-// Summary:     sudo / sudoedit application bodies (post-transport-unwrap) →
-//              LSIS Authorize Session.
-// Reads:       workspace.sudo.* (bridge — see Bridges below)
-//                .body (required, String) — the sudo body
-//                .pid (optional, String) — process id as string
-//                .hostname (optional, String) — host where sudo ran
-//                .time (optional, Int) — epoch nanoseconds
-// Writes:      workspace.lsis.parsed.* — 3003 (Authorize Session);
-//              sudo_to_otlp writes source-owned OTLP Resource, Body,
-//              and LogRecord attributes.
-// Category:    Endpoint / host audit (Unix)
+// Facade: process parse_sudo,
+//         process sudo_to_otlp
+// Category: Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sudo bodies in this header)
 //
 // Vendor notes — sudo (the Sudo Project — sudo/sudoedit; not pfexec, not
@@ -243,6 +235,15 @@ def function parse_sudo_message(msg) {
 // Top-level dispatcher
 // ---------------------------------------------------------------------------
 
+// Process: parse_sudo
+// Summary: sudo / sudoedit application bodies (post-transport-unwrap) → LSIS Authorize Session.
+// Reads: workspace.sudo.* (bridge — see Bridges below)
+//        .body (required, String) — the sudo body
+//        .pid (optional, String) — process id as string
+//        .hostname (optional, String) — host where sudo ran
+//        .time (optional, Int) — epoch nanoseconds
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_sudo {
     // @requires: workspace.sudo.body       (required, String)
     // @requires: workspace.sudo.pid        (optional, String)
@@ -488,6 +489,18 @@ def function sudo_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: sudo_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.sudo.*
+//        .hostname (optional, String)
+//        workspace.sudo_class.*
+//        .kind (optional, String)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process sudo_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Sudo Project" } }],

--- a/packaging/snippets/parsers/parse_sudo.limpid
+++ b/packaging/snippets/parsers/parse_sudo.limpid
@@ -6,7 +6,7 @@
 //                .hostname (optional, String) — host where sudo ran
 //                .time (optional, Int) — epoch nanoseconds
 // Writes:      workspace.lsis.parsed.* — 3003 (Authorize Session);
-//              sudo_to_otlp writes source-owned OTLP Resource, Scope, Body,
+//              sudo_to_otlp writes source-owned OTLP Resource, Body,
 //              and LogRecord attributes.
 // Category:    Endpoint / host audit (Unix)
 // Test corpus: synthetic (sample sudo bodies in this header)
@@ -494,10 +494,10 @@ def process sudo_to_otlp {
         [{ key: "observer.product", value: { string_value: "sudo" } }],
         [{ key: "observer.type", value: { string_value: "host" } }],
         switch workspace.sudo.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.sudo.hostname } }] } default { [] } },
+        [{ key: "service.name", value: { string_value: "sudo" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "sudo"
     workspace.lsis.shed.otlp.log_record.body = { string_value: workspace.sudo.body }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],

--- a/packaging/snippets/parsers/parse_suricata.limpid
+++ b/packaging/snippets/parsers/parse_suricata.limpid
@@ -7,7 +7,7 @@
 //   .time (optional, Int) — epoch ns override
 // Writes:      workspace.lsis.parsed.* — alert → 2004, dns → 4003, http → 4002,
 //              suricata_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Scope, Body, and LogRecord attributes.
+//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
 //              tls / flow / fileinfo → 4001; stats dropped; other
 //              event_types route to error_log.
 // Category:    OSS NDR
@@ -518,10 +518,10 @@ def process suricata_to_otlp {
             true { [{ key: "host.name", value: { string_value: workspace.suricata.hostname } }] }
             default { [] }
         },
+        [{ key: "service.name", value: { string_value: "suricata" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "suricata"
     workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: suricata_otlp_event_kind(body.event_type) } }],

--- a/packaging/snippets/parsers/parse_suricata.limpid
+++ b/packaging/snippets/parsers/parse_suricata.limpid
@@ -1,19 +1,11 @@
-// Suricata EVE JSON parser (vocabulary)
-//
-// Summary:     Suricata EVE JSON events → LSIS, dispatched by event_type.
-// Reads:       workspace.suricata.* (bridge — see Bridges below)
-//   .body (required, Object) — parsed EVE event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — alert → 2004, dns → 4003, http → 4002,
-//              tls / flow / fileinfo → 4001; stats dropped; other event_types
-//              route to error_log. suricata_to_otlp additionally writes
-//              source-specific workspace.lsis.shed.otlp Resource, Body, and
-//              LogRecord attributes.
-// Category:    OSS NDR
+// Facade: process parse_suricata,
+//         process suricata_to_otlp
+// Category: OSS NDR
 // Test corpus: public (elastic/integrations suricata corpus — 63 events
 //              across alert / dns / http / tls / flow / fileinfo / stats;
 //              Suricata 4.x-6.x EVE)
+//
+// Suricata EVE JSON parser (vocabulary)
 //
 // Vendor notes — OISF Suricata — open-source IDS / IPS / NSM that emits
 //           "Extensible Event Format" (EVE) as line-delimited JSON.
@@ -407,6 +399,14 @@ def function suricata_fileinfo_record(body, host, time_ns) {
 // Main process — dispatch by event_type
 // ---------------------------------------------------------------------------
 
+// Process: parse_suricata
+// Summary: Suricata EVE JSON events → LSIS, dispatched by event_type.
+// Reads: workspace.suricata.* (bridge — see Bridges below)
+//        .body (required, Object) — parsed EVE event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_suricata {
     // @requires: workspace.suricata.body      (required, Object — parsed EVE event)
     // @requires: workspace.suricata.hostname  (optional, String)
@@ -508,6 +508,16 @@ def function suricata_otlp_event_outcome(status_id) {
     }
 }
 
+// Process: suricata_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.suricata.*
+//        .body (optional, Object)
+//        workspace.lsis.parsed.*
+//        .status_id (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process suricata_to_otlp {
     let body = workspace.suricata.body
     workspace.lsis.shed.otlp.resource.attributes = concat(

--- a/packaging/snippets/parsers/parse_suricata.limpid
+++ b/packaging/snippets/parsers/parse_suricata.limpid
@@ -6,10 +6,10 @@
 //   .hostname (optional, String) — collector override
 //   .time (optional, Int) — epoch ns override
 // Writes:      workspace.lsis.parsed.* — alert → 2004, dns → 4003, http → 4002,
-//              suricata_to_otlp additionally writes source-specific
-//              workspace.lsis.shed.otlp Resource, Body, and LogRecord attributes.
-//              tls / flow / fileinfo → 4001; stats dropped; other
-//              event_types route to error_log.
+//              tls / flow / fileinfo → 4001; stats dropped; other event_types
+//              route to error_log. suricata_to_otlp additionally writes
+//              source-specific workspace.lsis.shed.otlp Resource, Body, and
+//              LogRecord attributes.
 // Category:    OSS NDR
 // Test corpus: public (elastic/integrations suricata corpus — 63 events
 //              across alert / dns / http / tls / flow / fileinfo / stats;

--- a/packaging/snippets/parsers/parse_syslog.limpid
+++ b/packaging/snippets/parsers/parse_syslog.limpid
@@ -6,8 +6,9 @@
 // Writes:      workspace.syslog.{pri, facility, severity, timestamp,
 //              hostname, appname, procid, msgid, msg} — the transport
 //              namespace, not LSIS. syslog_to_otlp writes source-owned OTLP
-//              Resource, Scope, Body, and transport attributes without
-//              promoting PRI severity to canonical severity.
+//              Resource (APP-NAME as `service.name`), Body, and transport
+//              attributes without promoting PRI severity to canonical
+//              severity.
 // Category:    Transport
 // Test corpus: synthetic (RFC 3164 / RFC 5424 sample wires in this header)
 //
@@ -46,10 +47,10 @@ def process parse_syslog {
 def process syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.syslog.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.syslog.hostname } }] } default { [] } },
+        switch workspace.syslog.appname != null { true { [{ key: "service.name", value: { string_value: workspace.syslog.appname } }] } default { [] } },
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = workspace.syslog.appname
     workspace.lsis.shed.otlp.log_record.body = switch workspace.syslog.msg != null {
         true    { { string_value: workspace.syslog.msg } }
         default { null }

--- a/packaging/snippets/parsers/parse_syslog.limpid
+++ b/packaging/snippets/parsers/parse_syslog.limpid
@@ -1,15 +1,6 @@
-// Summary:     RFC 3164 / RFC 5424 syslog wire → workspace.syslog.*
-//              transport fields (transport-layer parser; bridging the body
-//              into a vocabulary intake is the caller's job).
-// Reads:       ingress (raw wire) — <PRI>-prefixed syslog line, RFC 3164
-//              BSD vs RFC 5424 auto-detected
-// Writes:      workspace.syslog.{pri, facility, severity, timestamp,
-//              hostname, appname, procid, msgid, msg} — the transport
-//              namespace, not LSIS. syslog_to_otlp writes source-owned OTLP
-//              Resource (APP-NAME as `service.name`), Body, and transport
-//              attributes without promoting PRI severity to canonical
-//              severity.
-// Category:    Transport
+// Facade: process parse_syslog,
+//         process syslog_to_otlp
+// Category: Transport
 // Test corpus: synthetic (RFC 3164 / RFC 5424 sample wires in this header)
 //
 // Typically the first process in a pipeline whose `input` is `syslog_tcp`
@@ -40,10 +31,23 @@
 // does not invent an ECS event.category or event.type.
 // https://www.rfc-editor.org/rfc/rfc3164#section-4.1.2
 
+// Process: parse_syslog
+// Summary: RFC 3164 / RFC 5424 syslog wire → workspace.syslog.* transport fields (transport-layer parser; bridging the body into a vocabulary intake is the caller's job).
+// Reads: ingress
+// Writes: workspace.syslog.*
+//         .msg (optional, String)
 def process parse_syslog {
     workspace.syslog = syslog.parse(ingress)
 }
 
+// Process: syslog_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.syslog.*
+//        .hostname (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process syslog_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         switch workspace.syslog.hostname != null { true { [{ key: "host.name", value: { string_value: workspace.syslog.hostname } }] } default { [] } },

--- a/packaging/snippets/parsers/parse_sysmon.limpid
+++ b/packaging/snippets/parsers/parse_sysmon.limpid
@@ -1,17 +1,10 @@
-// Microsoft Sysmon parser (vocabulary)
-//
-// Summary:     Microsoft Sysmon Windows-event JSON (forwarder-shipped) → LSIS,
-//              dispatched by EventID.
-// Reads:       workspace.sysmon.* (bridge — see Bridges below)
-//   .body (required, Object) — parsed Sysmon event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-// Writes:      workspace.lsis.parsed.* — EventID 1 (ProcessCreate) → 1007,
-//              3 (NetworkConnect) → 4001, 11 (FileCreate) → 1001;
-//              unknown EventIDs route to error_log. sysmon_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    EDR
+// Facade: process parse_sysmon,
+//         process sysmon_to_otlp
+// Category: EDR
 // Test corpus: spec-only (Sysmon event schema reference; EventIDs 1 / 3 / 11
 //              only — the bulk of EDR/SOC consumption)
+//
+// Microsoft Sysmon parser (vocabulary)
 //
 // Vendor notes — Microsoft Sysinternals Sysmon (System Monitor) — the
 //           Windows kernel telemetry agent that produces detailed
@@ -78,6 +71,13 @@ include "../functions/proto_num.limpid"
 // Main parser
 // ---------------------------------------------------------------------------
 
+// Process: parse_sysmon
+// Summary: Microsoft Sysmon Windows-event JSON (forwarder-shipped) → LSIS, dispatched by EventID.
+// Reads: workspace.sysmon.* (bridge — see Bridges below)
+//        .body (required, Object) — parsed Sysmon event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_sysmon {
     // @requires: workspace.sysmon.body      (required, Object — already parse_json'd)
     // @requires: workspace.sysmon.hostname  (optional, String)
@@ -276,6 +276,17 @@ def function sysmon_otlp_event_type(class_uid) {
     switch class_uid { 1001 { "creation" } 1007 { "start" } default { "connection" } }
 }
 
+// Process: sysmon_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.lsis.parsed.*
+//        .process.name (optional, String)
+//        workspace.sysmon.*
+//        .body.Computer (optional, String)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process sysmon_to_otlp {
     let process_name = coalesce(workspace.lsis.parsed.process.name, workspace.lsis.parsed.actor.process.name)
     let process_pid = coalesce(workspace.lsis.parsed.process.pid, workspace.lsis.parsed.actor.process.pid)

--- a/packaging/snippets/parsers/parse_sysmon.limpid
+++ b/packaging/snippets/parsers/parse_sysmon.limpid
@@ -292,10 +292,11 @@ def process sysmon_to_otlp {
         [{ key: "observer.product", value: { string_value: "Sysmon" } }],
         [{ key: "observer.type", value: { string_value: "host" } }],
         switch workspace.sysmon.body.Computer != null { true { [{ key: "host.name", value: { string_value: workspace.sysmon.body.Computer } }] } default { [] } },
+        [{ key: "service.name", value: { string_value: "Microsoft-Windows-Sysmon" } }],
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )
-    workspace.lsis.shed.otlp.scope.name = "Microsoft-Windows-Sysmon"
+    workspace.lsis.shed.otlp.scope.name = workspace.sysmon.body.Channel
     workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }
     workspace.lsis.shed.otlp.log_record.attributes = concat(
         [{ key: "event.kind", value: { string_value: "event" } }],

--- a/packaging/snippets/parsers/parse_winevent_json.limpid
+++ b/packaging/snippets/parsers/parse_winevent_json.limpid
@@ -492,6 +492,7 @@ def process winevent_json_to_otlp {
         [{ key: "observer.product", value: { string_value: "Windows Event Log" } }],
         [{ key: "observer.type", value: { string_value: "host" } }],
         switch workspace.winevent.Hostname != null { true { [{ key: "host.name", value: { string_value: workspace.winevent.Hostname } }] } default { [] } },
+        switch workspace.winevent.SourceName != null { true { [{ key: "service.name", value: { string_value: workspace.winevent.SourceName } }] } default { [] } },
         [{ key: "telemetry.sdk.name", value: { string_value: "limpid" } }],
         [{ key: "telemetry.sdk.version", value: { string_value: version() } }]
     )

--- a/packaging/snippets/parsers/parse_winevent_json.limpid
+++ b/packaging/snippets/parsers/parse_winevent_json.limpid
@@ -1,12 +1,6 @@
-// Summary:     Windows Event Log JSON (NXLog field-naming shape;
-//              Security channel) → LSIS, dispatched by EventID.
-// Reads:       ingress (raw wire) — one Windows event record JSON object
-//              per ingress
-// Writes:      workspace.lsis.parsed.* — 3002 (logon/logoff), 1007 (process),
-//              3001 (account change), 3006 (group management), dispatched
-//              by EventID; unmapped IDs route to error_log. winevent_json_to_otlp
-//              writes source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    Endpoint / host audit (Windows)
+// Facade: process parse_winevent_json,
+//         process winevent_json_to_otlp
+// Category: Endpoint / host audit (Windows)
 // Test corpus: public (OTRF / Mordor dataset)
 //
 // Scope — Microsoft Windows Event Log channels (Security, System,
@@ -141,6 +135,11 @@ def process parse_winevent_json_normalize_severity {
     }
 }
 
+// Process: parse_winevent_json
+// Summary: Windows Event Log JSON (NXLog field-naming shape; Security channel) → LSIS, dispatched by EventID.
+// Reads: ingress
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_winevent_json {
     // parse_json always returns a `Value::Object` (non-object JSON
     // is wrapped under a `_json` key per the primitive's contract);
@@ -486,6 +485,17 @@ def function winevent_json_otlp_event_outcome(status_id) {
     switch status_id { 1 { "success" } 2 { "failure" } default { null } }
 }
 
+// Process: winevent_json_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.winevent.*
+//        .Hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process winevent_json_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Microsoft" } }],

--- a/packaging/snippets/parsers/parse_zeek_default.limpid
+++ b/packaging/snippets/parsers/parse_zeek_default.limpid
@@ -1,18 +1,16 @@
-// Zeek (formerly Bro) JSON parser — default-enabled scripts (vocabulary)
-//
-// Summary:     Zeek default-enabled JSON streams (conn / dns / http / ssl /
-//              files / x509 / weird / notice) → LSIS, dispatched by _path.
-// Reads:       workspace.zeek.* (bridge — see Bridges below)
-//   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — conn / ssl / files / x509 → 4001,
-//              dns → 4003, http → 4002, weird / notice → 2004; other
-//              _paths route to error_log. zeek_default_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    OSS NDR
+// Facade: process parse_zeek_default,
+//         function zeek_time_ns,
+//         function zeek_endpoint,
+//         function zeek_default_hostname,
+//         function zeek_metadata,
+//         process parse_zeek_default_native,
+//         process parse_zeek_default_flat,
+//         process zeek_default_to_otlp
+// Category: OSS NDR
 // Test corpus: public (elastic/integrations zeek corpus — 61 events across
 //              the 8 default streams, pre-unflattened to native nested form)
+//
+// Zeek (formerly Bro) JSON parser — default-enabled scripts (vocabulary)
 //
 // Vendor notes — Zeek Project — open-source network monitoring framework
 //           that passively observes traffic and emits per-protocol
@@ -64,6 +62,10 @@ include "../functions/http_method_activity_id.limpid"
 // Zeek `ts` is a float Unix epoch in seconds with microsecond
 // precision. Convert to nanoseconds (OCSF `time` convention) without
 // losing sub-second resolution.
+
+// Function: zeek_time_ns
+// Summary: Resolve Zeek event time to epoch nanoseconds.
+// Signature: zeek_time_ns(Object, Int | Null) → Int | Null
 def function zeek_time_ns(body, override) {
     coalesce(
         switch true {
@@ -75,6 +77,10 @@ def function zeek_time_ns(body, override) {
 }
 
 // Build the canonical OCSF endpoint from Zeek's nested `id` object.
+
+// Function: zeek_endpoint
+// Summary: Build one canonical endpoint from a Zeek id tuple.
+// Signature: zeek_endpoint(Object | Null, String) → Object | Null
 def function zeek_endpoint(id_obj, side) {
     switch true {
         id_obj == null { null }
@@ -171,6 +177,10 @@ def function zeek_http_status_id(code) {
 //     emitted this" than the limpid host's own name. Use it
 //     directly (string-shape — operators can resolve to a real
 //     hostname downstream if they want).
+
+// Function: zeek_default_hostname
+// Summary: Resolve the source-backed hostname used by Zeek records.
+// Signature: zeek_default_hostname(String | Null, String | Null) → String | Null
 def function zeek_default_hostname(src_ip, local_name) {
     switch true {
         src_ip == "127.0.0.1" { local_name }
@@ -179,6 +189,10 @@ def function zeek_default_hostname(src_ip, local_name) {
 }
 
 // Constant metadata block stamped on every Zeek-derived record.
+
+// Function: zeek_metadata
+// Summary: Build the shared Zeek product metadata object.
+// Signature: zeek_metadata() → Object
 def function zeek_metadata() {
     {
         product: {
@@ -481,6 +495,13 @@ def function zeek_notice_record(body, host, time_ns) {
 //                 Runs `nest_dotted_keys` first to recover the native
 //                 nested shape before dispatch.
 
+// Process: parse_zeek_default_native
+// Summary: Bridge one native Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_default_native {
     workspace.zeek = {
         body:     parse_json(ingress),
@@ -490,6 +511,13 @@ def process parse_zeek_default_native {
     process parse_zeek_default
 }
 
+// Process: parse_zeek_default_flat
+// Summary: Bridge one flat Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_default_flat {
     workspace.zeek = {
         body:     nest_dotted_keys(parse_json(ingress)),
@@ -503,6 +531,14 @@ def process parse_zeek_default_flat {
 // Main process — dispatch by `_path`
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_default
+// Summary: Zeek default-enabled JSON streams (conn / dns / http / ssl / files / x509 / weird / notice) → LSIS, dispatched by _path.
+// Reads: workspace.zeek.* (bridge — see Bridges below)
+//        .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_default {
     // @requires: workspace.zeek.body      (required, Object — parsed Zeek event)
     // @requires: workspace.zeek.hostname  (optional, String)
@@ -591,6 +627,17 @@ def function zeek_default_otlp_event_category(class_uid) { switch class_uid { 20
 def function zeek_default_otlp_event_type(class_uid) { switch class_uid { 2004 { "info" } 4002 { "access" } default { "protocol" } } }
 def function zeek_default_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
+// Process: zeek_default_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.zeek.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process zeek_default_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Zeek Project" } }],

--- a/packaging/snippets/parsers/parse_zeek_full.limpid
+++ b/packaging/snippets/parsers/parse_zeek_full.limpid
@@ -1,20 +1,12 @@
-// Zeek full-scope parser (vocabulary)
-//
-// Summary:     Zeek full-scope extension — remaining protocol streams, drop
-//              arms for low-signal streams, and a catch-all that wraps
-//              unknown _paths into 4001/unmapped, on top of parse_zeek_soc.
-// Reads:       workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
-//   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — 14 protocol streams → 4001 (generic);
-//              stats / capture_loss / known_* / software dropped; catch-all
-//              wraps any other _path into 4001 with the raw body under
-//              unmapped. zeek_full_to_otlp writes source-owned OTLP Resource,
-//              Scope, Body, and LogRecord attributes.
-// Category:    OSS NDR
+// Facade: process parse_zeek_full,
+//         process parse_zeek_full_native,
+//         process parse_zeek_full_flat,
+//         process zeek_full_to_otlp
+// Category: OSS NDR
 // Test corpus: spec-only (Zeek script reference; catch-all and drop arms are
 //              shape-level, not corpus-verified)
+//
+// Zeek full-scope parser (vocabulary)
 //
 // Extends `parse_zeek_soc.limpid` with:
 //   - Specialised handlers for the rest of the Zeek default protocol
@@ -76,6 +68,13 @@ include "parse_zeek_soc.limpid"
 // Convenience entry points — see parse_zeek_default.limpid for rationale.
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_full_native
+// Summary: Bridge one native Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_full_native {
     workspace.zeek = {
         body:     parse_json(ingress),
@@ -85,6 +84,13 @@ def process parse_zeek_full_native {
     process parse_zeek_full
 }
 
+// Process: parse_zeek_full_flat
+// Summary: Bridge one flat Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_full_flat {
     workspace.zeek = {
         body:     nest_dotted_keys(parse_json(ingress)),
@@ -265,6 +271,14 @@ def function zeek_rfb_record(body, host, time_ns) {
 // catch-all.
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_full
+// Summary: Zeek full-scope extension — remaining protocol streams, drop arms for low-signal streams, and a catch-all that wraps unknown _paths into 4001/unmapped, on top of parse_zeek_soc.
+// Reads: workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
+//        .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_full {
     switch workspace.zeek.body._path {
         // High-signal full-extra
@@ -424,6 +438,17 @@ def function zeek_full_otlp_event_type(class_uid, activity_id) {
 }
 def function zeek_full_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
+// Process: zeek_full_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.zeek.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process zeek_full_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Zeek Project" } }],

--- a/packaging/snippets/parsers/parse_zeek_soc.limpid
+++ b/packaging/snippets/parsers/parse_zeek_soc.limpid
@@ -1,22 +1,13 @@
-// Zeek SOC-scope parser (vocabulary)
-//
-// Summary:     Zeek SOC-scope extension — auth / protocol streams (ssh, smtp,
-//              ftp, dhcp, kerberos, ntlm, radius, smb_*, dce_rpc, snmp, rdp)
-//              on top of parse_zeek_default.
-// Reads:       workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
-//   .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
-//   .hostname (optional, String) — collector override
-//   .time (optional, Int) — epoch ns override
-// Writes:      workspace.lsis.parsed.* — ssh → 4007, smtp → 4009, ftp → 4008,
-//              dhcp → 4004, kerberos / ntlm / radius → 3002,
-//              smb_mapping / smb_cmd / smb_files → 4006,
-//              dce_rpc / snmp → 4001, rdp → 4005; stock streams fall
-//              through to parse_zeek_default. zeek_soc_to_otlp writes
-//              source-owned OTLP Resource, Scope, Body, and attributes.
-// Category:    OSS NDR
+// Facade: process parse_zeek_soc,
+//         process parse_zeek_soc_native,
+//         process parse_zeek_soc_flat,
+//         process zeek_soc_to_otlp
+// Category: OSS NDR
 // Test corpus: spec-only (Zeek per-protocol log reference; SOC-extra streams
 //              not yet corpus-verified — the stock streams inherit
 //              parse_zeek_default's public-corpus verification)
+//
+// Zeek SOC-scope parser (vocabulary)
 //
 // Composition — this file transitively includes parse_zeek_default,
 // so operators picking the SOC scope only write a single include line
@@ -516,6 +507,13 @@ def function zeek_rdp_record(body, host, time_ns) {
 // rationale. Mirror naming: `_native` / `_flat`.
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_soc_native
+// Summary: Bridge one native Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_soc_native {
     workspace.zeek = {
         body:     parse_json(ingress),
@@ -525,6 +523,13 @@ def process parse_zeek_soc_native {
     process parse_zeek_soc
 }
 
+// Process: parse_zeek_soc_flat
+// Summary: Bridge one flat Zeek JSON event into the shared Zeek intake.
+// Reads: ingress
+// Writes: workspace.zeek.*
+//         .body (required, Object)
+//         workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_soc_flat {
     workspace.zeek = {
         body:     nest_dotted_keys(parse_json(ingress)),
@@ -538,6 +543,14 @@ def process parse_zeek_soc_flat {
 // Main process — dispatch SOC-extra _paths, fall through to default
 // ---------------------------------------------------------------------------
 
+// Process: parse_zeek_soc
+// Summary: Zeek SOC-scope extension — auth / protocol streams (ssh, smtp, ftp, dhcp, kerberos, ntlm, radius, smb_*, dce_rpc, snmp, rdp) on top of parse_zeek_default.
+// Reads: workspace.zeek.* (bridge — see Bridges in parse_zeek_default.limpid)
+//        .body (required, Object) — parsed Zeek event (caller does `parse_json(ingress)`)
+//        .hostname (optional, String) — collector override
+//        .time (optional, Int) — epoch ns override
+// Writes: workspace.lsis.parsed.*
+//         .class_uid (required, Int)
 def process parse_zeek_soc {
     // @requires: workspace.zeek.body      (required, Object)
     // @requires: workspace.zeek.hostname  (optional, String)
@@ -651,6 +664,17 @@ def function zeek_soc_otlp_event_type(class_uid, activity_id) {
 }
 def function zeek_soc_otlp_event_outcome(status_id) { switch status_id { 1 { "success" } 2 { "failure" } default { null } } }
 
+// Process: zeek_soc_to_otlp
+// Summary: Project source facts and canonical scalars into source-owned OTLP fields.
+// Reads: workspace.zeek.*
+//        .hostname (optional, String)
+//        workspace.lsis.parsed.*
+//        .class_uid (optional, Int)
+// Writes: workspace.lsis.shed.otlp.*
+//         .resource.attributes (optional, Array)
+//         .scope.name (optional, String)
+//         .log_record.body (optional, Object)
+//         .log_record.attributes (optional, Array)
 def process zeek_soc_to_otlp {
     workspace.lsis.shed.otlp.resource.attributes = concat(
         [{ key: "observer.vendor", value: { string_value: "Zeek Project" } }],


### PR DESCRIPTION
## Release 0.7.15

Rolls the 0.7.15 line from `release/0.7.15` into `main`. 17 commits;
full detail in the [0.7.15 CHANGELOG section](CHANGELOG.md).

### Breaking

- **Transport / format unwrapping separated from vocabulary parsing.**
  Bundled CEF/syslog vendor parsers no longer unwrap their transport or
  format layer internally; each layer is its own pipeline stage. A new
  `parse_cef` format stage plus generic `cef_to_otlp` adapter joins
  `parse_syslog`. Out-of-tree chains must add the upstream stages (table
  in the changelog); extraction results are unchanged.
- **`cef.parse` isolates Extension keys from the positional header.**
  Extension `key=value` pairs move to a nested `workspace.cef.extension.*`
  sub-object and the raw blob is renamed `ext` → `extension_raw`, so a
  header-named extension can no longer shadow a positional header value.

### Correctness

- OTLP Scope/Resource placement follows the spec's two-tier identity
  reading (program identity → Resource `service.name`, not Scope).
- Undocumented RFC 3164-family timezone default is host-local, not UTC.
- `cef.parse` honors the header escapes `\|` and `\\`, so an escaped
  pipe no longer shifts every downstream field.

### DSL / analyzer

- Block primitives (`map` / `filter` / `find` / `reduce`) iterate object
  entries, not just arrays.
- Analyzer contracts match runtime value shapes (scoped wildcards,
  `String | Bytes` transport payloads, nullable primitive returns,
  user-defined arity checks, case-insensitive timezone keywords).
- Nullable expression inference follows runtime control flow through
  `coalesce` / `len` / null-presence guards.
- Snippet headers declare file facades and per-member contracts, with
  multi-root Reads/Writes grammar.

### Housekeeping

- Dependency dedupe (axum, webpki-roots).
- Version bump to 0.7.15; changelog dated 2026-07-20.

## Verification

Every commit landed on `release/0.7.15` through an individually
push-gated PR (uchgs 9/9 scopes each), with independent code review of
the CEF escape fix against the ArcSight spec and end-to-end verification
on Splunk Enterprise 10.4.1 (vendor chains, journald→RFC 5424 bridge,
non-UTF-8 payloads, CEF header escape, extension isolation, two-tier
Resource/Scope placement — all green, DLQ 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared CEF parser and expanded pipeline support for multi-stage transport and format parsing.
  * Added object and null collection support for `map`, `filter`, `find`, and `reduce`.
  * Expanded OTLP decoding to accept both strings and bytes.

* **Bug Fixes**
  * Improved CEF escaping and isolated extension fields to prevent collisions.
  * Improved timezone handling and nullable type accuracy across built-in functions.

* **Documentation**
  * Updated tutorials, examples, snippet inventories, and authoring guidance for the new pipeline and contract formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->