### PR TITLE
feat(metrics): report runtime gauges

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -316,6 +316,16 @@ impl ErrorLogWriter {
         }
     }
 
+    /// Hold the writer's `write_lock` so tests can observe
+    /// lifecycle state — such as the pipeline's `inflight`
+    /// gauge — while DLQ completion is blocked. The returned
+    /// guard serializes against every real `write` call, so
+    /// none can complete until the guard is dropped.
+    #[cfg(test)]
+    pub(crate) async fn hold_write_lock_for_testing(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.write_lock.lock().await
+    }
+
     /// Validate that the `error_log` path is reachable at startup.
     ///
     /// Checks:

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -82,6 +82,7 @@ pub struct PipelineMetrics {
     /// `tracing::error!` line, but operators should alarm on this
     /// counter — it means the replay path may be incomplete.
     pub(crate) events_errored_unwritable: Arc<registry_core::Counter>,
+    pub(crate) inflight: Arc<registry_core::Gauge>,
 }
 
 impl PipelineMetrics {
@@ -90,6 +91,15 @@ impl PipelineMetrics {
             ($name:literal, $help:literal) => {
                 registry
                     .counter($name)
+                    .label("pipeline", pipeline)
+                    .help($help)
+                    .build()?
+            };
+        }
+        macro_rules! gauge {
+            ($name:literal, $help:literal) => {
+                registry
+                    .gauge($name)
                     .label("pipeline", pipeline)
                     .help($help)
                     .build()?
@@ -119,6 +129,10 @@ impl PipelineMetrics {
             events_errored_unwritable: counter!(
                 "limpid_pipeline_events_errored_unwritable_total",
                 "Total pipeline errors whose recovery record could not be written."
+            ),
+            inflight: gauge!(
+                "limpid_pipeline_inflight",
+                "Pipeline executions currently in progress, including terminal bookkeeping."
             ),
         }))
     }
@@ -169,6 +183,8 @@ pub struct OutputMetrics {
     /// durable trace of it.
     pub(crate) events_errored_unwritable: Arc<registry_core::Counter>,
     pub(crate) bytes_written: Arc<registry_core::Counter>,
+    pub(crate) queue_depth: Arc<registry_core::Gauge>,
+    pub(crate) in_retry: Arc<registry_core::Gauge>,
 }
 
 impl OutputMetrics {
@@ -177,6 +193,15 @@ impl OutputMetrics {
             ($name:literal, $help:literal) => {
                 registry
                     .counter($name)
+                    .label("output", output)
+                    .help($help)
+                    .build()?
+            };
+        }
+        macro_rules! gauge {
+            ($name:literal, $help:literal) => {
+                registry
+                    .gauge($name)
                     .label("output", output)
                     .help($help)
                     .build()?
@@ -211,6 +236,14 @@ impl OutputMetrics {
             bytes_written: counter!(
                 "limpid_output_bytes_written_total",
                 "Total logical bytes whose transfer was confirmed by the output adapter."
+            ),
+            queue_depth: gauge!(
+                "limpid_output_queue_depth",
+                "Current unread or unacknowledged depth of the output queue."
+            ),
+            in_retry: gauge!(
+                "limpid_output_in_retry",
+                "Whether this output currently has an active retry cycle."
             ),
         }))
     }
@@ -350,6 +383,29 @@ mod registry_core {
     impl Gauge {
         pub(crate) fn set(&self, value: u64) {
             self.value.store(value, Ordering::Relaxed);
+        }
+
+        pub(crate) fn inc(&self) {
+            self.value.fetch_add(1, Ordering::Relaxed);
+        }
+
+        /// Decrement by one, saturating at zero. `fetch_update`
+        /// carries the concurrent CAS, and `checked_sub` keeps an
+        /// underflow at zero instead of wrapping to `u64::MAX`; the
+        /// `debug_assert!` surfaces a lifecycle imbalance loudly in
+        /// debug builds.
+        pub(crate) fn dec(&self) {
+            let updated = self
+                .value
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                    value.checked_sub(1)
+                });
+            debug_assert!(updated.is_ok(), "gauge decrement underflow");
+        }
+
+        #[cfg(test)]
+        pub(crate) fn load(&self, _ordering: Ordering) -> u64 {
+            self.value.load(Ordering::Relaxed)
         }
     }
 
