### PR TITLE
feat(limpidctl): render schema-v1 stats

### DIFF
--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -12,6 +12,8 @@
 //!
 //! Connects to limpid's control socket (default: /var/run/limpid/control.sock).
 
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
@@ -49,8 +51,11 @@ enum Command {
     /// Show pipeline/input/output metrics
     Stats {
         /// Output raw JSON instead of formatted text
-        #[arg(long)]
+        #[arg(long, conflicts_with = "details")]
         json: bool,
+        /// Show every metric family and series with complete labels
+        #[arg(long, conflicts_with = "json")]
+        details: bool,
     },
     /// Check daemon health
     Health {
@@ -216,11 +221,13 @@ fn main() {
                 format_list(&response);
             }
         }
-        Command::Stats { json } => {
+        Command::Stats { json, details } => {
             let response = query_command(&cli.socket, "stats");
             exit_on_daemon_error(&response);
             if json {
                 print!("{}", response);
+            } else if details {
+                format_stats_details(&response);
             } else {
                 format_stats(&response);
             }
@@ -444,126 +451,402 @@ fn format_duration(secs: u64) -> String {
     }
 }
 
+const PIPELINE_METRICS: [&str; 6] = [
+    "limpid_pipeline_events_received_total",
+    "limpid_pipeline_events_finished_total",
+    "limpid_pipeline_events_dropped_total",
+    "limpid_pipeline_events_discarded_total",
+    "limpid_pipeline_events_errored_total",
+    "limpid_pipeline_events_errored_unwritable_total",
+];
+const INPUT_METRICS: [&str; 3] = [
+    "limpid_input_events_received_total",
+    "limpid_input_events_invalid_total",
+    "limpid_input_events_injected_total",
+];
+const OUTPUT_METRICS: [&str; 7] = [
+    "limpid_output_events_received_total",
+    "limpid_output_events_injected_total",
+    "limpid_output_events_written_total",
+    "limpid_output_events_failed_total",
+    "limpid_output_retries_total",
+    "limpid_output_events_wedged_total",
+    "limpid_output_events_errored_unwritable_total",
+];
+
+type MetricValues = BTreeMap<String, u64>;
+
 fn format_stats(json: &str) {
-    let v: serde_json::Value = match serde_json::from_str(json) {
-        Ok(v) => v,
-        Err(_) => {
-            print!("{}", json);
-            return;
+    match render_default_stats(json) {
+        Some(rendered) => print!("{}", rendered),
+        None => print!("{}", json),
+    }
+}
+
+/// Renders the operator table (Pipelines, Inputs, Outputs) from a
+/// schema v1 snapshot. Families outside the canonical 16 are
+/// skipped here so the layout stays operator-runbook-shaped —
+/// well-formed non-canonical families render under `--details`,
+/// malformed ones trigger the raw fallback there too. A canonical
+/// family that fails validation returns `None`, so the caller falls
+/// back to the raw response rather than emit a partial table that
+/// omits or lies about a counter.
+fn render_default_stats(json: &str) -> Option<String> {
+    let snapshot: serde_json::Value = serde_json::from_str(json).ok()?;
+    if snapshot.get("schema")?.as_u64()? != 1 {
+        return None;
+    }
+    let metrics = snapshot.get("metrics")?.as_array()?;
+    let mut families = BTreeMap::<String, MetricValues>::new();
+
+    for metric in metrics {
+        let metric = metric.as_object()?;
+        let name = metric.get("name")?.as_str()?;
+        let Some(label_name) = known_metric_label(name) else {
+            continue;
+        };
+        if metric.get("type")?.as_str()? != "counter" || families.contains_key(name) {
+            return None;
         }
+        let series = metric.get("series")?.as_array()?;
+        if series.is_empty() {
+            return None;
+        }
+        let mut values = MetricValues::new();
+        for item in series {
+            let item = item.as_object()?;
+            let labels = item.get("labels")?.as_object()?;
+            if labels.len() != 1 {
+                return None;
+            }
+            let scope = labels.get(label_name)?.as_str()?;
+            let value = item.get("value")?.as_u64()?;
+            if values.insert(scope.to_owned(), value).is_some() {
+                return None;
+            }
+        }
+        families.insert(name.to_owned(), values);
+    }
+
+    validate_metric_group(&families, &PIPELINE_METRICS)?;
+    validate_metric_group(&families, &INPUT_METRICS)?;
+    validate_metric_group(&families, &OUTPUT_METRICS)?;
+
+    let mut rendered = String::new();
+    writeln!(rendered, "Pipelines:").ok()?;
+    for name in families.get(PIPELINE_METRICS[0])?.keys() {
+        let received = metric_value(&families, PIPELINE_METRICS[0], name)?;
+        let finished = metric_value(&families, PIPELINE_METRICS[1], name)?;
+        let dropped = metric_value(&families, PIPELINE_METRICS[2], name)?;
+        let discarded = metric_value(&families, PIPELINE_METRICS[3], name)?;
+        let errored = metric_value(&families, PIPELINE_METRICS[4], name)?;
+        let unwritable = metric_value(&families, PIPELINE_METRICS[5], name)?;
+        // Both errored and errored_unwritable zero → compact row
+        // (steady state). Either non-zero → the errored column is
+        // shown (its value may be 0); the errored_unwritable column
+        // is appended only when it is itself non-zero.
+        if errored == 0 && unwritable == 0 {
+            writeln!(
+                rendered,
+                "  {:<24} {:>8} received  {:>8} finished  {:>8} dropped  {:>8} discarded",
+                name, received, finished, dropped, discarded
+            )
+            .ok()?;
+        } else {
+            write!(
+                rendered,
+                "  {:<24} {:>8} received  {:>8} finished  {:>8} dropped  {:>8} discarded  {:>8} errored",
+                name, received, finished, dropped, discarded, errored
+            )
+            .ok()?;
+            if unwritable > 0 {
+                write!(rendered, "  {:>8} errored_unwritable", unwritable).ok()?;
+            }
+            rendered.push('\n');
+        }
+    }
+
+    writeln!(rendered, "\nInputs:").ok()?;
+    for name in families.get(INPUT_METRICS[0])?.keys() {
+        writeln!(
+            rendered,
+            "  {:<24} {:>8} received  {:>8} invalid  {:>8} injected",
+            name,
+            metric_value(&families, INPUT_METRICS[0], name)?,
+            metric_value(&families, INPUT_METRICS[1], name)?,
+            metric_value(&families, INPUT_METRICS[2], name)?,
+        )
+        .ok()?;
+    }
+
+    writeln!(rendered, "\nOutputs:").ok()?;
+    for name in families.get(OUTPUT_METRICS[0])?.keys() {
+        let received = metric_value(&families, OUTPUT_METRICS[0], name)?;
+        let injected = metric_value(&families, OUTPUT_METRICS[1], name)?;
+        let written = metric_value(&families, OUTPUT_METRICS[2], name)?;
+        let failed = metric_value(&families, OUTPUT_METRICS[3], name)?;
+        let retries = metric_value(&families, OUTPUT_METRICS[4], name)?;
+        let wedged = metric_value(&families, OUTPUT_METRICS[5], name)?;
+        let unwritable = metric_value(&families, OUTPUT_METRICS[6], name)?;
+        write!(
+            rendered,
+            "  {:<24} {:>8} received  {:>8} injected  {:>8} written  {:>8} failed  {:>8} retries",
+            name, received, injected, written, failed, retries
+        )
+        .ok()?;
+        // Alarm columns (`wedged`, `errored_unwritable`) print only
+        // when non-zero — same rationale as the pipeline row above.
+        if wedged > 0 {
+            write!(rendered, "  {:>8} wedged", wedged).ok()?;
+        }
+        if unwritable > 0 {
+            write!(rendered, "  {:>8} errored_unwritable", unwritable).ok()?;
+        }
+        rendered.push('\n');
+    }
+    Some(rendered)
+}
+
+fn known_metric_label(name: &str) -> Option<&'static str> {
+    if PIPELINE_METRICS.contains(&name) {
+        Some("pipeline")
+    } else if INPUT_METRICS.contains(&name) {
+        Some("input")
+    } else if OUTPUT_METRICS.contains(&name) {
+        Some("output")
+    } else {
+        None
+    }
+}
+
+fn validate_metric_group(families: &BTreeMap<String, MetricValues>, names: &[&str]) -> Option<()> {
+    let expected = families.get(*names.first()?)?;
+    for name in names {
+        let values = families.get(*name)?;
+        if !values.keys().eq(expected.keys()) {
+            return None;
+        }
+    }
+    Some(())
+}
+
+fn metric_value(
+    families: &BTreeMap<String, MetricValues>,
+    metric: &str,
+    scope: &str,
+) -> Option<u64> {
+    families.get(metric)?.get(scope).copied()
+}
+
+struct DetailMetric {
+    name: String,
+    help: String,
+    kind: DetailKind,
+}
+
+enum DetailKind {
+    Counter(Vec<ValueDetail>),
+    Gauge(Vec<ValueDetail>),
+    Histogram(Vec<HistogramDetail>),
+}
+
+struct ValueDetail {
+    labels: Vec<(String, String)>,
+    value: u64,
+}
+
+struct HistogramDetail {
+    labels: Vec<(String, String)>,
+    buckets: Vec<(f64, u64)>,
+    sum: f64,
+    count: u64,
+}
+
+fn format_stats_details(json: &str) {
+    match render_stats_details(json) {
+        Some(rendered) => print!("{}", rendered),
+        None => print!("{}", json),
+    }
+}
+
+fn render_stats_details(json: &str) -> Option<String> {
+    let snapshot: serde_json::Value = serde_json::from_str(json).ok()?;
+    if snapshot.get("schema")?.as_u64()? != 1 {
+        return None;
+    }
+    let mut metrics: Vec<DetailMetric> = snapshot
+        .get("metrics")?
+        .as_array()?
+        .iter()
+        .map(parse_detail_metric)
+        .collect::<Option<_>>()?;
+    // If a canonical family is present but the canonical set
+    // fails default validation, `--details` also bails to the
+    // raw fallback so no partial human view of the canonical
+    // subset leaks. Well-formed non-canonical families are
+    // intentionally unaffected — the fallback scopes to the
+    // canonical subset only.
+    if metrics
+        .iter()
+        .any(|metric| known_metric_label(&metric.name).is_some())
+        && render_default_stats(json).is_none()
+    {
+        return None;
+    }
+    metrics.sort_by(|left, right| left.name.cmp(&right.name));
+    if metrics.windows(2).any(|pair| pair[0].name == pair[1].name) {
+        return None;
+    }
+
+    let mut rendered = String::new();
+    for metric in metrics {
+        writeln!(rendered, "{}:", metric.name).ok()?;
+        writeln!(rendered, "  type: {}", metric.kind.name()).ok()?;
+        writeln!(rendered, "  help: {}", metric.help).ok()?;
+        match metric.kind {
+            DetailKind::Counter(series) | DetailKind::Gauge(series) => {
+                for item in series {
+                    writeln!(rendered, "  labels: {}", format_labels(&item.labels)).ok()?;
+                    writeln!(rendered, "    value: {}", item.value).ok()?;
+                }
+            }
+            DetailKind::Histogram(series) => {
+                for item in series {
+                    writeln!(rendered, "  labels: {}", format_labels(&item.labels)).ok()?;
+                    write!(rendered, "    buckets:").ok()?;
+                    for (bound, count) in item.buckets {
+                        write!(rendered, " {} => {}", bound, count).ok()?;
+                    }
+                    rendered.push('\n');
+                    writeln!(rendered, "    sum: {}", item.sum).ok()?;
+                    writeln!(rendered, "    count: {}", item.count).ok()?;
+                }
+            }
+        }
+    }
+    Some(rendered)
+}
+
+impl DetailKind {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Counter(_) => "counter",
+            Self::Gauge(_) => "gauge",
+            Self::Histogram(_) => "histogram",
+        }
+    }
+}
+
+fn parse_detail_metric(value: &serde_json::Value) -> Option<DetailMetric> {
+    let metric = value.as_object()?;
+    let name = metric.get("name")?.as_str()?.to_owned();
+    let help = metric.get("help")?.as_str()?.to_owned();
+    let series = metric.get("series")?.as_array()?;
+    let kind = match metric.get("type")?.as_str()? {
+        "counter" => DetailKind::Counter(parse_value_details(series)?),
+        "gauge" => DetailKind::Gauge(parse_value_details(series)?),
+        "histogram" => DetailKind::Histogram(parse_histogram_details(series)?),
+        _ => return None,
     };
+    Some(DetailMetric { name, help, kind })
+}
 
-    let get = |m: &serde_json::Value, k: &str| m.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
-
-    // Pipelines first — the main concept.
-    if let Some(pipelines) = v.get("pipelines").and_then(|v| v.as_object()) {
-        let mut names: Vec<&String> = pipelines.keys().collect();
-        names.sort();
-        if !names.is_empty() {
-            println!("Pipelines:");
-            for name in &names {
-                let m = &pipelines[*name];
-                let errored = get(m, "events_errored");
-                let unwritable = get(m, "events_errored_unwritable");
-                // Default row keeps the human-eye scan compact. The
-                // errored / errored_unwritable columns only print when
-                // they're non-zero — they're alarm signals, not steady-
-                // state numbers, so a column of zeros across every
-                // pipeline would just be visual noise.
-                if errored == 0 && unwritable == 0 {
-                    println!(
-                        "  {:<24} {:>8} received  {:>8} finished  {:>8} dropped  {:>8} discarded",
-                        name,
-                        get(m, "events_received"),
-                        get(m, "events_finished"),
-                        get(m, "events_dropped"),
-                        get(m, "events_discarded"),
-                    );
-                } else {
-                    println!(
-                        "  {:<24} {:>8} received  {:>8} finished  {:>8} dropped  {:>8} discarded  {:>8} errored{}",
-                        name,
-                        get(m, "events_received"),
-                        get(m, "events_finished"),
-                        get(m, "events_dropped"),
-                        get(m, "events_discarded"),
-                        errored,
-                        if unwritable > 0 {
-                            format!("  {:>8} errored_unwritable", unwritable)
-                        } else {
-                            String::new()
-                        },
-                    );
-                }
-            }
-        }
+fn parse_value_details(series: &[serde_json::Value]) -> Option<Vec<ValueDetail>> {
+    let mut parsed: Vec<ValueDetail> = series
+        .iter()
+        .map(|value| {
+            let value = value.as_object()?;
+            Some(ValueDetail {
+                labels: parse_labels(value.get("labels")?)?,
+                value: value.get("value")?.as_u64()?,
+            })
+        })
+        .collect::<Option<_>>()?;
+    parsed.sort_by(|left, right| left.labels.cmp(&right.labels));
+    if parsed
+        .windows(2)
+        .any(|pair| pair[0].labels == pair[1].labels)
+    {
+        return None;
     }
+    Some(parsed)
+}
 
-    if let Some(inputs) = v.get("inputs").and_then(|v| v.as_object()) {
-        let mut names: Vec<&String> = inputs.keys().collect();
-        names.sort();
-        if !names.is_empty() {
-            println!("\nInputs:");
-            for name in &names {
-                let m = &inputs[*name];
-                println!(
-                    "  {:<24} {:>8} received  {:>8} invalid  {:>8} injected",
-                    name,
-                    get(m, "events_received"),
-                    get(m, "events_invalid"),
-                    get(m, "events_injected"),
-                );
+fn parse_histogram_details(series: &[serde_json::Value]) -> Option<Vec<HistogramDetail>> {
+    let mut parsed: Vec<HistogramDetail> = series
+        .iter()
+        .map(|value| {
+            let value = value.as_object()?;
+            let buckets = value
+                .get("buckets")?
+                .as_array()?
+                .iter()
+                .map(|bucket| {
+                    let bucket = bucket.as_array()?;
+                    if bucket.len() != 2 {
+                        return None;
+                    }
+                    let bound = bucket[0].as_f64()?;
+                    if !bound.is_finite() {
+                        return None;
+                    }
+                    Some((bound, bucket[1].as_u64()?))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            if buckets.windows(2).any(|pair| pair[0].0 >= pair[1].0) {
+                return None;
             }
-        }
+            if buckets.windows(2).any(|pair| pair[0].1 > pair[1].1) {
+                return None;
+            }
+            // Bucket counts and the total `count` are loaded from
+            // independent atomics in the daemon, so observe ordering
+            // permits a transient last-bucket count that exceeds the
+            // total — do not reject on that inequality.
+            let sum = value.get("sum")?.as_f64()?;
+            if !sum.is_finite() {
+                return None;
+            }
+            Some(HistogramDetail {
+                labels: parse_labels(value.get("labels")?)?,
+                buckets,
+                sum,
+                count: value.get("count")?.as_u64()?,
+            })
+        })
+        .collect::<Option<_>>()?;
+    parsed.sort_by(|left, right| left.labels.cmp(&right.labels));
+    if parsed
+        .windows(2)
+        .any(|pair| pair[0].labels == pair[1].labels)
+    {
+        return None;
     }
+    Some(parsed)
+}
 
-    if let Some(outputs) = v.get("outputs").and_then(|v| v.as_object()) {
-        let mut names: Vec<&String> = outputs.keys().collect();
-        names.sort();
-        if !names.is_empty() {
-            println!("\nOutputs:");
-            for name in &names {
-                let m = &outputs[*name];
-                let wedged = get(m, "events_wedged");
-                let unwritable = get(m, "events_errored_unwritable");
-                // Same shape as the pipelines row above: the alarm
-                // columns (`wedged`, `errored_unwritable`) only print
-                // when non-zero. Zero-across-all-outputs would just be
-                // visual noise on a steady-state row.
-                if wedged == 0 && unwritable == 0 {
-                    println!(
-                        "  {:<24} {:>8} received  {:>8} injected  {:>8} written  {:>8} failed  {:>8} retries",
-                        name,
-                        get(m, "events_received"),
-                        get(m, "events_injected"),
-                        get(m, "events_written"),
-                        get(m, "events_failed"),
-                        get(m, "retries"),
-                    );
-                } else {
-                    println!(
-                        "  {:<24} {:>8} received  {:>8} injected  {:>8} written  {:>8} failed  {:>8} retries{}{}",
-                        name,
-                        get(m, "events_received"),
-                        get(m, "events_injected"),
-                        get(m, "events_written"),
-                        get(m, "events_failed"),
-                        get(m, "retries"),
-                        if wedged > 0 {
-                            format!("  {:>8} wedged", wedged)
-                        } else {
-                            String::new()
-                        },
-                        if unwritable > 0 {
-                            format!("  {:>8} errored_unwritable", unwritable)
-                        } else {
-                            String::new()
-                        },
-                    );
-                }
-            }
-        }
+fn parse_labels(value: &serde_json::Value) -> Option<Vec<(String, String)>> {
+    let mut labels: Vec<(String, String)> = value
+        .as_object()?
+        .iter()
+        .map(|(key, value)| Some((key.clone(), value.as_str()?.to_owned())))
+        .collect::<Option<_>>()?;
+    labels.sort();
+    Some(labels)
+}
+
+fn format_labels(labels: &[(String, String)]) -> String {
+    if labels.is_empty() {
+        return "{}".to_owned();
     }
+    labels
+        .iter()
+        .map(|(key, value)| {
+            let quoted = serde_json::to_string(value).expect("strings always serialize");
+            format!("{}={}", key, quoted)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn format_list(json: &str) {

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -388,7 +388,7 @@ fn details_renders_all_types_with_deterministic_order_and_complete_fields() {
                 "type": "counter",
                 "help": "Accepted events.",
                 "series": [
-                    {"labels": {"a": "two", "z": "last"}, "value": 2},
+                    {"labels": {"a": "two", "z": "first"}, "value": 2},
                     {"labels": {"a": "one", "z": "last"}, "value": 1}
                 ]
             },
@@ -422,27 +422,29 @@ fn details_renders_all_types_with_deterministic_order_and_complete_fields() {
     assert!(counter_block.contains("counter"));
     assert!(counter_block.contains("Accepted events."));
     assert!(text.find("a=\"one\"").unwrap() < text.find("a=\"two\"").unwrap());
-    assert!(counter_block.contains("a=\"one\", z=\"last\""));
-    assert!(counter_block.contains("value"));
-    assert!(counter_block.contains('1'));
-    assert!(counter_block.contains('2'));
+    assert!(counter_block.contains(
+        r#"  labels: a="one", z="last"
+    value: 1
+"#
+    ));
+    assert!(counter_block.contains(
+        r#"  labels: a="two", z="first"
+    value: 2
+"#
+    ));
     assert!(gauge_block.contains("gauge"));
     assert!(gauge_block.contains("Current depth."));
-    assert!(gauge_block.contains(r#"env="prod\"east\\one\nline""#));
-    assert!(gauge_block.contains("value"));
-    assert!(gauge_block.contains('9'));
+    assert!(gauge_block.contains(
+        r#"  labels: env="prod\"east\\one\nline"
+    value: 9
+"#
+    ));
     assert!(histogram_block.contains("histogram"));
     assert!(histogram_block.contains("Latency distribution."));
     assert!(histogram_block.contains("route=\"west\""));
-    assert!(histogram_block.contains("buckets"));
-    assert!(histogram_block.contains("0.125"));
-    assert!(histogram_block.contains("17"));
-    assert!(histogram_block.contains("0.875"));
-    assert!(histogram_block.contains("29"));
-    assert!(histogram_block.contains("sum"));
-    assert!(histogram_block.contains("13.75"));
-    assert!(histogram_block.contains("count"));
-    assert!(histogram_block.contains("31"));
+    assert!(histogram_block.contains("    buckets: 0.125 => 17 0.875 => 29\n"));
+    assert!(histogram_block.contains("    sum: 13.75\n"));
+    assert!(histogram_block.contains("    count: 31\n"));
     assert!(!histogram_block.contains("+Inf"));
 }
 

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -1,0 +1,596 @@
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+static NEXT_SOCKET: AtomicU64 = AtomicU64::new(0);
+
+fn process_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn socket_path() -> (PathBuf, PathBuf) {
+    let id = NEXT_SOCKET.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("limpidctl-stats-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("control.sock");
+    (dir, socket)
+}
+
+fn run_stats(response: &str, args: &[&str]) -> Output {
+    let _process_guard = process_lock();
+    let (dir, socket) = socket_path();
+    let server_socket = socket.clone();
+    let response = response.to_owned();
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+    let (child_started_tx, child_started_rx) = mpsc::sync_channel(1);
+    let server = thread::spawn(move || {
+        let listener = match UnixListener::bind(&server_socket) {
+            Ok(listener) => listener,
+            Err(error) => {
+                let _ = ready_tx.send(Err(format!(
+                    "failed to bind control socket {server_socket:?}: {error}"
+                )));
+                return;
+            }
+        };
+        if let Err(error) = listener.set_nonblocking(true) {
+            let _ = ready_tx.send(Err(format!(
+                "failed to configure control socket {server_socket:?}: {error}"
+            )));
+            return;
+        }
+        ready_tx
+            .send(Ok(()))
+            .expect("stats test caller dropped before server readiness");
+        child_started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("limpidctl child was not started within 2 seconds of server readiness");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut stream = loop {
+            match listener.accept() {
+                Ok((stream, _)) => break Some(stream),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        break None;
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to accept control connection: {error}"),
+            }
+        };
+        let Some(ref mut stream) = stream else {
+            return;
+        };
+        let mut request = String::new();
+        BufReader::new(stream.try_clone().unwrap())
+            .read_line(&mut request)
+            .unwrap();
+        assert_eq!(request, "stats\n");
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+
+    match ready_rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            server.join().unwrap();
+            std::fs::remove_dir_all(dir).unwrap();
+            panic!("stats test server setup failed: {error}");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            server.join().unwrap();
+            std::fs::remove_dir_all(dir).unwrap();
+            panic!("stats test server did not become ready within 2 seconds");
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let panic = server.join().err();
+            std::fs::remove_dir_all(dir).unwrap();
+            panic!("stats test server disconnected before readiness: {panic:?}");
+        }
+    }
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_limpidctl"));
+    command.arg("--socket").arg(&socket).arg("stats");
+    command.args(args);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let child = command.spawn().unwrap();
+    child_started_tx
+        .send(())
+        .expect("stats test server stopped before limpidctl child startup");
+    let output = child.wait_with_output().unwrap();
+
+    server.join().unwrap();
+    std::fs::remove_dir_all(dir).unwrap();
+    output
+}
+
+fn counter_family(
+    name: &str,
+    label: &str,
+    help: &str,
+    values: &[(&str, u64)],
+    reverse_series: bool,
+) -> Value {
+    let mut series: Vec<Value> = values
+        .iter()
+        .map(|(scope, value)| json!({"labels": {label: scope}, "value": value}))
+        .collect();
+    if reverse_series {
+        series.reverse();
+    }
+    json!({"name": name, "type": "counter", "help": help, "series": series})
+}
+
+fn histogram_snapshot(buckets: Value) -> String {
+    format!(
+        "{}\n",
+        json!({
+            "schema": 1,
+            "metrics": [{
+                "name": "metric_histogram",
+                "type": "histogram",
+                "help": "Histogram validation fixture.",
+                "series": [{
+                    "labels": {"scope": "one"},
+                    "buckets": buckets,
+                    "sum": 3.5,
+                    "count": 3
+                }]
+            }]
+        })
+    )
+}
+
+fn canonical_snapshot(reverse: bool) -> Value {
+    let mut metrics = vec![
+        counter_family(
+            "limpid_pipeline_events_received_total",
+            "pipeline",
+            "received",
+            &[
+                ("unwritable_only", 30),
+                ("compact", 10),
+                ("errored_only", 20),
+            ],
+            reverse,
+        ),
+        counter_family(
+            "limpid_pipeline_events_finished_total",
+            "pipeline",
+            "finished",
+            &[
+                ("unwritable_only", 29),
+                ("compact", 9),
+                ("errored_only", 19),
+            ],
+            false,
+        ),
+        counter_family(
+            "limpid_pipeline_events_dropped_total",
+            "pipeline",
+            "dropped",
+            &[("unwritable_only", 0), ("compact", 1), ("errored_only", 0)],
+            false,
+        ),
+        counter_family(
+            "limpid_pipeline_events_discarded_total",
+            "pipeline",
+            "discarded",
+            &[("unwritable_only", 1), ("compact", 0), ("errored_only", 1)],
+            false,
+        ),
+        counter_family(
+            "limpid_pipeline_events_errored_total",
+            "pipeline",
+            "errored",
+            &[("unwritable_only", 0), ("compact", 0), ("errored_only", 4)],
+            false,
+        ),
+        counter_family(
+            "limpid_pipeline_events_errored_unwritable_total",
+            "pipeline",
+            "unwritable",
+            &[("unwritable_only", 3), ("compact", 0), ("errored_only", 0)],
+            false,
+        ),
+        counter_family(
+            "limpid_input_events_received_total",
+            "input",
+            "received",
+            &[("zeta", 210), ("alpha", 110)],
+            false,
+        ),
+        counter_family(
+            "limpid_input_events_invalid_total",
+            "input",
+            "invalid",
+            &[("zeta", 3), ("alpha", 2)],
+            false,
+        ),
+        counter_family(
+            "limpid_input_events_injected_total",
+            "input",
+            "injected",
+            &[("zeta", 4), ("alpha", 3)],
+            false,
+        ),
+        counter_family(
+            "limpid_output_events_received_total",
+            "output",
+            "received",
+            &[
+                ("unwritable_only", 130),
+                ("compact", 110),
+                ("wedged_only", 120),
+            ],
+            false,
+        ),
+        counter_family(
+            "limpid_output_events_injected_total",
+            "output",
+            "injected",
+            &[("unwritable_only", 3), ("compact", 1), ("wedged_only", 2)],
+            false,
+        ),
+        counter_family(
+            "limpid_output_events_written_total",
+            "output",
+            "written",
+            &[
+                ("unwritable_only", 125),
+                ("compact", 105),
+                ("wedged_only", 115),
+            ],
+            false,
+        ),
+        counter_family(
+            "limpid_output_events_failed_total",
+            "output",
+            "failed",
+            &[("unwritable_only", 2), ("compact", 2), ("wedged_only", 2)],
+            false,
+        ),
+        counter_family(
+            "limpid_output_retries_total",
+            "output",
+            "retries",
+            &[("unwritable_only", 5), ("compact", 3), ("wedged_only", 4)],
+            false,
+        ),
+        counter_family(
+            "limpid_output_events_wedged_total",
+            "output",
+            "wedged",
+            &[("unwritable_only", 0), ("compact", 0), ("wedged_only", 2)],
+            false,
+        ),
+        counter_family(
+            "limpid_output_events_errored_unwritable_total",
+            "output",
+            "unwritable",
+            &[("unwritable_only", 1), ("compact", 0), ("wedged_only", 0)],
+            false,
+        ),
+    ];
+    if reverse {
+        metrics.reverse();
+    }
+    json!({"schema": 1, "metrics": metrics})
+}
+
+fn expected_default_table() -> String {
+    format!(
+        "Pipelines:\n\
+         {compact_pipeline}\n\
+         {errored_pipeline}\n\
+         {unwritable_pipeline}\n\
+         \nInputs:\n\
+         {alpha_input}\n\
+         {zeta_input}\n\
+         \nOutputs:\n\
+         {compact_output}\n\
+         {unwritable_output}\n\
+         {wedged_output}\n",
+        compact_pipeline = format_args!(
+            "  {:<24} {:>8} received  {:>8} finished  {:>8} dropped  {:>8} discarded",
+            "compact", 10, 9, 1, 0
+        ),
+        errored_pipeline = format_args!(
+            "  {:<24} {:>8} received  {:>8} finished  {:>8} dropped  {:>8} discarded  {:>8} errored",
+            "errored_only", 20, 19, 0, 1, 4
+        ),
+        unwritable_pipeline = format_args!(
+            "  {:<24} {:>8} received  {:>8} finished  {:>8} dropped  {:>8} discarded  {:>8} errored  {:>8} errored_unwritable",
+            "unwritable_only", 30, 29, 0, 1, 0, 3
+        ),
+        alpha_input = format_args!(
+            "  {:<24} {:>8} received  {:>8} invalid  {:>8} injected",
+            "alpha", 110, 2, 3
+        ),
+        zeta_input = format_args!(
+            "  {:<24} {:>8} received  {:>8} invalid  {:>8} injected",
+            "zeta", 210, 3, 4
+        ),
+        compact_output = format_args!(
+            "  {:<24} {:>8} received  {:>8} injected  {:>8} written  {:>8} failed  {:>8} retries",
+            "compact", 110, 1, 105, 2, 3
+        ),
+        unwritable_output = format_args!(
+            "  {:<24} {:>8} received  {:>8} injected  {:>8} written  {:>8} failed  {:>8} retries  {:>8} errored_unwritable",
+            "unwritable_only", 130, 3, 125, 2, 5, 1
+        ),
+        wedged_output = format_args!(
+            "  {:<24} {:>8} received  {:>8} injected  {:>8} written  {:>8} failed  {:>8} retries  {:>8} wedged",
+            "wedged_only", 120, 2, 115, 2, 4, 2
+        ),
+    )
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).unwrap()
+}
+
+#[test]
+fn default_stats_maps_schema_v1_to_the_existing_sorted_table() {
+    let expected = expected_default_table();
+    for reverse in [false, true] {
+        let response = format!("{}\n", canonical_snapshot(reverse));
+        let output = run_stats(&response, &[]);
+        assert!(output.status.success(), "{:?}", output);
+        assert_eq!(stdout(&output), expected);
+    }
+}
+
+#[test]
+fn json_mode_preserves_the_complete_control_response() {
+    let response = concat!(
+        "{\"schema\":1,\"metrics\":[",
+        "{\"name\":\"custom_gauge\",\"type\":\"gauge\",\"help\":\"all fields\",",
+        "\"series\":[{\"labels\":{\"scope\":\"one\"},\"value\":7}]}",
+        "]}\n"
+    );
+    let output = run_stats(response, &["--json"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout == response.as_bytes(), "raw JSON was changed");
+}
+
+#[test]
+fn details_renders_all_types_with_deterministic_order_and_complete_fields() {
+    let payload = json!({
+        "schema": 1,
+        "metrics": [
+            {
+                "name": "metric_zeta",
+                "type": "histogram",
+                "help": "Latency distribution.",
+                "series": [{
+                    "labels": {"route": "west"},
+                    "buckets": [[0.125, 17], [0.875, 29]],
+                    "sum": 13.75,
+                    "count": 31
+                }]
+            },
+            {
+                "name": "metric_alpha",
+                "type": "counter",
+                "help": "Accepted events.",
+                "series": [
+                    {"labels": {"a": "two", "z": "last"}, "value": 2},
+                    {"labels": {"a": "one", "z": "last"}, "value": 1}
+                ]
+            },
+            {
+                "name": "metric_middle",
+                "type": "gauge",
+                "help": "Current depth.",
+                "series": [{
+                    "labels": {"env": "prod\"east\\one\nline"},
+                    "value": 9
+                }]
+            }
+        ]
+    });
+    let response = format!("{payload}\n");
+    let output = run_stats(&response, &["--details"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = stdout(&output);
+
+    let counter = text.find("metric_alpha").unwrap();
+    let gauge = text.find("metric_middle").unwrap();
+    let histogram = text.find("metric_zeta").unwrap();
+    assert!(counter < gauge && gauge < histogram);
+    let counter_block = &text[counter..gauge];
+    let gauge_block = &text[gauge..histogram];
+    let histogram_block = &text[histogram..];
+    assert!(counter_block.contains("counter"));
+    assert!(counter_block.contains("Accepted events."));
+    assert!(text.find("a=\"one\"").unwrap() < text.find("a=\"two\"").unwrap());
+    assert!(counter_block.contains("a=\"one\", z=\"last\""));
+    assert!(counter_block.contains("value"));
+    assert!(counter_block.contains('1'));
+    assert!(counter_block.contains('2'));
+    assert!(gauge_block.contains("gauge"));
+    assert!(gauge_block.contains("Current depth."));
+    assert!(gauge_block.contains(r#"env="prod\"east\\one\nline""#));
+    assert!(gauge_block.contains("value"));
+    assert!(gauge_block.contains('9'));
+    assert!(histogram_block.contains("histogram"));
+    assert!(histogram_block.contains("Latency distribution."));
+    assert!(histogram_block.contains("route=\"west\""));
+    assert!(histogram_block.contains("buckets"));
+    assert!(histogram_block.contains("0.125"));
+    assert!(histogram_block.contains("17"));
+    assert!(histogram_block.contains("0.875"));
+    assert!(histogram_block.contains("29"));
+    assert!(histogram_block.contains("sum"));
+    assert!(histogram_block.contains("13.75"));
+    assert!(histogram_block.contains("count"));
+    assert!(histogram_block.contains("31"));
+    assert!(!histogram_block.contains("+Inf"));
+}
+
+#[test]
+fn details_rejects_invalid_histogram_sequences_without_repair() {
+    for buckets in [
+        json!([]),
+        json!([[0.5, 1]]),
+        json!([[0.125, 1], [0.875, 1], [2.0, 3]]),
+        // Bucket and total atomics are loaded independently, so observe ordering
+        // permits a transient last-bucket count greater than the total count.
+        json!([[0.125, 1], [0.875, 2], [2.0, 4]]),
+    ] {
+        let response = histogram_snapshot(buckets);
+        let output = run_stats(&response, &["--details"]);
+        assert!(output.status.success(), "{:?}", output);
+        assert_ne!(output.stdout, response.as_bytes());
+        assert!(stdout(&output).contains("metric_histogram"));
+    }
+
+    for buckets in [
+        json!([[1.0, 1], [1.0, 2]]),
+        json!([[2.0, 1], [1.0, 2]]),
+        json!([[1.0, 2], [2.0, 1]]),
+    ] {
+        let response = histogram_snapshot(buckets);
+        let output = run_stats(&response, &["--details"]);
+        assert!(output.status.success(), "{:?}", output);
+        assert_eq!(output.stdout, response.as_bytes());
+    }
+}
+
+#[test]
+fn default_ignores_unknown_families_but_details_includes_them() {
+    let mut payload = canonical_snapshot(false);
+    payload["metrics"].as_array_mut().unwrap().push(json!({
+        "name": "future_metric",
+        "type": "gauge",
+        "help": "Future metric.",
+        "series": [{"labels": {"scope": "future"}, "value": 42}]
+    }));
+    let response = format!("{payload}\n");
+
+    let default_output = run_stats(&response, &[]);
+    assert!(default_output.status.success(), "{:?}", default_output);
+    assert_eq!(stdout(&default_output), expected_default_table());
+    assert!(!stdout(&default_output).contains("future_metric"));
+
+    let details_output = run_stats(&response, &["--details"]);
+    assert!(details_output.status.success(), "{:?}", details_output);
+    assert!(stdout(&details_output).contains("future_metric"));
+    assert!(stdout(&details_output).contains("scope=\"future\""));
+    assert!(stdout(&details_output).contains("42"));
+}
+
+#[test]
+fn malformed_known_families_fall_back_to_the_raw_response() {
+    let canonical = canonical_snapshot(false);
+    let mut cases = Vec::new();
+
+    let mut missing = canonical.clone();
+    missing["metrics"].as_array_mut().unwrap().remove(0);
+    cases.push(missing);
+
+    let mut duplicate = canonical.clone();
+    let duplicate_family = duplicate["metrics"][0].clone();
+    duplicate["metrics"]
+        .as_array_mut()
+        .unwrap()
+        .push(duplicate_family);
+    cases.push(duplicate);
+
+    let mut wrong_type = canonical.clone();
+    wrong_type["metrics"][0]["type"] = json!("gauge");
+    cases.push(wrong_type);
+
+    let mut wrong_label = canonical.clone();
+    wrong_label["metrics"][0]["series"][0]["labels"] = json!({"wrong": "zeta"});
+    cases.push(wrong_label);
+
+    let mut extra_label = canonical.clone();
+    extra_label["metrics"][0]["series"][0]["labels"] =
+        json!({"pipeline": "unwritable_only", "extra": "x"});
+    cases.push(extra_label);
+
+    let mut wrong_value = canonical;
+    wrong_value["metrics"][0]["series"][0]["value"] = json!("30");
+    cases.push(wrong_value);
+
+    for (index, payload) in cases.into_iter().enumerate() {
+        let response = format!("{payload}\n");
+        let output = run_stats(&response, &[]);
+        assert!(
+            output.status.success(),
+            "stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout == response.as_bytes(),
+            "malformed known family did not use raw fallback"
+        );
+        if index == 0 {
+            let details = run_stats(&response, &["--details"]);
+            assert!(
+                details.status.success(),
+                "stderr={}",
+                String::from_utf8_lossy(&details.stderr)
+            );
+            assert!(
+                details.stdout == response.as_bytes(),
+                "malformed known family did not use details raw fallback"
+            );
+        }
+    }
+}
+
+#[test]
+fn invalid_and_unsupported_responses_preserve_raw_fallback() {
+    for response in [
+        "not json at all\n",
+        "{\"schema\":2,\"metrics\":[]}\n",
+        "{\"schema\":1,\"metrics\":\"wrong\"}\n",
+    ] {
+        for args in [&[][..], &["--details"][..]] {
+            let output = run_stats(response, args);
+            assert!(
+                output.status.success(),
+                "stderr={}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                output.stdout == response.as_bytes(),
+                "invalid or unsupported response did not use raw fallback"
+            );
+        }
+    }
+}
+
+#[test]
+fn json_and_details_are_mutually_exclusive() {
+    let _process_guard = process_lock();
+    let output = Command::new(env!("CARGO_BIN_EXE_limpidctl"))
+        .args(["stats", "--json", "--details"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("--json"));
+    assert!(stderr.contains("--details"));
+    assert!(stderr.contains("cannot be used with"));
+}


### PR DESCRIPTION
## Summary
- render the existing operator-focused `stats` table from schema-v1 metric families
- add `stats --details` for deterministic generic counter, gauge, and histogram output
- keep `stats --json` byte-preserving and fall back to the raw response for unsupported or malformed snapshots

## Validation
- `cargo test -p limpidctl`
- `cargo test --workspace`
- `cargo clippy -p limpidctl --all-targets -- -D warnings`
- `cargo clippy --workspace -- -D warnings`
- `cargo deny check advisories bans sources licenses`
- Ubuntu aarch64: schema-v1 integration tests and limpidctl all-target clippy

## Rollout
The comprehensive metrics operations documentation, including `stats`, `stats --details`, and `stats --json`, remains pinned to PR1.5 and must land before v0.8.0 is released.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--details` option to `limpidctl stats` for expanded counter, gauge, and histogram metrics.
  * Added clear, deterministic tables for pipeline, input, and output statistics.
  * Added support for displaying additional metric families with sorted labels and validated histogram buckets.

* **Bug Fixes**
  * Improved handling of malformed, incomplete, or unsupported statistics by preserving and displaying the raw response.
  * Prevented incompatible use of `--json` and `--details` together.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->