### PR TITLE
Address CodeRabbit follow-ups on PR #181 (test fixture, docs contract, MD040)

### DIFF
--- a/crates/xtask/src/header.rs
+++ b/crates/xtask/src/header.rs
@@ -1232,8 +1232,13 @@ def process example_to_otlp { }
     #[test]
     fn egress_write_is_valid_without_dot_declarations() {
         let source = clean_parser().replace(
-            "// Writes: workspace.lsis.shed.otlp.*\n//   .body (required, Object)",
+            "// Writes: workspace.lsis.shed.otlp.*\n//   .body (required, Bytes)",
             "// Writes: egress (OTLP protobuf bytes)",
+        );
+        assert_ne!(
+            source,
+            clean_parser(),
+            "egress fixture replacement must change the source"
         );
         assert!(
             lint(&parser(&source)).is_empty(),

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -43,7 +43,7 @@ Anywhere an expression is evaluated — there's no callsite restriction on the f
   def output proto_udp { type file path "/var/log/limpid/udp/events.log" }
   def pipeline split {
       input syslog_udp
-      process parse_cef                                  // sets workspace.cef.extension.proto
+      process parse_syslog | parse_cef                   // unwrap transport, then parse CEF
       switch normalize_proto(workspace.cef.extension.proto) {
           "tcp" { output proto_tcp }
           "udp" { output proto_udp }

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -28,7 +28,7 @@ Bad names give away the problem:
 
 If you catch yourself writing `and` in a process name, split it:
 
-```
+```limpid
 // Don't: one process doing three things — and parsing events you're
 // about to drop is wasted work.
 def process parse_and_enrich_fortigate {
@@ -76,7 +76,7 @@ When a file contains several leaves, put supplemental tags in the first comment
 block inside the leaf. One tag per line. Each tag names a field path in
 `workspace.*` (or, less commonly, `egress`).
 
-```
+```limpid
 def process compose_ocsf_authentication {
     // @requires: workspace.lsis.parsed.severity_number      (optional; normalized OTel SeverityNumber)
     // @requires: workspace.lsis.parsed.severity             (optional; exact source severity text)
@@ -152,7 +152,7 @@ If you need dedup, rate-limiting, or aggregation, use a primitive that limpid sh
 
 ### "God" processes with config-driven branches
 
-```
+```limpid
 // Don't — one body, many shapes, none of which is clearly the contract.
 def process fw_dispatch {
     if workspace.vendor == "Fortinet" {
@@ -170,7 +170,7 @@ def process fw_dispatch {
 
 Split these into `parse_fortigate`, `parse_paloalto`, `parse_cisco` and dispatch at the pipeline level with `switch`. The switch is load-bearing routing information — it deserves to be in the pipeline where routing lives, not hidden inside a process that reads like a parser.
 
-```
+```limpid
 def pipeline fw {
     input fw_syslog
     switch workspace.vendor {
@@ -239,7 +239,7 @@ Do not pack multiple unrelated schemas into a single file.
 
 Pick one canonical intermediate shape and have every parser write into it; have every composer read from it. limpid's library uses the namespace `workspace.lsis` for this — the Limpid Snippet Intermediate Schema (LSIS), stratified into `parsed` / `shed` / `composed` layers. See the [pack README](../../../packaging/snippets/README.md#lsis--the-limpid-snippet-intermediate-schema) for the layer contracts and slot registries; the summary that matters for this guide is the flow:
 
-```
+```text
 ingress
    │
    ▼
@@ -317,7 +317,7 @@ A vocabulary parser (or any snippet that consumes prior layer state in
 timestamp from. That binding is invisible from the dispatcher body, so
 state it explicitly in a header block at the top of the file:
 
-```
+```text
 // Vendor:   OpenSSH
 // Wire:     sshd application body (Accepted publickey for ... / Failed
 //           password for ... / Disconnected from ... etc.)


### PR DESCRIPTION
## Summary

Three follow-ups from CodeRabbit's review of #181, each landed as its own commit
so the final PR history stays readable.

- **`fix(xtask/header)`** — the `egress_write_is_valid_without_dot_declarations`
  test was vacuous: its `str::replace` target searched for `.body (required,
  Object)` while the fixture declares `.body (required, Bytes)`, so the replace
  no-oped and the test only re-confirmed the canonical fixture. Align the
  target with the fixture and add `assert_ne!(source, clean_parser())` so
  future fixture drift can never silently vacuum the test again.
- **`docs(user-defined)`** — a pipeline example ran `process parse_cef` directly
  after `input syslog_udp`, violating `parse_cef`'s documented contract (which
  reads `workspace.syslog.*` and errors loudly when the syslog body is unset).
  Restore the canonical `parse_syslog | parse_cef` sequence.
- **`docs(design-guide)`** — six fenced code blocks were missing language tags
  (MD040). Tag DSL blocks as `limpid` and the ASCII flow diagram / header
  comment example as `text`.

### On Finding 1 (Null-collection arity check)

CodeRabbit also flagged the `Null` branches in `map` / `filter` / `find` /
`reduce` (`crates/limpid/src/dsl/eval.rs`) as spuriously validating array-form
block arity. After independent verification the observed behavior is real but
matches the documented contract in
[`docs/src/functions/expression-functions.md`](../blob/release/0.7.15/docs/src/functions/expression-functions.md)
— `Null` is defined as "the established array behavior" and mismatched block
arity is specified as a hard error. Silencing the check in the `Null` branches
would open a symmetric hole for `Union(Array, Null)` inputs where a wrongly
shaped block would only surface on array-valued events, working against the
pack's loud-fail-fast policy. The underlying `Union(Object, Null)` ergonomics
gap is real but its correct fix is static block-arity checking in the analyzer
(`expr_types.rs`) using the collection's static type, which is out of scope for
0.7.15. See [PR #181 review comment reply][f1-reply] for details.

[f1-reply]: https://github.com/naoto256/limpid/pull/181#discussion_r3611933767

## Test plan

- [x] `cargo test -p xtask --locked` — 21/21 PASS (including the now-effective
      `egress_write_is_valid_without_dot_declarations`)
- [x] `mdbook build docs` — PASS
- [x] `markdownlint-cli2 docs/src/processing/design-guide.md` — MD040 count
      dropped from 6 to 0
- [x] Full workspace verified via uchgs 9-scope push gate (abstraction /
      boundary-contract / ci-precheck / cicd-pipeline / confidentiality / perf
      / readme-current / rust / security), all PASS, `would_push_succeed=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a user-defined function example to show parsing syslog transport before parsing CEF.
  * Corrected code and text formatting for examples, diagrams, and configuration guidance in the design guide.

* **Tests**
  * Strengthened validation to ensure rewriting produces an actual source change before linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->