@@ -1579,6 +1635,21 @@ mod registry_tests {
         let pipeline_shared = Arc::clone(&pipeline);
         let output_shared = Arc::clone(&output);
 
+        let initial = snapshot_json(&registry);
+        for (name, label, label_value) in [
+            ("limpid_pipeline_inflight", "pipeline", "route"),
+            ("limpid_output_queue_depth", "output", "egress"),
+            ("limpid_output_in_retry", "output", "egress"),
+        ] {
+            let family = metric(&initial, name);
+            assert_eq!(family["type"], "gauge");
+            let series = family["series"].as_array().expect("gauge series array");
+            assert_eq!(series.len(), 1, "{name} must be prepopulated once");
+            assert_eq!(series[0]["labels"].as_object().unwrap().len(), 1);
+            assert_eq!(series[0]["labels"][label], label_value);
+            assert_eq!(series[0]["value"], 0, "{name} must start at zero");
+        }
+
         macro_rules! inc {
             ($counter:expr, $times:expr) => {
                 for _ in 0..$times {
@@ -1597,6 +1668,7 @@ mod registry_tests {
         inc!(pipeline.events_discarded, 7);
         inc!(pipeline.events_errored, 8);
         inc!(pipeline.events_errored_unwritable, 9);
+        pipeline.inflight.set(2);
         inc!(output_shared.events_received, 10);
         inc!(output.events_injected, 11);
         inc!(output.events_written, 12);
@@ -1605,6 +1677,8 @@ mod registry_tests {
         inc!(output.events_wedged, 15);
         inc!(output.events_errored_unwritable, 16);
         output.bytes_written.inc_by(23);
+        output.queue_depth.set(3);
+        output.in_retry.set(1);
 
         let snapshot = snapshot_json(&registry);
         let metrics = snapshot["metrics"]
@@ -1612,7 +1686,7 @@ mod registry_tests {
             .expect("metrics must be an array");
         assert_eq!(
             metrics.len(),
-            18,
+            21,
             "only the documented metric set is registered"
         );
 
@@ -1705,12 +1779,113 @@ mod registry_tests {
             assert_eq!(series["value"], value);
         }
 
+        let expected_gauges = [
+            ("limpid_pipeline_inflight", "pipeline", "route", 2),
+            ("limpid_output_queue_depth", "output", "egress", 3),
+            ("limpid_output_in_retry", "output", "egress", 1),
+        ];
+        for (name, label, label_value, value) in expected_gauges {
+            let family = metric(&snapshot, name);
+            assert_eq!(family["type"], "gauge");
+            assert!(
+                family["help"].as_str().is_some_and(|help| !help.is_empty()),
+                "{name} must remain self-describing"
+            );
+            let series = family["series"]
+                .as_array()
+                .expect("series must be an array");
+            assert_eq!(series.len(), 1, "{name} must have exactly one series");
+            let labels = series[0]["labels"]
+                .as_object()
+                .expect("labels must be an object");
+            assert_eq!(labels.len(), 1, "{name} must have exactly one label");
+            assert_eq!(labels.get(label).and_then(Value::as_str), Some(label_value));
+            assert_eq!(series[0]["value"], value);
+        }
+
         let duplicate = match OutputMetrics::register(&registry, "egress") {
             Ok(_) => panic!("the bundle must register into the supplied shared registry"),
             Err(error) => error,
         };
         let diagnostic = duplicate.to_string();
         assert_output_duplicate(&duplicate, "egress", &diagnostic);
+    }
+
+    #[test]
+    fn gauge_delta_updates_are_atomic_across_threads() {
+        const THREADS: usize = 8;
+        const UPDATES: usize = 1_000;
+
+        let registry = Registry::new();
+        let gauge = build_ok(
+            registry
+                .gauge("limpid_test_concurrent_inflight")
+                .help("Concurrent gauge delta test.")
+                .label("pipeline", "unit")
+                .build(),
+        );
+        let start = Arc::new(std::sync::Barrier::new(THREADS + 1));
+        let incremented = Arc::new(std::sync::Barrier::new(THREADS + 1));
+        let decrement = Arc::new(std::sync::Barrier::new(THREADS + 1));
+
+        std::thread::scope(|scope| {
+            for _ in 0..THREADS {
+                let gauge = Arc::clone(&gauge);
+                let start = Arc::clone(&start);
+                let incremented = Arc::clone(&incremented);
+                let decrement = Arc::clone(&decrement);
+                scope.spawn(move || {
+                    start.wait();
+                    for _ in 0..UPDATES {
+                        gauge.inc();
+                    }
+                    incremented.wait();
+                    decrement.wait();
+                    for _ in 0..UPDATES {
+                        gauge.dec();
+                    }
+                });
+            }
+            start.wait();
+            incremented.wait();
+            let incremented_value = metric(
+                &snapshot_json(&registry),
+                "limpid_test_concurrent_inflight",
+            )["series"][0]["value"]
+                .clone();
+            decrement.wait();
+            assert_eq!(incremented_value, THREADS * UPDATES);
+        });
+
+        assert_eq!(
+            metric(&snapshot_json(&registry), "limpid_test_concurrent_inflight")["series"][0]["value"],
+            0
+        );
+    }
+
+    #[test]
+    fn gauge_decrement_underflow_never_wraps_the_exported_value() {
+        let registry = Registry::new();
+        let gauge = build_ok(
+            registry
+                .gauge("limpid_test_saturating_gauge")
+                .help("Saturating gauge test.")
+                .label("pipeline", "unit")
+                .build(),
+        );
+
+        #[cfg(debug_assertions)]
+        assert!(
+            std::panic::catch_unwind(|| gauge.dec()).is_err(),
+            "debug builds must surface a lifecycle imbalance"
+        );
+        #[cfg(not(debug_assertions))]
+        gauge.dec();
+
+        assert_eq!(
+            metric(&snapshot_json(&registry), "limpid_test_saturating_gauge")["series"][0]["value"],
+            0
+        );
     }
 
     fn assert_output_duplicate(error: &MetricsError, label_value: &str, diagnostic: &str) {
@@ -1728,11 +1903,37 @@ mod registry_tests {
                 "limpid_output_events_wedged_total",
                 "limpid_output_events_errored_unwritable_total",
                 "limpid_output_bytes_written_total",
+                "limpid_output_queue_depth",
+                "limpid_output_in_retry",
             ]
             .contains(&name.as_str())
         );
         assert_eq!(labelset, &[("output".to_owned(), label_value.to_owned())]);
         assert!(diagnostic.contains(&format!("name={name:?}")));
         assert!(diagnostic.contains(&format!("labelset={labelset:?}")));
+    }
+
+    #[test]
+    fn every_retry_loop_updates_the_pre_resolved_retry_gauge() {
+        let carriers = [
+            ("batched", include_str!("modules/output/batched.rs")),
+            ("file", include_str!("modules/output/file.rs")),
+            ("kafka", include_str!("modules/output/kafka.rs")),
+            ("stdout", include_str!("modules/output/stdout.rs")),
+            ("syslog_tcp", include_str!("modules/output/syslog_tcp.rs")),
+            ("syslog_udp", include_str!("modules/output/syslog_udp.rs")),
+            ("unix_socket", include_str!("modules/output/unix_socket.rs")),
+        ];
+
+        for (name, source) in carriers {
+            assert!(
+                source.contains("retries.inc()"),
+                "{name} must retain its retry counter"
+            );
+            assert!(
+                source.contains("in_retry"),
+                "{name} must update the shared fixed-label retry gauge"
+            );
+        }
     }
 }

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -712,6 +712,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
             };
             match send_outcome {
                 Some(Ok(outcome)) => {
+                    self.metrics.in_retry.set(0);
                     self.resolve_send_success(shippable, outcome).await;
                     return;
                 }
@@ -727,6 +728,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                     if attempt >= self.retry.max_attempts {
                         break e;
                     }
+                    self.metrics.in_retry.set(1);
                     // Cooperative shutdown cancel: if `shutdown()`
                     // signalled mid-retry, abandon the budget and
                     // route the shippable batch straight to DLQ.
@@ -780,6 +782,7 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
                 }
             }
         };
+        self.metrics.in_retry.set(0);
         // Terminal disposition: split by why we left the loop.
         //
         // - Shutdown cancelled the in-flight send → the wire state

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -255,6 +255,7 @@ impl Output for FileOutput {
             // shutdown-awareness bound lives.
             match self.write_payload(attempt_payload).await {
                 Ok(()) => {
+                    self.metrics.in_retry.set(0);
                     ack.resolve_delivered();
                     return Ok(());
                 }
@@ -262,6 +263,7 @@ impl Output for FileOutput {
                     attempt += 1;
                     self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
+                        self.metrics.in_retry.set(0);
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
                         let __dlq_outcome = crate::modules::route_event_to_dlq(
@@ -281,6 +283,7 @@ impl Output for FileOutput {
                         );
                         return Ok(());
                     }
+                    self.metrics.in_retry.set(1);
                     tracing::warn!(
                         "output '{}': write failed (attempt {}/{}): {} — retrying in {:?}",
                         self.name,
@@ -298,6 +301,7 @@ impl Output for FileOutput {
                     // shutdown arm. Route the pending event to DLQ,
                     // resolve `Recovered`, and return.
                     if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        self.metrics.in_retry.set(0);
                         let reason = format!(
                             "output write failed and shutdown observed mid-retry \
                              after {} attempts: {}",
@@ -2216,6 +2220,7 @@ mod tests {
 
         // Let the first attempt fail and the retry loop reach the sleep.
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert_eq!(out.metrics.in_retry.load(Ordering::Relaxed), 1);
         shutdown_tx.send(true).unwrap();
 
         let res = consume.await.unwrap();
@@ -2235,5 +2240,6 @@ mod tests {
             matches!(disposition, AckDisposition::Recovered),
             "expected Recovered, got {disposition:?}"
         );
+        assert_eq!(out.metrics.in_retry.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -2141,6 +2141,14 @@ def output o {{
             3,
             "the retries metric counts every failed attempt"
         );
+        assert_eq!(
+            output
+                .metrics
+                .in_retry
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "retry exhaustion must clear the retry state"
+        );
     }
 
     /// Regression pin: the retry backoff sleep must NOT wake early when
@@ -2199,6 +2207,14 @@ def output o {{
         assert_eq!(
             after_first, 1,
             "expected exactly the initial attempt to have hit the server before the notify race, got {after_first}"
+        );
+        assert_eq!(
+            output
+                .metrics
+                .in_retry
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the output must remain visibly in retry throughout backoff"
         );
 
         // Fire the threshold-flush notify while the retry loop is
@@ -2297,6 +2313,14 @@ def output o {{
         assert!(
             elapsed < Duration::from_millis(1500),
             "shutdown must short-circuit the retry sleep — took {elapsed:?} against a 5s floor"
+        );
+        assert_eq!(
+            output
+                .metrics
+                .in_retry
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "shutdown must clear retry state"
         );
 
         server.abort();

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -498,6 +498,7 @@ impl Output for KafkaOutput {
             // or by the runtime SIGTERM budget.
             match self.try_send(event, shutdown.clone()).await {
                 Ok(KafkaTrySendOutcome::Delivered) => {
+                    self.metrics.in_retry.set(0);
                     // `FutureProducer` resolves each message through
                     // an async delivery report — count only in the
                     // Delivered arm so the counter tracks a successful
@@ -508,6 +509,7 @@ impl Output for KafkaOutput {
                     return Ok(());
                 }
                 Ok(KafkaTrySendOutcome::PreSendShutdown) => {
+                    self.metrics.in_retry.set(0);
                     let reason = format!(
                         "output '{}': write attempt abandoned on shutdown (pre-send)",
                         self.name
@@ -529,6 +531,7 @@ impl Output for KafkaOutput {
                     attempt += 1;
                     self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
+                        self.metrics.in_retry.set(0);
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
                         let __dlq_outcome = crate::modules::route_event_to_dlq(
@@ -548,6 +551,7 @@ impl Output for KafkaOutput {
                         );
                         return Ok(());
                     }
+                    self.metrics.in_retry.set(1);
                     tracing::warn!(
                         "output '{}': write failed (attempt {}/{}): {} — retrying in {:?}",
                         self.name,
@@ -564,6 +568,7 @@ impl Output for KafkaOutput {
                     // shutdown arm. Route the pending event to DLQ, resolve
                     // `Recovered`, and return.
                     if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        self.metrics.in_retry.set(0);
                         let reason = format!(
                             "output write failed and shutdown observed mid-retry \
                              after {} attempts: {}",
@@ -754,6 +759,7 @@ impl KafkaOutput {
 mod tests {
     use super::*;
     use crate::dsl::ast::{Expr, ExprKind, Property};
+    use std::sync::atomic::Ordering;
     use tempfile::TempDir;
 
     fn kv(key: &str, kind: ExprKind) -> Property {
@@ -1261,6 +1267,60 @@ mod tests {
             0,
             "pre-send shutdown confirms no Kafka payload transfer"
         );
+        assert_eq!(output.metrics.retries.load(Ordering::Relaxed), 0);
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn brokerless_failure_sets_retry_gauge_until_shutdown() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+        use bytes::Bytes;
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let mut client = ClientConfig::new();
+        client
+            .set("bootstrap.servers", "127.0.0.1:1")
+            .set("message.timeout.ms", "100");
+        let output = Arc::new(KafkaOutput {
+            name: "k-retry".into(),
+            producer: client.create().expect("build producer"),
+            topic: "t".into(),
+            key_field: None,
+            queue_timeout: Duration::from_millis(100),
+            retry: RetryConfig {
+                max_attempts: 3,
+                initial_wait: Duration::from_secs(5),
+                max_wait: Duration::from_secs(5),
+                backoff: crate::queue::BackoffStrategy::Fixed,
+            },
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+            metrics: OutputMetrics::for_testing(),
+            shutdown_signal: shutdown_rx,
+        });
+        let event = Event::new(
+            Bytes::from_static(b"payload"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+        let task_output = Arc::clone(&output);
+        let task = tokio::spawn(async move { task_output.consume(&event, ack).await });
+        tokio::time::timeout(Duration::from_secs(3), async {
+            while output.metrics.retries.load(Ordering::Relaxed) != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("brokerless send must enter backoff");
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 1);
+        shutdown_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("shutdown must stop Kafka retry")
+            .unwrap()
+            .unwrap();
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -95,17 +95,28 @@ impl StdoutOutput {
         self.metrics.bytes_written.inc_by(buf.len() as u64);
         Ok(())
     }
-}
 
-#[async_trait::async_trait]
-impl Output for StdoutOutput {
-    async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+    /// Retry-loop seam shared by `consume` and its test scaffolding.
+    /// Production callers pass a closure that delegates to
+    /// `write_event`; test callers pass a scripted closure so
+    /// retry / shutdown / gauge state can be exercised without an
+    /// actual stdout write.
+    async fn consume_with_write<F>(
+        &self,
+        event: &Event,
+        ack: QueueAckHandle,
+        mut write: F,
+    ) -> Result<()>
+    where
+        F: FnMut(&Event) -> Result<()> + Send,
+    {
         let mut attempt = 0u32;
         let mut wait = self.retry.initial_wait;
         let mut shutdown = self.shutdown_signal.clone();
         loop {
-            match self.write_event(event) {
+            match write(event) {
                 Ok(()) => {
+                    self.metrics.in_retry.set(0);
                     self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
@@ -114,6 +125,7 @@ impl Output for StdoutOutput {
                     attempt += 1;
                     self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
+                        self.metrics.in_retry.set(0);
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
                         let __dlq_outcome = crate::modules::route_event_to_dlq(
@@ -133,6 +145,7 @@ impl Output for StdoutOutput {
                         );
                         return Ok(());
                     }
+                    self.metrics.in_retry.set(1);
                     tracing::warn!(
                         "output '{}': write failed (attempt {}/{}): {} — retrying in {:?}",
                         self.name,
@@ -149,6 +162,7 @@ impl Output for StdoutOutput {
                     // shutdown arm. Route the pending event to DLQ, resolve
                     // `Recovered`, and return.
                     if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        self.metrics.in_retry.set(0);
                         let reason = format!(
                             "output write failed and shutdown observed mid-retry \
                              after {} attempts: {}",
@@ -175,6 +189,14 @@ impl Output for StdoutOutput {
                 }
             }
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl Output for StdoutOutput {
+    async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        self.consume_with_write(event, ack, |event| self.write_event(event))
+            .await
     }
 
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
@@ -336,6 +358,148 @@ mod metrics_registration_tests {
                 .load(std::sync::atomic::Ordering::Relaxed),
             written.len() as u64,
             "a failed write must not add any bytes"
+        );
+        assert_eq!(
+            output
+                .metrics
+                .events_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scripted_retry_exposes_backoff_then_clears_on_success() {
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let output = Arc::new(StdoutOutput {
+            name: "stdout-retry".to_owned(),
+            retry: RetryConfig {
+                max_attempts: 2,
+                initial_wait: std::time::Duration::from_millis(50),
+                max_wait: std::time::Duration::from_millis(50),
+                backoff: crate::queue::BackoffStrategy::Fixed,
+            },
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+            metrics: OutputMetrics::for_testing(),
+            shutdown_signal: shutdown_rx,
+        });
+        let event = crate::event::Event::new(
+            bytes::Bytes::from_static(b"retry"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, mut ack_rx) = QueueAckHandle::for_test();
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (failed_tx, failed_rx) = tokio::sync::oneshot::channel();
+        let failed_tx = Arc::new(std::sync::Mutex::new(Some(failed_tx)));
+        let task_output = Arc::clone(&output);
+        let task_attempts = Arc::clone(&attempts);
+        let task = tokio::spawn(async move {
+            task_output
+                .consume_with_write(&event, ack, move |_| {
+                    let attempt = task_attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if attempt == 0 {
+                        failed_tx.lock().unwrap().take().unwrap().send(()).unwrap();
+                        anyhow::bail!("scripted first failure");
+                    }
+                    Ok(())
+                })
+                .await
+        });
+
+        failed_rx.await.unwrap();
+        tokio::task::yield_now().await;
+        assert_eq!(
+            output
+                .metrics
+                .in_retry
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        tokio::time::advance(output.retry.initial_wait).await;
+        task.await.unwrap().unwrap();
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(
+            output
+                .metrics
+                .in_retry
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            output
+                .metrics
+                .retries
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            output
+                .metrics
+                .events_written
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert!(matches!(
+            ack_rx.recv().await,
+            Some((_, crate::queue::AckDisposition::Delivered))
+        ));
+    }
+
+    #[tokio::test]
+    async fn active_shutdown_clears_scripted_retry_state() {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let output = Arc::new(StdoutOutput {
+            name: "stdout-shutdown".to_owned(),
+            retry: RetryConfig {
+                max_attempts: 3,
+                initial_wait: std::time::Duration::from_secs(5),
+                max_wait: std::time::Duration::from_secs(5),
+                backoff: crate::queue::BackoffStrategy::Fixed,
+            },
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+            metrics: OutputMetrics::for_testing(),
+            shutdown_signal: shutdown_rx,
+        });
+        let event = crate::event::Event::new(
+            bytes::Bytes::from_static(b"shutdown"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+        let (failed_tx, failed_rx) = tokio::sync::oneshot::channel();
+        let failed_tx = Arc::new(std::sync::Mutex::new(Some(failed_tx)));
+        let task_output = Arc::clone(&output);
+        let task = tokio::spawn(async move {
+            task_output
+                .consume_with_write(&event, ack, move |_| {
+                    if let Some(tx) = failed_tx.lock().unwrap().take() {
+                        tx.send(()).unwrap();
+                    }
+                    anyhow::bail!("scripted persistent failure")
+                })
+                .await
+        });
+        failed_rx.await.unwrap();
+        assert_eq!(
+            output
+                .metrics
+                .in_retry
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        shutdown_tx.send(true).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), task)
+            .await
+            .expect("shutdown must stop retry")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            output
+                .metrics
+                .in_retry
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
         );
         assert_eq!(
             output

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -365,6 +365,7 @@ impl Output for SyslogTcpOutput {
                 SyslogTcpWriteOutcome::Delivered => Ok(()),
                 SyslogTcpWriteOutcome::Err(e) => Err(e),
                 SyslogTcpWriteOutcome::PreSendShutdown => {
+                    self.metrics.in_retry.set(0);
                     let reason = format!(
                         "output '{}': write attempt abandoned on shutdown (pre-send)",
                         self.name
@@ -385,6 +386,7 @@ impl Output for SyslogTcpOutput {
             };
             match write_result {
                 Ok(()) => {
+                    self.metrics.in_retry.set(0);
                     self.metrics.events_written.inc();
                     ack.resolve_delivered();
                     return Ok(());
@@ -393,6 +395,7 @@ impl Output for SyslogTcpOutput {
                     attempt += 1;
                     self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
+                        self.metrics.in_retry.set(0);
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
                         let __dlq_outcome = crate::modules::route_event_to_dlq(
@@ -412,6 +415,7 @@ impl Output for SyslogTcpOutput {
                         );
                         return Ok(());
                     }
+                    self.metrics.in_retry.set(1);
                     tracing::warn!(
                         "output '{}': write failed (attempt {}/{}): {} — retrying in {:?}",
                         self.name,
@@ -428,6 +432,7 @@ impl Output for SyslogTcpOutput {
                     // shutdown arm. Route the pending event to DLQ, resolve
                     // `Recovered`, and return.
                     if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        self.metrics.in_retry.set(0);
                         let reason = format!(
                             "output write failed and shutdown observed mid-retry \
                              after {} attempts: {}",
@@ -729,6 +734,7 @@ mod tests {
     use crate::dsl::schema::SchemaErrorKind;
     use bytes::Bytes;
     use std::sync::atomic::Ordering;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     /// Structural pin: `consume_shutdown` routes its result through
@@ -1055,6 +1061,60 @@ mod tests {
 
         assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
         assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn connection_backoff_sets_retry_gauge_until_shutdown() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let mut ctx = crate::modules::BuildContext::for_testing();
+        ctx.shutdown_signal = shutdown_rx;
+        let output = Arc::new(
+            SyslogTcpOutput::from_properties(
+                "tcp-retry",
+                &mp(&[
+                    peer_plain("127.0.0.1", port as i64),
+                    block(
+                        "retry",
+                        vec![
+                            kv("max_attempts", ExprKind::IntLit(3)),
+                            kv("initial_wait", ExprKind::StringLit("5s".into())),
+                            kv("max_wait", ExprKind::StringLit("5s".into())),
+                        ],
+                    ),
+                ]),
+                &ctx,
+            )
+            .unwrap(),
+        );
+        let event = Event::new(
+            Bytes::from_static(b"<134>unreachable"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+        let task_output = Arc::clone(&output);
+        let task = tokio::spawn(async move { task_output.consume(&event, ack).await });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while output.metrics.retries.load(Ordering::Relaxed) != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("connection failure must enter backoff");
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 1);
+        shutdown_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("shutdown must stop TCP retry")
+            .unwrap()
+            .unwrap();
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 0);
     }
 
     struct PemFiles {

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -136,6 +136,7 @@ impl Output for SyslogUdpOutput {
                 SyslogUdpWriteOutcome::Delivered => Ok(()),
                 SyslogUdpWriteOutcome::Err(e) => Err(e),
                 SyslogUdpWriteOutcome::PreSendShutdown => {
+                    self.metrics.in_retry.set(0);
                     let reason = format!(
                         "output '{}': write attempt abandoned on shutdown (pre-send)",
                         self.name
@@ -156,6 +157,7 @@ impl Output for SyslogUdpOutput {
             };
             match write_result {
                 Ok(()) => {
+                    self.metrics.in_retry.set(0);
                     // `write_payload_shutdown_aware` (and its transport-
                     // only sibling `write_payload`) intentionally do NOT
                     // bump `events_written`; disposition ownership lives
@@ -172,6 +174,7 @@ impl Output for SyslogUdpOutput {
                     attempt += 1;
                     self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
+                        self.metrics.in_retry.set(0);
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
                         let __dlq_outcome = crate::modules::route_event_to_dlq(
@@ -191,6 +194,7 @@ impl Output for SyslogUdpOutput {
                         );
                         return Ok(());
                     }
+                    self.metrics.in_retry.set(1);
                     tracing::warn!(
                         "output '{}': write failed (attempt {}/{}): {} — retrying in {:?}",
                         self.name,
@@ -207,6 +211,7 @@ impl Output for SyslogUdpOutput {
                     // shutdown arm. Route the pending event to DLQ, resolve
                     // `Recovered`, and return.
                     if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        self.metrics.in_retry.set(0);
                         let reason = format!(
                             "output write failed and shutdown observed mid-retry \
                              after {} attempts: {}",
@@ -1009,5 +1014,62 @@ mod tests {
 
         assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
         assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn oversized_datagram_backoff_sets_retry_gauge_until_shutdown() {
+        use crate::event::Event;
+        use crate::queue::QueueAckHandle;
+        use bytes::Bytes;
+
+        let listener = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().unwrap().port() as i64;
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let mut ctx = crate::modules::BuildContext::for_testing();
+        ctx.shutdown_signal = shutdown_rx;
+        let output = Arc::new(
+            SyslogUdpOutput::build(
+                "udp-retry",
+                &mp(&[
+                    block(
+                        "peer",
+                        vec![
+                            kv("host", ExprKind::StringLit("127.0.0.1".into())),
+                            kv("port", ExprKind::IntLit(port)),
+                        ],
+                    ),
+                    block(
+                        "retry",
+                        vec![
+                            kv("max_attempts", ExprKind::IntLit(3)),
+                            kv("initial_wait", ExprKind::StringLit("5s".into())),
+                            kv("max_wait", ExprKind::StringLit("5s".into())),
+                        ],
+                    ),
+                ]),
+                &ctx,
+            )
+            .expect("build"),
+        );
+        let event = Event::new(Bytes::from(vec![0; 65_536]), "127.0.0.1:0".parse().unwrap());
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+        let task_output = Arc::clone(&output);
+        let task = tokio::spawn(async move { task_output.consume(&event, ack).await });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while output.metrics.retries.load(Ordering::Relaxed) != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("oversized datagram must enter backoff");
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 1);
+        shutdown_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("shutdown must stop UDP retry")
+            .unwrap()
+            .unwrap();
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -170,6 +170,7 @@ impl Output for UnixSocketOutput {
                 WriteReconnectOutcome::Delivered => Ok(()),
                 WriteReconnectOutcome::Err(e) => Err(e),
                 WriteReconnectOutcome::PreSendShutdown => {
+                    self.metrics.in_retry.set(0);
                     let reason = format!(
                         "output '{}': write attempt abandoned on shutdown (pre-send)",
                         self.name
@@ -190,6 +191,7 @@ impl Output for UnixSocketOutput {
             };
             match write_result {
                 Ok(()) => {
+                    self.metrics.in_retry.set(0);
                     // Metric ownership stays with the caller so
                     // `finalize_shutdown_singleton_disposition` on the
                     // shutdown-drain path (which also owns the
@@ -204,6 +206,7 @@ impl Output for UnixSocketOutput {
                     attempt += 1;
                     self.metrics.retries.inc();
                     if attempt >= self.retry.max_attempts {
+                        self.metrics.in_retry.set(0);
                         let reason =
                             format!("output write failed after {} attempts: {}", attempt, e);
                         let __dlq_outcome = crate::modules::route_event_to_dlq(
@@ -223,6 +226,7 @@ impl Output for UnixSocketOutput {
                         );
                         return Ok(());
                     }
+                    self.metrics.in_retry.set(1);
                     tracing::warn!(
                         "output '{}': write failed (attempt {}/{}): {} — retrying in {:?}",
                         self.name,
@@ -239,6 +243,7 @@ impl Output for UnixSocketOutput {
                     // shutdown arm. Route the pending event to DLQ, resolve
                     // `Recovered`, and return.
                     if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        self.metrics.in_retry.set(0);
                         let reason = format!(
                             "output write failed and shutdown observed mid-retry \
                              after {} attempts: {}",
@@ -711,6 +716,7 @@ mod tests {
         })
         .await
         .expect("first failed connection attempt must remain bounded");
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 1);
 
         let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
         let expected_len = expected.len();
@@ -731,6 +737,7 @@ mod tests {
             expected.len() as u64
         );
         assert_eq!(output.metrics.events_written.load(Ordering::Relaxed), 1);
+        assert_eq!(output.metrics.in_retry.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -231,6 +231,11 @@ impl DiskQueueSender {
 }
 
 impl DiskQueueReceiver {
+    pub(crate) fn depth(&self) -> u64 {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.write_seq.saturating_sub(state.acked_seq)
+    }
+
     pub async fn recv(&mut self) -> Option<(Event, AckPosition)> {
         loop {
             // Register for notification BEFORE checking — prevents missed-wakeup race.
@@ -730,6 +735,26 @@ mod tests {
 
         let (e2, _p2) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>msg2");
+    }
+
+    #[test]
+    fn disk_queue_depth_is_the_saturating_write_acked_sequence_difference() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_sender, receiver) =
+            create_disk_queue(dir.path().to_str().expect("UTF-8 temp path"), 0).unwrap();
+
+        {
+            let mut state = receiver.state.lock().unwrap();
+            state.write_seq = 9;
+            state.acked_seq = 4;
+        }
+        assert_eq!(receiver.depth(), 5);
+
+        {
+            let mut state = receiver.state.lock().unwrap();
+            state.acked_seq = 12;
+        }
+        assert_eq!(receiver.depth(), 0, "depth must never underflow");
     }
 
     #[test]

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -526,6 +526,13 @@ enum ReceiverInner {
 }
 
 impl QueueReceiver {
+    pub(crate) fn depth(&self) -> u64 {
+        match &self.inner {
+            ReceiverInner::Memory(rx) => rx.len() as u64,
+            ReceiverInner::Disk(rx) => rx.depth(),
+        }
+    }
+
     /// Which backend is behind this receiver. See [`QueueBackendKind`].
     pub fn backend_kind(&self) -> QueueBackendKind {
         match &self.inner {
@@ -1074,6 +1081,7 @@ pub async fn run_queue_consumer(
     // follows the first push is synchronous, the only state that can
     // survive across select re-entries is an empty buffer.
     let mut batch: Vec<(Event, AckPosition)> = Vec::with_capacity(RECV_BATCH_MAX);
+    metrics.queue_depth.set(receiver.depth());
 
     loop {
         tokio::select! {
@@ -1124,6 +1132,7 @@ pub async fn run_queue_consumer(
                         QueueBackendKind::Memory => {
                             receiver.close();
                             while let Some((event, position)) = receiver.recv().await {
+                                metrics.queue_depth.set(receiver.depth());
                                 if let Some(tap) = &tap {
                                     tap.emit(&format!("output {}", name), &event).await;
                                 }
@@ -1206,6 +1215,7 @@ pub async fn run_queue_consumer(
                     // stay at the in-flight front.
                 } else {
                     receiver.ack_to(position);
+                    metrics.queue_depth.set(receiver.depth());
                 }
                 in_flight = in_flight.saturating_sub(1);
                 // Natural queue-closure or wedge exit: the
@@ -1222,6 +1232,7 @@ pub async fn run_queue_consumer(
             }
 
             n = receiver.recv_many(&mut batch, RECV_BATCH_MAX), if accepting => {
+                metrics.queue_depth.set(receiver.depth());
                 if n == 0 {
                     // `recv_many` returned 0 ⇔ `recv().await` observed
                     // `None` ⇔ queue closed and empty. Same semantics as
@@ -1309,6 +1320,7 @@ pub async fn run_queue_consumer(
         let is_dropped_on_disk = matches!(disposition, AckDisposition::Dropped) && is_disk_position;
         if !is_dropped_on_disk {
             receiver.ack_to(position);
+            metrics.queue_depth.set(receiver.depth());
         }
         in_flight = in_flight.saturating_sub(1);
     }
@@ -1319,6 +1331,7 @@ pub async fn run_queue_consumer(
             in_flight,
         );
     }
+    metrics.queue_depth.set(0);
 
     if wedged {
         tracing::error!(
@@ -1614,6 +1627,37 @@ mod consumer_lifecycle_tests {
         }
     }
 
+    struct StalledWriter {
+        metrics: Arc<crate::metrics::OutputMetrics>,
+        entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: tokio::sync::Notify,
+    }
+
+    impl HasMetrics for StalledWriter {
+        type Stats = crate::metrics::OutputMetrics;
+
+        fn metrics(&self) -> Arc<Self::Stats> {
+            Arc::clone(&self.metrics)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Output for StalledWriter {
+        async fn consume(&self, _event: &Event, ack: QueueAckHandle) -> anyhow::Result<()> {
+            let entered = self.entered.lock().unwrap().take();
+            if let Some(entered) = entered {
+                let _ = entered.send(());
+                self.release.notified().await;
+            }
+            ack.resolve_delivered();
+            Ok(())
+        }
+
+        async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> anyhow::Result<()> {
+            self.consume(event, ack).await
+        }
+    }
+
     // ---- queue boundary error tests ----
 
     #[tokio::test]
@@ -1635,6 +1679,86 @@ mod consumer_lifecycle_tests {
             matches!(err, QueueSendError::ChannelClosed),
             "expected ChannelClosed, got {:?}",
             err
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_queue_depth_is_the_current_receiver_length() {
+        let (sender, mut receiver) = create_queue(
+            "depth".into(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 4,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(receiver.depth(), 0);
+        sender.send(owned_event()).await.unwrap();
+        sender.send(owned_event()).await.unwrap();
+        assert_eq!(receiver.depth(), 2);
+        receiver.recv().await.expect("first queued event");
+        assert_eq!(receiver.depth(), 1);
+        receiver.recv().await.expect("second queued event");
+        assert_eq!(receiver.depth(), 0);
+    }
+
+    #[tokio::test]
+    async fn consumer_publishes_memory_backlog_and_clears_depth_on_close() {
+        let event_count = RECV_BATCH_MAX + 6;
+        let (sender, receiver) = create_queue(
+            "depth-consumer".into(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: event_count + 4,
+            },
+        )
+        .unwrap();
+        for _ in 0..event_count {
+            sender.send(owned_event()).await.unwrap();
+        }
+
+        let metrics = crate::metrics::OutputMetrics::for_testing();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let writer = Arc::new(StalledWriter {
+            metrics: Arc::clone(&metrics),
+            entered: Mutex::new(Some(entered_tx)),
+            release: tokio::sync::Notify::new(),
+        });
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let task = tokio::spawn(run_queue_consumer(
+            receiver,
+            writer.clone(),
+            None,
+            Arc::clone(&metrics),
+            None,
+            shutdown_rx,
+        ));
+        tokio::time::timeout(std::time::Duration::from_secs(2), entered_rx)
+            .await
+            .expect("consumer must reach stalled writer")
+            .expect("stalled writer readiness sender");
+        assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 6);
+
+        writer.release.notify_one();
+        drop(sender);
+        tokio::time::timeout(std::time::Duration::from_secs(2), task)
+            .await
+            .expect("consumer must drain and close")
+            .expect("consumer task must not panic");
+        assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn queue_consumer_publishes_receiver_depth_through_the_output_handle() {
+        let source = include_str!("mod.rs");
+        let start = source
+            .find("pub async fn run_queue_consumer(")
+            .expect("queue consumer must exist");
+        let body = &source[start..];
+        assert!(
+            body.contains("metrics.queue_depth.set") && body.contains("receiver.depth()"),
+            "queue consumer must publish backend depth through its pre-resolved gauge"
         );
     }
 
@@ -2988,6 +3112,7 @@ mod consumer_lifecycle_tests {
             3,
             "memory drain must deliver all buffered events to consume_shutdown",
         );
+        assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 0);
     }
 
     /// Disk backend: shutdown must NOT drain unread WAL entries
@@ -3025,6 +3150,7 @@ mod consumer_lifecycle_tests {
             .await
             .expect("consumer must exit")
             .expect("consumer task must not panic");
+        assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 0);
 
         assert_eq!(
             writer.calls(),

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -715,6 +715,7 @@ async fn process_event(
         if i > 0 {
             bump.reset();
         }
+        worker.metrics.inflight.inc();
         match run_pipeline_with_outputs(&worker.def, event, ctx, bump).await {
             Ok(result) => {
                 use crate::pipeline::PipelineTermination;
@@ -788,6 +789,7 @@ async fn process_event(
                 .await;
             }
         }
+        worker.metrics.inflight.dec();
     }
 }
 
@@ -1055,6 +1057,94 @@ mod tests {
         // All 8 events should have been attributed to the shared worker.
         assert_eq!(worker.metrics.events_received.load(Ordering::Relaxed), 8);
         assert_eq!(worker.metrics.events_dropped.load(Ordering::Relaxed), 8);
+        assert_eq!(worker.metrics.inflight.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn pipeline_inflight_counts_concurrent_runs_and_returns_to_zero() {
+        let def = pipeline_def("def pipeline p { input a, b; output sink; finish }");
+        let metrics_registry = Registry::new();
+        let worker = Arc::new(
+            PipelineWorker::new(def, &metrics_registry).expect("pipeline metrics must register"),
+        );
+        let workers: Arc<Vec<Arc<PipelineWorker>>> = Arc::new(vec![Arc::clone(&worker)]);
+
+        let (queue_sender, mut queue_receiver) = crate::queue::create_queue(
+            "sink".to_owned(),
+            crate::queue::QueueConfig {
+                queue_type: crate::queue::QueueType::Memory,
+                capacity: 1,
+            },
+        )
+        .expect("memory queue");
+        queue_sender
+            .send(Event::new(
+                Bytes::from_static(b"filler"),
+                "127.0.0.1:0".parse().unwrap(),
+            ))
+            .await
+            .expect("prefill queue");
+
+        let cfg = CompiledConfig::from_config(parse_config("").unwrap()).unwrap();
+        let tap = TapRegistry::new();
+        tap.register("input a").await;
+        tap.register("input b").await;
+        let ctx = Arc::new(PipelineContext {
+            output_senders: Arc::new(HashMap::from([("sink".to_owned(), queue_sender)])),
+            disk_outputs: Arc::new(HashSet::new()),
+            config: Arc::new(cfg),
+            funcs: Arc::new(FunctionRegistry::new()),
+            tap,
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+        });
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (tx_a, rx_a) = mpsc::channel(1);
+        let (tx_b, rx_b) = mpsc::channel(1);
+        let h_a = {
+            let workers = Arc::clone(&workers);
+            let ctx = Arc::clone(&ctx);
+            let shutdown = shutdown_rx.clone();
+            tokio::spawn(async move {
+                run_pipeline_workers(rx_a, &workers, &ctx, "a", shutdown).await;
+            })
+        };
+        let h_b = {
+            let workers = Arc::clone(&workers);
+            let ctx = Arc::clone(&ctx);
+            tokio::spawn(async move {
+                run_pipeline_workers(rx_b, &workers, &ctx, "b", shutdown_rx).await;
+            })
+        };
+
+        let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
+        tx_a.send(Event::new(Bytes::from_static(b"a"), addr))
+            .await
+            .unwrap();
+        tx_b.send(Event::new(Bytes::from_static(b"b"), addr))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while worker.metrics.inflight.load(Ordering::Relaxed) != 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both blocked pipeline runs must become observable");
+
+        for _ in 0..3 {
+            queue_receiver.recv().await.expect("queued event");
+        }
+        drop(tx_a);
+        drop(tx_b);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            h_a.await.unwrap();
+            h_b.await.unwrap();
+        })
+        .await
+        .expect("pipeline workers must drain");
+        assert_eq!(worker.metrics.inflight.load(Ordering::Relaxed), 0);
+        assert_eq!(worker.metrics.events_finished.load(Ordering::Relaxed), 2);
     }
 
     fn make_err_ctx(reason: &str) -> crate::pipeline::ErroredEventContext {
@@ -1193,6 +1283,65 @@ mod tests {
             .collect();
         names.sort();
         assert_eq!(names, vec!["sink_a".to_string(), "sink_b".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn pipeline_inflight_covers_errored_termination_and_direct_error_dlq_work() {
+        for (body, reason) in [
+            ("error \"terminal failure\"", "terminal failure"),
+            (
+                "error missing_runtime_function()",
+                "missing_runtime_function",
+            ),
+        ] {
+            let def = pipeline_def(&format!("def pipeline p {{ input i; {body} }}"));
+            let registry = Registry::new();
+            let worker = Arc::new(
+                PipelineWorker::new(def, &registry).expect("pipeline metrics must register"),
+            );
+            let dir = tempfile::tempdir().unwrap();
+            let log_path = dir.path().join("pipeline-errors.jsonl");
+            let error_log = Arc::new(crate::error_log::ErrorLogWriter::new(log_path.clone()));
+            let guard = error_log.hold_write_lock_for_testing().await;
+            let cfg = CompiledConfig::from_config(parse_config("").unwrap()).unwrap();
+            let ctx = PipelineContext {
+                output_senders: Arc::new(HashMap::new()),
+                disk_outputs: Arc::new(HashSet::new()),
+                config: Arc::new(cfg),
+                funcs: Arc::new(FunctionRegistry::new()),
+                tap: TapRegistry::new(),
+                error_log: Some(Arc::clone(&error_log)),
+                error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+            };
+            let event = Event::new(
+                Bytes::from_static(b"payload"),
+                SocketAddr::from_str("127.0.0.1:0").unwrap(),
+            );
+            let task_worker = Arc::clone(&worker);
+            let task = tokio::spawn(async move {
+                let mut bump = bumpalo::Bump::new();
+                process_event(&event, &[task_worker], &ctx, "input i", &mut bump).await;
+            });
+
+            tokio::time::timeout(Duration::from_secs(2), async {
+                while worker.metrics.events_errored.load(Ordering::Relaxed) != 1 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("runtime error must reach terminal bookkeeping");
+            assert!(!task.is_finished(), "DLQ write must still be held");
+            assert_eq!(worker.metrics.inflight.load(Ordering::Relaxed), 1);
+
+            drop(guard);
+            tokio::time::timeout(Duration::from_secs(2), task)
+                .await
+                .expect("DLQ completion must release the pipeline")
+                .expect("pipeline task must not panic");
+            assert_eq!(worker.metrics.inflight.load(Ordering::Relaxed), 0);
+            let record = tokio::fs::read_to_string(&log_path).await.unwrap();
+            assert!(record.contains(reason), "unexpected DLQ record: {record}");
+        }
     }
 
     /// Structural pin: the pipeline worker's shutdown arm closes

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -74,7 +74,7 @@ daemon startup instead of being ignored.
 
 ## Current metric families
 
-These are the current counter families registered by the daemon. Each series
+These are the current metric families registered by the daemon. Each series
 has exactly the fixed label shown; the label value is the configured component
 name, so label cardinality is bounded by the configured components.
 
@@ -88,6 +88,7 @@ name, so label cardinality is bounded by the configured components.
 | `limpid_pipeline_events_discarded_total` | `pipeline` | Events that completed without reaching any output. |
 | `limpid_pipeline_events_errored_total` | `pipeline` | Events that failed at a pipeline-side producer site and were routed to the [error log](./error-log.md). |
 | `limpid_pipeline_events_errored_unwritable_total` | `pipeline` | Pipeline-side error-log writes that failed. |
+| `limpid_pipeline_inflight` | `pipeline` | Pipeline executions currently in progress, including terminal bookkeeping. |
 
 `events_discarded` is a possible routing-misconfiguration signal: the event
 completed the pipeline but was never sent anywhere.
@@ -123,6 +124,8 @@ from synthetic and replay traffic.
 | `limpid_output_events_wedged_total` | `output` | Disk-queue fail-stop wedges observed by the output. |
 | `limpid_output_events_errored_unwritable_total` | `output` | Sink-side error-log writes that failed. |
 | `limpid_output_bytes_written_total` | `output` | Logical bytes whose transfer to the destination was confirmed. |
+| `limpid_output_queue_depth` | `output` | Current unread or unacknowledged output queue depth. |
+| `limpid_output_in_retry` | `output` | Whether an output retry cycle is active (`0` or `1`). |
 
 `events_failed` includes retry-budget exhaustion, per-event render failures in
 batched output flushes, shutdown-drain leftovers after a final flush failure,
@@ -143,6 +146,29 @@ Useful relationships are approximate during concurrent updates:
 - `output.received - output.injected` is traffic delivered by pipelines.
 - `output.received - output.written - output.failed` approximates events still
   pending in the queue.
+
+### Runtime gauges
+
+`limpid_output_queue_depth{output}` reports the memory receiver's current
+length for memory queues. For disk queues it reports the saturating difference
+between the current write-segment sequence and acknowledged-segment sequence.
+The disk value therefore tracks durable segment progress rather than an exact
+event count. Both backends publish zero when their consumer terminates.
+
+`limpid_output_in_retry{output}` changes to one after the first failed attempt
+enters a retry cycle. It returns to zero when an attempt succeeds, the retry
+budget is exhausted, or shutdown interrupts the cycle. An output that observes
+shutdown before making an attempt remains zero.
+
+`limpid_pipeline_inflight{pipeline}` increments immediately before pipeline
+execution and decrements only after its terminal counters and any error-log
+work have completed. It therefore includes executions waiting on terminal
+bookkeeping, not only expression evaluation.
+
+Gauge updates and snapshot reads are concurrent relaxed atomic operations. A
+snapshot is a useful point-in-time observation of each series, but values from
+different series are not loaded as one transaction and need not describe the
+same instant.
 
 ### Byte-counter boundary
 


### PR DESCRIPTION
## Summary
- add prepopulated output queue depth, output retry, and pipeline inflight gauges
- publish gauge values at the authoritative queue, retry, and pipeline lifecycle owners
- document queue formulas, lifecycle boundaries, and relaxed snapshot semantics

## Validation
- `cargo fmt --all -- --check`
- focused registry, gauge, queue, inflight, and retry tests
- `cargo test -p limpid --bin limpid` — 983 passed, 1 ignored
- `cargo test -p limpid --all-targets --features kafka` — 1012 passed, 1 ignored; CLI integration 29 passed
- `cargo test --workspace`
- `cargo clippy -p limpid --all-targets --features kafka -- -D warnings`
- `cargo clippy --workspace -- -D warnings`
- release-mode gauge underflow saturation test
- `mdbook build docs`
- `cargo xtask lint-snippet-headers`
- `cargo xtask gen-snippet-inventory --check`
- `cargo deny check advisories bans sources licenses`

The journal feature requires libsystemd and is not built on macOS; Ubuntu CI owns that platform validation boundary.

## Notes
- this change adds only the three pinned gauge families
- labels remain fixed from configuration and hot paths use pre-resolved atomic handles
- no Phase 2.3+ metric, config, dependency, or public API change
- the formal cumulative Phase 2 benchmark remains pinned to PR2.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics for pipeline executions currently in progress.
  * Added output queue-depth metrics to show backlog levels.
  * Added retry-state metrics that indicate when outputs are retrying delivery.
  * Metrics now remain accurate during successful delivery, failures, shutdowns, and retry backoff periods.
* **Bug Fixes**
  * Improved metric consistency across all supported output destinations and queue types.
  * Prevented queue-depth values from becoming negative.
* **Documentation**
  * Expanded metrics documentation with details about the new gauges and their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->