### PR TITLE
feat(metrics): wire registry into daemon

### DIFF
--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -30,7 +30,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::dsl::ast::*;
 use crate::event::Event;
-use crate::metrics::MetricsRegistry;
+use crate::metrics::Registry;
 use crate::pipeline::CompiledConfig;
 use crate::queue::QueueSender;
 use crate::tap::TapRegistry;
@@ -413,7 +413,7 @@ fn parent_dir_owner_is_untrusted(uid: u32, self_euid: u32) -> bool {
 pub struct ControlServer {
     socket_path: PathBuf,
     tap: TapRegistry,
-    metrics: Arc<MetricsRegistry>,
+    metrics: Arc<Registry>,
     config: Arc<CompiledConfig>,
     input_senders: Arc<HashMap<String, InputInjectTarget>>,
     output_senders: Arc<HashMap<String, QueueSender>>,
@@ -424,7 +424,7 @@ impl ControlServer {
     pub fn new(
         socket_path: Option<String>,
         tap: TapRegistry,
-        metrics: Arc<MetricsRegistry>,
+        metrics: Arc<Registry>,
         config: Arc<CompiledConfig>,
         input_senders: HashMap<String, InputInjectTarget>,
         output_senders: Arc<HashMap<String, QueueSender>>,
@@ -751,7 +751,7 @@ impl ControlServer {
 async fn handle_connection(
     stream: tokio::net::UnixStream,
     tap: Arc<TapRegistry>,
-    metrics: Arc<MetricsRegistry>,
+    metrics: Arc<Registry>,
     config: Arc<CompiledConfig>,
     input_senders: Arc<HashMap<String, InputInjectTarget>>,
     output_senders: Arc<HashMap<String, QueueSender>>,
@@ -874,7 +874,8 @@ async fn handle_connection(
                 let uptime = started_at.elapsed().as_secs();
                 json!({"status": "ok", "uptime_seconds": uptime}).to_string()
             }
-            "stats" => metrics.to_json(),
+            "stats" => serde_json::to_string(&metrics.snapshot())
+                .expect("MetricsSnapshot serialization must remain infallible"),
             "list" => build_list_json(&config),
             _ => json!({"error": format!("unknown command '{}'", cmd)}).to_string(),
         };
@@ -1098,9 +1099,7 @@ async fn handle_inject(
             Target::Input(tx, metrics) => {
                 let sent = tx.send(event).await.is_ok();
                 if sent {
-                    metrics
-                        .events_injected
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    metrics.events_injected.inc();
                 }
                 sent
             }
@@ -1112,8 +1111,7 @@ async fn handle_inject(
                 // is the only entry.
                 let sent = tx.send(event).await.is_ok();
                 if sent && let Some(m) = tx.metrics() {
-                    m.events_injected
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    m.events_injected.inc();
                 }
                 sent
             }
@@ -1256,10 +1254,19 @@ def pipeline p { input i; output o }
         )
         .expect("compile");
 
+        let metrics = Arc::new(crate::metrics::Registry::new());
+        let received = metrics
+            .counter("limpid_input_events_received_total")
+            .help("Total events received by an input.")
+            .label("input", "control_test")
+            .build()
+            .expect("test metric registration must succeed");
+        received.inc();
+
         let server = ControlServer::new(
             Some(socket_path.to_string_lossy().into_owned()),
             TapRegistry::new(),
-            Arc::new(MetricsRegistry::new()),
+            metrics,
             Arc::new(config),
             HashMap::new(),
             Arc::new(HashMap::new()),
@@ -1319,15 +1326,26 @@ def pipeline p { input i; output o }
     async fn stats_command_as_built_by_limpidctl_and_prometheus() {
         let (socket_path, _dir, shutdown_tx) = spawn_server().await;
         let resp = send_command(&socket_path, "stats").await;
-        // Any well-formed JSON object counts as "parsed", as opposed to
-        // the `{"error":"unknown command '...'"}"` fallback.
         assert!(
             !resp.contains("unknown command"),
             "stats command was not recognised: {}",
             resp
         );
         let parsed: serde_json::Value = serde_json::from_str(resp.trim()).expect("valid JSON");
-        assert!(parsed.is_object(), "stats response not an object: {}", resp);
+        assert_eq!(parsed["schema"], 1);
+        let metrics = parsed["metrics"]
+            .as_array()
+            .expect("stats metrics must be an array");
+        let family = metrics
+            .iter()
+            .find(|metric| metric["name"] == "limpid_input_events_received_total")
+            .expect("stats must serialize the typed registry snapshot");
+        assert_eq!(family["type"], "counter");
+        assert_eq!(family["series"][0]["labels"]["input"], "control_test");
+        assert_eq!(family["series"][0]["value"], 1);
+        assert!(parsed.get("inputs").is_none());
+        assert!(parsed.get("pipelines").is_none());
+        assert!(parsed.get("outputs").is_none());
         let _ = shutdown_tx.send(true);
     }
 

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -1,10 +1,12 @@
-//! Shared metrics counters.
+//! Shared self-describing metrics registry and fully-labelled handles.
 //!
-//! Each component owns its own `Arc<XxxMetrics>` and counts internally.
-//! `MetricsRegistry` holds references for aggregated access (stats command).
-//! Runtime never counts — it only distributes handles.
+//! Metric-emitting inputs, the pipeline worker, and outputs hold
+//! their corresponding per-role bundle (`InputMetrics`,
+//! `PipelineMetrics`, `OutputMetrics`); each bundle's `register`
+//! helper materialises its canonical fully-labelled counter series
+//! in the shared registry.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -14,27 +16,50 @@ use serde::Serialize;
 pub struct InputMetrics {
     /// Events actually received by the input module (network, socket, file, etc).
     /// Injected events are NOT counted here — see `events_injected`.
-    pub events_received: AtomicU64,
-    pub events_invalid: AtomicU64,
+    pub(crate) events_received: Arc<registry_core::Counter>,
+    pub(crate) events_invalid: Arc<registry_core::Counter>,
     /// Events pushed into this input's channel via `limpidctl inject`.
-    pub events_injected: AtomicU64,
+    pub(crate) events_injected: Arc<registry_core::Counter>,
 }
 
-impl Default for InputMetrics {
-    fn default() -> Self {
-        Self {
-            events_received: AtomicU64::new(0),
-            events_invalid: AtomicU64::new(0),
-            events_injected: AtomicU64::new(0),
+impl InputMetrics {
+    pub(crate) fn register(registry: &Registry, input: &str) -> Result<Arc<Self>, MetricsError> {
+        macro_rules! counter {
+            ($name:literal, $help:literal) => {
+                registry
+                    .counter($name)
+                    .label("input", input)
+                    .help($help)
+                    .build()?
+            };
         }
+        Ok(Arc::new(Self {
+            events_received: counter!(
+                "limpid_input_events_received_total",
+                "Total events received by the input."
+            ),
+            events_invalid: counter!(
+                "limpid_input_events_invalid_total",
+                "Total invalid events rejected by the input."
+            ),
+            events_injected: counter!(
+                "limpid_input_events_injected_total",
+                "Total events injected into the input through the control socket."
+            ),
+        }))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_testing() -> Arc<Self> {
+        Self::register(&Registry::new(), "test-input").expect("test input metrics must register")
     }
 }
 
 pub struct PipelineMetrics {
-    pub events_received: AtomicU64,
-    pub events_finished: AtomicU64,
-    pub events_dropped: AtomicU64,
-    pub events_discarded: AtomicU64,
+    pub(crate) events_received: Arc<registry_core::Counter>,
+    pub(crate) events_finished: Arc<registry_core::Counter>,
+    pub(crate) events_dropped: Arc<registry_core::Counter>,
+    pub(crate) events_discarded: Arc<registry_core::Counter>,
     /// Events for which a `process` statement raised a runtime error
     /// (unknown identifier, type mismatch, regex compile failure, …).
     /// The event is routed to the dead-letter queue: the configured
@@ -45,37 +70,70 @@ pub struct PipelineMetrics {
     /// from `events_discarded` so operators can tell a config-bug-
     /// shaped routing miss apart from a logic-bug-shaped runtime
     /// failure.
-    pub events_errored: AtomicU64,
+    pub(crate) events_errored: Arc<registry_core::Counter>,
     /// Subset of `events_errored` for which the configured
     /// `error_log` write itself failed (disk full, permissions,
     /// rotation race). The runtime falls back to a structured
     /// `tracing::error!` line, but operators should alarm on this
     /// counter — it means the replay path may be incomplete.
-    pub events_errored_unwritable: AtomicU64,
+    pub(crate) events_errored_unwritable: Arc<registry_core::Counter>,
 }
 
-impl Default for PipelineMetrics {
-    fn default() -> Self {
-        Self {
-            events_received: AtomicU64::new(0),
-            events_finished: AtomicU64::new(0),
-            events_dropped: AtomicU64::new(0),
-            events_discarded: AtomicU64::new(0),
-            events_errored: AtomicU64::new(0),
-            events_errored_unwritable: AtomicU64::new(0),
+impl PipelineMetrics {
+    pub(crate) fn register(registry: &Registry, pipeline: &str) -> Result<Arc<Self>, MetricsError> {
+        macro_rules! counter {
+            ($name:literal, $help:literal) => {
+                registry
+                    .counter($name)
+                    .label("pipeline", pipeline)
+                    .help($help)
+                    .build()?
+            };
         }
+        Ok(Arc::new(Self {
+            events_received: counter!(
+                "limpid_pipeline_events_received_total",
+                "Total events received by the pipeline."
+            ),
+            events_finished: counter!(
+                "limpid_pipeline_events_finished_total",
+                "Total events that finished pipeline processing."
+            ),
+            events_dropped: counter!(
+                "limpid_pipeline_events_dropped_total",
+                "Total events dropped by the pipeline."
+            ),
+            events_discarded: counter!(
+                "limpid_pipeline_events_discarded_total",
+                "Total events discarded by pipeline routing."
+            ),
+            events_errored: counter!(
+                "limpid_pipeline_events_errored_total",
+                "Total events that encountered a pipeline processing error."
+            ),
+            events_errored_unwritable: counter!(
+                "limpid_pipeline_events_errored_unwritable_total",
+                "Total pipeline errors whose recovery record could not be written."
+            ),
+        }))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_testing() -> Arc<Self> {
+        Self::register(&Registry::new(), "test-pipeline")
+            .expect("test pipeline metrics must register")
     }
 }
 
 pub struct OutputMetrics {
     /// Total events that entered this output's queue (from pipelines + injects).
     /// `events_received - events_injected` = events delivered via pipelines.
-    pub events_received: AtomicU64,
+    pub(crate) events_received: Arc<registry_core::Counter>,
     /// Events pushed into this output's queue via `limpidctl inject`.
-    pub events_injected: AtomicU64,
-    pub events_written: AtomicU64,
-    pub events_failed: AtomicU64,
-    pub retries: AtomicU64,
+    pub(crate) events_injected: Arc<registry_core::Counter>,
+    pub(crate) events_written: Arc<registry_core::Counter>,
+    pub(crate) events_failed: Arc<registry_core::Counter>,
+    pub(crate) retries: Arc<registry_core::Counter>,
     /// Disk queue consumers that stopped accepting new events after
     /// observing an `AckDisposition::Dropped` — `Dropped` cannot
     /// advance a disk cursor without hiding data loss, and
@@ -89,7 +147,7 @@ pub struct OutputMetrics {
     /// daemon so the disk queue can replay from the wedge point.
     /// See `docs/src/operations/error-log.md` for the manual
     /// intervention runbook.
-    pub events_wedged: AtomicU64,
+    pub(crate) events_wedged: Arc<registry_core::Counter>,
     /// Sink-side counterpart to `PipelineMetrics::events_errored_unwritable`:
     /// bumped when an output's own `route_event_to_dlq` call
     /// failed to write the DLQ record (`error_log` was configured
@@ -104,141 +162,52 @@ pub struct OutputMetrics {
     /// replay path so the event is actually lost, and this counter
     /// is the operator alarm signal for that loss rather than a
     /// durable trace of it.
-    pub events_errored_unwritable: AtomicU64,
+    pub(crate) events_errored_unwritable: Arc<registry_core::Counter>,
 }
 
-impl Default for OutputMetrics {
-    fn default() -> Self {
-        Self {
-            events_received: AtomicU64::new(0),
-            events_injected: AtomicU64::new(0),
-            events_written: AtomicU64::new(0),
-            events_failed: AtomicU64::new(0),
-            retries: AtomicU64::new(0),
-            events_wedged: AtomicU64::new(0),
-            events_errored_unwritable: AtomicU64::new(0),
+impl OutputMetrics {
+    pub(crate) fn register(registry: &Registry, output: &str) -> Result<Arc<Self>, MetricsError> {
+        macro_rules! counter {
+            ($name:literal, $help:literal) => {
+                registry
+                    .counter($name)
+                    .label("output", output)
+                    .help($help)
+                    .build()?
+            };
         }
-    }
-}
-
-/// Central registry holding Arc references to all metrics counters.
-pub struct MetricsRegistry {
-    inputs: HashMap<String, Arc<InputMetrics>>,
-    pipelines: HashMap<String, Arc<PipelineMetrics>>,
-    outputs: HashMap<String, Arc<OutputMetrics>>,
-}
-
-impl MetricsRegistry {
-    pub fn new() -> Self {
-        Self {
-            inputs: HashMap::new(),
-            pipelines: HashMap::new(),
-            outputs: HashMap::new(),
-        }
-    }
-
-    /// Collect a metrics handle from a module that owns it.
-    pub fn register_input(&mut self, name: &str, metrics: Arc<InputMetrics>) {
-        self.inputs.insert(name.to_string(), metrics);
-    }
-
-    /// Collect a metrics handle from a pipeline worker that owns it.
-    pub fn register_pipeline(&mut self, name: &str, metrics: Arc<PipelineMetrics>) {
-        self.pipelines.insert(name.to_string(), metrics);
-    }
-
-    /// Collect a metrics handle from an output module that owns it.
-    pub fn register_output(&mut self, name: &str, metrics: Arc<OutputMetrics>) {
-        self.outputs.insert(name.to_string(), metrics);
+        Ok(Arc::new(Self {
+            events_received: counter!(
+                "limpid_output_events_received_total",
+                "Total events received by the output queue."
+            ),
+            events_injected: counter!(
+                "limpid_output_events_injected_total",
+                "Total events injected into the output through the control socket."
+            ),
+            events_written: counter!(
+                "limpid_output_events_written_total",
+                "Total events successfully written by the output."
+            ),
+            events_failed: counter!(
+                "limpid_output_events_failed_total",
+                "Total events that reached a terminal failure disposition for this output."
+            ),
+            retries: counter!("limpid_output_retries_total", "Total output write retries."),
+            events_wedged: counter!(
+                "limpid_output_events_wedged_total",
+                "Total disk queue consumers wedged after an unrecoverable drop."
+            ),
+            events_errored_unwritable: counter!(
+                "limpid_output_events_errored_unwritable_total",
+                "Total output errors whose recovery record could not be written."
+            ),
+        }))
     }
 
-    pub fn to_json(&self) -> String {
-        let mut map = serde_json::Map::new();
-
-        // Pipelines first — they're the main concept.
-        let mut pipelines = serde_json::Map::new();
-        for (name, m) in &self.pipelines {
-            let mut p = serde_json::Map::new();
-            p.insert(
-                "events_received".into(),
-                m.events_received.load(Ordering::Relaxed).into(),
-            );
-            p.insert(
-                "events_finished".into(),
-                m.events_finished.load(Ordering::Relaxed).into(),
-            );
-            p.insert(
-                "events_dropped".into(),
-                m.events_dropped.load(Ordering::Relaxed).into(),
-            );
-            p.insert(
-                "events_discarded".into(),
-                m.events_discarded.load(Ordering::Relaxed).into(),
-            );
-            p.insert(
-                "events_errored".into(),
-                m.events_errored.load(Ordering::Relaxed).into(),
-            );
-            p.insert(
-                "events_errored_unwritable".into(),
-                m.events_errored_unwritable.load(Ordering::Relaxed).into(),
-            );
-            pipelines.insert(name.clone(), serde_json::Value::Object(p));
-        }
-        map.insert("pipelines".into(), serde_json::Value::Object(pipelines));
-
-        let mut inputs = serde_json::Map::new();
-        for (name, m) in &self.inputs {
-            let mut i = serde_json::Map::new();
-            i.insert(
-                "events_received".into(),
-                m.events_received.load(Ordering::Relaxed).into(),
-            );
-            i.insert(
-                "events_invalid".into(),
-                m.events_invalid.load(Ordering::Relaxed).into(),
-            );
-            i.insert(
-                "events_injected".into(),
-                m.events_injected.load(Ordering::Relaxed).into(),
-            );
-            inputs.insert(name.clone(), serde_json::Value::Object(i));
-        }
-        map.insert("inputs".into(), serde_json::Value::Object(inputs));
-
-        let mut outputs = serde_json::Map::new();
-        for (name, m) in &self.outputs {
-            let mut o = serde_json::Map::new();
-            o.insert(
-                "events_received".into(),
-                m.events_received.load(Ordering::Relaxed).into(),
-            );
-            o.insert(
-                "events_injected".into(),
-                m.events_injected.load(Ordering::Relaxed).into(),
-            );
-            o.insert(
-                "events_written".into(),
-                m.events_written.load(Ordering::Relaxed).into(),
-            );
-            o.insert(
-                "events_failed".into(),
-                m.events_failed.load(Ordering::Relaxed).into(),
-            );
-            o.insert("retries".into(), m.retries.load(Ordering::Relaxed).into());
-            o.insert(
-                "events_wedged".into(),
-                m.events_wedged.load(Ordering::Relaxed).into(),
-            );
-            o.insert(
-                "events_errored_unwritable".into(),
-                m.events_errored_unwritable.load(Ordering::Relaxed).into(),
-            );
-            outputs.insert(name.clone(), serde_json::Value::Object(o));
-        }
-        map.insert("outputs".into(), serde_json::Value::Object(outputs));
-
-        serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_default()
+    #[cfg(test)]
+    pub(crate) fn for_testing() -> Arc<Self> {
+        Self::register(&Registry::new(), "test-output").expect("test output metrics must register")
     }
 }
 
@@ -251,9 +220,6 @@ impl MetricsRegistry {
 /// must propagate to daemon startup and must not be swallowed at the
 /// emit site.
 ///
-/// The module intentionally coexists unwired with the active legacy
-/// `MetricsRegistry` above; the `#[allow(dead_code)]` is temporary and
-/// applies only while no in-tree consumer of this module exists.
 #[allow(dead_code)]
 mod registry_core {
     use super::*;
@@ -355,6 +321,11 @@ mod registry_core {
     impl Counter {
         pub(crate) fn inc(&self) {
             self.value.fetch_add(1, Ordering::Relaxed);
+        }
+
+        #[cfg(test)]
+        pub(crate) fn load(&self, _ordering: Ordering) -> u64 {
+            self.value.load(Ordering::Relaxed)
         }
     }
 
@@ -996,8 +967,11 @@ pub(crate) use registry_core::{MetricsError, MetricsSnapshot, Registry};
 
 #[cfg(test)]
 mod registry_tests {
-    use super::{MetricsError, MetricsSnapshot, Registry};
+    use super::{
+        InputMetrics, MetricsError, MetricsSnapshot, OutputMetrics, PipelineMetrics, Registry,
+    };
     use serde_json::Value;
+    use std::sync::Arc;
 
     fn build_ok<T>(result: Result<T, MetricsError>) -> T {
         match result {
@@ -1556,5 +1530,168 @@ mod registry_tests {
             .collect();
         assert_eq!(values_by_source.get("one"), Some(&1));
         assert_eq!(values_by_source.get("two"), Some(&2));
+    }
+
+    #[test]
+    fn documented_metric_bundles_share_one_registry_without_shadow_series() {
+        let registry = Registry::new();
+        let input: Arc<InputMetrics> = build_ok(InputMetrics::register(&registry, "ingress"));
+        let pipeline: Arc<PipelineMetrics> =
+            build_ok(PipelineMetrics::register(&registry, "route"));
+        let output: Arc<OutputMetrics> = build_ok(OutputMetrics::register(&registry, "egress"));
+        let input_shared = Arc::clone(&input);
+        let pipeline_shared = Arc::clone(&pipeline);
+        let output_shared = Arc::clone(&output);
+
+        macro_rules! inc {
+            ($counter:expr, $times:expr) => {
+                for _ in 0..$times {
+                    $counter.inc();
+                }
+            };
+        }
+
+        inc!(input_shared.events_received, 1);
+        inc!(input.events_invalid, 2);
+        inc!(input.events_injected, 3);
+        inc!(pipeline_shared.events_received, 4);
+        inc!(pipeline.events_finished, 5);
+        inc!(pipeline.events_dropped, 6);
+        inc!(pipeline.events_discarded, 7);
+        inc!(pipeline.events_errored, 8);
+        inc!(pipeline.events_errored_unwritable, 9);
+        inc!(output_shared.events_received, 10);
+        inc!(output.events_injected, 11);
+        inc!(output.events_written, 12);
+        inc!(output.events_failed, 13);
+        inc!(output.retries, 14);
+        inc!(output.events_wedged, 15);
+        inc!(output.events_errored_unwritable, 16);
+
+        let snapshot = snapshot_json(&registry);
+        let metrics = snapshot["metrics"]
+            .as_array()
+            .expect("metrics must be an array");
+        assert_eq!(
+            metrics.len(),
+            16,
+            "only the documented metric set is registered"
+        );
+
+        let expected = [
+            ("limpid_input_events_received_total", "input", "ingress", 1),
+            ("limpid_input_events_invalid_total", "input", "ingress", 2),
+            ("limpid_input_events_injected_total", "input", "ingress", 3),
+            (
+                "limpid_pipeline_events_received_total",
+                "pipeline",
+                "route",
+                4,
+            ),
+            (
+                "limpid_pipeline_events_finished_total",
+                "pipeline",
+                "route",
+                5,
+            ),
+            (
+                "limpid_pipeline_events_dropped_total",
+                "pipeline",
+                "route",
+                6,
+            ),
+            (
+                "limpid_pipeline_events_discarded_total",
+                "pipeline",
+                "route",
+                7,
+            ),
+            (
+                "limpid_pipeline_events_errored_total",
+                "pipeline",
+                "route",
+                8,
+            ),
+            (
+                "limpid_pipeline_events_errored_unwritable_total",
+                "pipeline",
+                "route",
+                9,
+            ),
+            (
+                "limpid_output_events_received_total",
+                "output",
+                "egress",
+                10,
+            ),
+            (
+                "limpid_output_events_injected_total",
+                "output",
+                "egress",
+                11,
+            ),
+            ("limpid_output_events_written_total", "output", "egress", 12),
+            ("limpid_output_events_failed_total", "output", "egress", 13),
+            ("limpid_output_retries_total", "output", "egress", 14),
+            ("limpid_output_events_wedged_total", "output", "egress", 15),
+            (
+                "limpid_output_events_errored_unwritable_total",
+                "output",
+                "egress",
+                16,
+            ),
+        ];
+        for (name, label, label_value, value) in expected {
+            let family = metric(&snapshot, name);
+            assert_eq!(family["type"], "counter");
+            assert!(
+                family["help"].as_str().is_some_and(|help| !help.is_empty()),
+                "{name} must remain self-describing"
+            );
+            let series = family["series"]
+                .as_array()
+                .expect("series must be an array");
+            assert_eq!(series.len(), 1, "{name} must have exactly one series");
+            let series = &series[0];
+            let labels = series["labels"]
+                .as_object()
+                .expect("labels must be an object");
+            assert_eq!(labels.len(), 1, "{name} must have exactly one label");
+            assert_eq!(
+                labels.get(label).and_then(Value::as_str),
+                Some(label_value),
+                "{name} must have the documented labelset"
+            );
+            assert_eq!(series["value"], value);
+        }
+
+        let duplicate = match OutputMetrics::register(&registry, "egress") {
+            Ok(_) => panic!("the bundle must register into the supplied shared registry"),
+            Err(error) => error,
+        };
+        let diagnostic = duplicate.to_string();
+        assert_output_duplicate(&duplicate, "egress", &diagnostic);
+    }
+
+    fn assert_output_duplicate(error: &MetricsError, label_value: &str, diagnostic: &str) {
+        let (name, labelset) = match error {
+            MetricsError::DuplicateSeries { name, labelset } => (name, labelset),
+            other => panic!("expected DuplicateSeries, got {other:?}"),
+        };
+        assert!(
+            [
+                "limpid_output_events_received_total",
+                "limpid_output_events_injected_total",
+                "limpid_output_events_written_total",
+                "limpid_output_events_failed_total",
+                "limpid_output_retries_total",
+                "limpid_output_events_wedged_total",
+                "limpid_output_events_errored_unwritable_total",
+            ]
+            .contains(&name.as_str())
+        );
+        assert_eq!(labelset, &[("output".to_owned(), label_value.to_owned())]);
+        assert!(diagnostic.contains(&format!("name={name:?}")));
+        assert!(diagnostic.contains(&format!("labelset={labelset:?}")));
     }
 }

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -94,9 +94,9 @@ impl Module for JournalInput {
     }
 
     fn from_properties(
-        _name: &str,
+        name: &str,
         properties: &crate::dsl::module_props::ModuleProperties,
-        _ctx: &crate::modules::BuildContext,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let properties = properties.user_properties();
         // Repeatable `match` — walk every occurrence so multi-filter
@@ -130,7 +130,7 @@ impl Module for JournalInput {
                     "input '{}': journal `match` requires `FIELD=value` shape (got \"{}\") — \
                      each match string must contain '='; see \
                      `docs/src/inputs/journal.md` for the filter combining rules",
-                    _name,
+                    name,
                     m
                 );
             }
@@ -146,7 +146,7 @@ impl Module for JournalInput {
             matches,
             state_file,
             poll_interval,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::register(&ctx.metrics, name)?,
         })
     }
 }
@@ -248,7 +248,7 @@ impl Input for JournalInput {
                 entry = entry_rx.recv() => {
                     match entry {
                         Some((bytes, cursor)) => {
-                            metrics.events_received.fetch_add(1, Ordering::Relaxed);
+                            metrics.events_received.inc();
                             let ack = Arc::new(AckHandle::new(
                                 AckPosition::Cursor(cursor),
                                 ack_tx.clone(),

--- a/crates/limpid/src/modules/input/otlp/grpc.rs
+++ b/crates/limpid/src/modules/input/otlp/grpc.rs
@@ -34,7 +34,6 @@
 
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
 use opentelemetry_proto::tonic::collector::logs::v1::{
@@ -94,7 +93,7 @@ impl Module for OtlpGrpcInput {
     fn from_properties(
         name: &str,
         properties: &crate::dsl::module_props::ModuleProperties,
-        _ctx: &crate::modules::BuildContext,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let properties = properties.user_properties();
         let bind =
@@ -105,7 +104,7 @@ impl Module for OtlpGrpcInput {
             bind_addr: bind,
             rate_limit,
             tls,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::register(&ctx.metrics, name)?,
         })
     }
 }
@@ -216,7 +215,7 @@ impl LogsService for LogsServiceImpl {
         // Track every RPC as a "received" event for backpressure
         // visibility — even if the body is empty / malformed we want
         // to see the flow through input metrics.
-        self.metrics.events_received.fetch_add(1, Ordering::Relaxed);
+        self.metrics.events_received.inc();
 
         // Fallback: tonic should always know the peer for a
         // TCP-served RPC, but a non-TCP transport (uds, mock) might
@@ -408,7 +407,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         let svc = LogsServiceImpl {
             tx,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::for_testing(),
             rate_limiter: None,
         };
         let req = Request::new(ExportLogsServiceRequest {
@@ -450,7 +449,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         let svc = LogsServiceImpl {
             tx,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::for_testing(),
             rate_limiter: None,
         };
         let req = Request::new(ExportLogsServiceRequest {
@@ -467,7 +466,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         let svc = LogsServiceImpl {
             tx,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::for_testing(),
             rate_limiter: None,
         };
         let lr = |t: u64| LogRecord {

--- a/crates/limpid/src/modules/input/otlp/http.rs
+++ b/crates/limpid/src/modules/input/otlp/http.rs
@@ -54,7 +54,6 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -170,7 +169,7 @@ impl Module for OtlpHttpInput {
     fn from_properties(
         name: &str,
         properties: &crate::dsl::module_props::ModuleProperties,
-        _ctx: &crate::modules::BuildContext,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let properties = properties.user_properties();
         let tls_config =
@@ -216,7 +215,7 @@ impl Module for OtlpHttpInput {
             request_rate_limit,
             max_concurrent_requests,
             tls_config,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::register(&ctx.metrics, name)?,
         })
     }
 }
@@ -345,10 +344,7 @@ async fn handle_logs(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> impl IntoResponse {
-    state
-        .metrics
-        .events_received
-        .fetch_add(1, Ordering::Relaxed);
+    state.metrics.events_received.inc();
 
     // Concurrency cap (semaphore) bounds simultaneous decode work.
     // Combined with body_limit, this turns the worst-case decode
@@ -397,7 +393,7 @@ async fn handle_logs(
                     "otlp_http [{peer}]: JSON decode failed: {}",
                     truncate_decode_err(&e.to_string())
                 );
-                state.metrics.events_invalid.fetch_add(1, Ordering::Relaxed);
+                state.metrics.events_invalid.inc();
                 return (StatusCode::BAD_REQUEST, "invalid OTLP/JSON payload").into_response();
             }
         },
@@ -408,7 +404,7 @@ async fn handle_logs(
                     "otlp_http [{peer}]: protobuf decode failed: {}",
                     truncate_decode_err(&e.to_string())
                 );
-                state.metrics.events_invalid.fetch_add(1, Ordering::Relaxed);
+                state.metrics.events_invalid.inc();
                 return (StatusCode::BAD_REQUEST, "invalid OTLP/protobuf payload").into_response();
             }
         },

--- a/crates/limpid/src/modules/input/otlp/mod.rs
+++ b/crates/limpid/src/modules/input/otlp/mod.rs
@@ -9,7 +9,6 @@ pub mod http;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
 use opentelemetry_proto::tonic::{
@@ -82,7 +81,7 @@ pub async fn split_request(
                 let mut buf = Vec::with_capacity(singleton.encoded_len());
                 if let Err(e) = singleton.encode(&mut buf) {
                     warn!("{transport_name} [{peer}]: re-encode failed: {e}");
-                    metrics.events_invalid.fetch_add(1, Ordering::Relaxed);
+                    metrics.events_invalid.inc();
                     rejected += 1;
                     continue;
                 }

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -164,7 +164,7 @@ impl Module for SyslogTcpInput {
     fn from_properties(
         name: &str,
         properties: &crate::dsl::module_props::ModuleProperties,
-        _ctx: &crate::modules::BuildContext,
+        ctx: &crate::modules::BuildContext,
     ) -> anyhow::Result<Self> {
         let properties = properties.user_properties();
         let tls_config =
@@ -199,7 +199,7 @@ impl Module for SyslogTcpInput {
             tls_config,
             max_connections,
             rate_limit,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::register(&ctx.metrics, name)?,
         })
     }
 }
@@ -491,8 +491,7 @@ pub(crate) async fn read_octet_counting<R: tokio::io::AsyncRead + Unpin>(
                 addr, e,
             );
             if let Some(m) = metrics {
-                m.events_invalid
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                m.events_invalid.inc();
             }
             return CloseReason::FramingError(format!("invalid PRI: {}", e));
         }
@@ -507,8 +506,7 @@ pub(crate) async fn read_octet_counting<R: tokio::io::AsyncRead + Unpin>(
             return CloseReason::ChannelClosed;
         }
         if let Some(m) = metrics {
-            m.events_received
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            m.events_received.inc();
         }
     }
 }
@@ -635,8 +633,7 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
                                 addr, e
                             );
                             if let Some(m) = metrics {
-                                m.events_invalid
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                m.events_invalid.inc();
                             }
                         } else {
                             if let Some(limiter) = limiter {
@@ -648,8 +645,7 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
                                 return CloseReason::ChannelClosed;
                             }
                             if let Some(m) = metrics {
-                                m.events_received
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                m.events_received.inc();
                             }
                         }
                     }
@@ -679,8 +675,7 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
                 addr, e,
             );
             if let Some(m) = metrics {
-                m.events_invalid
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                m.events_invalid.inc();
             }
             return CloseReason::FramingError(format!("invalid PRI: {}", e));
         }
@@ -695,8 +690,7 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
             return CloseReason::ChannelClosed;
         }
         if let Some(m) = metrics {
-            m.events_received
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            m.events_received.inc();
         }
     }
 }
@@ -1200,7 +1194,7 @@ mod tests {
         tokio::sync::mpsc::Receiver<Event>,
         Arc<InputMetrics>,
     ) {
-        let metrics = Arc::new(InputMetrics::default());
+        let metrics = InputMetrics::for_testing();
         let input = SyslogTcpInput {
             bind_addr,
             framing: TcpFraming::OctetCounting,

--- a/crates/limpid/src/modules/input/syslog_udp.rs
+++ b/crates/limpid/src/modules/input/syslog_udp.rs
@@ -2,6 +2,7 @@
 //! Invalid PRI messages are dropped with a warning.
 
 use std::sync::Arc;
+#[cfg(test)]
 use std::sync::atomic::Ordering;
 
 use anyhow::Result;
@@ -46,9 +47,9 @@ impl Module for SyslogUdpInput {
     }
 
     fn from_properties(
-        _name: &str,
+        name: &str,
         properties: &crate::dsl::module_props::ModuleProperties,
-        _ctx: &crate::modules::BuildContext,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let properties = properties.user_properties();
         let bind =
@@ -57,7 +58,7 @@ impl Module for SyslogUdpInput {
         Ok(Self {
             bind_addr: bind,
             rate_limit,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::register(&ctx.metrics, name)?,
         })
     }
 }
@@ -104,11 +105,11 @@ impl Input for SyslogUdpInput {
 
                             if let Err(e) = validate_pri(data) {
                                 warn!("syslog_udp [{}]: dropping invalid message ({})", addr, e);
-                                metrics.events_invalid.fetch_add(1, Ordering::Relaxed);
+                                metrics.events_invalid.inc();
                                 continue;
                             }
 
-                            metrics.events_received.fetch_add(1, Ordering::Relaxed);
+                            metrics.events_received.inc();
 
                             if let Some(ref limiter) = limiter {
                                 limiter.acquire().await;
@@ -157,7 +158,7 @@ mod tests {
         tokio::sync::mpsc::Receiver<Event>,
         Arc<InputMetrics>,
     ) {
-        let metrics = Arc::new(InputMetrics::default());
+        let metrics = InputMetrics::for_testing();
         let input = SyslogUdpInput {
             bind_addr,
             rate_limit: None,

--- a/crates/limpid/src/modules/input/tail.rs
+++ b/crates/limpid/src/modules/input/tail.rs
@@ -14,7 +14,6 @@
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -73,7 +72,7 @@ impl Module for TailInput {
     fn from_properties(
         name: &str,
         properties: &crate::dsl::module_props::ModuleProperties,
-        _ctx: &crate::modules::BuildContext,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let properties = properties.user_properties();
         let path = props::get_string(properties, "path")
@@ -87,7 +86,7 @@ impl Module for TailInput {
             path: PathBuf::from(path),
             state_file,
             poll_interval,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::register(&ctx.metrics, name)?,
         })
     }
 }
@@ -361,7 +360,7 @@ impl TailInput {
                 continue;
             }
 
-            self.metrics.events_received.fetch_add(1, Ordering::Relaxed);
+            self.metrics.events_received.inc();
 
             // Stamp the event with the post-line offset. When the pipeline
             // worker finishes (or fans out across multiple workers and the
@@ -468,7 +467,7 @@ mod tests {
             path: path.to_path_buf(),
             state_file: state_file.map(|p| p.to_path_buf()),
             poll_interval: Duration::from_millis(10),
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::for_testing(),
         }
     }
 

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -7,7 +7,6 @@
 
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
@@ -190,7 +189,7 @@ impl Module for UnixSocketInput {
     fn from_properties(
         name: &str,
         properties: &crate::dsl::module_props::ModuleProperties,
-        _ctx: &crate::modules::BuildContext,
+        ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let properties = properties.user_properties();
         let path = props::get_string(properties, "path")
@@ -212,7 +211,7 @@ impl Module for UnixSocketInput {
             .with_context(|| format!("input '{}': unix_socket startup validation failed", name))?;
         Ok(Self {
             path,
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::register(&ctx.metrics, name)?,
         })
     }
 }
@@ -424,11 +423,11 @@ impl Input for UnixSocketInput {
 
                             if let Err(e) = validate_pri(data) {
                                 warn!("unix_socket: dropping invalid message ({})", e);
-                                self.metrics.events_invalid.fetch_add(1, Ordering::Relaxed);
+                                self.metrics.events_invalid.inc();
                                 continue;
                             }
 
-                            self.metrics.events_received.fetch_add(1, Ordering::Relaxed);
+                            self.metrics.events_received.inc();
 
                             let event = Event::new(Bytes::copy_from_slice(data), source_addr);
                             if tx.send(event).await.is_err() {
@@ -477,7 +476,7 @@ mod tests {
     ) {
         let input = UnixSocketInput {
             path: path.display().to_string(),
-            metrics: Arc::new(InputMetrics::default()),
+            metrics: InputMetrics::for_testing(),
         };
         let (tx, rx) = tokio::sync::mpsc::channel(16);
         let (sd_tx, sd_rx) = tokio::sync::watch::channel(false);

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -41,6 +41,10 @@ use crate::metrics::{InputMetrics, OutputMetrics};
 #[derive(Clone)]
 pub struct BuildContext {
     pub funcs: Arc<crate::functions::FunctionRegistry>,
+    /// Shared metrics registry — one instance is distributed to every
+    /// module so all counters land in the same `stats` snapshot. A
+    /// fresh registry is paired with each `Runtime::start`.
+    pub metrics: Arc<crate::metrics::Registry>,
     pub error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     /// Operator-selected confidentiality policy for tracing-side DLQ
     /// fallback emission (unset `error_log`, or `error_log` write
@@ -155,6 +159,7 @@ impl BuildContext {
         Box::leak(Box::new(_tx));
         Self {
             funcs: Arc::new(crate::functions::FunctionRegistry::new()),
+            metrics: Arc::new(crate::metrics::Registry::new()),
             error_log: None,
             error_log_fallback: crate::error_log::ErrorLogFallback::default(),
             shutdown_signal: rx,
@@ -566,10 +571,9 @@ pub async fn finalize_shutdown_singleton_disposition(
     event: &Event,
     ack: crate::queue::QueueAckHandle,
 ) {
-    use std::sync::atomic::Ordering;
     match result {
         Ok(()) => {
-            metrics.events_written.fetch_add(1, Ordering::Relaxed);
+            metrics.events_written.inc();
             ack.resolve_delivered();
         }
         Err(e) => {
@@ -636,10 +640,9 @@ pub async fn finalize_shutdown_singleton_disposition_ambiguous(
     event: &Event,
     ack: crate::queue::QueueAckHandle,
 ) {
-    use std::sync::atomic::Ordering;
     match result {
         Ok(()) => {
-            metrics.events_written.fetch_add(1, Ordering::Relaxed);
+            metrics.events_written.inc();
             ack.resolve_delivered();
         }
         Err(e) => {
@@ -699,8 +702,6 @@ pub async fn route_shutdown_batch_to_dlq(
     events: Vec<(Event, crate::queue::QueueAckHandle)>,
     flush_err: &anyhow::Error,
 ) {
-    use std::sync::atomic::Ordering;
-
     if events.is_empty() {
         return;
     }
@@ -726,9 +727,7 @@ pub async fn route_shutdown_batch_to_dlq(
                         Some(position),
                         Some(&write_err),
                     );
-                    metrics
-                        .events_errored_unwritable
-                        .fetch_add(1, Ordering::Relaxed);
+                    metrics.events_errored_unwritable.inc();
                     DlqRouteOutcome::Dropped
                 }
             };
@@ -815,8 +814,6 @@ pub async fn route_shutdown_batch_ambiguous_to_dlq(
     events: Vec<(Event, crate::queue::QueueAckHandle)>,
     flush_err: &anyhow::Error,
 ) {
-    use std::sync::atomic::Ordering;
-
     if events.is_empty() {
         return;
     }
@@ -843,9 +840,7 @@ pub async fn route_shutdown_batch_ambiguous_to_dlq(
                     Some(position),
                     Some(&write_err),
                 );
-                metrics
-                    .events_errored_unwritable
-                    .fetch_add(1, Ordering::Relaxed);
+                metrics.events_errored_unwritable.inc();
             }
             // The DLQ record has been written (or the tracing
             // fallback fired per ladder) for operator visibility,
@@ -1066,10 +1061,9 @@ pub fn resolve_ack_from_dlq_outcome(
     metrics: &OutputMetrics,
 ) {
     use crate::queue::AckPosition;
-    use std::sync::atomic::Ordering;
     match (outcome, ack.position()) {
         (DlqRouteOutcome::Recovered, _) | (DlqRouteOutcome::Dropped, AckPosition::Memory) => {
-            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            metrics.events_failed.inc();
             ack.resolve_recovered();
         }
         (DlqRouteOutcome::Dropped, AckPosition::Disk { .. }) => {
@@ -1133,7 +1127,6 @@ pub async fn route_event_to_dlq(
     position: crate::queue::AckPosition,
     reason: &str,
 ) -> DlqRouteOutcome {
-    use std::sync::atomic::Ordering;
     if let Some(writer) = error_log {
         let ctx = crate::pipeline::ErroredEventContext::Output {
             timestamp: chrono::Utc::now(),
@@ -1169,9 +1162,7 @@ pub async fn route_event_to_dlq(
                     Some(position),
                     Some(&write_err),
                 );
-                metrics
-                    .events_errored_unwritable
-                    .fetch_add(1, Ordering::Relaxed);
+                metrics.events_errored_unwritable.inc();
                 DlqRouteOutcome::Dropped
             }
         }
@@ -1557,7 +1548,7 @@ mod resolve_ack_from_dlq_outcome_tests {
     #[tokio::test]
     async fn recovered_outcome_resolves_recovered_on_memory() {
         let (ack, mut rx) = QueueAckHandle::for_test();
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         resolve_ack_from_dlq_outcome(ack, DlqRouteOutcome::Recovered, &metrics);
         assert_eq!(
             rx.recv().await,
@@ -1573,7 +1564,7 @@ mod resolve_ack_from_dlq_outcome_tests {
             offset: 128,
         };
         let (ack, mut rx) = QueueAckHandle::for_test_with_position(position);
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         resolve_ack_from_dlq_outcome(ack, DlqRouteOutcome::Recovered, &metrics);
         assert_eq!(rx.recv().await, Some((position, AckDisposition::Recovered)));
         assert_eq!(metrics.events_failed.load(Ordering::Relaxed), 1);
@@ -1591,7 +1582,7 @@ mod resolve_ack_from_dlq_outcome_tests {
     #[tokio::test]
     async fn dropped_outcome_resolves_recovered_on_memory() {
         let (ack, mut rx) = QueueAckHandle::for_test();
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         resolve_ack_from_dlq_outcome(ack, DlqRouteOutcome::Dropped, &metrics);
         assert_eq!(
             rx.recv().await,
@@ -1615,7 +1606,7 @@ mod resolve_ack_from_dlq_outcome_tests {
             offset: 4242,
         };
         let (ack, mut rx) = QueueAckHandle::for_test_with_position(position);
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         resolve_ack_from_dlq_outcome(ack, DlqRouteOutcome::Dropped, &metrics);
         assert_eq!(rx.recv().await, Some((position, AckDisposition::Dropped)));
         assert_eq!(metrics.events_failed.load(Ordering::Relaxed), 0);

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -615,9 +615,9 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
         let rejected = outcome.rejected.min(count);
         let written = count - rejected;
         if written > 0 {
-            self.metrics
-                .events_written
-                .fetch_add(written, Ordering::Relaxed);
+            for _ in 0..written {
+                self.metrics.events_written.inc();
+            }
         }
         let split = (count - rejected) as usize;
         let mut iter = shippable.into_iter();
@@ -727,7 +727,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                 }
                 Some(Err(e)) => {
                     attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
                         break e;
                     }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -20,7 +20,6 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
 use tokio::fs::OpenOptions;
@@ -178,7 +177,7 @@ impl Module for FileOutput {
             retry,
             error_log,
             error_log_fallback: ctx.error_log_fallback,
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::register(&ctx.metrics, name)?,
             shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
@@ -261,7 +260,7 @@ impl Output for FileOutput {
                 }
                 Err(e) => {
                     attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
@@ -601,7 +600,7 @@ impl FileOutput {
         // than the event count claims. The syscall is cheap and turns
         // "write returned Ok" into an OS-visible commitment.
         file.flush().await?;
-        self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+        self.metrics.events_written.inc();
 
         Ok(())
     }
@@ -1229,7 +1228,7 @@ mod tests {
             retry: RetryConfig::default(),
             error_log: None,
             error_log_fallback: crate::error_log::ErrorLogFallback::default(),
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::for_testing(),
             shutdown_signal: crate::modules::BuildContext::for_testing().shutdown_signal,
         }
     }
@@ -2195,7 +2194,7 @@ mod tests {
             },
             error_log: None,
             error_log_fallback: crate::error_log::ErrorLogFallback::default(),
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::for_testing(),
             shutdown_signal: shutdown_rx,
         };
 

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -403,7 +403,7 @@ impl Module for HttpOutput {
         let rotation = RotatingPeers::new(peers.len());
 
         let retry = RetryConfig::from_output_properties(properties)?;
-        let metrics = Arc::new(OutputMetrics::default());
+        let metrics = OutputMetrics::register(&ctx.metrics, name)?;
         let policy = HttpSinkPolicy {
             peers,
             rotation,

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -30,7 +30,6 @@
 //! own them.
 
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -446,7 +445,7 @@ impl Module for KafkaOutput {
             retry,
             error_log,
             error_log_fallback: ctx.error_log_fallback,
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::register(&ctx.metrics, name)?,
             shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
@@ -499,7 +498,7 @@ impl Output for KafkaOutput {
             // or by the runtime SIGTERM budget.
             match self.try_send(event, shutdown.clone()).await {
                 Ok(KafkaTrySendOutcome::Delivered) => {
-                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
                 }
@@ -523,7 +522,7 @@ impl Output for KafkaOutput {
                 }
                 Err(e) => {
                     attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
@@ -1230,7 +1229,7 @@ mod tests {
             retry: RetryConfig::default(),
             error_log: None,
             error_log_fallback: crate::error_log::ErrorLogFallback::default(),
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::for_testing(),
             shutdown_signal: rx.clone(),
         };
         let event = Event::new(

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -288,7 +288,7 @@ impl Module for OtlpGrpcOutput {
 
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
-        let metrics = Arc::new(OutputMetrics::default());
+        let metrics = OutputMetrics::register(&ctx.metrics, name)?;
         let policy = OtlpGrpcSinkPolicy {
             peers,
             rotation,

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -406,7 +406,7 @@ impl Module for OtlpHttpOutput {
 
         let retry_config = RetryConfig::from_output_properties(properties)?;
 
-        let metrics = Arc::new(OutputMetrics::default());
+        let metrics = OutputMetrics::register(&ctx.metrics, name)?;
         let policy = OtlpHttpSinkPolicy {
             peers,
             rotation,

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -1,7 +1,6 @@
 //! Stdout output: prints event messages to standard output (debugging/testing).
 
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
 
@@ -43,7 +42,7 @@ impl Module for StdoutOutput {
             retry,
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             error_log_fallback: ctx.error_log_fallback,
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::register(&ctx.metrics, name)?,
             shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
@@ -98,13 +97,13 @@ impl Output for StdoutOutput {
         loop {
             match self.write_event(event) {
                 Ok(()) => {
-                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
                 }
                 Err(e) => {
                     attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
@@ -189,5 +188,59 @@ impl Output for StdoutOutput {
         )
         .await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod metrics_registration_tests {
+    use super::*;
+    use crate::dsl::module_props::ModuleProperties;
+    use crate::metrics::{MetricsError, OutputMetrics, Registry};
+
+    fn assert_output_duplicate(error: &MetricsError, label_value: &str, diagnostic: &str) {
+        let (name, labelset) = match error {
+            MetricsError::DuplicateSeries { name, labelset } => (name, labelset),
+            other => panic!("expected DuplicateSeries, got {other:?}"),
+        };
+        assert!(
+            [
+                "limpid_output_events_received_total",
+                "limpid_output_events_injected_total",
+                "limpid_output_events_written_total",
+                "limpid_output_events_failed_total",
+                "limpid_output_retries_total",
+                "limpid_output_events_wedged_total",
+                "limpid_output_events_errored_unwritable_total",
+            ]
+            .contains(&name.as_str())
+        );
+        assert_eq!(labelset, &[("output".to_owned(), label_value.to_owned())]);
+        assert!(diagnostic.contains(&format!("name={name:?}")));
+        assert!(diagnostic.contains(&format!("labelset={labelset:?}")));
+    }
+
+    #[test]
+    fn factory_uses_the_shared_registry_and_propagates_registration_conflicts() {
+        let registry = Arc::new(Registry::new());
+        OutputMetrics::register(&registry, "conflicting")
+            .expect("preseeded output metrics must register");
+        let mut ctx = crate::modules::BuildContext::for_testing();
+        ctx.metrics = Arc::clone(&registry);
+        let properties = ModuleProperties::from_parts("stdout", Vec::new());
+
+        let error = match StdoutOutput::from_properties("conflicting", &properties, &ctx) {
+            Ok(_) => panic!("factory unexpectedly swallowed the registration conflict"),
+            Err(error) => error,
+        };
+        let diagnostic = format!("{error:#}");
+        let metrics_error = error
+            .chain()
+            .find_map(|source| source.downcast_ref::<MetricsError>())
+            .unwrap_or_else(|| {
+                panic!(
+                    "MetricsError must remain downcastable in the anyhow source chain: {error:#}"
+                )
+            });
+        assert_output_duplicate(metrics_error, "conflicting", &diagnostic);
     }
 }

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::task::{Context as TaskContext, Poll};
 use std::time::Instant;
 
@@ -222,7 +221,7 @@ impl Module for SyslogTcpOutput {
             retry,
             error_log,
             error_log_fallback: ctx.error_log_fallback,
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::register(&ctx.metrics, name)?,
             shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
@@ -386,13 +385,13 @@ impl Output for SyslogTcpOutput {
             };
             match write_result {
                 Ok(()) => {
-                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
                 }
                 Err(e) => {
                     attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -1,6 +1,7 @@
 //! Syslog UDP output: sends event messages to remote syslog UDP endpoints.
 
 use std::sync::Arc;
+#[cfg(test)]
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
@@ -91,7 +92,7 @@ impl Module for SyslogUdpOutput {
             retry,
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             error_log_fallback: ctx.error_log_fallback,
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::register(&ctx.metrics, name)?,
             shutdown_signal: ctx.shutdown_signal.clone(),
         })
     }
@@ -163,13 +164,13 @@ impl Output for SyslogUdpOutput {
                     // "one bump" contract. Sibling `syslog_tcp` uses the
                     // identical shape (see the comment at the analogous
                     // `write_payload_shutdown_aware` return site).
-                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
                 }
                 Err(e) => {
                     attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+#[cfg(test)]
 use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result};
@@ -131,7 +132,7 @@ impl Module for UnixSocketOutput {
             retry,
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             error_log_fallback: ctx.error_log_fallback,
-            metrics: Arc::new(OutputMetrics::default()),
+            metrics: OutputMetrics::register(&ctx.metrics, name)?,
             shutdown_signal: ctx.shutdown_signal.clone(),
             allowed_peer_uids,
         })
@@ -195,13 +196,13 @@ impl Output for UnixSocketOutput {
                     // success bump) does not double-count against the
                     // transport helper. Sibling syslog_udp uses the
                     // identical shape after the previous fix.
-                    self.metrics.events_written.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
                 }
                 Err(e) => {
                     attempt += 1;
-                    self.metrics.retries.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -277,8 +277,7 @@ impl QueueSender {
         };
         if let Some(m) = &self.metrics {
             if result.is_ok() {
-                m.events_received
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                m.events_received.inc();
             } else {
                 // Enqueue failure: memory-queue receiver dropped (=
                 // consumer task gone, daemon usually shutting down),
@@ -290,8 +289,7 @@ impl QueueSender {
                 // metrics; the pipeline-side caller additionally
                 // routes the lost event through the dead-letter
                 // path.
-                m.events_failed
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                m.events_failed.inc();
             }
         }
         result
@@ -1338,7 +1336,6 @@ fn handle_ack_disposition(
     name: &str,
     metrics: &crate::metrics::OutputMetrics,
 ) {
-    use std::sync::atomic::Ordering;
     match disposition {
         AckDisposition::Delivered => {
             // The output bumped `events_written` itself on the success
@@ -1389,7 +1386,7 @@ fn handle_ack_disposition(
                  panic logs)",
                 name
             );
-            metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+            metrics.events_failed.inc();
         }
     }
 }
@@ -1419,12 +1416,11 @@ fn record_wedge_transition_if_first(
     name: &str,
     metrics: &crate::metrics::OutputMetrics,
 ) {
-    use std::sync::atomic::Ordering;
     let is_disk_position = matches!(position, AckPosition::Disk { .. });
     let is_dropped_on_disk = matches!(disposition, AckDisposition::Dropped) && is_disk_position;
     if is_dropped_on_disk && !*wedged {
         *wedged = true;
-        metrics.events_wedged.fetch_add(1, Ordering::Relaxed);
+        metrics.events_wedged.inc();
         tracing::error!(
             "output '{}': disk queue wedged after AckDisposition::Dropped at position {:?} — \
              the consumer will drain in-flight events and stop accepting new ones. Fix the \
@@ -1450,7 +1446,7 @@ mod wedge_transition_helper_tests {
     #[test]
     fn first_dropped_on_disk_sets_wedge_and_bumps() {
         let mut wedged = false;
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         record_wedge_transition_if_first(
             disk_pos(1),
             AckDisposition::Dropped,
@@ -1465,7 +1461,7 @@ mod wedge_transition_helper_tests {
     #[test]
     fn subsequent_dropped_on_disk_is_idempotent() {
         let mut wedged = true;
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         record_wedge_transition_if_first(
             disk_pos(2),
             AckDisposition::Dropped,
@@ -1480,7 +1476,7 @@ mod wedge_transition_helper_tests {
     #[test]
     fn dropped_on_memory_is_noop() {
         let mut wedged = false;
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         record_wedge_transition_if_first(
             AckPosition::Memory,
             AckDisposition::Dropped,
@@ -1495,7 +1491,7 @@ mod wedge_transition_helper_tests {
     #[test]
     fn recovered_on_disk_is_noop() {
         let mut wedged = false;
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         record_wedge_transition_if_first(
             disk_pos(3),
             AckDisposition::Recovered,
@@ -1510,7 +1506,7 @@ mod wedge_transition_helper_tests {
     #[test]
     fn delivered_on_disk_is_noop() {
         let mut wedged = false;
-        let metrics = OutputMetrics::default();
+        let metrics = OutputMetrics::for_testing();
         record_wedge_transition_if_first(
             disk_pos(4),
             AckDisposition::Delivered,
@@ -1565,7 +1561,7 @@ mod consumer_lifecycle_tests {
             Self {
                 script: Mutex::new(script),
                 calls: std::sync::atomic::AtomicUsize::new(0),
-                metrics: Arc::new(crate::metrics::OutputMetrics::default()),
+                metrics: crate::metrics::OutputMetrics::for_testing(),
             }
         }
         fn calls(&self) -> usize {
@@ -1743,7 +1739,7 @@ mod consumer_lifecycle_tests {
             Outcome::Delivered,
             Outcome::Delivered,
         ]));
-        let metrics = Arc::new(crate::metrics::OutputMetrics::default());
+        let metrics = crate::metrics::OutputMetrics::for_testing();
         let (sender, shutdown, handle) =
             spawn_consumer(writer.clone() as Arc<dyn Output>, Arc::clone(&metrics)).await;
         for _ in 0..3 {
@@ -1770,7 +1766,7 @@ mod consumer_lifecycle_tests {
             return;
         }
         let writer = Arc::new(ScriptedWriter::new(vec![Outcome::Bug]));
-        let metrics = Arc::new(crate::metrics::OutputMetrics::default());
+        let metrics = crate::metrics::OutputMetrics::for_testing();
         let (sender, shutdown, handle) =
             spawn_consumer(writer.clone() as Arc<dyn Output>, Arc::clone(&metrics)).await;
         sender.send(owned_event()).await.unwrap();
@@ -1814,7 +1810,7 @@ mod consumer_lifecycle_tests {
                 shutdown_mode: mode,
                 shutdown_called: std::sync::atomic::AtomicBool::new(false),
                 consume_calls: std::sync::atomic::AtomicUsize::new(0),
-                metrics: Arc::new(crate::metrics::OutputMetrics::default()),
+                metrics: crate::metrics::OutputMetrics::for_testing(),
             }
         }
     }
@@ -1864,7 +1860,7 @@ mod consumer_lifecycle_tests {
                         // Mirror the real shutdown DLQ recovery path:
                         // failed final flush → resolve Recovered after
                         // routing each event to error_log.
-                        self.metrics.events_failed.fetch_add(1, Ordering::Relaxed);
+                        self.metrics.events_failed.inc();
                         ack.resolve_recovered();
                     }
                 }
@@ -1884,7 +1880,7 @@ mod consumer_lifecycle_tests {
     #[tokio::test]
     async fn shutdown_drains_batched_buffer_before_consumer_exits() {
         let writer = Arc::new(BatchedMockWriter::new(ShutdownMode::DeliverAll));
-        let metrics = Arc::new(crate::metrics::OutputMetrics::default());
+        let metrics = crate::metrics::OutputMetrics::for_testing();
         let (sender, shutdown, handle) =
             spawn_consumer(writer.clone() as Arc<dyn Output>, Arc::clone(&metrics)).await;
         for _ in 0..5 {
@@ -1922,7 +1918,7 @@ mod consumer_lifecycle_tests {
     #[tokio::test]
     async fn shutdown_routes_failed_batch_to_dlq() {
         let writer = Arc::new(BatchedMockWriter::new(ShutdownMode::FailAll));
-        let metrics = Arc::new(crate::metrics::OutputMetrics::default());
+        let metrics = crate::metrics::OutputMetrics::for_testing();
         let (sender, shutdown, handle) =
             spawn_consumer(writer.clone() as Arc<dyn Output>, Arc::clone(&metrics)).await;
         for _ in 0..3 {
@@ -2317,7 +2313,7 @@ mod consumer_lifecycle_tests {
             send_calls: AtomicUsize::new(0),
             shutdown_called: AtomicBool::new(false),
             shutdown_wedged_called: AtomicBool::new(false),
-            metrics: Arc::new(crate::metrics::OutputMetrics::default()),
+            metrics: crate::metrics::OutputMetrics::for_testing(),
         });
         let metrics = Arc::clone(&writer.metrics);
         let (sender, shutdown_tx, handle) = spawn_consumer_with_queue(

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -2,7 +2,7 @@
 //! into a running system.
 //!
 //! Runtime does NOT count metrics — each component counts its own.
-//! Runtime only collects metrics handles into MetricsRegistry for stats.
+//! Runtime distributes one shared metrics registry to every component.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -17,7 +17,7 @@ use crate::dsl::ast::*;
 use crate::dsl::props;
 use crate::event::Event;
 use crate::functions::FunctionRegistry;
-use crate::metrics::{MetricsRegistry, PipelineMetrics};
+use crate::metrics::{PipelineMetrics, Registry};
 use crate::modules::{self, HasMetrics, ModuleRegistry};
 use crate::pipeline::CompiledConfig;
 use crate::queue::{self, QueueConfig, QueueSender};
@@ -32,6 +32,14 @@ pub struct Runtime {
 
 impl Runtime {
     pub async fn start(config: CompiledConfig, config_file: PathBuf) -> Result<Self> {
+        Self::start_with_registry(config, config_file, Arc::new(Registry::new())).await
+    }
+
+    pub(crate) async fn start_with_registry(
+        config: CompiledConfig,
+        config_file: PathBuf,
+        metrics_registry: Arc<Registry>,
+    ) -> Result<Self> {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
@@ -50,7 +58,6 @@ impl Runtime {
         config.validate()?;
         let registry = Arc::new(registry);
 
-        let mut metrics_registry = MetricsRegistry::new();
         let tap = TapRegistry::new();
 
         // Optional dead-letter queue for events that fail in `process`
@@ -116,6 +123,7 @@ impl Runtime {
         // land as new fields on this struct rather than as new parameters.
         let build_ctx = crate::modules::BuildContext {
             funcs: Arc::clone(&func_registry),
+            metrics: Arc::clone(&metrics_registry),
             error_log: error_log.as_ref().map(Arc::clone),
             error_log_fallback,
             shutdown_signal: shutdown_rx.clone(),
@@ -168,9 +176,7 @@ impl Runtime {
             sender.attach_metrics(Arc::clone(&created.metrics));
             output_senders.insert(name.clone(), sender);
 
-            // Collect metrics handle (output owns the data, we just hold a reference)
             let output_metrics = Arc::clone(&created.metrics);
-            metrics_registry.register_output(name, created.metrics);
             tap.register(&format!("output {}", name)).await;
 
             output_receivers.push((name.clone(), receiver, created.output, output_metrics));
@@ -207,8 +213,10 @@ impl Runtime {
         let mut input_pipelines: HashMap<String, Vec<Arc<PipelineWorker>>> = HashMap::new();
 
         for pipeline_def in config.pipelines.values() {
-            let worker = Arc::new(PipelineWorker::new(pipeline_def.clone()));
-            metrics_registry.register_pipeline(&pipeline_def.name, worker.metrics());
+            let worker = Arc::new(PipelineWorker::new(
+                pipeline_def.clone(),
+                &metrics_registry,
+            )?);
             let input_names = get_pipeline_inputs(pipeline_def);
             for input_name in input_names {
                 input_pipelines
@@ -297,12 +305,10 @@ impl Runtime {
                 input_name.clone(),
                 (sender_for_inject, Arc::clone(&created.metrics)),
             );
-            metrics_registry.register_input(&input_name, created.metrics);
             handles.push(created.handle);
         }
 
         // --- 4. Start control socket (after all metrics are registered) ---
-        let metrics_registry = Arc::new(metrics_registry);
         let control_path = config
             .global_blocks
             .get("control")
@@ -485,11 +491,9 @@ struct PipelineWorker {
 }
 
 impl PipelineWorker {
-    fn new(def: PipelineDef) -> Self {
-        Self {
-            def,
-            metrics: Arc::new(PipelineMetrics::default()),
-        }
+    fn new(def: PipelineDef, registry: &Registry) -> Result<Self, crate::metrics::MetricsError> {
+        let metrics = PipelineMetrics::register(registry, &def.name)?;
+        Ok(Self { def, metrics })
     }
 }
 
@@ -696,10 +700,7 @@ async fn process_event(
 ) {
     ctx.tap.emit(input_tap_key, event).await;
     for (i, worker) in workers.iter().enumerate() {
-        worker
-            .metrics
-            .events_received
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        worker.metrics.events_received.inc();
 
         // Pass the event by reference. `run_pipeline` views it into
         // the arena (read-only on the input owned form) and any DLQ
@@ -719,16 +720,10 @@ async fn process_event(
                 use crate::pipeline::PipelineTermination;
                 match result.termination {
                     PipelineTermination::Dropped => {
-                        worker
-                            .metrics
-                            .events_dropped
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        worker.metrics.events_dropped.inc();
                     }
                     PipelineTermination::Errored => {
-                        worker
-                            .metrics
-                            .events_errored
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        worker.metrics.events_errored.inc();
                         // Drain every accumulated DLQ record. For a
                         // pipeline-side failure this is exactly one
                         // record; for a runtime-side per-failed-output
@@ -755,15 +750,9 @@ async fn process_event(
                     }
                     PipelineTermination::Finished => {
                         if !result.had_outputs {
-                            worker
-                                .metrics
-                                .events_discarded
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            worker.metrics.events_discarded.inc();
                         } else {
-                            worker
-                                .metrics
-                                .events_finished
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            worker.metrics.events_finished.inc();
                         }
                     }
                 }
@@ -781,10 +770,7 @@ async fn process_event(
                 // `PipelineTermination::Errored` so the metric +
                 // file record stay consistent across both shapes
                 // of runtime error.
-                worker
-                    .metrics
-                    .events_errored
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                worker.metrics.events_errored.inc();
                 let owned = event.to_owned();
                 let err_ctx = crate::pipeline::ErroredEventContext::Process {
                     timestamp: chrono::Utc::now(),
@@ -830,9 +816,7 @@ async fn write_errored_to_dlq(
     match error_log {
         Some(writer) => {
             if let Err(e) = writer.write(err_ctx).await {
-                worker_metrics
-                    .events_errored_unwritable
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                worker_metrics.events_errored_unwritable.inc();
                 crate::modules::emit_dlq_tracing_fallback(
                     /* error_log_configured */ true,
                     error_log_fallback,
@@ -876,11 +860,34 @@ mod tests {
     use super::*;
     use crate::dsl::parser::parse_config;
     use crate::event::Event;
+    use crate::metrics::{MetricsError, OutputMetrics, Registry};
     use bytes::Bytes;
     use std::net::SocketAddr;
     use std::str::FromStr;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
+
+    fn assert_output_duplicate(error: &MetricsError, label_value: &str, diagnostic: &str) {
+        let (name, labelset) = match error {
+            MetricsError::DuplicateSeries { name, labelset } => (name, labelset),
+            other => panic!("expected DuplicateSeries, got {other:?}"),
+        };
+        assert!(
+            [
+                "limpid_output_events_received_total",
+                "limpid_output_events_injected_total",
+                "limpid_output_events_written_total",
+                "limpid_output_events_failed_total",
+                "limpid_output_retries_total",
+                "limpid_output_events_wedged_total",
+                "limpid_output_events_errored_unwritable_total",
+            ]
+            .contains(&name.as_str())
+        );
+        assert_eq!(labelset, &[("output".to_owned(), label_value.to_owned())]);
+        assert!(diagnostic.contains(&format!("name={name:?}")));
+        assert!(diagnostic.contains(&format!("labelset={labelset:?}")));
+    }
 
     fn pipeline_def(src: &str) -> PipelineDef {
         let cfg = parse_config(src).unwrap();
@@ -890,6 +897,56 @@ mod tests {
             }
         }
         panic!("no pipeline in src");
+    }
+
+    #[tokio::test]
+    async fn startup_preserves_metric_registration_errors_from_real_factories() {
+        let config = CompiledConfig::from_config(
+            parse_config("def output conflicting { type stdout }").expect("parse"),
+        )
+        .expect("compile");
+        let registry = Arc::new(Registry::new());
+        OutputMetrics::register(&registry, "conflicting")
+            .expect("preseeded output metrics must register");
+
+        let error = match Runtime::start_with_registry(
+            config,
+            PathBuf::from("metrics-conflict-test.limpid"),
+            registry,
+        )
+        .await
+        {
+            Ok(_) => panic!("daemon startup unexpectedly swallowed the registration conflict"),
+            Err(error) => error,
+        };
+        let diagnostic = format!("{error:#}");
+        let metrics_error = error
+            .chain()
+            .find_map(|source| source.downcast_ref::<MetricsError>())
+            .unwrap_or_else(|| {
+                panic!(
+                    "MetricsError must remain downcastable in the startup error chain: {error:#}"
+                )
+            });
+        assert_output_duplicate(metrics_error, "conflicting", &diagnostic);
+    }
+
+    #[tokio::test]
+    async fn public_start_delegates_to_the_registry_wired_startup_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
+            .expect("secure control parent");
+        let socket = dir.path().join("control.sock");
+        let source = format!("control {{ socket {:?} }}", socket.display().to_string());
+        let config =
+            CompiledConfig::from_config(parse_config(&source).expect("parse")).expect("compile");
+
+        let runtime = Runtime::start(config, PathBuf::from("public-start-test.limpid"))
+            .await
+            .expect("public start must use the working registry-wired startup path");
+        runtime.shutdown().await;
     }
 
     #[test]
@@ -924,7 +981,10 @@ mod tests {
         // Minimal pipeline with a single `drop` step; the body doesn't matter
         // for this test — we only care that events flow through the worker.
         let def = pipeline_def("def pipeline p { input a, b; drop }");
-        let worker = Arc::new(PipelineWorker::new(def));
+        let metrics_registry = Registry::new();
+        let worker = Arc::new(
+            PipelineWorker::new(def, &metrics_registry).expect("pipeline metrics must register"),
+        );
         let workers: Arc<Vec<Arc<PipelineWorker>>> = Arc::new(vec![Arc::clone(&worker)]);
 
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -1017,7 +1077,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("dlq.jsonl");
         let writer = Arc::new(crate::error_log::ErrorLogWriter::new(log_path.clone()));
-        let metrics = PipelineMetrics::default();
+        let metrics = PipelineMetrics::for_testing();
         let err_ctx = make_err_ctx("simulated runtime error");
 
         write_errored_to_dlq(
@@ -1057,7 +1117,7 @@ mod tests {
         // line is observed via `tracing` subscribers in operator
         // setups; the test here pins the no-panic contract so the
         // logged-only branch can't regress to an unwrap somewhere.
-        let metrics = PipelineMetrics::default();
+        let metrics = PipelineMetrics::for_testing();
         let err_ctx = make_err_ctx("no DLQ configured");
 
         write_errored_to_dlq(


### PR DESCRIPTION
## Summary
- distribute one shared self-describing metrics registry through runtime and module construction
- register the existing input, pipeline, and output counter bundles with fixed labels
- serve schema-v1 snapshots from the existing `stats` command and remove the legacy collector path

## Validation
- `cargo test --workspace`
- `cargo test --workspace --features kafka`
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy --workspace --features kafka -- -D warnings`
- `cargo deny check advisories bans sources licenses`
- Ubuntu aarch64: `cargo test --workspace --all-targets --all-features`
- canonical A-D benchmarks: all integrity counters exact; candidate/baseline median ratios 116.624%, 96.695%, 100.931%, 98.901%

## Rollout
This is the daemon-wiring step of the v0.8.0 metrics rollout. The follow-up limpidctl, Prometheus translation, and documentation/benchmark steps must land before v0.8.0 is released.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics are now collected through a shared registry across inputs, pipelines, outputs, queues, and runtime components.
  * Control-socket statistics now return structured JSON with metric types, labels, and values.
  * Duplicate metric-series conflicts are reported during component and runtime setup.

* **Bug Fixes**
  * Improved consistency and accuracy of event, delivery, retry, failure, and injection counters across supported modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->