### PR TITLE
feat(metrics): count adapter bytes

### DIFF
--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -20,6 +20,7 @@ pub struct InputMetrics {
     pub(crate) events_invalid: Arc<registry_core::Counter>,
     /// Events pushed into this input's channel via `limpidctl inject`.
     pub(crate) events_injected: Arc<registry_core::Counter>,
+    pub(crate) bytes_received: Arc<registry_core::Counter>,
 }
 
 impl InputMetrics {
@@ -45,6 +46,10 @@ impl InputMetrics {
             events_injected: counter!(
                 "limpid_input_events_injected_total",
                 "Total events injected into the input through the control socket."
+            ),
+            bytes_received: counter!(
+                "limpid_input_bytes_received_total",
+                "Total logical bytes received by the input adapter before validation."
             ),
         }))
     }
@@ -163,6 +168,7 @@ pub struct OutputMetrics {
     /// is the operator alarm signal for that loss rather than a
     /// durable trace of it.
     pub(crate) events_errored_unwritable: Arc<registry_core::Counter>,
+    pub(crate) bytes_written: Arc<registry_core::Counter>,
 }
 
 impl OutputMetrics {
@@ -201,6 +207,10 @@ impl OutputMetrics {
             events_errored_unwritable: counter!(
                 "limpid_output_events_errored_unwritable_total",
                 "Total output errors whose recovery record could not be written."
+            ),
+            bytes_written: counter!(
+                "limpid_output_bytes_written_total",
+                "Total logical bytes whose transfer was confirmed by the output adapter."
             ),
         }))
     }
