### PR TITLE
fix(syslog): preserve space-padded RFC3164 timestamps

### DIFF
--- a/crates/limpid/src/functions/syslog/parse.rs
+++ b/crates/limpid/src/functions/syslog/parse.rs
@@ -135,7 +135,7 @@ fn parse_rfc3164<'bump>(
     builder: &mut ObjectBuilder<'bump>,
 ) {
     let mut rest = input;
-    let timestamp_str = match nth_space(rest, 3) {
+    let timestamp_str = match rfc3164_timestamp_end(rest) {
         Some(idx) => {
             let s = &rest[..idx];
             rest = &rest[idx..];
@@ -253,16 +253,72 @@ fn next_token(input: &str) -> (&str, &str) {
     }
 }
 
-fn nth_space(input: &str, n: usize) -> Option<usize> {
-    let mut count = 0;
-    for (i, b) in input.bytes().enumerate() {
-        if b == b' ' {
-            count += 1;
-            if count == n {
-                return Some(i + 1);
+/// Returns the byte offset just past the ASCII space that follows
+/// the RFC 3164 header's three non-empty fields (separated by the
+/// required ASCII-space shape), or `None` when the input does not
+/// begin with that shape.
+///
+/// Separator cardinality is exact: field 1 → 1 or 2 ASCII spaces →
+/// field 2 → exactly one ASCII space → field 3. Only the first gap
+/// ever varies, because `%e` widens a single-digit day with one
+/// leading space. Any non-space whitespace character (`\t`, `\n`,
+/// `NBSP`, `EM SPACE`, …) is rejected: the RFC 3164 header is
+/// defined against ASCII, and downstream parsing expects only that
+/// shape.
+///
+/// Only literal ASCII spaces reach the returned offset, so
+/// `offset + 1` is always a UTF-8 boundary. Content validation
+/// (month name, day range, time validity) is deferred to the
+/// downstream parser; this function checks shape only.
+fn rfc3164_timestamp_end(input: &str) -> Option<usize> {
+    let mut field = 0;
+    let mut month_spaces = 0;
+
+    for (offset, ch) in input.char_indices() {
+        if ch != ' ' && ch.is_whitespace() {
+            return None;
+        }
+
+        match field {
+            0 => {
+                if ch == ' ' {
+                    if offset == 0 {
+                        return None;
+                    }
+                    field = 1;
+                    month_spaces = 1;
+                }
             }
+            1 => {
+                if ch == ' ' {
+                    month_spaces += 1;
+                    if month_spaces > 2 {
+                        return None;
+                    }
+                } else {
+                    field = 2;
+                }
+            }
+            2 => {
+                if ch == ' ' {
+                    field = 3;
+                }
+            }
+            3 => {
+                if ch == ' ' {
+                    return None;
+                }
+                field = 4;
+            }
+            4 => {
+                if ch == ' ' {
+                    return Some(offset + 1);
+                }
+            }
+            _ => unreachable!(),
         }
     }
+
     None
 }
 
@@ -369,6 +425,42 @@ mod tests {
             lookup(entries, "msg"),
             Some(Value::String("Failed password"))
         );
+    }
+
+    #[test]
+    fn rfc3164_space_padded_single_digit_day_keeps_complete_timestamp() {
+        let bump = ::bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let owned = dummy_event();
+        let bevent = owned.view_in(&arena);
+        let reg = make_registry();
+        let line = arena.alloc_str("<134>Aug  9 02:38:03 myhost sshd: Accepted password");
+        let v = parse_into(&reg, &bevent, &arena, line);
+        let Value::Object(entries) = v else {
+            panic!("expected Object");
+        };
+        assert_eq!(
+            lookup(entries, "timestamp"),
+            Some(Value::String("Aug  9 02:38:03"))
+        );
+        assert_eq!(lookup(entries, "hostname"), Some(Value::String("myhost")));
+        assert_eq!(lookup(entries, "appname"), Some(Value::String("sshd")));
+        assert_eq!(
+            lookup(entries, "msg"),
+            Some(Value::String("Accepted password"))
+        );
+    }
+
+    #[test]
+    fn rfc3164_timestamp_separator_cardinality_is_exact() {
+        assert!(rfc3164_timestamp_end("Aug 19 02:38:03 host").is_some());
+        assert!(rfc3164_timestamp_end("Aug  9 02:38:03 host").is_some());
+        assert_eq!(rfc3164_timestamp_end("Aug   9 02:38:03 host"), None);
+        assert_eq!(rfc3164_timestamp_end("Aug  9  02:38:03 host"), None);
+        assert_eq!(rfc3164_timestamp_end("Aug\t9 02:38:03 host"), None);
+        assert_eq!(rfc3164_timestamp_end("Aug\n9 02:38:03 host"), None);
+        assert_eq!(rfc3164_timestamp_end("Aug\u{00a0}9 02:38:03 host"), None);
+        assert_eq!(rfc3164_timestamp_end("Au\u{2003}g  9 02:38:03 host"), None);
     }
 
     #[test]

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -1837,6 +1837,35 @@ def pipeline zeek_full_otlp {
     }
 
     #[test]
+    fn juniper_rfc3164_space_padded_single_digit_day_preserves_source_time() {
+        use chrono::{Datelike, Duration, TimeZone, Utc};
+
+        let now = Utc::now();
+        let this_year = Utc
+            .with_ymd_and_hms(now.year(), 8, 9, 2, 38, 3)
+            .single()
+            .expect("valid RFC 3164 fixture time");
+        let expected = if this_year > now + Duration::days(1) {
+            Utc.with_ymd_and_hms(now.year() - 1, 8, 9, 2, 38, 3)
+                .single()
+                .expect("valid previous-year RFC 3164 fixture time")
+        } else {
+            this_year
+        }
+        .timestamp_nanos_opt()
+        .expect("fixture fits i64");
+
+        let event = run_packaged_parser_json(
+            &["parse_juniper_srx_syslog"],
+            Some("workspace.juniper_srx_syslog = { body: ingress, timezone: \"UTC\" }"),
+            "parse_juniper_srx_syslog",
+            b"<14>Aug  9 02:38:03 srx01 RT_IDP: IDP_ATTACK_LOG_EVENT: IDP: at 1778905950, SIG Attack log <198.51.100.10/63074->192.0.2.100/445> for TCP protocol and service SERVICE_IDP application SMB by rule Tap of rulebase IPS in policy Tap. attack: id=19519, repeat=0, action=DROP, threat-severity=HIGH, name=Example, NAT <198.51.100.10:0->0.0.0.0:0>",
+        );
+
+        assert_eq!(event["time"], expected);
+    }
+
+    #[test]
     fn packaged_parsers_preserve_source_event_time_as_nanoseconds() {
         use chrono::{Datelike, Duration, TimeZone, Timelike, Utc};
 

--- a/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
+++ b/packaging/snippets/parsers/parse_juniper_srx_syslog.limpid
@@ -91,9 +91,14 @@ def function juniper_srx_syslog_action_status_id(action) {
 // collector forwarding many SRXs still reports each event's true
 // origin.
 def function parse_juniper_srx_syslog_classify(text) {
+    // Accepts the RFC 3164 `%e` day padding (a single-digit day widens
+    // to two chars with a leading space). The header is extracted here
+    // rather than via parse_syslog; the separator shape must match the
+    // contract implemented by the sibling helper `rfc3164_timestamp_end`
+    // in the syslog parser.
     let m = regex_parse(
         text,
-        "^<\\d+>(?P<timestamp>\\S+ \\S+ \\S+) (?P<host>\\S+) RT_(?P<daemon>[A-Z]+): (?P<msgid>[A-Z][A-Z0-9_]+): (?P<body>.*)$"
+        "^<\\d+>(?P<timestamp>\\S+[ ]{1,2}\\S+ \\S+) (?P<host>\\S+) RT_(?P<daemon>[A-Z]+): (?P<msgid>[A-Z][A-Z0-9_]+): (?P<body>.*)$"
     )
     switch true {
         m == null { null }


### PR DESCRIPTION
## Summary
- preserve complete RFC 3164 timestamps when `%e` space-pads a single-digit day
- keep the generic syslog parser and the Juniper raw classifier on the same exact ASCII-space contract
- add deterministic regressions and remove the now-unused private delimiter helper

## Contract
- month to day: exactly 1–2 ASCII spaces
- day to time: exactly 1 ASCII space
- tabs, extra spaces, and non-ASCII whitespace remain rejected
- no new timestamp formats, public API, config, schema, dependency, or parser feature

## Sibling scan
Scanned the shipped raw-ingress parser classifiers for the same RFC 3164 timestamp shape. Juniper SRX was the only independent raw classifier; the other relevant parsers use the generic syslog path or RFC 5424 and needed no change.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo xtask lint-snippet-headers`
- `cargo clippy --workspace -- -D warnings`
- `cargo deny check advisories bans sources licenses`
- uchgs push gate: 9/9 confirmed

## Performance
Canonical playground measurement (Ubuntu 24.04 aarch64, two-core affinity), baseline `f04e04f` vs candidate `d8ce67d`, three measured runs per workload:
- A passthrough: 95.74%
- B syslog parse: 98.23%
- C parse + regex + routing: 104.87%
- D OCSF compose + JSON: 100.17%

All required workload medians remained at or above 95% of baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RFC 3164 syslog timestamp parsing for single-digit days with space padding.
  * Added support for valid one- and two-space date separators while rejecting malformed whitespace.
  * Corrected Juniper SRX timestamp handling, including year rollover scenarios.
  * Added regression coverage to ensure parsed event times preserve the original timestamp accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->