@@ -321,6 +331,10 @@ mod registry_core {
     impl Counter {
         pub(crate) fn inc(&self) {
             self.value.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub(crate) fn inc_by(&self, value: u64) {
+            self.value.fetch_add(value, Ordering::Relaxed);
         }
 
         #[cfg(test)]
@@ -1533,6 +1547,28 @@ mod registry_tests {
     }
 
     #[test]
+    fn counter_inc_by_adds_the_exact_delta_and_zero_is_a_noop() {
+        let registry = Registry::new();
+        let counter = build_ok(
+            registry
+                .counter("limpid_test_bytes_total")
+                .help("Test byte counter.")
+                .label("input", "fixture")
+                .build(),
+        );
+
+        counter.inc_by(0);
+        counter.inc_by(4_096);
+        counter.inc();
+
+        let snapshot = snapshot_json(&registry);
+        assert_eq!(
+            metric(&snapshot, "limpid_test_bytes_total")["series"][0]["value"],
+            4_097
+        );
+    }
+
+    #[test]
     fn documented_metric_bundles_share_one_registry_without_shadow_series() {
         let registry = Registry::new();
         let input: Arc<InputMetrics> = build_ok(InputMetrics::register(&registry, "ingress"));
@@ -1554,6 +1590,7 @@ mod registry_tests {
         inc!(input_shared.events_received, 1);
         inc!(input.events_invalid, 2);
         inc!(input.events_injected, 3);
+        input.bytes_received.inc_by(17);
         inc!(pipeline_shared.events_received, 4);
         inc!(pipeline.events_finished, 5);
         inc!(pipeline.events_dropped, 6);
@@ -1567,6 +1604,7 @@ mod registry_tests {
         inc!(output.retries, 14);
         inc!(output.events_wedged, 15);
         inc!(output.events_errored_unwritable, 16);
+        output.bytes_written.inc_by(23);
 
         let snapshot = snapshot_json(&registry);
         let metrics = snapshot["metrics"]
@@ -1574,7 +1612,7 @@ mod registry_tests {
             .expect("metrics must be an array");
         assert_eq!(
             metrics.len(),
-            16,
+            18,
             "only the documented metric set is registered"
         );
 
@@ -1582,6 +1620,7 @@ mod registry_tests {
             ("limpid_input_events_received_total", "input", "ingress", 1),
             ("limpid_input_events_invalid_total", "input", "ingress", 2),
             ("limpid_input_events_injected_total", "input", "ingress", 3),
+            ("limpid_input_bytes_received_total", "input", "ingress", 17),
             (
                 "limpid_pipeline_events_received_total",
                 "pipeline",
@@ -1640,6 +1679,7 @@ mod registry_tests {
                 "egress",
                 16,
             ),
+            ("limpid_output_bytes_written_total", "output", "egress", 23),
         ];
         for (name, label, label_value, value) in expected {
             let family = metric(&snapshot, name);
@@ -1687,6 +1727,7 @@ mod registry_tests {
                 "limpid_output_retries_total",
                 "limpid_output_events_wedged_total",
                 "limpid_output_events_errored_unwritable_total",
+                "limpid_output_bytes_written_total",
             ]
             .contains(&name.as_str())
         );

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -249,6 +249,7 @@ impl Input for JournalInput {
                     match entry {
                         Some((bytes, cursor)) => {
                             metrics.events_received.inc();
+                            metrics.bytes_received.inc_by(bytes.len() as u64);
                             let ack = Arc::new(AckHandle::new(
                                 AckPosition::Cursor(cursor),
                                 ack_tx.clone(),
@@ -541,6 +542,27 @@ mod tests {
             started.elapsed() < Duration::from_millis(50),
             "pre-set flag must short-circuit immediately; took {:?}",
             started.elapsed()
+        );
+    }
+
+    #[test]
+    fn generated_json_buffer_length_is_recorded_at_the_async_adapter_boundary() {
+        let src = include_str!("journal.rs");
+        let start = src
+            .find("Some((bytes, cursor)) =>")
+            .expect("journal adapter branch must exist");
+        let end = src[start..]
+            .find("let event = Event::with_ack(")
+            .expect("journal Event construction must follow receipt");
+        let receipt = &src[start..start + end];
+        assert!(
+            receipt.contains("bytes_received.inc_by(bytes.len() as u64)"),
+            "journal counts the generated JSON Vec, not an unavailable physical wire size"
+        );
+        assert_eq!(
+            receipt.matches("bytes_received.inc_by(").count(),
+            1,
+            "each generated JSON buffer is counted once"
         );
     }
 

--- a/crates/limpid/src/modules/input/otlp/grpc.rs
+++ b/crates/limpid/src/modules/input/otlp/grpc.rs
@@ -40,6 +40,7 @@ use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsPartialSuccess, ExportLogsServiceRequest, ExportLogsServiceResponse,
     logs_service_server::{LogsService, LogsServiceServer},
 };
+use prost::Message;
 use tokio::sync::mpsc;
 use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 use tonic::{Request, Response, Status};
@@ -216,6 +217,9 @@ impl LogsService for LogsServiceImpl {
         // visibility — even if the body is empty / malformed we want
         // to see the flow through input metrics.
         self.metrics.events_received.inc();
+        self.metrics
+            .bytes_received
+            .inc_by(request.get_ref().encoded_len() as u64);
 
         // Fallback: tonic should always know the peer for a
         // TCP-served RPC, but a non-TCP transport (uds, mock) might
@@ -405,12 +409,13 @@ mod tests {
         // Drive the service trait directly (no socket) so the test
         // exercises the splitting logic without taking up a port.
         let (tx, mut rx) = mpsc::channel(8);
+        let metrics = InputMetrics::for_testing();
         let svc = LogsServiceImpl {
             tx,
-            metrics: InputMetrics::for_testing(),
+            metrics: Arc::clone(&metrics),
             rate_limiter: None,
         };
-        let req = Request::new(ExportLogsServiceRequest {
+        let request = ExportLogsServiceRequest {
             resource_logs: vec![ResourceLogs {
                 resource: Some(Resource {
                     attributes: vec![],
@@ -434,7 +439,9 @@ mod tests {
                 }],
                 schema_url: String::new(),
             }],
-        });
+        };
+        let expected_bytes = request.encoded_len() as u64;
+        let req = Request::new(request);
         let resp = svc.export(req).await.unwrap();
         assert!(resp.into_inner().partial_success.is_none());
         let event = rx.recv().await.expect("event must have been emitted");
@@ -442,14 +449,22 @@ mod tests {
         assert_eq!(decoded.scope_logs.len(), 1);
         assert_eq!(decoded.scope_logs[0].log_records.len(), 1);
         assert_eq!(decoded.scope_logs[0].log_records[0].time_unix_nano, 42);
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            expected_bytes,
+            "gRPC input uses the canonical protobuf encoded length once per request"
+        );
     }
 
     #[tokio::test]
     async fn empty_request_is_a_noop() {
         let (tx, mut rx) = mpsc::channel(8);
+        let metrics = InputMetrics::for_testing();
         let svc = LogsServiceImpl {
             tx,
-            metrics: InputMetrics::for_testing(),
+            metrics: Arc::clone(&metrics),
             rate_limiter: None,
         };
         let req = Request::new(ExportLogsServiceRequest {
@@ -459,6 +474,13 @@ mod tests {
         assert!(resp.into_inner().partial_success.is_none());
         // No event should have been emitted.
         assert!(rx.try_recv().is_err());
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "an empty canonical protobuf message contributes zero bytes"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/input/otlp/http.rs
+++ b/crates/limpid/src/modules/input/otlp/http.rs
@@ -345,6 +345,7 @@ async fn handle_logs(
     body: axum::body::Bytes,
 ) -> impl IntoResponse {
     state.metrics.events_received.inc();
+    state.metrics.bytes_received.inc_by(body.len() as u64);
 
     // Concurrency cap (semaphore) bounds simultaneous decode work.
     // Combined with body_limit, this turns the worst-case decode
@@ -771,6 +772,7 @@ mod tests {
     #[tokio::test]
     async fn body_limit_accepts_request_under_cap() {
         use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+        use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -785,6 +787,7 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
+        let metrics = input.metrics();
         let (tx, mut rx) = mpsc::channel(8);
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let server_task = tokio::spawn(async move {
@@ -792,12 +795,22 @@ mod tests {
         });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Empty request is well under any size cap.
+        // A valid non-empty canonical protobuf request is well under the cap.
         let req = ExportLogsServiceRequest {
-            resource_logs: vec![],
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord {
+                        time_unix_nano: 123,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
         };
         let mut body = Vec::new();
         req.encode(&mut body).unwrap();
+        let expected_bytes = body.len() as u64;
         let resp = reqwest::Client::new()
             .post(format!("http://{}/v1/logs", addr))
             .header("Content-Type", "application/x-protobuf")
@@ -806,13 +819,68 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), reqwest::StatusCode::OK);
-
-        // Empty payload → no Events emitted (events_received still
-        // bumped per RPC, but the channel stays clean).
-        assert!(rx.try_recv().is_err());
+        let _received = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for decoded event")
+            .expect("valid request must emit an event");
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            expected_bytes,
+            "valid input counts the canonical request body exactly once"
+        );
 
         let _ = shutdown_tx.send(true);
         let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn invalid_body_counts_logical_bytes_before_validation_and_empty_is_zero() {
+        let (tx, _rx) = mpsc::channel(8);
+        let metrics = InputMetrics::for_testing();
+        let state = AppState {
+            tx,
+            metrics: Arc::clone(&metrics),
+            rate_limiter: None,
+            request_limiter: None,
+            concurrency: None,
+        };
+        let peer: SocketAddr = "127.0.0.1:4318".parse().unwrap();
+        let invalid = axum::body::Bytes::from_static(b"not protobuf");
+
+        let response = handle_logs(
+            State(state.clone()),
+            ConnectInfo(peer),
+            HeaderMap::new(),
+            invalid.clone(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            invalid.len() as u64
+        );
+
+        let response = handle_logs(
+            State(state),
+            ConnectInfo(peer),
+            HeaderMap::new(),
+            axum::body::Bytes::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            invalid.len() as u64,
+            "an empty request must not change the byte counter"
+        );
     }
 
     #[test]

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -474,16 +474,9 @@ pub(crate) async fn read_octet_counting<R: tokio::io::AsyncRead + Unpin>(
 
         // --- Read SYSLOG-MSG (exactly msg_len bytes) ---
         let mut buf = vec![0u8; msg_len];
-        match tokio::time::timeout(IDLE_TIMEOUT, reader.read_exact(&mut buf)).await {
-            Ok(Ok(_)) => {}
-            Ok(Err(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                return CloseReason::Eof;
-            }
-            Ok(Err(e)) => return CloseReason::IoError(e),
-            Err(_) => return CloseReason::Timeout,
-        }
-        if let Some(m) = metrics {
-            m.bytes_received.inc_by(msg_len as u64);
+        match read_exact_counted(reader, &mut buf, metrics).await {
+            Ok(()) => {}
+            Err(reason) => return reason,
         }
 
         // --- Validate PRI (RFC 5424 §6.2.1) ---
@@ -511,6 +504,49 @@ pub(crate) async fn read_octet_counting<R: tokio::io::AsyncRead + Unpin>(
         if let Some(m) = metrics {
             m.events_received.inc();
         }
+    }
+}
+
+/// Read exactly `buf.len()` bytes, counting each successful
+/// non-zero `read().await` result against `metrics` as it is
+/// returned. If a subsequent read fails or the outer timeout
+/// fires mid-frame, the partial-read bytes stay counted — they
+/// reached the adapter, and counting what was received before
+/// the failure preserves that fact.
+async fn read_exact_counted<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut BufReader<R>,
+    buf: &mut [u8],
+    metrics: Option<&InputMetrics>,
+) -> std::result::Result<(), CloseReason> {
+    match tokio::time::timeout(IDLE_TIMEOUT, async {
+        let mut offset = 0usize;
+        while offset < buf.len() {
+            match reader.read(&mut buf[offset..]).await {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "syslog frame ended before its declared length",
+                    ));
+                }
+                Ok(n) => {
+                    if let Some(m) = metrics {
+                        m.bytes_received.inc_by(n as u64);
+                    }
+                    offset += n;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    })
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+            Err(CloseReason::Eof)
+        }
+        Ok(Err(error)) => Err(CloseReason::IoError(error)),
+        Err(_) => Err(CloseReason::Timeout),
     }
 }
 
@@ -625,11 +661,8 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
         buf.clear();
 
         // Read until we hit LF, NUL, or EOF
-        let delimiter_len = match read_until_delimiter(reader, &mut buf, addr).await {
+        match read_until_delimiter(reader, &mut buf, addr, metrics).await {
             Ok(false) => {
-                if let Some(m) = metrics {
-                    m.bytes_received.inc_by(buf.len() as u64);
-                }
                 // EOF — emit any remaining data as final message
                 if !buf.is_empty() {
                     // Strip trailing CR
@@ -662,14 +695,8 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
                 }
                 return CloseReason::Eof;
             }
-            Ok(true) => {
-                // Delimiter found — buf contains message without trailer
-                1usize
-            }
+            Ok(true) => {}
             Err(reason) => return reason,
-        };
-        if let Some(m) = metrics {
-            m.bytes_received.inc_by((buf.len() + delimiter_len) as u64);
         }
 
         // Strip trailing CR (for CRLF case)
@@ -717,6 +744,7 @@ async fn read_until_delimiter<R: tokio::io::AsyncRead + Unpin>(
     reader: &mut BufReader<R>,
     buf: &mut Vec<u8>,
     addr: SocketAddr,
+    metrics: Option<&InputMetrics>,
 ) -> std::result::Result<bool, CloseReason> {
     loop {
         // Use fill_buf + consume to leverage the BufReader's internal buffer
@@ -738,6 +766,9 @@ async fn read_until_delimiter<R: tokio::io::AsyncRead + Unpin>(
             // Consume up to and including the delimiter
             let consume_len = pos + 1;
             reader.consume(consume_len);
+            if let Some(m) = metrics {
+                m.bytes_received.inc_by(consume_len as u64);
+            }
             return Ok(true);
         }
 
@@ -758,6 +789,9 @@ async fn read_until_delimiter<R: tokio::io::AsyncRead + Unpin>(
 
         buf.extend_from_slice(available);
         reader.consume(len);
+        if let Some(m) = metrics {
+            m.bytes_received.inc_by(len as u64);
+        }
     }
 }
 
@@ -768,7 +802,66 @@ async fn read_until_delimiter<R: tokio::io::AsyncRead + Unpin>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use tokio::io::BufReader;
+
+    enum ReadStep {
+        Data(Vec<u8>),
+        Error(std::io::ErrorKind),
+        Pending,
+    }
+
+    struct ScriptedReader {
+        steps: VecDeque<ReadStep>,
+    }
+
+    impl ScriptedReader {
+        fn new(steps: impl IntoIterator<Item = ReadStep>) -> Self {
+            Self {
+                steps: steps.into_iter().collect(),
+            }
+        }
+    }
+
+    impl tokio::io::AsyncRead for ScriptedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            dst: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            loop {
+                match self.steps.pop_front() {
+                    Some(ReadStep::Data(bytes)) => {
+                        if bytes.is_empty() {
+                            continue;
+                        }
+                        let len = bytes.len().min(dst.remaining());
+                        dst.put_slice(&bytes[..len]);
+                        if len < bytes.len() {
+                            self.steps.push_front(ReadStep::Data(bytes[len..].to_vec()));
+                        }
+                        return Poll::Ready(Ok(()));
+                    }
+                    Some(ReadStep::Error(kind)) => {
+                        return Poll::Ready(Err(std::io::Error::from(kind)));
+                    }
+                    Some(ReadStep::Pending) => {
+                        self.steps.push_front(ReadStep::Pending);
+                        return Poll::Pending;
+                    }
+                    None => return Poll::Ready(Ok(())),
+                }
+            }
+        }
+    }
+
+    fn bytes_received(metrics: &InputMetrics) -> u64 {
+        metrics
+            .bytes_received
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
 
     fn addr() -> SocketAddr {
         "127.0.0.1:514".parse().unwrap()
@@ -858,9 +951,73 @@ mod tests {
         let data = b"20 <134>hello";
         let mut reader = BufReader::new(&data[..]);
         let (tx, _rx) = tokio::sync::mpsc::channel(10);
+        let metrics = InputMetrics::for_testing();
 
-        let reason = read_octet_counting(&mut reader, addr(), &tx, None, None).await;
+        let reason = read_octet_counting(&mut reader, addr(), &tx, None, Some(&metrics)).await;
         assert!(matches!(reason, CloseReason::Eof));
+        assert_eq!(
+            bytes_received(&metrics),
+            data.len() as u64,
+            "count the received prefix, separator, and only the payload bytes actually read"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oc_counts_partial_payload_before_io_error() {
+        let scripted = ScriptedReader::new([
+            ReadStep::Data(b"8 ".to_vec()),
+            ReadStep::Data(b"<13".to_vec()),
+            ReadStep::Error(std::io::ErrorKind::ConnectionReset),
+        ]);
+        let mut reader = BufReader::with_capacity(3, scripted);
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let metrics = InputMetrics::for_testing();
+
+        let reason = read_octet_counting(&mut reader, addr(), &tx, None, Some(&metrics)).await;
+        assert!(matches!(reason, CloseReason::IoError(_)));
+        assert_eq!(bytes_received(&metrics), 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_oc_counts_partial_payload_before_timeout() {
+        let scripted = ScriptedReader::new([
+            ReadStep::Data(b"8 ".to_vec()),
+            ReadStep::Data(b"<13".to_vec()),
+            ReadStep::Pending,
+        ]);
+        let mut reader = BufReader::with_capacity(3, scripted);
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let metrics = InputMetrics::for_testing();
+
+        let reason = read_octet_counting(&mut reader, addr(), &tx, None, Some(&metrics)).await;
+        assert!(matches!(reason, CloseReason::Timeout));
+        assert_eq!(bytes_received(&metrics), 5);
+    }
+
+    #[tokio::test]
+    async fn test_oc_oversize_declaration_counts_prefix_only() {
+        let data = format!("{} ", MAX_MESSAGE_SIZE + 1);
+        let mut reader = BufReader::new(data.as_bytes());
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let metrics = InputMetrics::for_testing();
+
+        let reason = read_octet_counting(&mut reader, addr(), &tx, None, Some(&metrics)).await;
+        assert!(matches!(reason, CloseReason::FramingError(_)));
+        assert_eq!(bytes_received(&metrics), data.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn test_oc_complete_then_partial_accumulates_without_reset_or_double_bump() {
+        let data = b"10 <134>hello20 <134>hello";
+        let mut reader = BufReader::new(&data[..]);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+        let metrics = InputMetrics::for_testing();
+
+        let reason = read_octet_counting(&mut reader, addr(), &tx, None, Some(&metrics)).await;
+        assert!(matches!(reason, CloseReason::Eof));
+        assert_eq!(&*rx.recv().await.unwrap().ingress, b"<134>hello");
+        assert!(rx.try_recv().is_err());
+        assert_eq!(bytes_received(&metrics), data.len() as u64);
     }
 
     // --- Non-Transparent Framing ---
@@ -919,15 +1076,69 @@ mod tests {
     #[tokio::test]
     async fn test_ntf_eof_without_trailer() {
         // Message without trailing delimiter — should still be emitted
-        let data = b"<134>unterminated";
-        let mut reader = BufReader::new(&data[..]);
+        let scripted = ScriptedReader::new([
+            ReadStep::Data(b"<134>".to_vec()),
+            ReadStep::Data(b"unterminated".to_vec()),
+        ]);
+        let mut reader = BufReader::with_capacity(5, scripted);
         let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+        let metrics = InputMetrics::for_testing();
 
-        let reason = read_non_transparent(&mut reader, addr(), &tx, None, None).await;
+        let reason = read_non_transparent(&mut reader, addr(), &tx, None, Some(&metrics)).await;
         drop(tx);
         assert!(matches!(reason, CloseReason::Eof));
 
         assert_eq!(&*rx.recv().await.unwrap().ingress, b"<134>unterminated");
+        assert_eq!(bytes_received(&metrics), b"<134>unterminated".len() as u64);
+    }
+
+    #[tokio::test]
+    async fn test_ntf_counts_consumed_chunks_before_io_error() {
+        let scripted = ScriptedReader::new([
+            ReadStep::Data(b"<134>".to_vec()),
+            ReadStep::Data(b"partial".to_vec()),
+            ReadStep::Error(std::io::ErrorKind::ConnectionReset),
+        ]);
+        let mut reader = BufReader::with_capacity(7, scripted);
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let metrics = InputMetrics::for_testing();
+
+        let reason = read_non_transparent(&mut reader, addr(), &tx, None, Some(&metrics)).await;
+        assert!(matches!(reason, CloseReason::IoError(_)));
+        assert_eq!(bytes_received(&metrics), b"<134>partial".len() as u64);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_ntf_counts_consumed_chunks_before_timeout() {
+        let scripted = ScriptedReader::new([
+            ReadStep::Data(b"<134>".to_vec()),
+            ReadStep::Data(b"partial".to_vec()),
+            ReadStep::Pending,
+        ]);
+        let mut reader = BufReader::with_capacity(7, scripted);
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let metrics = InputMetrics::for_testing();
+
+        let reason = read_non_transparent(&mut reader, addr(), &tx, None, Some(&metrics)).await;
+        assert!(matches!(reason, CloseReason::Timeout));
+        assert_eq!(bytes_received(&metrics), b"<134>partial".len() as u64);
+    }
+
+    #[tokio::test]
+    async fn test_ntf_oversize_counts_only_prior_consumed_chunks() {
+        const CHUNK: usize = 8;
+        let data = vec![b'x'; MAX_MESSAGE_SIZE + CHUNK];
+        let mut reader = BufReader::with_capacity(CHUNK, &data[..]);
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let metrics = InputMetrics::for_testing();
+
+        let reason = read_non_transparent(&mut reader, addr(), &tx, None, Some(&metrics)).await;
+        assert!(matches!(reason, CloseReason::FramingError(_)));
+        assert_eq!(
+            bytes_received(&metrics),
+            MAX_MESSAGE_SIZE as u64,
+            "the chunk rejected by the size guard remains unread and uncounted"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -467,7 +467,7 @@ pub(crate) async fn read_octet_counting<R: tokio::io::AsyncRead + Unpin>(
 ) -> CloseReason {
     loop {
         // --- Read MSG-LEN SP ---
-        let msg_len = match read_msg_len(reader, addr).await {
+        let msg_len = match read_msg_len(reader, addr, metrics).await {
             Ok(n) => n,
             Err(reason) => return reason,
         };
@@ -481,6 +481,9 @@ pub(crate) async fn read_octet_counting<R: tokio::io::AsyncRead + Unpin>(
             }
             Ok(Err(e)) => return CloseReason::IoError(e),
             Err(_) => return CloseReason::Timeout,
+        }
+        if let Some(m) = metrics {
+            m.bytes_received.inc_by(msg_len as u64);
         }
 
         // --- Validate PRI (RFC 5424 §6.2.1) ---
@@ -520,6 +523,7 @@ pub(crate) async fn read_octet_counting<R: tokio::io::AsyncRead + Unpin>(
 async fn read_msg_len<R: tokio::io::AsyncRead + Unpin>(
     reader: &mut BufReader<R>,
     addr: SocketAddr,
+    metrics: Option<&InputMetrics>,
 ) -> std::result::Result<usize, CloseReason> {
     let mut len_buf = [0u8; 1];
     let mut len_str = String::with_capacity(8);
@@ -535,6 +539,9 @@ async fn read_msg_len<R: tokio::io::AsyncRead + Unpin>(
         }
 
         let byte = len_buf[0];
+        if let Some(m) = metrics {
+            m.bytes_received.inc();
+        }
 
         if byte == b' ' {
             // End of MSG-LEN
@@ -618,8 +625,11 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
         buf.clear();
 
         // Read until we hit LF, NUL, or EOF
-        match read_until_delimiter(reader, &mut buf, addr).await {
+        let delimiter_len = match read_until_delimiter(reader, &mut buf, addr).await {
             Ok(false) => {
+                if let Some(m) = metrics {
+                    m.bytes_received.inc_by(buf.len() as u64);
+                }
                 // EOF — emit any remaining data as final message
                 if !buf.is_empty() {
                     // Strip trailing CR
@@ -654,8 +664,12 @@ pub(crate) async fn read_non_transparent<R: tokio::io::AsyncRead + Unpin>(
             }
             Ok(true) => {
                 // Delimiter found — buf contains message without trailer
+                1usize
             }
             Err(reason) => return reason,
+        };
+        if let Some(m) = metrics {
+            m.bytes_received.inc_by((buf.len() + delimiter_len) as u64);
         }
 
         // Strip trailing CR (for CRLF case)
@@ -767,8 +781,9 @@ mod tests {
         let data = b"10 <134>hello18 <165>world message";
         let mut reader = BufReader::new(&data[..]);
         let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+        let metrics = InputMetrics::for_testing();
 
-        let reason = read_octet_counting(&mut reader, addr(), &tx, None, None).await;
+        let reason = read_octet_counting(&mut reader, addr(), &tx, None, Some(&metrics)).await;
         drop(tx);
         assert!(matches!(reason, CloseReason::Eof));
 
@@ -779,6 +794,13 @@ mod tests {
         assert_eq!(&*e2.ingress, b"<165>world message");
 
         assert!(rx.recv().await.is_none());
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            data.len() as u64,
+            "octet-count headers and separators are adapter framing bytes"
+        );
     }
 
     #[tokio::test]
@@ -787,9 +809,17 @@ mod tests {
         let data = b"5 hello";
         let mut reader = BufReader::new(&data[..]);
         let (tx, _rx) = tokio::sync::mpsc::channel(10);
+        let metrics = InputMetrics::for_testing();
 
-        let reason = read_octet_counting(&mut reader, addr(), &tx, None, None).await;
+        let reason = read_octet_counting(&mut reader, addr(), &tx, None, Some(&metrics)).await;
         assert!(matches!(reason, CloseReason::FramingError(_)));
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            data.len() as u64,
+            "invalid payload bytes are still received bytes"
+        );
     }
 
     #[tokio::test]
@@ -840,14 +870,22 @@ mod tests {
         let data = b"<134>hello\n<165>world\n";
         let mut reader = BufReader::new(&data[..]);
         let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+        let metrics = InputMetrics::for_testing();
 
-        let reason = read_non_transparent(&mut reader, addr(), &tx, None, None).await;
+        let reason = read_non_transparent(&mut reader, addr(), &tx, None, Some(&metrics)).await;
         drop(tx);
         assert!(matches!(reason, CloseReason::Eof));
 
         assert_eq!(&*rx.recv().await.unwrap().ingress, b"<134>hello");
         assert_eq!(&*rx.recv().await.unwrap().ingress, b"<165>world");
         assert!(rx.recv().await.is_none());
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            data.len() as u64,
+            "line delimiters are adapter framing bytes"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -1126,7 +1126,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ntf_oversize_counts_only_prior_consumed_chunks() {
-        const CHUNK: usize = 8;
+        const CHUNK: usize = 7;
         let data = vec![b'x'; MAX_MESSAGE_SIZE + CHUNK];
         let mut reader = BufReader::with_capacity(CHUNK, &data[..]);
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
@@ -1136,7 +1136,7 @@ mod tests {
         assert!(matches!(reason, CloseReason::FramingError(_)));
         assert_eq!(
             bytes_received(&metrics),
-            MAX_MESSAGE_SIZE as u64,
+            (MAX_MESSAGE_SIZE - (MAX_MESSAGE_SIZE % CHUNK)) as u64,
             "the chunk rejected by the size guard remains unread and uncounted"
         );
     }
@@ -1423,10 +1423,9 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // Accept-loop end-to-end tests: max_connections wire enforcement +
-    // valid-event delivery. Coverage-gap audit Agent A flagged these
-    // paths as High risk: the framing helpers are well-tested but the
-    // listener that wraps them is not.
+    // Accept-loop end-to-end tests cover max_connections wire enforcement
+    // and valid-event delivery through the listener, complementing the
+    // focused framing-helper tests.
     // ---------------------------------------------------------------------
 
     fn pick_port() -> u16 {

--- a/crates/limpid/src/modules/input/syslog_udp.rs
+++ b/crates/limpid/src/modules/input/syslog_udp.rs
@@ -102,6 +102,7 @@ impl Input for SyslogUdpInput {
                     match result {
                         Ok((len, addr)) => {
                             let data = &buf[..len];
+                            metrics.bytes_received.inc_by(len as u64);
 
                             if let Err(e) = validate_pri(data) {
                                 warn!("syslog_udp [{}]: dropping invalid message ({})", addr, e);
@@ -196,6 +197,10 @@ mod tests {
         assert_eq!(&event.ingress[..], b"<13>hello");
         assert_eq!(metrics.events_received.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.events_invalid.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            metrics.bytes_received.load(Ordering::Relaxed),
+            b"<13>hello".len() as u64
+        );
 
         let _ = sd_tx.send(true);
         let _ = handle.await;
@@ -223,6 +228,28 @@ mod tests {
         );
         assert_eq!(metrics.events_invalid.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.events_received.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            metrics.bytes_received.load(Ordering::Relaxed),
+            b"not a valid syslog line".len() as u64,
+            "validation must not hide bytes that reached the adapter"
+        );
+
+        let _ = sd_tx.send(true);
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn empty_datagram_is_a_zero_byte_noop() {
+        let port = pick_port();
+        let bind = format!("127.0.0.1:{port}");
+        let (handle, sd_tx, _rx, metrics) = spawn_input(bind.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let sender = StdUdpSocket::bind("127.0.0.1:0").unwrap();
+        sender.send_to(&[], &bind).unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert_eq!(metrics.bytes_received.load(Ordering::Relaxed), 0);
 
         let _ = sd_tx.send(true);
         let _ = handle.await;

--- a/crates/limpid/src/modules/input/tail.rs
+++ b/crates/limpid/src/modules/input/tail.rs
@@ -357,6 +357,7 @@ impl TailInput {
             // Trim trailing newline
             let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
             if trimmed.is_empty() {
+                self.metrics.bytes_received.inc_by(bytes_read as u64);
                 continue;
             }
 
@@ -394,6 +395,11 @@ impl TailInput {
                 current_offset -= bytes_read as u64;
                 break;
             }
+            // Count only after the send succeeds — the rewind and
+            // incomplete-line branches above must not have fired for
+            // this line, otherwise a retry would double-count the
+            // same bytes.
+            self.metrics.bytes_received.inc_by(bytes_read as u64);
         }
 
         Ok(current_offset)
@@ -550,6 +556,14 @@ mod tests {
             .await
             .unwrap();
         let _ = rx.recv().await; // drain "complete"
+        assert_eq!(
+            input
+                .metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            b"complete\n".len() as u64,
+            "an incomplete trailing line is not counted before completion"
+        );
         // Writer appends the newline.
         {
             let mut f = std::fs::OpenOptions::new()
@@ -565,6 +579,14 @@ mod tests {
         assert_eq!(off2, 17);
         let e = rx.recv().await.unwrap();
         assert_eq!(&e.ingress[..], b"partial");
+        assert_eq!(
+            input
+                .metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            b"complete\npartial\n".len() as u64,
+            "the completed line, including its delimiter, is counted once"
+        );
     }
 
     #[test]
@@ -673,6 +695,31 @@ mod tests {
         assert_eq!(
             next_off, 0,
             "send failure must rewind so the un-sent line is retried",
+        );
+        assert_eq!(
+            input
+                .metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "a rewound line must not be counted before its successful completion"
+        );
+
+        std::fs::write(&path, b"line1\n").unwrap();
+        let (retry_tx, mut retry_rx) = tokio::sync::mpsc::channel::<Event>(1);
+        let next_off = input
+            .read_new_lines(0, &retry_tx, dummy_addr(), dummy_ack_tx(), 0)
+            .await
+            .unwrap();
+        assert_eq!(next_off, b"line1\n".len() as u64);
+        assert_eq!(&retry_rx.recv().await.unwrap().ingress[..], b"line1");
+        assert_eq!(
+            input
+                .metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            b"line1\n".len() as u64,
+            "rewind and re-read must not double count"
         );
     }
 

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -420,6 +420,7 @@ impl Input for UnixSocketInput {
                     match result {
                         Ok(len) => {
                             let data = &buf[..len];
+                            self.metrics.bytes_received.inc_by(len as u64);
 
                             if let Err(e) = validate_pri(data) {
                                 warn!("unix_socket: dropping invalid message ({})", e);
@@ -474,14 +475,27 @@ mod tests {
         tokio::sync::watch::Sender<bool>,
         tokio::sync::mpsc::Receiver<Event>,
     ) {
+        let (handle, shutdown, events, _metrics) = spawn_with_path_and_metrics(path);
+        (handle, shutdown, events)
+    }
+
+    fn spawn_with_path_and_metrics(
+        path: &std::path::Path,
+    ) -> (
+        tokio::task::JoinHandle<Result<()>>,
+        tokio::sync::watch::Sender<bool>,
+        tokio::sync::mpsc::Receiver<Event>,
+        Arc<InputMetrics>,
+    ) {
+        let metrics = InputMetrics::for_testing();
         let input = UnixSocketInput {
             path: path.display().to_string(),
-            metrics: InputMetrics::for_testing(),
+            metrics: Arc::clone(&metrics),
         };
         let (tx, rx) = tokio::sync::mpsc::channel(16);
         let (sd_tx, sd_rx) = tokio::sync::watch::channel(false);
         let handle = tokio::spawn(async move { input.run(tx, sd_rx).await });
-        (handle, sd_tx, rx)
+        (handle, sd_tx, rx, metrics)
     }
 
     #[tokio::test]
@@ -640,7 +654,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("sock");
 
-        let (handle, sd_tx, mut rx) = spawn_with_path(&socket_path);
+        let (handle, sd_tx, mut rx, metrics) = spawn_with_path_and_metrics(&socket_path);
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let sender = StdUnixDatagram::unbound().unwrap();
@@ -651,6 +665,35 @@ mod tests {
             .expect("recv timed out")
             .expect("channel closed");
         assert_eq!(&event.ingress[..], b"<13>test message");
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            b"<13>test message".len() as u64
+        );
+        let _ = sd_tx.send(true);
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn invalid_datagram_still_counts_adapter_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("sock");
+        let (handle, sd_tx, mut rx, metrics) = spawn_with_path_and_metrics(&socket_path);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let invalid = b"not syslog";
+        let sender = StdUnixDatagram::unbound().unwrap();
+        sender.send_to(invalid, &socket_path).unwrap();
+        let got = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
+        assert!(got.is_err(), "invalid datagram must not become an Event");
+        assert_eq!(
+            metrics
+                .bytes_received
+                .load(std::sync::atomic::Ordering::Relaxed),
+            invalid.len() as u64
+        );
+
         let _ = sd_tx.send(true);
         let _ = handle.await;
     }

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -614,11 +614,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
         let count = shippable.len() as u64;
         let rejected = outcome.rejected.min(count);
         let written = count - rejected;
-        if written > 0 {
-            for _ in 0..written {
-                self.metrics.events_written.inc();
-            }
-        }
+        self.metrics.events_written.inc_by(written);
         let split = (count - rejected) as usize;
         let mut iter = shippable.into_iter();
         for (_, ack, _permit) in iter.by_ref().take(split) {

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -600,6 +600,7 @@ impl FileOutput {
         // than the event count claims. The syscall is cheap and turns
         // "write returned Ok" into an OS-visible commitment.
         file.flush().await?;
+        self.metrics.bytes_written.inc_by(buf.len() as u64);
         self.metrics.events_written.inc();
 
         Ok(())
@@ -1172,6 +1173,7 @@ mod tests {
     use crate::event::Event;
     use crate::functions::table::TableStore;
     use std::net::SocketAddr;
+    use std::sync::atomic::Ordering;
 
     /// Test helper: resolve a path against an OwnedEvent without
     /// duplicating arena boilerplate at every call site. Mirrors what
@@ -1552,6 +1554,11 @@ mod tests {
         expected.push(b'\n');
         let on_disk = std::fs::read(&path).unwrap();
         assert_eq!(on_disk, expected, "bytes must survive verbatim");
+        assert_eq!(
+            out.metrics.bytes_written.load(Ordering::Relaxed),
+            expected.len() as u64,
+            "the adapter-added newline is part of the confirmed write buffer"
+        );
         // Belt-and-braces: the U+FFFD replacement sequence must NOT
         // appear at any offset in the on-disk output.
         assert!(
@@ -1983,6 +1990,8 @@ mod tests {
             0,
             "payload must not have been written when metadata apply failed"
         );
+        assert_eq!(out.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert_eq!(out.metrics.events_written.load(Ordering::Relaxed), 0);
     }
 
     /// The output birth-mode contract exists to close a specific

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -191,6 +191,7 @@ struct HttpSinkPolicy {
     content_type: String,
     headers: Vec<(String, String)>,
     compress: bool,
+    metrics: Arc<OutputMetrics>,
 }
 
 pub struct HttpOutput {
@@ -411,6 +412,7 @@ impl Module for HttpOutput {
             content_type,
             headers,
             compress,
+            metrics: Arc::clone(&metrics),
         };
         // The shared skeleton spawns the flusher actor that owns
         // every send — both batched flushes and singleton
@@ -570,6 +572,7 @@ async fn send_once(peer: &HttpPeer, policy: &HttpSinkPolicy, body: &[u8]) -> Res
         .send()
         .await
         .with_context(|| format!("http output: request to {} failed", peer.url))?;
+    policy.metrics.bytes_written.inc_by(body.len() as u64);
 
     let status = response.status();
     if !status.is_success() {
@@ -602,6 +605,7 @@ mod tests {
     use crate::event::Event;
     use crate::modules::output::syslog_peers::PEER_COOLDOWN;
     use std::net::SocketAddr;
+    use std::sync::atomic::Ordering;
     use std::time::Instant;
     use tokio::sync::Mutex;
 
@@ -623,6 +627,15 @@ mod tests {
             key: key.to_string(),
             key_span: None,
             value: Expr::spanless(ExprKind::IntLit(val)),
+            value_span: None,
+        }
+    }
+
+    fn prop_bool(key: &str, val: bool) -> Property {
+        Property::KeyValue {
+            key: key.to_string(),
+            key_span: None,
+            value: Expr::spanless(ExprKind::BoolLit(val)),
             value_span: None,
         }
     }
@@ -953,6 +966,68 @@ mod tests {
         server.abort();
         let got = received.lock().await.clone();
         assert_eq!(got, vec!["hello-single".to_string()]);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            b"hello-single".len() as u64
+        );
+    }
+
+    #[tokio::test]
+    async fn compressed_batch_counts_the_exact_prepared_body() {
+        use axum::{Router, extract::State, http::StatusCode, routing::post};
+
+        #[derive(Clone)]
+        struct Capture(Arc<tokio::sync::Mutex<Vec<Vec<u8>>>>);
+        async fn capture(State(state): State<Capture>, body: axum::body::Bytes) -> StatusCode {
+            state.0.lock().await.push(body.to_vec());
+            StatusCode::OK
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let bodies = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/", post(capture))
+            .with_state(Capture(Arc::clone(&bodies)));
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        let output = HttpOutput::from_properties(
+            "compressed-bytes",
+            &mp(&[
+                peer_block(&format!("http://{addr}/")),
+                prop_int("batch_size", 2),
+                prop_bool("compress", true),
+            ]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let payloads = vec![
+            bytes::Bytes::from_static(b"compress-one"),
+            bytes::Bytes::from_static(b"compress-two"),
+        ];
+        let expected = output.sink.inner.policy.prepare(payloads.clone()).unwrap();
+
+        for payload in payloads {
+            let event = Event::new(payload, "127.0.0.1:0".parse().unwrap());
+            consume(&output, &event).await.unwrap();
+        }
+        for _ in 0..50 {
+            if !bodies.lock().await.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        server.abort();
+        assert_eq!(
+            bodies.lock().await.as_slice(),
+            std::slice::from_ref(&expected)
+        );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            expected.len() as u64,
+            "gzip bytes, not pre-compression payload bytes, define the adapter boundary"
+        );
     }
 
     #[tokio::test]
@@ -1062,6 +1137,67 @@ mod tests {
         );
         s_a.abort();
         s_b.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_connection_then_confirmed_retry_counts_the_body_once() {
+        let dead_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dead_addr = dead_listener.local_addr().unwrap();
+        drop(dead_listener);
+        let (healthy_addr, received, server) = run_echo_collector().await;
+        let retry = Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 2),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+                Property::KeyValue {
+                    key: "backoff".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
+                    value_span: None,
+                },
+            ],
+        };
+        let output = HttpOutput::from_properties(
+            "retry-bytes",
+            &mp(&[
+                peers_block_with(vec![
+                    peer_block(&format!("http://{dead_addr}/")),
+                    peer_block(&format!("http://{healthy_addr}/")),
+                ]),
+                prop_int("batch_size", 1),
+                retry,
+            ]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+
+        let disposition = consume_and_wait_disposition(
+            &output,
+            &event_with("retry-once"),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            disposition,
+            crate::queue::AckDisposition::Delivered
+        ));
+        for _ in 0..50 {
+            if !received.lock().await.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        server.abort();
+        assert_eq!(received.lock().await.as_slice(), &["retry-once"]);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            b"retry-once".len() as u64,
+            "the failed connection contributes zero; the confirmed retry contributes once"
+        );
     }
 
     #[test]
@@ -1585,14 +1721,19 @@ def output o {{
         // exhausts the budget and DLQ-routes both events.
         let (ack2, mut rx2) = QueueAckHandle::for_test();
         output.consume(&event_with("e2"), ack2).await.unwrap();
+        let dispositions = tokio::time::timeout(Duration::from_secs(2), async {
+            (rx1.recv().await, rx2.recv().await)
+        })
+        .await;
         server.abort();
 
+        let (disp1, disp2) = dispositions.expect("batch acknowledgements must resolve promptly");
         assert!(matches!(
-            rx1.recv().await,
+            disp1,
             Some((_, crate::queue::AckDisposition::Recovered))
         ));
         assert!(matches!(
-            rx2.recv().await,
+            disp2,
             Some((_, crate::queue::AckDisposition::Recovered))
         ));
         assert_eq!(
@@ -1605,6 +1746,12 @@ def output o {{
         let body = tokio::fs::read_to_string(&dlq_path).await.unwrap();
         let n_lines = body.lines().count();
         assert_eq!(n_lines, 2, "expected one DLQ record per buffered event");
+        assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            b"e1\ne2".len() as u64,
+            "a non-2xx response still confirms transfer of the complete prepared body"
+        );
     }
 
     #[tokio::test]
@@ -1710,6 +1857,11 @@ def output o {{
         assert!(
             body.contains("ev1") && body.contains("ev2"),
             "shutdown POST must carry the buffered events; got: {body}"
+        );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            b"ev1\nev2".len() as u64,
+            "shutdown counts the exact joined body once"
         );
     }
 

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -498,6 +498,11 @@ impl Output for KafkaOutput {
             // or by the runtime SIGTERM budget.
             match self.try_send(event, shutdown.clone()).await {
                 Ok(KafkaTrySendOutcome::Delivered) => {
+                    // `FutureProducer` resolves each message through
+                    // an async delivery report — count only in the
+                    // Delivered arm so the counter tracks a successful
+                    // delivery report, not a client-side enqueue.
+                    self.metrics.bytes_written.inc_by(event.egress.len() as u64);
                     self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
@@ -1244,6 +1249,43 @@ mod tests {
                 KafkaTrySendOutcome::Delivered => "Delivered",
                 KafkaTrySendOutcome::PreSendShutdown => "PreSendShutdown",
             }
+        );
+        assert_eq!(
+            output
+                .metrics
+                .bytes_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "pre-send shutdown confirms no Kafka payload transfer"
+        );
+    }
+
+    #[test]
+    fn delivered_branch_owns_the_kafka_payload_byte_bump() {
+        let src = include_str!("kafka.rs");
+        let start = src
+            .find("async fn consume(&self, event: &Event")
+            .expect("Kafka consume implementation must exist");
+        let end = src[start..]
+            .find("async fn consume_shutdown(")
+            .expect("consume_shutdown must follow consume");
+        let body = &src[start..start + end];
+        let delivered = body
+            .find("KafkaTrySendOutcome::Delivered")
+            .expect("delivery branch must exist");
+        let pre_send = body
+            .find("KafkaTrySendOutcome::PreSendShutdown")
+            .expect("pre-send branch must exist");
+        let delivered_arm = &body[delivered..pre_send];
+        assert!(
+            delivered_arm.contains("bytes_written.inc_by(event.egress.len() as u64)"),
+            "Kafka bytes must bump exactly at the delivery-report boundary"
+        );
+        assert_eq!(
+            body.matches("bytes_written.inc_by(event.egress.len() as u64)")
+                .count(),
+            1,
+            "steady-state Kafka delivery must record the payload once"
         );
     }
 }

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -629,7 +629,10 @@ impl Output for KafkaOutput {
         // does not support at this boundary.
         let (_no_shutdown_tx, no_shutdown_rx) = tokio::sync::watch::channel(false);
         let result = match self.try_send(event, no_shutdown_rx).await {
-            Ok(KafkaTrySendOutcome::Delivered) => Ok(()),
+            Ok(KafkaTrySendOutcome::Delivered) => {
+                self.metrics.bytes_written.inc_by(event.egress.len() as u64);
+                Ok(())
+            }
             Ok(KafkaTrySendOutcome::PreSendShutdown) => {
                 // The receiver we passed can never observe
                 // shutdown — this branch is a defensive
@@ -1286,6 +1289,90 @@ mod tests {
                 .count(),
             1,
             "steady-state Kafka delivery must record the payload once"
+        );
+    }
+
+    fn match_arm_block<'a>(source: &'a str, pattern: &str) -> &'a str {
+        let pattern_start = source.find(pattern).expect("match arm must exist");
+        let arrow = source[pattern_start..]
+            .find("=>")
+            .map(|offset| pattern_start + offset)
+            .expect("match arm must have an arrow");
+        let block_start = source[arrow..]
+            .find('{')
+            .map(|offset| arrow + offset)
+            .expect("match arm must have a block");
+        let mut depth = 0usize;
+        for (offset, byte) in source.as_bytes()[block_start..].iter().enumerate() {
+            match byte {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[block_start..=block_start + offset];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("match arm block must be balanced");
+    }
+
+    #[test]
+    fn delivered_arm_extraction_is_order_independent() {
+        let reordered = r#"
+            match outcome {
+                Ok(KafkaTrySendOutcome::PreSendShutdown) => { unreachable!() }
+                Err(error) => { return Err(error); }
+                Ok(KafkaTrySendOutcome::Delivered) => {
+                    self.metrics.bytes_written.inc_by(event.egress.len() as u64);
+                    Ok(())
+                }
+            }
+        "#;
+        assert!(
+            match_arm_block(reordered, "Ok(KafkaTrySendOutcome::Delivered)")
+                .contains("bytes_written.inc_by(event.egress.len() as u64)"),
+            "Delivered-arm ownership must remain detectable after arm reordering"
+        );
+    }
+
+    #[test]
+    fn shutdown_delivered_branch_owns_one_kafka_payload_byte_bump() {
+        let src = include_str!("kafka.rs");
+        let steady_start = src
+            .find("async fn consume(&self, event: &Event")
+            .expect("Kafka consume implementation must exist");
+        let shutdown_start = src[steady_start..]
+            .find("async fn consume_shutdown(")
+            .map(|offset| steady_start + offset)
+            .expect("consume_shutdown must follow consume");
+        let shutdown_end = src[shutdown_start..]
+            .find("impl KafkaOutput {")
+            .map(|offset| shutdown_start + offset)
+            .expect("consume_shutdown must end before the next impl");
+        let steady_body = &src[steady_start..shutdown_start];
+        let shutdown_body = &src[shutdown_start..shutdown_end];
+
+        assert_eq!(
+            steady_body
+                .matches("bytes_written.inc_by(event.egress.len() as u64)")
+                .count(),
+            1,
+            "steady-state Delivered must count the payload exactly once"
+        );
+        let delivered_arm = match_arm_block(shutdown_body, "Ok(KafkaTrySendOutcome::Delivered)");
+        assert!(
+            delivered_arm.contains("bytes_written.inc_by(event.egress.len() as u64)"),
+            "shutdown delivery must count the payload at the delivery-report boundary"
+        );
+        assert_eq!(
+            shutdown_body
+                .matches("bytes_written.inc_by(event.egress.len() as u64)")
+                .count(),
+            1,
+            "shutdown Delivered must count the payload exactly once; Err and defensive \
+             PreSendShutdown paths must remain zero"
         );
     }
 }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -53,6 +53,7 @@ use bytes::Bytes;
 use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsServiceRequest, logs_service_client::LogsServiceClient,
 };
+use prost::Message;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 use crate::dsl::ast::Property;
@@ -95,6 +96,7 @@ struct OtlpGrpcSinkPolicy {
     rotation: RotatingPeers,
     batch_level: BatchLevel,
     headers: Vec<(String, String)>,
+    metrics: Arc<OutputMetrics>,
 }
 
 pub struct OtlpGrpcOutput {
@@ -294,6 +296,7 @@ impl Module for OtlpGrpcOutput {
             rotation,
             batch_level,
             headers,
+            metrics: Arc::clone(&metrics),
         };
         // The shared skeleton spawns the flusher actor; see
         // `crate::modules::output::batched` for the actor / shutdown
@@ -386,6 +389,7 @@ impl BatchSinkPolicy for OtlpGrpcSinkPolicy {
         let idx = self.rotation.select().await;
         match send_once(&self.peers[idx], self, req).await {
             Ok(outcome) => {
+                self.metrics.bytes_written.inc_by(req.encoded_len() as u64);
                 self.rotation.mark_success(idx).await;
                 Ok(outcome)
             }
@@ -890,12 +894,15 @@ mod tests {
             &crate::modules::BuildContext::for_testing(),
         )
         .unwrap();
-        consume(
-            &output,
-            &event_with_egress(singleton_bytes(1_700_000_000_000_000_000)),
-        )
-        .await
-        .unwrap();
+        let payload = singleton_bytes(1_700_000_000_000_000_000);
+        let expected_bytes = output
+            .sink
+            .inner
+            .policy
+            .prepare(vec![payload.clone()])
+            .unwrap()
+            .encoded_len() as u64;
+        consume(&output, &event_with_egress(payload)).await.unwrap();
 
         let probe = || {
             let g = received.try_lock().ok()?;
@@ -907,6 +914,11 @@ mod tests {
         assert_eq!(got.len(), 1);
         let lr = &got[0].resource_logs[0].scope_logs[0].log_records[0];
         assert_eq!(lr.time_unix_nano, 1_700_000_000_000_000_000);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            expected_bytes,
+            "gRPC output counts the canonical serialized request once"
+        );
     }
 
     /// Test-only LogsService that ALWAYS reports `partial_success.
@@ -971,8 +983,16 @@ mod tests {
         )
         .unwrap();
 
-        for i in 0..3 {
-            let ev = event_with_egress(singleton_bytes(1_000_000_000 + i));
+        let payloads: Vec<_> = (0..3).map(|i| singleton_bytes(1_000_000_000 + i)).collect();
+        let expected_bytes = output
+            .sink
+            .inner
+            .policy
+            .prepare(payloads.clone())
+            .unwrap()
+            .encoded_len() as u64;
+        for payload in payloads {
+            let ev = event_with_egress(payload);
             // With batch_size=3 the per-event disposition isn't observable
             // via the test shim's freshly-allocated handle channel — the
             // first two events stay buffered (handle held by the output)
@@ -1005,6 +1025,11 @@ mod tests {
         assert_eq!(
             failed, 2,
             "expected 2 failed, got {failed} (written={written})"
+        );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            expected_bytes,
+            "partial rejection still confirms transfer of the full canonical request"
         );
     }
 
@@ -1107,6 +1132,16 @@ mod tests {
             matches!(disp, crate::queue::AckDisposition::Recovered),
             "stalled peer must surface as Recovered, got {:?}",
             disp
+        );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            0,
+            "a stalled peer never confirms transfer of the prepared request"
+        );
+        assert_eq!(
+            output.metrics.events_written.load(Ordering::Relaxed),
+            0,
+            "the event and byte success counters remain independent on failure"
         );
         let _ = output.shutdown(None).await;
         stall.abort();

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -134,6 +134,7 @@ struct OtlpHttpSinkPolicy {
     protocol: HttpProtocol,
     batch_level: BatchLevel,
     headers: Vec<(String, String)>,
+    metrics: Arc<OutputMetrics>,
 }
 
 pub struct OtlpHttpOutput {
@@ -413,6 +414,7 @@ impl Module for OtlpHttpOutput {
             protocol,
             batch_level,
             headers,
+            metrics: Arc::clone(&metrics),
         };
         // The shared skeleton spawns the flusher actor; see
         // `crate::modules::output::batched` for the actor / shutdown
@@ -531,6 +533,7 @@ async fn send_once(
         HttpProtocol::Json => serde_json::to_vec(req)
             .map_err(|e| anyhow!("output otlp_http: JSON encode failed: {e}"))?,
     };
+    let body_len = body.len();
     let mut http_req = peer
         .client
         .post(&peer.endpoint)
@@ -543,6 +546,7 @@ async fn send_once(
         .send()
         .await
         .with_context(|| format!("output otlp_http: POST {} failed", peer.endpoint))?;
+    policy.metrics.bytes_written.inc_by(body_len as u64);
     let status = resp.status();
     if !status.is_success() {
         // 4 KiB byte cap, 500 chars on the lossy decode for the log
@@ -1062,6 +1066,7 @@ def output o {{
     ) -> (
         SocketAddr,
         Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+        Arc<Mutex<Vec<usize>>>,
         tokio::task::JoinHandle<()>,
     ) {
         use axum::{
@@ -1075,6 +1080,7 @@ def output o {{
         #[derive(Clone)]
         struct AppState {
             received: Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+            received_body_lengths: Arc<Mutex<Vec<usize>>>,
             protocol: &'static str,
         }
 
@@ -1088,6 +1094,7 @@ def output o {{
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or("")
                 .to_string();
+            let body_len = body.len();
             let req: ExportLogsServiceRequest = match state.protocol {
                 "http_protobuf" => {
                     if !ct.starts_with("application/x-protobuf") {
@@ -1122,6 +1129,7 @@ def output o {{
                 }
                 _ => unreachable!("test-only enumeration"),
             };
+            state.received_body_lengths.lock().await.push(body_len);
             state.received.lock().await.push(req);
             (StatusCode::OK, "").into_response()
         }
@@ -1129,16 +1137,18 @@ def output o {{
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let received = Arc::new(Mutex::new(Vec::new()));
+        let received_body_lengths = Arc::new(Mutex::new(Vec::new()));
         let app = Router::new()
             .route("/v1/logs", post(handle))
             .with_state(AppState {
                 received: Arc::clone(&received),
+                received_body_lengths: Arc::clone(&received_body_lengths),
                 protocol,
             });
         let handle = tokio::spawn(async move {
             let _ = axum::serve(listener, app).await;
         });
-        (addr, received, handle)
+        (addr, received, received_body_lengths, handle)
     }
 
     #[tokio::test]
@@ -1331,8 +1341,110 @@ def output o {{
     }
 
     #[tokio::test]
+    async fn non_success_response_confirms_the_full_prepared_body() {
+        use axum::{Router, extract::State, http::StatusCode, routing::post};
+
+        #[derive(Clone)]
+        struct AppState {
+            body_lengths: Arc<Mutex<Vec<usize>>>,
+        }
+
+        async fn reject(State(state): State<AppState>, body: axum::body::Bytes) -> StatusCode {
+            state.body_lengths.lock().await.push(body.len());
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let body_lengths = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/logs", post(reject))
+            .with_state(AppState {
+                body_lengths: Arc::clone(&body_lengths),
+            });
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let endpoint = format!("http://{}/v1/logs", addr);
+        let mut props = one_peer_props(&endpoint);
+        props.push(prop_str("protocol", "http_protobuf"));
+        props.push(prop_int("batch_size", 1));
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpHttpOutput::from_properties(
+            "test",
+            &mp(&props),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let disp = consume_and_wait_disposition(
+            &output,
+            &event_with_egress(singleton_bytes(789)),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(disp, crate::queue::AckDisposition::Recovered));
+        let body_lengths = body_lengths.lock().await.clone();
+        assert_eq!(body_lengths.len(), 1);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            body_lengths[0] as u64,
+            "a non-success response still confirms transfer of the prepared body"
+        );
+        assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn connection_failure_without_a_receipt_counts_no_bytes() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let endpoint = format!("http://{}/v1/logs", addr);
+        let mut props = one_peer_props(&endpoint);
+        props.push(prop_str("protocol", "http_protobuf"));
+        props.push(prop_int("batch_size", 1));
+        props.push(Property::Block {
+            key: "retry".into(),
+            key_span: None,
+            properties: vec![
+                prop_int("max_attempts", 1),
+                prop_str("initial_wait", "1ms"),
+                prop_str("max_wait", "1ms"),
+            ],
+        });
+        let output = OtlpHttpOutput::from_properties(
+            "test",
+            &mp(&props),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let disp = consume_and_wait_disposition(
+            &output,
+            &event_with_egress(singleton_bytes(790)),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(disp, crate::queue::AckDisposition::Recovered));
+        assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
     async fn round_trip_protobuf() {
-        let (addr, received, server) = run_http_collector("http_protobuf").await;
+        let (addr, received, received_body_lengths, server) =
+            run_http_collector("http_protobuf").await;
         let endpoint = format!("http://{}/v1/logs", addr);
         let mut props = one_peer_props(&endpoint);
         props.push(prop_str("protocol", "http_protobuf"));
@@ -1357,11 +1469,18 @@ def output o {{
             got[0].resource_logs[0].scope_logs[0].log_records[0].time_unix_nano,
             123
         );
+        let body_lengths = received_body_lengths.lock().await.clone();
+        assert_eq!(body_lengths.len(), 1);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            body_lengths[0] as u64,
+            "protobuf bytes match the body received by the collector"
+        );
     }
 
     #[tokio::test]
     async fn round_trip_json() {
-        let (addr, received, server) = run_http_collector("http_json").await;
+        let (addr, received, received_body_lengths, server) = run_http_collector("http_json").await;
         let endpoint = format!("http://{}/v1/logs", addr);
         let mut props = one_peer_props(&endpoint);
         props.push(prop_str("protocol", "http_json"));
@@ -1385,6 +1504,13 @@ def output o {{
         assert_eq!(
             got[0].resource_logs[0].scope_logs[0].log_records[0].time_unix_nano,
             456
+        );
+        let body_lengths = received_body_lengths.lock().await.clone();
+        assert_eq!(body_lengths.len(), 1);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            body_lengths[0] as u64,
+            "JSON bytes use the actual serialized body, not protobuf encoded_len"
         );
     }
 
@@ -1455,8 +1581,16 @@ def output o {{
         )
         .unwrap();
 
-        for i in 0..3 {
-            let ev = event_with_egress(singleton_bytes(900_000_000 + i));
+        let payloads: Vec<_> = (0..3).map(|i| singleton_bytes(900_000_000 + i)).collect();
+        let expected_bytes = output
+            .sink
+            .inner
+            .policy
+            .prepare(payloads.clone())
+            .unwrap()
+            .encoded_len() as u64;
+        for payload in payloads {
+            let ev = event_with_egress(payload);
             // With batch_size=3 the per-event disposition isn't observable
             // via the test shim's freshly-allocated handle channel — the
             // first two events stay buffered (handle held by the output)
@@ -1487,6 +1621,11 @@ def output o {{
         assert_eq!(
             failed, 2,
             "expected 2 failed, got {failed} (written={written})"
+        );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            expected_bytes,
+            "partial_success does not apportion the transferred request body"
         );
     }
 
@@ -1609,7 +1748,8 @@ def output o {{
         // `shutdown()` must signal/join the actor and final-drain
         // any leftover buffer with one bounded send attempt (or
         // DLQ drain) so every parked handle resolves.
-        let (addr, received, server) = run_http_collector("http_protobuf").await;
+        let (addr, received, _received_body_lengths, server) =
+            run_http_collector("http_protobuf").await;
         let endpoint = format!("http://{}/v1/logs", addr);
         let mut props = one_peer_props(&endpoint);
         props.push(prop_str("protocol", "http_protobuf"));
@@ -1899,7 +2039,8 @@ def output o {{
 
     #[tokio::test]
     async fn shutdown_success_does_not_touch_error_log() {
-        let (addr, received, server) = run_http_collector("http_protobuf").await;
+        let (addr, received, _received_body_lengths, server) =
+            run_http_collector("http_protobuf").await;
         let endpoint = format!("http://{}/v1/logs", addr);
         let mut props = one_peer_props(&endpoint);
         props.push(prop_str("protocol", "http_protobuf"));

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -80,10 +80,19 @@ impl StdoutOutput {
     /// on the payload and then fail on the delimiter, leaving an
     /// unterminated line that a retry would double.
     fn write_event(&self, event: &Event) -> Result<()> {
-        use std::io::Write;
-        let buf = super::frame_with_newline(&event.egress);
         let mut out = std::io::stdout().lock();
+        self.write_event_to(&mut out, event)
+    }
+
+    /// Private writer seam: `write_event` locks stdout and delegates
+    /// here so the confirmed-bytes contract stays testable against
+    /// an arbitrary `impl Write`. The counter bump follows the
+    /// `write_all` `?`, so a partial or failing write leaves the
+    /// counter untouched.
+    fn write_event_to(&self, out: &mut impl std::io::Write, event: &Event) -> Result<()> {
+        let buf = super::frame_with_newline(&event.egress);
         out.write_all(&buf).context("stdout write failed")?;
+        self.metrics.bytes_written.inc_by(buf.len() as u64);
         Ok(())
     }
 }
@@ -211,6 +220,7 @@ mod metrics_registration_tests {
                 "limpid_output_retries_total",
                 "limpid_output_events_wedged_total",
                 "limpid_output_events_errored_unwritable_total",
+                "limpid_output_bytes_written_total",
             ]
             .contains(&name.as_str())
         );
@@ -242,5 +252,97 @@ mod metrics_registration_tests {
                 )
             });
         assert_output_duplicate(metrics_error, "conflicting", &diagnostic);
+    }
+
+    #[tokio::test]
+    async fn successful_write_counts_payload_and_adapter_newline_once() {
+        let ctx = crate::modules::BuildContext::for_testing();
+        let properties = ModuleProperties::from_parts("stdout", Vec::new());
+        let output = StdoutOutput::from_properties("stdout-bytes", &properties, &ctx).unwrap();
+        let payload = bytes::Bytes::from_static(b"stdout-payload");
+        let event = crate::event::Event::new(payload.clone(), "127.0.0.1:0".parse().unwrap());
+        let (ack, _ack_rx) = crate::queue::QueueAckHandle::for_test();
+
+        output.consume(&event, ack).await.unwrap();
+
+        assert_eq!(
+            output
+                .metrics
+                .bytes_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            (payload.len() + 1) as u64
+        );
+        assert_eq!(
+            output
+                .metrics
+                .events_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "event and byte counters remain independent"
+        );
+    }
+
+    #[test]
+    fn writer_seam_counts_only_a_fully_confirmed_stdout_frame() {
+        use std::io::{self, Write};
+
+        struct AlwaysFails;
+
+        impl Write for AlwaysFails {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "test failure"))
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let ctx = crate::modules::BuildContext::for_testing();
+        let properties = ModuleProperties::from_parts("stdout", Vec::new());
+        let output = StdoutOutput::from_properties("stdout-writer", &properties, &ctx).unwrap();
+        let event = crate::event::Event::new(
+            bytes::Bytes::from_static(b"stdout-payload"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+
+        let mut written = Vec::new();
+        output.write_event_to(&mut written, &event).unwrap();
+        assert_eq!(written, b"stdout-payload\n");
+        assert_eq!(
+            output
+                .metrics
+                .bytes_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            written.len() as u64
+        );
+        assert_eq!(
+            output
+                .metrics
+                .events_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "the private write seam owns bytes, not event disposition"
+        );
+
+        let mut failing = AlwaysFails;
+        output
+            .write_event_to(&mut failing, &event)
+            .expect_err("an unconfirmed stdout write must fail");
+        assert_eq!(
+            output
+                .metrics
+                .bytes_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            written.len() as u64,
+            "a failed write must not add any bytes"
+        );
+        assert_eq!(
+            output
+                .metrics
+                .events_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
     }
 }

--- a/crates/limpid/src/modules/output/syslog_peers.rs
+++ b/crates/limpid/src/modules/output/syslog_peers.rs
@@ -218,11 +218,17 @@ where
 /// guarantee — a timeout-cancelled `write_all` mid-loop can
 /// still leave partial bytes, which the at-least-once retry
 /// contract acknowledges.
+///
+/// The exact frame-buffer length is returned only after both
+/// `write_all` and `flush` complete successfully — this is
+/// adapter-level completion, not peer receipt. A mid-write or
+/// mid-flush error surfaces as `Err` and yields no confirmed
+/// length.
 pub async fn write_framed<S>(
     stream: &mut S,
     framing: SyslogFraming,
     payload: &Bytes,
-) -> anyhow::Result<()>
+) -> anyhow::Result<usize>
 where
     S: AsyncWrite + Unpin,
 {
@@ -244,7 +250,7 @@ where
     };
     stream.write_all(&buf).await?;
     stream.flush().await?;
-    Ok(())
+    Ok(buf.len())
 }
 
 /// Per-peer mutable state. C is the connection type (TcpStream,
@@ -1085,5 +1091,93 @@ mod tests {
         let mut got = Vec::new();
         server.read_to_end(&mut got).await.unwrap();
         assert_eq!(got, b"<134>hello\n");
+    }
+
+    #[tokio::test]
+    async fn write_framed_returns_the_confirmed_exact_frame_length() {
+        use tokio::io::AsyncReadExt;
+
+        for framing in [SyslogFraming::OctetCounting, SyslogFraming::NonTransparent] {
+            for payload_len in [0usize, 9, 10, 99, 100] {
+                let payload = Bytes::from(vec![b'x'; payload_len]);
+                let expected = match framing {
+                    SyslogFraming::OctetCounting => {
+                        let mut frame = format!("{} ", payload.len()).into_bytes();
+                        frame.extend_from_slice(&payload);
+                        frame
+                    }
+                    SyslogFraming::NonTransparent => {
+                        let mut frame = payload.to_vec();
+                        frame.push(b'\n');
+                        frame
+                    }
+                };
+                let (mut writer, mut reader) = tokio::io::duplex(1024);
+                let payload_clone = payload.clone();
+                let task = tokio::spawn(async move {
+                    let confirmed: usize = write_framed(&mut writer, framing, &payload_clone)
+                        .await
+                        .expect("write and flush");
+                    confirmed
+                });
+                let mut actual = Vec::new();
+                reader.read_to_end(&mut actual).await.unwrap();
+                let confirmed = task.await.unwrap();
+
+                assert_eq!(actual, expected, "framing={framing:?}, len={payload_len}");
+                assert_eq!(
+                    confirmed,
+                    expected.len(),
+                    "write_framed must return the length of the exact buffer it wrote and flushed"
+                );
+            }
+        }
+    }
+
+    struct FlushFailure {
+        written: Vec<u8>,
+    }
+
+    impl tokio::io::AsyncWrite for FlushFailure {
+        fn poll_write(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            self.written.extend_from_slice(buf);
+            std::task::Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected flush failure",
+            )))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn write_framed_has_no_confirmed_length_before_flush_succeeds() {
+        let payload = Bytes::from_static(b"1234567890");
+        let mut writer = FlushFailure {
+            written: Vec::new(),
+        };
+
+        let result = write_framed(&mut writer, SyslogFraming::OctetCounting, &payload).await;
+        assert!(
+            result.is_err(),
+            "flush failure cannot confirm a frame length"
+        );
+        assert_eq!(writer.written, b"10 1234567890");
     }
 }

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -520,6 +520,7 @@ impl SyslogTcpOutput {
         shutdown: &mut tokio::sync::watch::Receiver<bool>,
     ) -> SyslogTcpWriteOutcome {
         let framing = self.framing;
+        let confirmed_len = framed_len(framing, payload.egress.len());
         let connectors = self.connectors.clone();
         let result = self
             .peers
@@ -630,7 +631,10 @@ impl SyslogTcpOutput {
             .await;
 
         match result {
-            Ok(()) => SyslogTcpWriteOutcome::Delivered,
+            Ok(()) => {
+                self.metrics.bytes_written.inc_by(confirmed_len as u64);
+                SyslogTcpWriteOutcome::Delivered
+            }
             Err(PeerSendError::PreSendShutdown) => SyslogTcpWriteOutcome::PreSendShutdown,
             Err(e) => SyslogTcpWriteOutcome::Err(e.into()),
         }
@@ -646,6 +650,7 @@ impl SyslogTcpOutput {
     /// this method would tick the counter.
     async fn write_payload(&self, payload: SyslogPayload) -> Result<()> {
         let framing = self.framing;
+        let confirmed_len = framed_len(framing, payload.egress.len());
         let connectors = self.connectors.clone();
         let result = self
             .peers
@@ -706,9 +711,30 @@ impl SyslogTcpOutput {
             .await;
 
         match result {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                self.metrics.bytes_written.inc_by(confirmed_len as u64);
+                Ok(())
+            }
             Err(err) => Err(anyhow::anyhow!("{}", err)),
         }
+    }
+}
+
+/// Length of the exact buffer handed to the write path. Must
+/// mirror the framing bytes the stream adds (octet-count digits
+/// plus SP for `OctetCounting`, trailing LF for `NonTransparent`);
+/// drift here would silently mis-count sent bytes.
+fn framed_len(framing: SyslogFraming, payload_len: usize) -> usize {
+    match framing {
+        SyslogFraming::OctetCounting => {
+            let digits = if payload_len == 0 {
+                1
+            } else {
+                payload_len.ilog10() as usize + 1
+            };
+            digits + 1 + payload_len
+        }
+        SyslogFraming::NonTransparent => payload_len + 1,
     }
 }
 
@@ -721,6 +747,8 @@ mod tests {
     use super::*;
     use crate::dsl::ast::{Expr, ExprKind, Property};
     use crate::dsl::schema::SchemaErrorKind;
+    use bytes::Bytes;
+    use std::sync::atomic::Ordering;
     use tempfile::TempDir;
 
     /// Structural pin: `consume_shutdown` routes its result through
@@ -753,6 +781,88 @@ mod tests {
             "consume_shutdown must not fall back to the plain finalizer — the wire state \
              cannot be proved pre-boundary from outside write_payload."
         );
+    }
+
+    #[tokio::test]
+    async fn successful_octet_counted_write_includes_the_generated_header() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let expected = b"10 <134>hello";
+        let receiver = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0; expected.len()];
+            stream.read_exact(&mut buf).await.unwrap();
+            buf
+        });
+        let output = SyslogTcpOutput::from_properties(
+            "tcp-bytes",
+            &mp(&[
+                peer_plain("127.0.0.1", addr.port() as i64),
+                kv("framing", ExprKind::Ident(vec!["octet_counting".into()])),
+            ]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let event = Event::new(
+            Bytes::from_static(b"<134>hello"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+
+        output.consume(&event, ack).await.unwrap();
+
+        assert_eq!(receiver.await.unwrap(), expected);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            expected.len() as u64,
+            "the generated octet-count header belongs to the adapter buffer"
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_failure_counts_neither_bytes_nor_written_events() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let output = SyslogTcpOutput::from_properties(
+            "tcp-failure",
+            &mp(&[
+                peer_plain("127.0.0.1", port as i64),
+                block(
+                    "retry",
+                    vec![
+                        kv("max_attempts", ExprKind::IntLit(1)),
+                        kv("initial_wait", ExprKind::StringLit("1ms".into())),
+                        kv("max_wait", ExprKind::StringLit("1ms".into())),
+                    ],
+                ),
+            ]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let event = Event::new(
+            Bytes::from_static(b"<134>unreachable"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            output.consume(&event, ack),
+        )
+        .await
+        .expect("connection failure must remain bounded")
+        .unwrap();
+
+        assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
     }
 
     struct PemFiles {

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -520,8 +520,8 @@ impl SyslogTcpOutput {
         shutdown: &mut tokio::sync::watch::Receiver<bool>,
     ) -> SyslogTcpWriteOutcome {
         let framing = self.framing;
-        let confirmed_len = framed_len(framing, payload.egress.len());
         let connectors = self.connectors.clone();
+        let metrics = Arc::clone(&self.metrics);
         let result = self
             .peers
             .write_with_rotation_shutdown_aware(
@@ -531,6 +531,7 @@ impl SyslogTcpOutput {
                     let address = peer.address();
                     let server_name = peer.host.clone();
                     let connector = connectors[idx].clone();
+                    let metrics = Arc::clone(&metrics);
                     Box::pin(async move {
                         if state.conn.is_none() {
                             // Pre-send phase: connect + TLS handshake
@@ -613,13 +614,15 @@ impl SyslogTcpOutput {
                         // Dropped → disk queue holds cursor and
                         // replays on next start.
                         let stream = state.conn.as_mut().expect("connection should be present");
-                        let write_result = tokio::time::timeout(
-                            PEER_WRITE_TIMEOUT,
-                            write_framed(stream, framing, &egress),
-                        )
+                        let write_result = tokio::time::timeout(PEER_WRITE_TIMEOUT, async {
+                            let confirmed_len = write_framed(stream, framing, &egress).await?;
+                            metrics.bytes_written.inc_by(confirmed_len as u64);
+                            Ok::<(), anyhow::Error>(())
+                        })
                         .await
-                        .map_err(|_| anyhow::anyhow!("syslog_tcp write to {} timed out", address))
-                        .and_then(|res| res);
+                        .map_err(|_| {
+                            anyhow::anyhow!("syslog_tcp write to {} timed out", address)
+                        })?;
                         if write_result.is_err() {
                             state.conn = None;
                         }
@@ -631,10 +634,7 @@ impl SyslogTcpOutput {
             .await;
 
         match result {
-            Ok(()) => {
-                self.metrics.bytes_written.inc_by(confirmed_len as u64);
-                SyslogTcpWriteOutcome::Delivered
-            }
+            Ok(()) => SyslogTcpWriteOutcome::Delivered,
             Err(PeerSendError::PreSendShutdown) => SyslogTcpWriteOutcome::PreSendShutdown,
             Err(e) => SyslogTcpWriteOutcome::Err(e.into()),
         }
@@ -650,8 +650,8 @@ impl SyslogTcpOutput {
     /// this method would tick the counter.
     async fn write_payload(&self, payload: SyslogPayload) -> Result<()> {
         let framing = self.framing;
-        let confirmed_len = framed_len(framing, payload.egress.len());
         let connectors = self.connectors.clone();
+        let metrics = Arc::clone(&self.metrics);
         let result = self
             .peers
             .write_with_rotation_now(move |idx, peer, state| {
@@ -659,6 +659,7 @@ impl SyslogTcpOutput {
                 let address = peer.address();
                 let server_name = peer.host.clone();
                 let connector = connectors[idx].clone();
+                let metrics = Arc::clone(&metrics);
                 Box::pin(async move {
                     if state.conn.is_none() {
                         let tcp = tokio::time::timeout(
@@ -695,13 +696,13 @@ impl SyslogTcpOutput {
                     }
 
                     let stream = state.conn.as_mut().expect("connection should be present");
-                    let write_result = tokio::time::timeout(
-                        PEER_WRITE_TIMEOUT,
-                        write_framed(stream, framing, &egress),
-                    )
+                    let write_result = tokio::time::timeout(PEER_WRITE_TIMEOUT, async {
+                        let confirmed_len = write_framed(stream, framing, &egress).await?;
+                        metrics.bytes_written.inc_by(confirmed_len as u64);
+                        Ok::<(), anyhow::Error>(())
+                    })
                     .await
-                    .map_err(|_| anyhow::anyhow!("syslog_tcp write to {} timed out", address))
-                    .and_then(|res| res);
+                    .map_err(|_| anyhow::anyhow!("syslog_tcp write to {} timed out", address))?;
                     if write_result.is_err() {
                         state.conn = None;
                     }
@@ -711,30 +712,9 @@ impl SyslogTcpOutput {
             .await;
 
         match result {
-            Ok(()) => {
-                self.metrics.bytes_written.inc_by(confirmed_len as u64);
-                Ok(())
-            }
+            Ok(()) => Ok(()),
             Err(err) => Err(anyhow::anyhow!("{}", err)),
         }
-    }
-}
-
-/// Length of the exact buffer handed to the write path. Must
-/// mirror the framing bytes the stream adds (octet-count digits
-/// plus SP for `OctetCounting`, trailing LF for `NonTransparent`);
-/// drift here would silently mis-count sent bytes.
-fn framed_len(framing: SyslogFraming, payload_len: usize) -> usize {
-    match framing {
-        SyslogFraming::OctetCounting => {
-            let digits = if payload_len == 0 {
-                1
-            } else {
-                payload_len.ilog10() as usize + 1
-            };
-            digits + 1 + payload_len
-        }
-        SyslogFraming::NonTransparent => payload_len + 1,
     }
 }
 
@@ -821,6 +801,218 @@ mod tests {
             expected.len() as u64,
             "the generated octet-count header belongs to the adapter buffer"
         );
+    }
+
+    #[test]
+    fn byte_confirmation_is_owned_by_the_framed_write_result() {
+        fn statement_end(source: &str, start: usize) -> usize {
+            let mut parens = 0usize;
+            let mut brackets = 0usize;
+            let mut braces = 0usize;
+            for (offset, byte) in source.as_bytes()[start..].iter().enumerate() {
+                match byte {
+                    b'(' => parens += 1,
+                    b')' => parens -= 1,
+                    b'[' => brackets += 1,
+                    b']' => brackets -= 1,
+                    b'{' => braces += 1,
+                    b'}' => braces -= 1,
+                    b';' if parens == 0 && brackets == 0 && braces == 0 => {
+                        return start + offset + 1;
+                    }
+                    _ => {}
+                }
+            }
+            panic!("let statement must have a balanced terminator");
+        }
+
+        fn call_end(source: &str, call: &str) -> usize {
+            assert!(
+                source.starts_with(call),
+                "initializer must start directly with {call}"
+            );
+            let open = call.len() - 1;
+            let mut depth = 0usize;
+            for (offset, byte) in source.as_bytes()[open..].iter().enumerate() {
+                match byte {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return open + offset + 1;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            panic!("framed-write call must be balanced");
+        }
+
+        fn assert_normal_await_propagation(mut suffix: &str) {
+            suffix = suffix.trim();
+            suffix = suffix
+                .strip_prefix(".await")
+                .expect("write_framed's successful value must be awaited directly");
+            loop {
+                suffix = suffix.trim();
+                if suffix == "?" {
+                    return;
+                }
+                let method = [".context(", ".with_context("]
+                    .into_iter()
+                    .find(|method| suffix.starts_with(method))
+                    .expect("only ordinary error-context propagation may follow await");
+                let end = call_end(suffix, method);
+                suffix = &suffix[end..];
+            }
+        }
+
+        fn write_binding<'a>(body: &'a str, write: &str) -> (&'a str, usize) {
+            let write_start = body.find(write).expect("framed write must exist");
+            let mut search_end = write_start;
+            while let Some(binding_start) = body[..search_end].rfind("let ") {
+                let end = statement_end(body, binding_start);
+                if write_start < end {
+                    let statement = &body[binding_start..end];
+                    let (left, right) = statement
+                        .strip_prefix("let ")
+                        .expect("binding must start with let")
+                        .split_once('=')
+                        .expect("binding must have an initializer");
+                    assert_eq!(
+                        right.matches(write).count(),
+                        1,
+                        "the binding RHS must contain exactly one framed write"
+                    );
+                    let initializer = right
+                        .trim()
+                        .strip_suffix(';')
+                        .expect("let initializer must end at its statement terminator")
+                        .trim();
+                    let call_end = call_end(initializer, write);
+                    assert_normal_await_propagation(&initializer[call_end..]);
+                    let identifier = left
+                        .split_once(':')
+                        .map_or(left, |(identifier, _)| identifier)
+                        .trim();
+                    assert!(
+                        !identifier.is_empty()
+                            && !identifier.as_bytes()[0].is_ascii_digit()
+                            && identifier
+                                .bytes()
+                                .all(|byte| byte == b'_' || byte.is_ascii_alphanumeric()),
+                        "the framed result must use a plain local identifier"
+                    );
+                    return (identifier, end);
+                }
+                search_end = binding_start;
+            }
+            panic!("write_framed must occur inside a let initializer");
+        }
+
+        fn assert_confirmed_result_ownership(body: &str) {
+            assert_eq!(
+                body.matches("write_framed(").count(),
+                1,
+                "each send path must perform exactly one framed write"
+            );
+            assert!(
+                !body.contains("framed_len("),
+                "callers must not independently reconstruct the framing length"
+            );
+
+            let (confirmed, statement_end) = write_binding(body, "write_framed(");
+
+            let bump = "bytes_written.inc_by(";
+            assert_eq!(
+                body.matches(bump).count(),
+                1,
+                "each successful send path must record exactly one confirmed length"
+            );
+            let bump_start = body.find(bump).expect("confirmed byte bump must exist");
+            assert!(
+                statement_end <= bump_start,
+                "the framed-result binding must end before the byte bump"
+            );
+            let argument_start = bump_start + bump.len();
+            let argument_end = body[argument_start..]
+                .find(')')
+                .map(|offset| argument_start + offset)
+                .expect("byte bump must close");
+            let argument = body[argument_start..argument_end]
+                .trim()
+                .strip_suffix(" as u64")
+                .unwrap_or(body[argument_start..argument_end].trim());
+            assert_eq!(
+                argument, confirmed,
+                "the byte bump must consume the same local bound by write_framed"
+            );
+        }
+
+        fn assert_rejected(body: &str) {
+            assert!(
+                std::panic::catch_unwind(|| assert_confirmed_result_ownership(body)).is_err(),
+                "counterexample must fail the ownership check: {body}"
+            );
+        }
+
+        assert_confirmed_result_ownership(
+            "let renamed: usize =\n                 write_framed(stream, framing_for(mode), &payload).await?;\
+             bytes_written.inc_by(renamed as u64);",
+        );
+        assert_confirmed_result_ownership(
+            "let contextual = write_framed(stream, framing, payload)\n\
+                 .await\n\
+                 .context(\"write failed\")?;\
+             bytes_written.inc_by(contextual as u64);",
+        );
+        assert_rejected(
+            "let confirmed = { write_framed(stream, framing, payload).await?; \
+                 payload.len() + 1 }; bytes_written.inc_by(confirmed as u64);",
+        );
+        assert_rejected(
+            "let confirmed = { let _ = write_framed(stream, framing, payload).await?; 0 }; \
+             bytes_written.inc_by(confirmed as u64);",
+        );
+        assert_rejected(
+            "let confirmed = payload.len() + 1; write_framed(stream, framing, payload).await?; \
+             bytes_written.inc_by(confirmed as u64);",
+        );
+        assert_rejected(
+            "let n = 0; write_framed(stream, framing, payload).await?; \
+             bytes_written.inc_by(n as u64);",
+        );
+        assert_rejected("let n = write_framed(stream, framing, payload).await?;");
+        assert_rejected(
+            "let n = write_framed(stream, framing, payload).await?; \
+             bytes_written.inc_by(n as u64); bytes_written.inc_by(n as u64);",
+        );
+        assert_rejected(
+            "let n = write_framed(stream, framing, payload).await?; \
+             bytes_written.inc_by(payload.len() as u64);",
+        );
+        assert_rejected(
+            "let n = write_framed(stream, framing, payload).await?; let old = framed_len(f, 1); \
+             bytes_written.inc_by(n as u64);",
+        );
+
+        let src = include_str!("syslog_tcp.rs");
+        let shutdown_aware_start = src
+            .find("async fn write_payload_shutdown_aware(")
+            .expect("shutdown-aware writer must exist");
+        let normal_start = src[shutdown_aware_start..]
+            .find("async fn write_payload(&self")
+            .map(|offset| shutdown_aware_start + offset)
+            .expect("normal writer must follow shutdown-aware writer");
+        let helper_end = src[normal_start..]
+            .find("\n}\n")
+            .map(|offset| normal_start + offset)
+            .expect("writer impl must have a top-level end");
+        let shutdown_aware = &src[shutdown_aware_start..normal_start];
+        let normal = &src[normal_start..helper_end];
+
+        assert_confirmed_result_ownership(shutdown_aware);
+        assert_confirmed_result_ownership(normal);
     }
 
     #[tokio::test]

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -306,7 +306,6 @@ impl SyslogUdpOutput {
                     let address = peer.address();
                     let metrics = Arc::clone(&metrics);
                     Box::pin(async move {
-                        let _ = &metrics; // silence unused-if-no-write-path lint
                         if state.conn.is_none() {
                             // Pre-send phase: DNS lookup, ephemeral
                             // bind, and UDP `connect` are all
@@ -458,7 +457,9 @@ impl SyslogUdpOutput {
                         if send_result.is_err() {
                             state.conn = None;
                         }
-                        send_result.map(|_| ())
+                        send_result.map(|len| {
+                            metrics.bytes_written.inc_by(len as u64);
+                        })
                     })
                 },
                 shutdown,
@@ -483,11 +484,13 @@ impl SyslogUdpOutput {
     /// [`Self::write_payload_shutdown_aware`] so its pre-send DNS /
     /// bind / connect phase can race the shutdown signal.
     async fn write_payload(&self, payload: SyslogPayload) -> Result<()> {
+        let metrics = Arc::clone(&self.metrics);
         let result = self
             .peers
             .write_with_rotation_now(move |_idx, peer, state| {
                 let egress = payload.egress.clone();
                 let address = peer.address();
+                let metrics = Arc::clone(&metrics);
                 Box::pin(async move {
                     if state.conn.is_none() {
                         // Resolve the peer address and walk every
@@ -582,7 +585,9 @@ impl SyslogUdpOutput {
                     if send_result.is_err() {
                         state.conn = None;
                     }
-                    send_result.map(|_| ())
+                    send_result.map(|len| {
+                        metrics.bytes_written.inc_by(len as u64);
+                    })
                 })
             })
             .await;
@@ -895,6 +900,11 @@ mod tests {
             0,
             "successful send must not bump events_failed"
         );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            event.egress.len() as u64,
+            "UDP counts the length confirmed by send"
+        );
     }
 
     /// Shutdown-drain success bumps `events_written` exactly once,
@@ -950,5 +960,54 @@ mod tests {
             0,
             "successful drain must not bump events_failed"
         );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            event.egress.len() as u64,
+            "shutdown and steady-state use the same confirmed-byte contract"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_datagram_send_error_counts_no_confirmed_bytes() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+        use bytes::Bytes;
+
+        let listener = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().unwrap().port() as i64;
+        let output = SyslogUdpOutput::build(
+            "udp-failure",
+            &mp(&[
+                block(
+                    "peer",
+                    vec![
+                        kv("host", ExprKind::StringLit("127.0.0.1".into())),
+                        kv("port", ExprKind::IntLit(port)),
+                    ],
+                ),
+                block(
+                    "retry",
+                    vec![
+                        kv("max_attempts", ExprKind::IntLit(1)),
+                        kv("initial_wait", ExprKind::StringLit("1ms".into())),
+                        kv("max_wait", ExprKind::StringLit("1ms".into())),
+                    ],
+                ),
+            ]),
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("build");
+        // Exceeds the maximum UDP payload on every supported platform, so
+        // send must fail locally without depending on ICMP timing.
+        let event = Event::new(Bytes::from(vec![0; 65_536]), "127.0.0.1:0".parse().unwrap());
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+
+        tokio::time::timeout(Duration::from_secs(2), output.consume(&event, ack))
+            .await
+            .expect("oversized datagram failure must remain bounded")
+            .unwrap();
+
+        assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -167,7 +167,12 @@ impl Output for UnixSocketOutput {
             )
             .await
             {
-                WriteReconnectOutcome::Delivered => Ok(()),
+                WriteReconnectOutcome::Delivered => {
+                    self.metrics
+                        .bytes_written
+                        .inc_by((event.egress.len() + 1) as u64);
+                    Ok(())
+                }
                 WriteReconnectOutcome::Err(e) => Err(e),
                 WriteReconnectOutcome::PreSendShutdown => {
                     let reason = format!(
@@ -287,7 +292,13 @@ impl Output for UnixSocketOutput {
         )
         .await
         {
-            Ok(r) => r,
+            Ok(Ok(())) => {
+                self.metrics
+                    .bytes_written
+                    .inc_by((event.egress.len() + 1) as u64);
+                Ok(())
+            }
+            Ok(Err(error)) => Err(error),
             Err(_) => Err(anyhow::anyhow!(
                 "timed out after {:?}",
                 crate::modules::SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT
@@ -458,6 +469,11 @@ mod tests {
             0,
             "successful send must not bump events_failed"
         );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            (event.egress.len() + 1) as u64,
+            "the newline in the Unix-stream frame is part of the transferred buffer"
+        );
     }
 
     /// Shutdown-drain success via `finalize_shutdown_singleton_disposition`
@@ -492,6 +508,65 @@ mod tests {
             0,
             "successful drain must not bump events_failed"
         );
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            (event.egress.len() + 1) as u64,
+            "shutdown and steady-state count the same framed buffer"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_peer_counts_neither_bytes_nor_written_events() {
+        use crate::dsl::ast::{Expr, ExprKind, Property};
+        use crate::dsl::module_props::ModuleProperties;
+
+        let dir = TempDir::new().unwrap();
+        let socket_path = dir.path().join("missing.sock");
+        let props = ModuleProperties::from_parts(
+            "unix_socket",
+            vec![
+                Property::KeyValue {
+                    key: "path".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::StringLit(
+                        socket_path.to_str().unwrap().to_string(),
+                    )),
+                    value_span: None,
+                },
+                Property::Block {
+                    key: "retry".into(),
+                    key_span: None,
+                    properties: vec![Property::KeyValue {
+                        key: "max_attempts".into(),
+                        key_span: None,
+                        value: Expr::spanless(ExprKind::IntLit(1)),
+                        value_span: None,
+                    }],
+                },
+            ],
+        );
+        let output = UnixSocketOutput::from_properties(
+            "unix-failure",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let event = Event::new(
+            Bytes::from_static(b"unreachable"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            output.consume(&event, ack),
+        )
+        .await
+        .expect("missing peer failure must remain bounded")
+        .unwrap();
+
+        assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
     }
 
     /// Structural pin: `consume_shutdown` routes its result through

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -167,12 +167,7 @@ impl Output for UnixSocketOutput {
             )
             .await
             {
-                WriteReconnectOutcome::Delivered => {
-                    self.metrics
-                        .bytes_written
-                        .inc_by((event.egress.len() + 1) as u64);
-                    Ok(())
-                }
+                WriteReconnectOutcome::Delivered => Ok(()),
                 WriteReconnectOutcome::Err(e) => Err(e),
                 WriteReconnectOutcome::PreSendShutdown => {
                     let reason = format!(
@@ -292,12 +287,7 @@ impl Output for UnixSocketOutput {
         )
         .await
         {
-            Ok(Ok(())) => {
-                self.metrics
-                    .bytes_written
-                    .inc_by((event.egress.len() + 1) as u64);
-                Ok(())
-            }
+            Ok(Ok(())) => Ok(()),
             Ok(Err(error)) => Err(error),
             Err(_) => Err(anyhow::anyhow!(
                 "timed out after {:?}",
@@ -381,6 +371,11 @@ impl PersistentConn for UnixSocketOutput {
         let buf = super::frame_with_newline(payload);
         stream.write_all(&buf).await?;
         stream.flush().await?;
+        // After `write_all` and `flush` both return successfully,
+        // record the exact framed-buffer length as adapter-confirmed;
+        // this does not assert peer receipt. Callers must not
+        // duplicate the bump on their success arms.
+        self.metrics.bytes_written.inc_by(buf.len() as u64);
         Ok(())
     }
 }
@@ -513,6 +508,229 @@ mod tests {
             (event.egress.len() + 1) as u64,
             "shutdown and steady-state count the same framed buffer"
         );
+    }
+
+    #[test]
+    fn concrete_writer_owns_confirmed_newline_frame_bytes() {
+        fn braced_body<'a>(source: &'a str, signature: &str) -> &'a str {
+            let signature_start = source.find(signature).expect("function must exist");
+            let block_start = source[signature_start..]
+                .find('{')
+                .map(|offset| signature_start + offset)
+                .expect("function must have a body");
+            let mut depth = 0usize;
+            for (offset, byte) in source.as_bytes()[block_start..].iter().enumerate() {
+                match byte {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return &source[block_start..=block_start + offset];
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            panic!("function body must be balanced");
+        }
+
+        fn assert_writer_ownership(source: &str, caller_paths: &str) {
+            let writer = braced_body(source, "async fn write_frame(&self");
+            let frame_call = "super::frame_with_newline(payload)";
+            assert_eq!(
+                writer.matches(frame_call).count(),
+                1,
+                "the concrete writer must construct one exact framed buffer"
+            );
+            let call_start = writer.find(frame_call).expect("framing call must exist");
+            let binding_start = writer[..call_start]
+                .rfind("let ")
+                .expect("framed buffer must have a local binding");
+            let statement_end = writer[call_start..]
+                .find(';')
+                .map(|offset| call_start + offset + 1)
+                .expect("framed-buffer binding must end");
+            let statement = &writer[binding_start..statement_end];
+            let (left, right) = statement
+                .strip_prefix("let ")
+                .expect("binding must start with let")
+                .split_once('=')
+                .expect("binding must have an initializer");
+            assert_eq!(
+                right.matches(frame_call).count(),
+                1,
+                "the framed buffer must originate in the same let statement"
+            );
+            let identifier = left
+                .split_once(':')
+                .map_or(left, |(identifier, _)| identifier)
+                .trim();
+            assert!(
+                !identifier.is_empty()
+                    && !identifier.as_bytes()[0].is_ascii_digit()
+                    && identifier
+                        .bytes()
+                        .all(|byte| byte == b'_' || byte.is_ascii_alphanumeric()),
+                "the framed buffer must use a plain local identifier"
+            );
+
+            let write_pattern = format!("write_all(&{identifier})");
+            let bump_pattern = format!("bytes_written.inc_by({identifier}.len() as u64)");
+            assert_eq!(
+                writer.matches(&write_pattern).count(),
+                1,
+                "the exact framed local must flow to one write_all"
+            );
+            assert_eq!(
+                writer.matches(&bump_pattern).count(),
+                1,
+                "the exact framed local must flow to one byte bump"
+            );
+            let write = writer
+                .find(&write_pattern)
+                .expect("framed write must exist");
+            let flush = writer
+                .find("flush().await")
+                .expect("the concrete writer must flush before confirming bytes");
+            let bump = writer.find(&bump_pattern).expect("byte bump must exist");
+            assert!(
+                statement_end <= write && write < flush && flush < bump,
+                "bytes are confirmed only after the exact buffer is written and flushed"
+            );
+            assert!(
+                !caller_paths.contains("bytes_written")
+                    && !caller_paths.contains("event.egress.len() + 1"),
+                "callers must not own byte bumps or reconstruct the exact newline frame length"
+            );
+        }
+
+        fn assert_rejected(source: &str, caller_paths: &str) {
+            assert!(
+                std::panic::catch_unwind(|| assert_writer_ownership(source, caller_paths)).is_err(),
+                "counterexample must fail the ownership check"
+            );
+        }
+
+        let renamed = r#"
+            async fn write_frame(&self, payload: &Bytes) {
+                let framed_local = super::frame_with_newline(payload);
+                attempt += 1;
+                stream.write_all(&framed_local).await?;
+                stream.flush().await?;
+                self.metrics.bytes_written.inc_by(framed_local.len() as u64);
+            }
+            // trailing comment and unrelated helper placement are allowed.
+            fn helper() { let attempt = 1 + 1; }
+        "#;
+        assert_writer_ownership(renamed, "attempt += 1;");
+        assert_rejected(
+            &renamed.replace("write_all(&framed_local)", "write_all(payload)"),
+            "",
+        );
+        assert_rejected(
+            r#"
+                async fn write_frame(&self, payload: &Bytes) {
+                    let framed_local = super::frame_with_newline(payload);
+                    stream.write_all(&framed_local).await?;
+                    self.metrics.bytes_written.inc_by(framed_local.len() as u64);
+                    stream.flush().await?;
+                }
+            "#,
+            "",
+        );
+        assert_rejected(renamed, "self.metrics.bytes_written.inc_by(1);");
+        assert_rejected(
+            r#"
+                async fn write_frame(&self, payload: &Bytes) {
+                    let framed_local = super::frame_with_newline(payload);
+                    stream.write_all(&framed_local).await?;
+                    stream.flush().await?;
+                    self.metrics.bytes_written.inc_by(framed_local.len() as u64);
+                    self.metrics.bytes_written.inc_by(framed_local.len() as u64);
+                }
+            "#,
+            "",
+        );
+        assert_rejected(renamed, "let n = event.egress.len() + 1;");
+
+        let src = include_str!("unix_socket.rs");
+        let consume_start = src
+            .find("async fn consume(&self, event: &Event")
+            .expect("consume must exist");
+        let impl_end = src[consume_start..]
+            .find("impl PersistentConn for UnixSocketOutput")
+            .map(|offset| consume_start + offset)
+            .expect("PersistentConn impl must follow Output impl");
+        let output_paths = &src[consume_start..impl_end];
+        assert_writer_ownership(src, output_paths);
+    }
+
+    #[tokio::test]
+    async fn write_frame_failure_counts_no_bytes() {
+        let dir = TempDir::new().unwrap();
+        let output = build_test_output(&dir.path().join("unused.sock")).await;
+        let (mut writer, peer) = tokio::net::UnixStream::pair().unwrap();
+        drop(peer);
+
+        let result = <UnixSocketOutput as PersistentConn>::write_frame(
+            &output,
+            &mut writer,
+            &Bytes::from_static(b"payload"),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "a closed peer cannot confirm transferred bytes"
+        );
+        assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn retry_counts_only_the_eventually_confirmed_frame_once() {
+        use tokio::io::AsyncReadExt;
+
+        let dir = TempDir::new().unwrap();
+        let socket_path = dir.path().join("retry.sock");
+        let output = std::sync::Arc::new(build_test_output_with_retry(&socket_path).await);
+        let event = Event::new(
+            Bytes::from_static(b"retry-payload"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let expected = super::super::frame_with_newline(&event.egress);
+        let (ack, _rx) = QueueAckHandle::for_test();
+        let output_for_task = output.clone();
+        let event_for_task = event.clone();
+        let consume = tokio::spawn(async move {
+            output_for_task.consume(&event_for_task, ack).await.unwrap();
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while output.metrics.retries.load(Ordering::Relaxed) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first failed connection attempt must remain bounded");
+
+        let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+        let expected_len = expected.len();
+        let receiver = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut actual = vec![0; expected_len];
+            stream.read_exact(&mut actual).await.unwrap();
+            actual
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), consume)
+            .await
+            .expect("retry must complete")
+            .unwrap();
+        assert_eq!(receiver.await.unwrap(), expected);
+        assert_eq!(
+            output.metrics.bytes_written.load(Ordering::Relaxed),
+            expected.len() as u64
+        );
+        assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -797,5 +1015,53 @@ mod tests {
         );
         UnixSocketOutput::from_properties("u", &props, &crate::modules::BuildContext::for_testing())
             .expect("build")
+    }
+
+    async fn build_test_output_with_retry(socket_path: &std::path::Path) -> UnixSocketOutput {
+        use crate::dsl::ast::{Expr, ExprKind, Property};
+        use crate::dsl::module_props::ModuleProperties;
+        let props = ModuleProperties::from_parts(
+            "unix_socket",
+            vec![
+                Property::KeyValue {
+                    key: "path".into(),
+                    key_span: None,
+                    value: Expr::spanless(ExprKind::StringLit(
+                        socket_path.to_str().unwrap().to_string(),
+                    )),
+                    value_span: None,
+                },
+                Property::Block {
+                    key: "retry".into(),
+                    key_span: None,
+                    properties: vec![
+                        Property::KeyValue {
+                            key: "max_attempts".into(),
+                            key_span: None,
+                            value: Expr::spanless(ExprKind::IntLit(3)),
+                            value_span: None,
+                        },
+                        Property::KeyValue {
+                            key: "initial_wait".into(),
+                            key_span: None,
+                            value: Expr::spanless(ExprKind::StringLit("20ms".into())),
+                            value_span: None,
+                        },
+                        Property::KeyValue {
+                            key: "max_wait".into(),
+                            key_span: None,
+                            value: Expr::spanless(ExprKind::StringLit("20ms".into())),
+                            value_span: None,
+                        },
+                    ],
+                },
+            ],
+        );
+        UnixSocketOutput::from_properties(
+            "u-retry",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .expect("build")
     }
 }

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -74,9 +74,9 @@ daemon startup instead of being ignored.
 
 ## Current metric families
 
-These are the 16 counter families currently registered by the daemon. Each
-series has exactly the fixed label shown; the label value is the configured
-component name.
+These are the current counter families registered by the daemon. Each series
+has exactly the fixed label shown; the label value is the configured component
+name, so label cardinality is bounded by the configured components.
 
 ### Pipelines
 
@@ -106,6 +106,7 @@ original event is preserved when the configured error-log write succeeds; see
 | `limpid_input_events_received_total` | `input` | Events received from the source; injected events are excluded. |
 | `limpid_input_events_invalid_total` | `input` | Events rejected by the input parser or protocol boundary. |
 | `limpid_input_events_injected_total` | `input` | Events pushed into the input through `limpidctl inject`. |
+| `limpid_input_bytes_received_total` | `input` | Logical bytes received by the input adapter before validation. |
 
 Keeping `received` and `injected` separate makes source traffic distinguishable
 from synthetic and replay traffic.
@@ -121,6 +122,7 @@ from synthetic and replay traffic.
 | `limpid_output_retries_total` | `output` | Retry attempts across all events. |
 | `limpid_output_events_wedged_total` | `output` | Disk-queue fail-stop wedges observed by the output. |
 | `limpid_output_events_errored_unwritable_total` | `output` | Sink-side error-log writes that failed. |
+| `limpid_output_bytes_written_total` | `output` | Logical bytes whose transfer to the destination was confirmed. |
 
 `events_failed` includes retry-budget exhaustion, per-event render failures in
 batched output flushes, shutdown-drain leftovers after a final flush failure,
@@ -141,6 +143,32 @@ Useful relationships are approximate during concurrent updates:
 - `output.received - output.injected` is traffic delivered by pipelines.
 - `output.received - output.written - output.failed` approximates events still
   pending in the queue.
+
+### Byte-counter boundary
+
+The byte counters measure logical buffers at adapter boundaries, not physical
+wire traffic. They exclude transport overhead such as TCP/IP, TLS, HTTP/2, and
+Kafka protocol framing. They include framing, line feeds, compression, or
+serialization only when that is part of the exact buffer the adapter receives
+or hands to its transport.
+
+`limpid_input_bytes_received_total{input}` counts a logical input buffer before
+validation, so invalid input is included and an empty buffer adds zero. A
+partially read tail record is counted once when it becomes complete; rewinding
+or rereading it does not count it again. For structured sources without an
+equivalent raw adapter buffer, OTLP gRPC uses the decoded request's canonical
+protobuf encoded length, and journal input uses the length of the generated
+JSON buffer.
+
+`limpid_output_bytes_written_total{output}` counts the complete prepared body
+only when the adapter can confirm its transfer to the transport. This includes
+an HTTP non-success response and an OTLP partial rejection because the complete
+request body was transferred. A connection or send failure without transfer
+confirmation adds zero. A retry counts a confirmed attempt once, including
+during shutdown, and the byte count is never apportioned to the accepted subset
+of a batch. File, standard output, Unix-socket, and syslog counters include any
+line feed or header added to the handed-off buffer; syslog UDP uses the length
+confirmed by `send`.
 
 ## Viewing metrics with limpidctl
 


### PR DESCRIPTION
## Summary
- add fixed-label logical byte counters for every current input/output adapter
- count input buffers before validation and output bodies only after adapter-confirmed transfer
- document adapter-boundary semantics and physical-wire exclusions

## Validation
- `cargo test --workspace`
- `cargo test -p limpid --all-targets --features kafka`
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy -p limpid --all-targets --features kafka -- -D warnings`
- `cargo fmt --all -- --check`
- `mdbook build docs`
- `cargo xtask lint-snippet-headers`
- `cargo xtask gen-snippet-inventory --check`
- `cargo deny check advisories bans sources licenses`

## Notes
- journal feature requires libsystemd-dev and is exercised by Ubuntu CI; local macOS build stops at that existing platform precondition
- private inc_by also replaces the equivalent batched N-increment loop; no public API/config change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added input and output byte metrics for tracking received and written data.
  * Byte counts now cover journal, OTLP, syslog, socket, file, HTTP, Kafka, stdout, and tail integrations.
  * Metrics reflect protocol framing, serialized payload sizes, confirmed transfers, and successful writes.

* **Bug Fixes**
  * Corrected accounting for retries, failed deliveries, invalid inputs, partial reads, and shutdown operations.
  * Improved event counter updates for batched output.

* **Documentation**
  * Documented byte-counter behavior and measurement rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->