### PR TITLE
refactor(metrics): share schema v1 wire types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
  "glob",
  "indexmap",
  "libc",
+ "limpid-metrics-schema",
  "maxminddb",
  "md-5",
  "opentelemetry-proto",
@@ -1144,6 +1145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "limpid-metrics-schema"
+version = "0.7.15"
+dependencies = [
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "limpid-prometheus"
 version = "0.7.15"
 dependencies = [
@@ -1151,6 +1161,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "limpid-metrics-schema",
  "serde_json",
  "tempfile",
  "tokio",
@@ -1163,6 +1174,7 @@ dependencies = [
  "chrono",
  "clap",
  "libc",
+ "limpid-metrics-schema",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ resolver = "3"
 # `crates.io` all stop warning about missing field.
 [workspace.package]
 license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+limpid-metrics-schema = { version = "0.7.15", path = "crates/limpid-metrics-schema" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = ["crates/limpid", "crates/limpidctl", "crates/limpid-prometheus", "crates/xtask"]
+members = [
+    "crates/limpid",
+    "crates/limpidctl",
+    "crates/limpid-metrics-schema",
+    "crates/limpid-prometheus",
+    "crates/xtask",
+]
 resolver = "3"
 
 # Shared package metadata. Each member crate inherits via

--- a/crates/limpid-metrics-schema/Cargo.toml
+++ b/crates/limpid-metrics-schema/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "limpid-metrics-schema"
+version = "0.7.15"
+edition = "2024"
+description = "Wire DTOs for limpid schema-v1 metrics snapshots"
+license.workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"
+syn = { version = "2", features = ["full", "visit"] }

--- a/crates/limpid-metrics-schema/src/lib.rs
+++ b/crates/limpid-metrics-schema/src/lib.rs
@@ -1,0 +1,169 @@
+//! Wire-only data transfer objects for schema-v1 metrics snapshots.
+//!
+//! These wire DTOs keep the daemon's runtime state out of consumer
+//! dependency graphs. Serde is the crate's only production dependency,
+//! and architecture tests enforce that boundary.
+
+use std::collections::BTreeMap;
+
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MetricsSnapshot {
+    pub schema: u32,
+    pub metrics: Vec<MetricFamily>,
+}
+
+impl MetricsSnapshot {
+    pub fn new(metrics: Vec<MetricFamily>) -> Self {
+        Self { schema: 1, metrics }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MetricType {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum MetricFamily {
+    Counter {
+        name: String,
+        help: String,
+        series: Vec<ValueSeries>,
+    },
+    Gauge {
+        name: String,
+        help: String,
+        series: Vec<ValueSeries>,
+    },
+    Histogram {
+        name: String,
+        help: String,
+        series: Vec<HistogramSeries>,
+    },
+}
+
+// Keep the existing raw schema-v1 member order (`name`, `type`, `help`,
+// `series`). Serde's internally tagged derive writes the tag before
+// variant fields, so this explicit serializer preserves the raw stats
+// byte shape.
+impl Serialize for MetricFamily {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut family = serializer.serialize_struct("MetricFamily", 4)?;
+        family.serialize_field("name", self.name())?;
+        match self {
+            Self::Counter { help, series, .. } => {
+                family.serialize_field("type", "counter")?;
+                family.serialize_field("help", help)?;
+                family.serialize_field("series", series)?;
+            }
+            Self::Gauge { help, series, .. } => {
+                family.serialize_field("type", "gauge")?;
+                family.serialize_field("help", help)?;
+                family.serialize_field("series", series)?;
+            }
+            Self::Histogram { help, series, .. } => {
+                family.serialize_field("type", "histogram")?;
+                family.serialize_field("help", help)?;
+                family.serialize_field("series", series)?;
+            }
+        }
+        family.end()
+    }
+}
+
+impl MetricFamily {
+    pub fn counter(name: String, help: String, series: Vec<ValueSeries>) -> Self {
+        Self::Counter { name, help, series }
+    }
+
+    pub fn gauge(name: String, help: String, series: Vec<ValueSeries>) -> Self {
+        Self::Gauge { name, help, series }
+    }
+
+    pub fn histogram(name: String, help: String, series: Vec<HistogramSeries>) -> Self {
+        Self::Histogram { name, help, series }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Counter { name, .. }
+            | Self::Gauge { name, .. }
+            | Self::Histogram { name, .. } => name,
+        }
+    }
+
+    pub fn help(&self) -> &str {
+        match self {
+            Self::Counter { help, .. }
+            | Self::Gauge { help, .. }
+            | Self::Histogram { help, .. } => help,
+        }
+    }
+
+    pub fn metric_type(&self) -> MetricType {
+        match self {
+            Self::Counter { .. } => MetricType::Counter,
+            Self::Gauge { .. } => MetricType::Gauge,
+            Self::Histogram { .. } => MetricType::Histogram,
+        }
+    }
+
+    pub fn value_series(&self) -> Option<&[ValueSeries]> {
+        match self {
+            Self::Counter { series, .. } | Self::Gauge { series, .. } => Some(series),
+            Self::Histogram { .. } => None,
+        }
+    }
+
+    pub fn histogram_series(&self) -> Option<&[HistogramSeries]> {
+        match self {
+            Self::Histogram { series, .. } => Some(series),
+            Self::Counter { .. } | Self::Gauge { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ValueSeries {
+    pub labels: BTreeMap<String, String>,
+    pub value: u64,
+}
+
+impl ValueSeries {
+    pub fn new(labels: BTreeMap<String, String>, value: u64) -> Self {
+        Self { labels, value }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HistogramSeries {
+    pub labels: BTreeMap<String, String>,
+    pub buckets: Vec<(f64, u64)>,
+    pub sum: f64,
+    pub count: u64,
+}
+
+impl HistogramSeries {
+    pub fn new(
+        labels: BTreeMap<String, String>,
+        buckets: Vec<(f64, u64)>,
+        sum: f64,
+        count: u64,
+    ) -> Self {
+        Self {
+            labels,
+            buckets,
+            sum,
+            count,
+        }
+    }
+}

--- a/crates/limpid-metrics-schema/tests/consumer_boundaries.rs
+++ b/crates/limpid-metrics-schema/tests/consumer_boundaries.rs
@@ -1,0 +1,289 @@
+use std::collections::{HashMap, HashSet};
+use std::process::Command;
+
+use syn::visit::Visit;
+
+fn has_one_live_normal_dependency(dependencies: &[serde_json::Value]) -> bool {
+    let matching = dependencies
+        .iter()
+        .filter(|dependency| dependency["name"] == "limpid-metrics-schema")
+        .collect::<Vec<_>>();
+    matching.len() == 1 && matching[0]["kind"].is_null() && matching[0]["target"].is_null()
+}
+
+fn type_ends_with(ty: &syn::Type, expected: &str) -> bool {
+    let syn::Type::Reference(reference) = ty else {
+        return false;
+    };
+    let syn::Type::Path(path) = reference.elem.as_ref() else {
+        return false;
+    };
+    path.path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == expected)
+}
+
+#[derive(Default)]
+struct FunctionBodyFacts {
+    local_calls: HashSet<String>,
+    serde_roundtrips: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for FunctionBodyFacts {
+    fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
+        if path.path.segments.len() == 1 {
+            self.local_calls
+                .insert(path.path.segments[0].ident.to_string());
+        }
+        syn::visit::visit_expr_path(self, path);
+    }
+
+    fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(path) = call.func.as_ref() {
+            let segments = path
+                .path
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>();
+            if segments.len() == 1 {
+                self.local_calls.insert(segments[0].clone());
+            }
+            if segments
+                .first()
+                .is_some_and(|segment| segment == "serde_json")
+                && segments.last().is_some_and(|segment| {
+                    matches!(
+                        segment.as_str(),
+                        "to_value" | "to_string" | "from_value" | "from_str"
+                    )
+                })
+            {
+                self.serde_roundtrips.push(segments.join("::"));
+            }
+        }
+        syn::visit::visit_expr_call(self, call);
+    }
+}
+
+fn type_mentions_serde_value(ty: &syn::Type) -> bool {
+    struct Finder(bool);
+    impl<'ast> Visit<'ast> for Finder {
+        fn visit_path(&mut self, path: &'ast syn::Path) {
+            let segments = path
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>();
+            if segments.ends_with(&["serde_json".to_owned(), "Value".to_owned()]) {
+                self.0 = true;
+            }
+            syn::visit::visit_path(self, path);
+        }
+    }
+    let mut finder = Finder(false);
+    finder.visit_type(ty);
+    finder.0
+}
+
+fn has_wire_deserialize_shape(item: &syn::ItemStruct) -> bool {
+    let derives_deserialize = item.attrs.iter().any(|attribute| {
+        if !attribute.path().is_ident("derive") {
+            return false;
+        }
+        attribute
+            .parse_args_with(
+                syn::punctuated::Punctuated::<syn::Path, syn::Token![,]>::parse_terminated,
+            )
+            .is_ok_and(|paths| {
+                paths.iter().any(|path| {
+                    path.segments
+                        .last()
+                        .is_some_and(|segment| segment.ident == "Deserialize")
+                })
+            })
+    });
+    if !derives_deserialize {
+        return false;
+    }
+    let fields = item
+        .fields
+        .iter()
+        .filter_map(|field| field.ident.as_ref().map(ToString::to_string))
+        .collect::<HashSet<_>>();
+    [
+        ["schema", "metrics"].as_slice(),
+        ["name", "help", "series"].as_slice(),
+    ]
+    .iter()
+    .any(|shape| shape.iter().all(|field| fields.contains(*field)))
+        || (fields.contains("labels")
+            && (fields.contains("value")
+                || (fields.contains("buckets")
+                    && fields.contains("sum")
+                    && fields.contains("count"))))
+}
+
+fn limpidctl_typed_renderer_violations(source: &str) -> Vec<String> {
+    let file = syn::parse_file(source).unwrap();
+    let functions = file
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Fn(function) => Some((function.sig.ident.to_string(), function)),
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+    let mut violations = file
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Struct(item) if has_wire_deserialize_shape(item) => {
+                Some(format!("local wire DTO {}", item.ident))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut pending = vec![
+        "render_default_stats".to_owned(),
+        "render_stats_details".to_owned(),
+    ];
+    let mut visited = HashSet::new();
+
+    while let Some(name) = pending.pop() {
+        if !visited.insert(name.clone()) {
+            continue;
+        }
+        let Some(function) = functions.get(&name) else {
+            violations.push(format!("missing renderer {name}"));
+            continue;
+        };
+        if matches!(
+            name.as_str(),
+            "render_default_stats" | "render_stats_details"
+        ) {
+            let typed = function
+                .sig
+                .inputs
+                .first()
+                .is_some_and(|input| match input {
+                    syn::FnArg::Typed(argument) => type_ends_with(&argument.ty, "MetricsSnapshot"),
+                    syn::FnArg::Receiver(_) => false,
+                });
+            if !typed {
+                violations.push(format!("{name} is not typed"));
+            }
+        }
+        for input in &function.sig.inputs {
+            if let syn::FnArg::Typed(argument) = input
+                && type_mentions_serde_value(&argument.ty)
+            {
+                violations.push(format!("{name} accepts serde_json::Value"));
+            }
+        }
+        if let syn::ReturnType::Type(_, ty) = &function.sig.output
+            && type_mentions_serde_value(ty)
+        {
+            violations.push(format!("{name} returns serde_json::Value"));
+        }
+        let mut facts = FunctionBodyFacts::default();
+        facts.visit_block(&function.block);
+        violations.extend(
+            facts
+                .serde_roundtrips
+                .into_iter()
+                .map(|roundtrip| format!("{name} uses {roundtrip}")),
+        );
+        pending.extend(
+            facts
+                .local_calls
+                .into_iter()
+                .filter(|callee| functions.contains_key(callee)),
+        );
+    }
+    violations
+}
+
+#[test]
+fn dependency_guard_rejects_dev_only_and_target_specific_entries() {
+    let normal = serde_json::json!({
+        "name": "limpid-metrics-schema", "kind": null, "target": null
+    });
+    let dev = serde_json::json!({
+        "name": "limpid-metrics-schema", "kind": "dev", "target": null
+    });
+    let targeted = serde_json::json!({
+        "name": "limpid-metrics-schema", "kind": null, "target": "cfg(unix)"
+    });
+    assert!(has_one_live_normal_dependency(&[normal]));
+    assert!(!has_one_live_normal_dependency(&[dev]));
+    assert!(!has_one_live_normal_dependency(&[targeted]));
+}
+
+#[test]
+fn limpidctl_typed_renderer_guard_rejects_roundtrip_bridges_and_local_wire_dtos() {
+    let direct = r#"
+        struct MetricsSnapshot;
+        fn render_default_stats(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        fn render_stats_details(snapshot: &MetricsSnapshot) -> Option<String> {
+            semantic(snapshot)
+        }
+        fn semantic(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+    "#;
+    assert!(limpidctl_typed_renderer_violations(direct).is_empty());
+
+    let bridge = r#"
+        struct MetricsSnapshot;
+        fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> { bridge(snapshot) }
+        fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        fn bridge(snapshot: &MetricsSnapshot) -> Option<String> {
+            let _ = serde_json::to_value(snapshot);
+            Some(String::new())
+        }
+    "#;
+    assert!(!limpidctl_typed_renderer_violations(bridge).is_empty());
+
+    let legacy = r#"
+        struct MetricsSnapshot;
+        #[derive(serde::Deserialize)] struct LegacySnapshot { schema: u32, metrics: Vec<()> }
+        fn render_default_stats(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+    "#;
+    assert!(!limpidctl_typed_renderer_violations(legacy).is_empty());
+}
+
+#[test]
+fn limpidctl_production_renderers_use_the_shared_type_without_a_legacy_bridge() {
+    let source = include_str!("../../limpidctl/src/main.rs");
+    let violations = limpidctl_typed_renderer_violations(source);
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn producer_and_both_consumers_have_a_live_normal_dependency() {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let output = Command::new(cargo)
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let mut invalid = Vec::new();
+    for package_name in ["limpid", "limpidctl", "limpid-prometheus"] {
+        let package = metadata["packages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|package| package["name"] == package_name)
+            .unwrap();
+        if !has_one_live_normal_dependency(package["dependencies"].as_array().unwrap()) {
+            invalid.push(package_name);
+        }
+    }
+    assert!(
+        invalid.is_empty(),
+        "not live normal dependencies: {invalid:?}"
+    );
+}

--- a/crates/limpid-metrics-schema/tests/consumer_boundaries.rs
+++ b/crates/limpid-metrics-schema/tests/consumer_boundaries.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
 use std::process::Command;
 
 use syn::visit::Visit;
@@ -24,21 +26,82 @@ fn type_ends_with(ty: &syn::Type, expected: &str) -> bool {
         .is_some_and(|segment| segment.ident == expected)
 }
 
-#[derive(Default)]
-struct FunctionBodyFacts {
-    local_calls: HashSet<String>,
-    serde_roundtrips: Vec<String>,
+fn is_serde_constructor(name: &str) -> bool {
+    name.starts_with("from_") || name.starts_with("to_")
 }
 
-impl<'ast> Visit<'ast> for FunctionBodyFacts {
-    fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
-        if path.path.segments.len() == 1 {
-            self.local_calls
-                .insert(path.path.segments[0].ident.to_string());
-        }
-        syn::visit::visit_expr_path(self, path);
-    }
+#[derive(Default)]
+struct SerdeJsonImports {
+    namespaces: HashSet<String>,
+    constructors: HashSet<String>,
+    glob: bool,
+}
 
+fn collect_serde_json_imports(
+    tree: &syn::UseTree,
+    prefix: &mut Vec<String>,
+    imports: &mut SerdeJsonImports,
+) {
+    match tree {
+        syn::UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            collect_serde_json_imports(&path.tree, prefix, imports);
+            prefix.pop();
+        }
+        syn::UseTree::Name(name) => {
+            prefix.push(name.ident.to_string());
+            if prefix.as_slice() == ["serde_json"] || prefix.as_slice() == ["serde_json", "self"] {
+                imports.namespaces.insert("serde_json".to_owned());
+            } else if prefix.first().is_some_and(|part| part == "serde_json")
+                && prefix.last().is_some_and(|part| is_serde_constructor(part))
+            {
+                imports.constructors.insert(name.ident.to_string());
+            }
+            prefix.pop();
+        }
+        syn::UseTree::Rename(rename) => {
+            prefix.push(rename.ident.to_string());
+            if prefix.as_slice() == ["serde_json"] || prefix.as_slice() == ["serde_json", "self"] {
+                imports.namespaces.insert(rename.rename.to_string());
+            } else if prefix.first().is_some_and(|part| part == "serde_json")
+                && prefix.last().is_some_and(|part| is_serde_constructor(part))
+            {
+                imports.constructors.insert(rename.rename.to_string());
+            }
+            prefix.pop();
+        }
+        syn::UseTree::Group(group) => {
+            for tree in &group.items {
+                collect_serde_json_imports(tree, prefix, imports);
+            }
+        }
+        syn::UseTree::Glob(_) => {
+            if prefix.as_slice() == ["serde_json"] {
+                imports.glob = true;
+            }
+        }
+    }
+}
+
+struct FunctionBodyFacts<'a> {
+    local_calls: HashSet<String>,
+    serde_roundtrips: Vec<String>,
+    serde_imports: &'a SerdeJsonImports,
+    top_level_functions: &'a HashSet<String>,
+}
+
+impl<'a> FunctionBodyFacts<'a> {
+    fn new(serde_imports: &'a SerdeJsonImports, top_level_functions: &'a HashSet<String>) -> Self {
+        Self {
+            local_calls: HashSet::new(),
+            serde_roundtrips: Vec::new(),
+            serde_imports,
+            top_level_functions,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for FunctionBodyFacts<'_> {
     fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
         if let syn::Expr::Path(path) = call.func.as_ref() {
             let segments = path
@@ -47,23 +110,46 @@ impl<'ast> Visit<'ast> for FunctionBodyFacts {
                 .iter()
                 .map(|segment| segment.ident.to_string())
                 .collect::<Vec<_>>();
-            if segments.len() == 1 {
+            if segments.len() == 1
+                && segments[0]
+                    .chars()
+                    .next()
+                    .is_some_and(|first| first.is_ascii_lowercase())
+            {
                 self.local_calls.insert(segments[0].clone());
             }
-            if segments
-                .first()
-                .is_some_and(|segment| segment == "serde_json")
-                && segments.last().is_some_and(|segment| {
-                    matches!(
-                        segment.as_str(),
-                        "to_value" | "to_string" | "from_value" | "from_str"
-                    )
-                })
-            {
+            let qualified = segments.len() >= 2
+                && segments
+                    .first()
+                    .is_some_and(|segment| self.serde_imports.namespaces.contains(segment))
+                && segments
+                    .last()
+                    .is_some_and(|name| is_serde_constructor(name));
+            let bare = segments.len() == 1
+                && segments.first().is_some_and(|name| {
+                    self.serde_imports.constructors.contains(name)
+                        || (self.serde_imports.glob && is_serde_constructor(name))
+                });
+            if qualified || bare {
                 self.serde_roundtrips.push(segments.join("::"));
             }
         }
         syn::visit::visit_expr_call(self, call);
+    }
+
+    fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
+        if path.qself.is_none()
+            && path.path.segments.len() == 1
+            && let Some(name) = path
+                .path
+                .segments
+                .first()
+                .map(|segment| segment.ident.to_string())
+            && self.top_level_functions.contains(&name)
+        {
+            self.local_calls.insert(name);
+        }
+        syn::visit::visit_expr_path(self, path);
     }
 }
 
@@ -135,6 +221,14 @@ fn limpidctl_typed_renderer_violations(source: &str) -> Vec<String> {
             _ => None,
         })
         .collect::<HashMap<_, _>>();
+    let top_level_functions = functions.keys().cloned().collect::<HashSet<_>>();
+    let mut serde_imports = SerdeJsonImports::default();
+    serde_imports.namespaces.insert("serde_json".to_owned());
+    for item in &file.items {
+        if let syn::Item::Use(item) = item {
+            collect_serde_json_imports(&item.tree, &mut Vec::new(), &mut serde_imports);
+        }
+    }
     let mut violations = file
         .items
         .iter()
@@ -187,7 +281,7 @@ fn limpidctl_typed_renderer_violations(source: &str) -> Vec<String> {
         {
             violations.push(format!("{name} returns serde_json::Value"));
         }
-        let mut facts = FunctionBodyFacts::default();
+        let mut facts = FunctionBodyFacts::new(&serde_imports, &top_level_functions);
         facts.visit_block(&function.block);
         violations.extend(
             facts
@@ -195,14 +289,58 @@ fn limpidctl_typed_renderer_violations(source: &str) -> Vec<String> {
                 .into_iter()
                 .map(|roundtrip| format!("{name} uses {roundtrip}")),
         );
-        pending.extend(
-            facts
-                .local_calls
-                .into_iter()
-                .filter(|callee| functions.contains_key(callee)),
-        );
+        for callee in facts.local_calls {
+            if functions.contains_key(&callee) {
+                pending.push(callee);
+            } else if !serde_imports.constructors.contains(&callee)
+                && !(serde_imports.glob && is_serde_constructor(&callee))
+            {
+                violations.push(format!("{name} has unresolved top-level helper {callee}"));
+            }
+        }
     }
     violations
+}
+
+fn top_level_function_edges(source: &str, function_name: &str) -> Option<HashSet<String>> {
+    let file = syn::parse_file(source).ok()?;
+    let functions = file
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Fn(function) => Some((function.sig.ident.to_string(), function)),
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+    let top_level_functions = functions.keys().cloned().collect::<HashSet<_>>();
+    let mut serde_imports = SerdeJsonImports::default();
+    serde_imports.namespaces.insert("serde_json".to_owned());
+    for item in &file.items {
+        if let syn::Item::Use(item) = item {
+            collect_serde_json_imports(&item.tree, &mut Vec::new(), &mut serde_imports);
+        }
+    }
+    let function = functions.get(function_name)?;
+    let mut facts = FunctionBodyFacts::new(&serde_imports, &top_level_functions);
+    facts.visit_block(&function.block);
+    Some(facts.local_calls)
+}
+
+fn manifest_entries<'a>(manifest: &'a str, section: &str, key: &str) -> Vec<&'a str> {
+    let mut current_section = "";
+    let mut entries = Vec::new();
+    for line in manifest.lines() {
+        let line = line.split('#').next().unwrap().trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            current_section = line.trim_matches(['[', ']']);
+        } else if current_section == section
+            && let Some((entry_key, value)) = line.split_once('=')
+            && entry_key.trim() == key
+        {
+            entries.push(value.trim());
+        }
+    }
+    entries
 }
 
 #[test]
@@ -222,7 +360,7 @@ fn dependency_guard_rejects_dev_only_and_target_specific_entries() {
 }
 
 #[test]
-fn limpidctl_typed_renderer_guard_rejects_roundtrip_bridges_and_local_wire_dtos() {
+fn limpidctl_top_level_renderer_guard_rejects_roundtrip_bridges_and_local_wire_dtos() {
     let direct = r#"
         struct MetricsSnapshot;
         fn render_default_stats(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
@@ -251,6 +389,129 @@ fn limpidctl_typed_renderer_guard_rejects_roundtrip_bridges_and_local_wire_dtos(
         fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
     "#;
     assert!(!limpidctl_typed_renderer_violations(legacy).is_empty());
+
+    for bridge in [
+        r#"
+            struct MetricsSnapshot;
+            use serde_json as json;
+            fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+                bridge(snapshot)
+            }
+            fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+            fn bridge(snapshot: &MetricsSnapshot) -> Option<String> {
+                let _ = json::to_string_pretty(snapshot);
+                Some(String::new())
+            }
+        "#,
+        r#"
+            struct MetricsSnapshot;
+            use serde_json::from_slice as decode;
+            fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+                bridge(snapshot)
+            }
+            fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+            fn bridge(_: &MetricsSnapshot) -> Option<String> {
+                let _: Result<MetricsSnapshot, _> = decode(b"{}");
+                Some(String::new())
+            }
+        "#,
+        r#"
+            struct MetricsSnapshot;
+            use serde_json::{from_reader, to_writer};
+            fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+                bridge(snapshot)
+            }
+            fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+            fn bridge(_: &MetricsSnapshot) -> Option<String> {
+                let _: Result<MetricsSnapshot, _> = from_reader(&b"{}"[..]);
+                let _ = to_writer(Vec::new(), &());
+                Some(String::new())
+            }
+        "#,
+        r#"
+            struct MetricsSnapshot;
+            use serde_json::*;
+            fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+                bridge(snapshot)
+            }
+            fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+            fn bridge(snapshot: &MetricsSnapshot) -> Option<String> {
+                let _ = to_vec(snapshot);
+                Some(String::new())
+            }
+        "#,
+        r#"
+            struct MetricsSnapshot;
+            fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+                bridge(snapshot)
+            }
+            fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+            fn bridge(snapshot: &MetricsSnapshot) -> Option<String> {
+                let _: Result<MetricsSnapshot, _> = serde_json::from_slice(b"{}");
+                let _ = serde_json::to_vec(snapshot);
+                Some(String::new())
+            }
+        "#,
+    ] {
+        assert!(!limpidctl_typed_renderer_violations(bridge).is_empty());
+    }
+
+    let custom_names = r#"
+        struct MetricsSnapshot;
+        fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+            semantic(snapshot)
+        }
+        fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        fn semantic(_: &MetricsSnapshot) -> Option<String> {
+            custom_from_snapshot();
+            custom_to_text();
+            Some(String::new())
+        }
+        fn custom_from_snapshot() {}
+        fn custom_to_text() {}
+    "#;
+    assert!(limpidctl_typed_renderer_violations(custom_names).is_empty());
+
+    let function_item_bridge = r#"
+        struct MetricsSnapshot;
+        fn render_default_stats(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        fn render_stats_details(snapshot: &MetricsSnapshot) -> Option<String> {
+            let _ = [snapshot].iter().map(helper);
+            Some(String::new())
+        }
+        fn helper(snapshot: &&MetricsSnapshot) -> String {
+            serde_json::to_string(snapshot).unwrap()
+        }
+    "#;
+    assert!(!limpidctl_typed_renderer_violations(function_item_bridge).is_empty());
+
+    let typed_function_items = r#"
+        struct MetricsSnapshot;
+        fn render_default_stats(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        fn render_stats_details(snapshot: &MetricsSnapshot) -> Option<String> {
+            let mapper: fn(String) -> String = std::convert::identity;
+            let _ = [snapshot].iter().map(helper).map(mapper);
+            Some(String::new())
+        }
+        fn helper(_: &&MetricsSnapshot) -> String { String::new() }
+    "#;
+    assert!(limpidctl_typed_renderer_violations(typed_function_items).is_empty());
+
+    for incomplete in [
+        r#"
+            struct MetricsSnapshot;
+            fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        "#,
+        r#"
+            struct MetricsSnapshot;
+            fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+                missing_helper(snapshot)
+            }
+            fn render_stats_details(_: &MetricsSnapshot) -> Option<String> { Some(String::new()) }
+        "#,
+    ] {
+        assert!(!limpidctl_typed_renderer_violations(incomplete).is_empty());
+    }
 }
 
 #[test]
@@ -258,6 +519,8 @@ fn limpidctl_production_renderers_use_the_shared_type_without_a_legacy_bridge() 
     let source = include_str!("../../limpidctl/src/main.rs");
     let violations = limpidctl_typed_renderer_violations(source);
     assert!(violations.is_empty(), "{violations:?}");
+    let detail_edges = top_level_function_edges(source, "render_stats_details").unwrap();
+    assert!(detail_edges.contains("parse_detail_metric"));
 }
 
 #[test]
@@ -286,4 +549,36 @@ fn producer_and_both_consumers_have_a_live_normal_dependency() {
         invalid.is_empty(),
         "not live normal dependencies: {invalid:?}"
     );
+}
+
+#[test]
+fn consumers_inherit_the_schema_dependency_from_the_workspace() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace = crate_root.join("../..");
+    let schema = fs::read_to_string(crate_root.join("Cargo.toml")).unwrap();
+    let schema_versions = manifest_entries(&schema, "package", "version");
+    assert_eq!(schema_versions.len(), 1);
+    let schema_version = schema_versions[0].trim_matches('"');
+
+    let root = fs::read_to_string(workspace.join("Cargo.toml")).unwrap();
+    let root_entries = manifest_entries(&root, "workspace.dependencies", "limpid-metrics-schema");
+    assert_eq!(root_entries.len(), 1);
+    let root_entry = root_entries[0].replace(char::is_whitespace, "");
+    assert!(root_entry.contains(&format!("version=\"{schema_version}\"")));
+    assert!(root_entry.contains("path=\"crates/limpid-metrics-schema\""));
+
+    for manifest in [
+        "crates/limpid/Cargo.toml",
+        "crates/limpidctl/Cargo.toml",
+        "crates/limpid-prometheus/Cargo.toml",
+    ] {
+        let source = fs::read_to_string(workspace.join(manifest)).unwrap();
+        let entries = manifest_entries(&source, "dependencies", "limpid-metrics-schema");
+        assert_eq!(entries.len(), 1, "{manifest}");
+        assert_eq!(
+            entries[0].replace(char::is_whitespace, ""),
+            "{workspace=true}",
+            "{manifest}"
+        );
+    }
 }

--- a/crates/limpid-metrics-schema/tests/fixtures/schema-v1.json
+++ b/crates/limpid-metrics-schema/tests/fixtures/schema-v1.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "metrics": [
+    {
+      "name": "requests_total",
+      "type": "counter",
+      "help": "Requests.",
+      "series": [
+        {
+          "labels": {
+            "route": "west"
+          },
+          "value": 7
+        }
+      ]
+    },
+    {
+      "name": "queue_depth",
+      "type": "gauge",
+      "help": "Queue depth.",
+      "series": [
+        {
+          "labels": {
+            "output": "sink"
+          },
+          "value": 3
+        }
+      ]
+    },
+    {
+      "name": "latency_seconds",
+      "type": "histogram",
+      "help": "Latency.",
+      "series": [
+        {
+          "labels": {
+            "route": "west"
+          },
+          "buckets": [
+            [0.5, 2],
+            [1.0, 3]
+          ],
+          "sum": 1.75,
+          "count": 4
+        }
+      ]
+    }
+  ]
+}

--- a/crates/limpid-metrics-schema/tests/purity.rs
+++ b/crates/limpid-metrics-schema/tests/purity.rs
@@ -1,0 +1,222 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use syn::visit::Visit;
+
+fn rust_sources(directory: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            rust_sources(&path, files);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+#[derive(Default)]
+struct RuntimeReferences {
+    hits: Vec<String>,
+    forbidden_aliases: HashSet<String>,
+}
+
+fn is_runtime_path(segments: &[String]) -> bool {
+    if segments.first().is_some_and(|segment| segment == "limpid") {
+        return true;
+    }
+    let Some(sync) = segments.windows(2).position(|pair| pair == ["std", "sync"]) else {
+        return false;
+    };
+    segments[sync + 2..].iter().any(|segment| {
+        matches!(
+            segment.as_str(),
+            "Arc"
+                | "Weak"
+                | "Mutex"
+                | "RwLock"
+                | "Condvar"
+                | "Barrier"
+                | "OnceLock"
+                | "LazyLock"
+                | "atomic"
+        ) || segment.starts_with("Atomic")
+    })
+}
+
+fn is_sync_namespace(segments: &[String]) -> bool {
+    segments == ["std", "sync"] || segments == ["std", "sync", "self"]
+}
+
+fn collect_imports(
+    tree: &syn::UseTree,
+    prefix: &mut Vec<String>,
+    aliases: &mut HashSet<String>,
+    hits: &mut Vec<String>,
+) {
+    match tree {
+        syn::UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            collect_imports(&path.tree, prefix, aliases, hits);
+            prefix.pop();
+        }
+        syn::UseTree::Name(name) => {
+            prefix.push(name.ident.to_string());
+            if is_runtime_path(prefix) || is_sync_namespace(prefix) {
+                aliases.insert(name.ident.to_string());
+                hits.push(prefix.join("::"));
+            }
+            prefix.pop();
+        }
+        syn::UseTree::Rename(rename) => {
+            prefix.push(rename.ident.to_string());
+            if is_runtime_path(prefix) || is_sync_namespace(prefix) {
+                aliases.insert(rename.rename.to_string());
+                hits.push(prefix.join("::"));
+            }
+            prefix.pop();
+        }
+        syn::UseTree::Group(group) => {
+            for item in &group.items {
+                collect_imports(item, prefix, aliases, hits);
+            }
+        }
+        syn::UseTree::Glob(_) => {
+            if is_runtime_path(prefix) {
+                hits.push(format!("{}::*", prefix.join("::")));
+            }
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for RuntimeReferences {
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        let segments = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect::<Vec<_>>();
+        if is_runtime_path(&segments)
+            || segments
+                .first()
+                .is_some_and(|segment| self.forbidden_aliases.contains(segment))
+        {
+            self.hits.push(segments.join("::"));
+        }
+        syn::visit::visit_path(self, path);
+    }
+
+    fn visit_attribute(&mut self, attribute: &'ast syn::Attribute) {
+        if attribute.path().is_ident("serde") {
+            let _ = attribute.parse_nested_meta(|meta| {
+                if meta.path.is_ident("deny_unknown_fields") {
+                    self.hits.push("deny_unknown_fields".to_owned());
+                }
+                Ok(())
+            });
+        }
+        syn::visit::visit_attribute(self, attribute);
+    }
+
+    fn visit_lit_str(&mut self, literal: &'ast syn::LitStr) {
+        if literal.value().starts_with("limpid_") {
+            self.hits.push(literal.value());
+        }
+        syn::visit::visit_lit_str(self, literal);
+    }
+}
+
+fn inspect(source: &str) -> Vec<String> {
+    let syntax = syn::parse_file(source).unwrap();
+    let mut references = RuntimeReferences::default();
+    for item in &syntax.items {
+        if let syn::Item::Use(item_use) = item {
+            collect_imports(
+                &item_use.tree,
+                &mut Vec::new(),
+                &mut references.forbidden_aliases,
+                &mut references.hits,
+            );
+        }
+    }
+    references.visit_file(&syntax);
+    references.hits
+}
+
+#[test]
+fn schema_crate_has_only_serde_as_a_normal_dependency() {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let output = Command::new(cargo)
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let package = metadata["packages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|package| package["name"] == "limpid-metrics-schema")
+        .unwrap();
+    let normal = package["dependencies"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|dependency| dependency["kind"].is_null())
+        .map(|dependency| {
+            (
+                dependency["name"].as_str().unwrap(),
+                dependency["target"].as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(normal, [("serde", None)]);
+}
+
+#[test]
+fn every_schema_source_file_is_free_of_runtime_types_and_semantics() {
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&source_root, &mut files);
+    files.sort();
+    assert!(!files.is_empty());
+
+    for file in files {
+        let source = fs::read_to_string(&file).unwrap();
+        assert!(inspect(&source).is_empty(), "{}", file.display());
+    }
+}
+
+#[test]
+fn purity_guard_allows_wire_collections_and_serde_derives() {
+    let source = r#"
+        // std::sync::Arc and limpid::metrics::Registry in comments are inert.
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct WireValue {
+            labels: std::collections::BTreeMap<String, String>,
+        }
+
+        fn decode<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+            serde::Deserialize::deserialize(deserializer)
+        }
+    "#;
+    assert!(inspect(source).is_empty());
+}
+
+#[test]
+fn purity_guard_detects_each_forbidden_runtime_reference() {
+    for source in [
+        "fn leak(_: limpid::metrics::Registry) {}",
+        "type Shared = std::sync::Arc<u64>;",
+        "type Cell = std::sync::atomic::AtomicU64;",
+        "fn build(_: limpid::metrics::RuntimeBuilder) {}",
+        "use std::sync::Arc as Shared; struct State(Shared<u64>);",
+        "use std::sync::{Mutex as Lock, RwLock}; struct State(Lock<u64>, RwLock<u64>);",
+        "use std::sync as synchronization; struct State(synchronization::Arc<u64>);",
+        "#[serde(deny_unknown_fields)] struct Closed;",
+        "const FAMILY: &str = \"limpid_runtime_total\";",
+    ] {
+        assert!(!inspect(source).is_empty(), "{source}");
+    }
+}

--- a/crates/limpid-metrics-schema/tests/purity.rs
+++ b/crates/limpid-metrics-schema/tests/purity.rs
@@ -83,7 +83,7 @@ fn collect_imports(
             }
         }
         syn::UseTree::Glob(_) => {
-            if is_runtime_path(prefix) {
+            if is_runtime_path(prefix) || is_sync_namespace(prefix) {
                 hits.push(format!("{}::*", prefix.join("::")));
             }
         }
@@ -109,12 +109,7 @@ impl<'ast> Visit<'ast> for RuntimeReferences {
 
     fn visit_attribute(&mut self, attribute: &'ast syn::Attribute) {
         if attribute.path().is_ident("serde") {
-            let _ = attribute.parse_nested_meta(|meta| {
-                if meta.path.is_ident("deny_unknown_fields") {
-                    self.hits.push("deny_unknown_fields".to_owned());
-                }
-                Ok(())
-            });
+            let _ = attribute.parse_nested_meta(|meta| inspect_serde_meta(meta, &mut self.hits));
         }
         syn::visit::visit_attribute(self, attribute);
     }
@@ -125,6 +120,21 @@ impl<'ast> Visit<'ast> for RuntimeReferences {
         }
         syn::visit::visit_lit_str(self, literal);
     }
+}
+
+fn inspect_serde_meta(
+    meta: syn::meta::ParseNestedMeta<'_>,
+    hits: &mut Vec<String>,
+) -> syn::Result<()> {
+    if meta.path.is_ident("deny_unknown_fields") {
+        hits.push("deny_unknown_fields".to_owned());
+    }
+    if meta.input.peek(syn::Token![=]) {
+        let _: syn::Expr = meta.value()?.parse()?;
+    } else if meta.input.peek(syn::token::Paren) {
+        meta.parse_nested_meta(|nested| inspect_serde_meta(nested, hits))?;
+    }
+    Ok(())
 }
 
 fn inspect(source: &str) -> Vec<String> {
@@ -200,6 +210,13 @@ fn purity_guard_allows_wire_collections_and_serde_derives() {
         fn decode<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
             serde::Deserialize::deserialize(deserializer)
         }
+
+        use serde::*;
+        use std::collections::*;
+        #[serde(rename = "wire", default)]
+        struct Additive;
+        #[serde(rename(serialize = "out", deserialize = "in"), bound(deserialize = "T: serde::Deserialize<'de>"))]
+        struct Generic<T>(T);
     "#;
     assert!(inspect(source).is_empty());
 }
@@ -213,8 +230,13 @@ fn purity_guard_detects_each_forbidden_runtime_reference() {
         "fn build(_: limpid::metrics::RuntimeBuilder) {}",
         "use std::sync::Arc as Shared; struct State(Shared<u64>);",
         "use std::sync::{Mutex as Lock, RwLock}; struct State(Lock<u64>, RwLock<u64>);",
+        "use std::sync::*; struct State(Arc<u64>);",
         "use std::sync as synchronization; struct State(synchronization::Arc<u64>);",
         "#[serde(deny_unknown_fields)] struct Closed;",
+        "#[serde(rename = \"wire\", deny_unknown_fields)] struct Closed;",
+        "#[serde(default, rename = \"wire\", deny_unknown_fields)] struct Closed;",
+        "#[serde(rename(serialize = \"out\", deserialize = \"in\"), deny_unknown_fields)] struct Closed;",
+        "#[serde(bound(deserialize = \"T: serde::Deserialize<'de>\"), deny_unknown_fields)] struct Closed<T>(T);",
         "const FAMILY: &str = \"limpid_runtime_total\";",
     ] {
         assert!(!inspect(source).is_empty(), "{source}");

--- a/crates/limpid-metrics-schema/tests/wire_contract.rs
+++ b/crates/limpid-metrics-schema/tests/wire_contract.rs
@@ -1,0 +1,188 @@
+use limpid_metrics_schema::MetricsSnapshot;
+use serde_json::{Value, json};
+
+const FIXTURE: &str = include_str!("fixtures/schema-v1.json");
+
+fn fixture() -> Value {
+    serde_json::from_str(FIXTURE).unwrap()
+}
+
+fn assert_rejected(mut mutate: impl FnMut(&mut Value)) {
+    let mut candidate = fixture();
+    mutate(&mut candidate);
+    assert!(serde_json::from_value::<MetricsSnapshot>(candidate).is_err());
+}
+
+#[test]
+fn schema_v1_fixture_round_trips_through_the_wire_dto() {
+    let snapshot: MetricsSnapshot = serde_json::from_str(FIXTURE).unwrap();
+    assert_eq!(serde_json::to_value(snapshot).unwrap(), fixture());
+}
+
+#[test]
+fn serialization_preserves_the_legacy_object_member_order() {
+    let snapshot: MetricsSnapshot = serde_json::from_str(FIXTURE).unwrap();
+    assert_eq!(
+        serde_json::to_string(&snapshot).unwrap(),
+        r#"{"schema":1,"metrics":[{"name":"requests_total","type":"counter","help":"Requests.","series":[{"labels":{"route":"west"},"value":7}]},{"name":"queue_depth","type":"gauge","help":"Queue depth.","series":[{"labels":{"output":"sink"},"value":3}]},{"name":"latency_seconds","type":"histogram","help":"Latency.","series":[{"labels":{"route":"west"},"buckets":[[0.5,2],[1.0,3]],"sum":1.75,"count":4}]}]}"#
+    );
+}
+
+#[test]
+fn every_wire_level_tolerates_additive_unknown_fields() {
+    let mut mixed = fixture();
+    mixed["future_root"] = json!({"version": 2});
+    mixed["metrics"][0]["future_family"] = json!(["ignored"]);
+    mixed["metrics"][0]["series"][0]["future_value_series"] = json!({"ignored": true});
+    mixed["metrics"][2]["series"][0]["future_histogram_series"] = json!("ignored");
+
+    let parsed: MetricsSnapshot = serde_json::from_value(mixed).unwrap();
+    assert_eq!(serde_json::to_value(parsed).unwrap(), fixture());
+}
+
+#[test]
+fn family_type_selects_the_series_shape_without_sibling_field_confusion() {
+    let mut counter_with_histogram_siblings = fixture();
+    let value = &mut counter_with_histogram_siblings["metrics"][0]["series"][0];
+    value["buckets"] = json!([[0.5, 1]]);
+    value["sum"] = json!(0.5);
+    value["count"] = json!(1);
+    let parsed: MetricsSnapshot = serde_json::from_value(counter_with_histogram_siblings).unwrap();
+    assert_eq!(serde_json::to_value(parsed).unwrap(), fixture());
+
+    let mut histogram_with_value_sibling = fixture();
+    histogram_with_value_sibling["metrics"][2]["series"][0]["value"] = json!(99);
+    let parsed: MetricsSnapshot = serde_json::from_value(histogram_with_value_sibling).unwrap();
+    assert_eq!(serde_json::to_value(parsed).unwrap(), fixture());
+}
+
+#[test]
+fn family_type_rejects_wrong_or_mixed_series_shapes() {
+    assert_rejected(|root| {
+        let histogram = root["metrics"][2]["series"].clone();
+        root["metrics"][0]["series"] = histogram;
+    });
+    assert_rejected(|root| {
+        let histogram = root["metrics"][2]["series"].clone();
+        root["metrics"][1]["series"] = histogram;
+    });
+    assert_rejected(|root| {
+        let value = root["metrics"][0]["series"].clone();
+        root["metrics"][2]["series"] = value;
+    });
+    assert_rejected(|root| {
+        let histogram = root["metrics"][2]["series"][0].clone();
+        root["metrics"][0]["series"]
+            .as_array_mut()
+            .unwrap()
+            .push(histogram);
+    });
+    assert_rejected(|root| {
+        let histogram = root["metrics"][2]["series"][0].clone();
+        root["metrics"][1]["series"]
+            .as_array_mut()
+            .unwrap()
+            .push(histogram);
+    });
+    assert_rejected(|root| {
+        let value = root["metrics"][0]["series"][0].clone();
+        root["metrics"][2]["series"]
+            .as_array_mut()
+            .unwrap()
+            .push(value);
+    });
+}
+
+#[test]
+fn every_required_wire_field_is_required_independently() {
+    assert_rejected(|root| {
+        root.as_object_mut().unwrap().remove("schema");
+    });
+    assert_rejected(|root| {
+        root.as_object_mut().unwrap().remove("metrics");
+    });
+    for field in ["name", "type", "help", "series"] {
+        assert_rejected(|root| {
+            root["metrics"][0].as_object_mut().unwrap().remove(field);
+        });
+    }
+    for field in ["labels", "value"] {
+        assert_rejected(|root| {
+            root["metrics"][0]["series"][0]
+                .as_object_mut()
+                .unwrap()
+                .remove(field);
+        });
+    }
+    for field in ["labels", "buckets", "sum", "count"] {
+        assert_rejected(|root| {
+            root["metrics"][2]["series"][0]
+                .as_object_mut()
+                .unwrap()
+                .remove(field);
+        });
+    }
+}
+
+#[test]
+fn wire_scalar_and_collection_types_are_strict() {
+    assert_rejected(|root| root["schema"] = json!(1.0));
+    assert_rejected(|root| root["metrics"] = json!({}));
+    assert_rejected(|root| root["metrics"][0]["name"] = json!(false));
+    assert_rejected(|root| root["metrics"][0]["type"] = json!(1));
+    assert_rejected(|root| root["metrics"][0]["help"] = json!([]));
+    assert_rejected(|root| root["metrics"][0]["series"] = json!({}));
+    assert_rejected(|root| root["metrics"][0]["series"][0]["labels"] = json!([]));
+    assert_rejected(|root| root["metrics"][0]["series"][0]["labels"]["route"] = json!(1));
+    assert_rejected(|root| root["metrics"][0]["series"][0]["value"] = json!(true));
+    assert_rejected(|root| root["metrics"][2]["series"][0]["buckets"] = json!({}));
+    assert_rejected(|root| root["metrics"][2]["series"][0]["buckets"][0][0] = json!("0.5"));
+    assert_rejected(|root| root["metrics"][2]["series"][0]["buckets"][0][1] = json!(1.5));
+    assert_rejected(|root| root["metrics"][2]["series"][0]["sum"] = json!("1.75"));
+    assert_rejected(|root| root["metrics"][2]["series"][0]["count"] = json!(false));
+}
+
+#[test]
+fn integer_and_float_edge_representations_are_rejected() {
+    let overflow: Value = serde_json::from_str("18446744073709551616").unwrap();
+    for invalid in [json!(-1), json!(1.5), overflow] {
+        assert_rejected(|root| root["metrics"][0]["series"][0]["value"] = invalid.clone());
+    }
+    for invalid in [json!(-1), json!(1.5)] {
+        assert_rejected(|root| root["metrics"][2]["series"][0]["buckets"][0][1] = invalid.clone());
+        assert_rejected(|root| root["metrics"][2]["series"][0]["count"] = invalid.clone());
+    }
+    assert_rejected(|root| {
+        root["metrics"][2]["series"][0]["buckets"][0][1] =
+            serde_json::from_str("18446744073709551616").unwrap()
+    });
+    assert_rejected(|root| {
+        root["metrics"][2]["series"][0]["count"] =
+            serde_json::from_str("18446744073709551616").unwrap()
+    });
+    assert_rejected(|root| root["metrics"][2]["series"][0]["buckets"][0][0] = Value::Null);
+    assert_rejected(|root| root["metrics"][2]["series"][0]["sum"] = Value::Null);
+}
+
+#[test]
+fn schema_uses_the_full_u32_wire_domain_without_enforcing_version_semantics() {
+    for invalid in [
+        json!(-1),
+        json!(1.5),
+        Value::Null,
+        json!(u64::from(u32::MAX) + 1),
+    ] {
+        assert_rejected(|root| root["schema"] = invalid.clone());
+    }
+
+    let mut maximum = fixture();
+    maximum["schema"] = json!(u32::MAX);
+    assert!(serde_json::from_value::<MetricsSnapshot>(maximum).is_ok());
+}
+
+#[test]
+fn an_empty_histogram_bucket_list_is_valid() {
+    let mut candidate = fixture();
+    candidate["metrics"][2]["series"][0]["buckets"] = json!([]);
+    assert!(serde_json::from_value::<MetricsSnapshot>(candidate).is_ok());
+}

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -10,7 +10,7 @@ name = "limpid-prometheus"
 path = "src/main.rs"
 
 [dependencies]
-limpid-metrics-schema = { version = "0.7.15", path = "../limpid-metrics-schema" }
+limpid-metrics-schema = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 # Explicit feature list instead of "full": the exporter only needs the
 # multi-thread runtime + macros (tokio::main / spawn), sockets (net),

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -10,6 +10,7 @@ name = "limpid-prometheus"
 path = "src/main.rs"
 
 [dependencies]
+limpid-metrics-schema = { version = "0.7.15", path = "../limpid-metrics-schema" }
 clap = { version = "4", features = ["derive"] }
 # Explicit feature list instead of "full": the exporter only needs the
 # multi-thread runtime + macros (tokio::main / spawn), sockets (net),

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -288,7 +288,6 @@ fn parse_snapshot(root: &serde_json::Value) -> Result<Vec<ExpositionFamily>, Str
         let metric = metric
             .as_object()
             .ok_or_else(|| "metric family must be an object".to_string())?;
-        require_exact_fields(metric, &["name", "type", "help", "series"], "metric family")?;
         let name = required_nonempty_string(metric, "name", "metric family")?.to_string();
         if !is_legacy_metric_name(&name) {
             return Err(format!("invalid Prometheus metric name: {name:?}"));
@@ -392,7 +391,6 @@ fn parse_series(
     let labels = parse_labels(object.get("labels"), metric_name)?;
     match metric_type {
         ExpositionType::Counter | ExpositionType::Gauge => {
-            require_exact_fields(object, &["labels", "value"], "value series")?;
             let value = object
                 .get("value")
                 .and_then(serde_json::Value::as_u64)
@@ -400,11 +398,6 @@ fn parse_series(
             Ok(ExpositionSeries::Value { labels, value })
         }
         ExpositionType::Histogram => {
-            require_exact_fields(
-                object,
-                &["labels", "buckets", "sum", "count"],
-                "histogram series",
-            )?;
             let buckets = parse_buckets(object.get("buckets"), metric_name)?;
             let sum = object
                 .get("sum")
@@ -507,18 +500,6 @@ fn parse_buckets(
         buckets.push((bound, count));
     }
     Ok(buckets)
-}
-
-fn require_exact_fields(
-    object: &serde_json::Map<String, serde_json::Value>,
-    fields: &[&str],
-    context: &str,
-) -> Result<(), String> {
-    if object.len() == fields.len() && fields.iter().all(|field| object.contains_key(*field)) {
-        Ok(())
-    } else {
-        Err(format!("{context} has invalid fields"))
-    }
 }
 
 fn required_string<'a>(
@@ -870,16 +851,8 @@ mod tests {
                 r#"{"schema":1,"metrics":[{"name":"metric","type":"counter","series":[]}]}"#,
             ),
             (
-                "extra family field",
-                r#"{"schema":1,"metrics":[{"name":"metric","type":"counter","help":"Metric.","series":[],"extra":true}]}"#,
-            ),
-            (
                 "missing series field",
                 r#"{"schema":1,"metrics":[{"name":"metric","type":"counter","help":"Metric.","series":[{"labels":{}}]}]}"#,
-            ),
-            (
-                "extra series field",
-                r#"{"schema":1,"metrics":[{"name":"metric","type":"counter","help":"Metric.","series":[{"labels":{},"value":1,"extra":true}]}]}"#,
             ),
             (
                 "unsupported type",
@@ -925,6 +898,63 @@ mod tests {
 
         let empty_histogram = r#"{"schema":1,"metrics":[{"name":"metric","type":"histogram","help":"Metric.","series":[{"labels":{},"buckets":[],"sum":0.0,"count":0}]}]}"#;
         assert!(json_to_prometheus(empty_histogram).is_ok());
+    }
+
+    #[test]
+    fn schema_v1_ignores_unknown_fields_at_every_wire_level() {
+        let baseline = serde_json::json!({
+            "schema": 1,
+            "metrics": [
+                {
+                    "name": "requests_total",
+                    "type": "counter",
+                    "help": "Requests.",
+                    "series": [{"labels": {"route": "west"}, "value": 7}]
+                },
+                {
+                    "name": "latency_seconds",
+                    "type": "histogram",
+                    "help": "Latency.",
+                    "series": [{
+                        "labels": {"route": "west"},
+                        "buckets": [[0.5, 2], [1.0, 3]],
+                        "sum": 1.75,
+                        "count": 4
+                    }]
+                }
+            ]
+        });
+        let expected = json_to_prometheus(&baseline.to_string()).unwrap();
+
+        let mut root = baseline.clone();
+        root["future_root"] = serde_json::json!({"version": 2});
+
+        let mut family = baseline.clone();
+        family["metrics"][0]["future_family"] = serde_json::json!(["ignored"]);
+
+        let mut value_series = baseline.clone();
+        value_series["metrics"][0]["series"][0]["future_value_series"] =
+            serde_json::json!({"ignored": true});
+
+        let mut histogram_series = baseline.clone();
+        histogram_series["metrics"][1]["series"][0]["future_histogram_series"] =
+            serde_json::json!("ignored");
+
+        let translations = [
+            ("root", root),
+            ("family", family),
+            ("value series", value_series),
+            ("histogram series", histogram_series),
+        ]
+        .map(|(level, snapshot)| (level, json_to_prometheus(&snapshot.to_string())));
+
+        for (level, translation) in translations {
+            assert_eq!(
+                translation.unwrap(),
+                expected,
+                "unknown {level} field must not change exposition"
+            );
+        }
     }
 
     #[test]

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -14,7 +14,7 @@
 //! scrape segment behind a firewall — because anyone who can reach
 //! the port can read pipeline names and event counts.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
 use std::fmt::Write as _;
 use std::net::SocketAddr;
@@ -28,6 +28,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use limpid_metrics_schema::{MetricFamily, MetricType, MetricsSnapshot};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, UnixStream};
@@ -200,7 +201,7 @@ async fn handle_request(
 
 /// Convert limpid JSON stats to Prometheus text exposition format.
 fn json_to_prometheus(json: &str) -> Result<String, String> {
-    let root: serde_json::Value =
+    let root: MetricsSnapshot =
         serde_json::from_str(json).map_err(|e| format!("invalid json: {}", e))?;
     let families = parse_snapshot(&root)?;
     Ok(render_snapshot(&families))
@@ -216,12 +217,11 @@ enum ExpositionType {
 }
 
 impl ExpositionType {
-    fn parse(value: &str) -> Result<Self, String> {
+    fn from_wire(value: MetricType) -> Self {
         match value {
-            "counter" => Ok(Self::Counter),
-            "gauge" => Ok(Self::Gauge),
-            "histogram" => Ok(Self::Histogram),
-            other => Err(format!("unsupported metric type: {other}")),
+            MetricType::Counter => Self::Counter,
+            MetricType::Gauge => Self::Gauge,
+            MetricType::Histogram => Self::Histogram,
         }
     }
 
@@ -270,43 +270,62 @@ struct ExpositionFamily {
 /// output; Prometheus text format has no display-order
 /// semantics, so this is a reproducibility contract, not
 /// Grafana display ordering.
-fn parse_snapshot(root: &serde_json::Value) -> Result<Vec<ExpositionFamily>, String> {
-    let root = root
-        .as_object()
-        .ok_or_else(|| "schema-v1 snapshot must be an object".to_string())?;
-    if root.get("schema").and_then(serde_json::Value::as_u64) != Some(1) {
+fn parse_snapshot(root: &MetricsSnapshot) -> Result<Vec<ExpositionFamily>, String> {
+    if root.schema != 1 {
         return Err("unsupported or missing metrics schema".to_string());
     }
-    let metrics = root
-        .get("metrics")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| "schema-v1 snapshot requires a metrics array".to_string())?;
 
     let mut names = BTreeSet::new();
-    let mut families = Vec::with_capacity(metrics.len());
-    for metric in metrics {
-        let metric = metric
-            .as_object()
-            .ok_or_else(|| "metric family must be an object".to_string())?;
-        let name = required_nonempty_string(metric, "name", "metric family")?.to_string();
+    let mut families = Vec::with_capacity(root.metrics.len());
+    for metric in &root.metrics {
+        let name = metric.name().to_string();
+        if name.is_empty() {
+            return Err("metric family field name must not be empty".to_string());
+        }
         if !is_legacy_metric_name(&name) {
             return Err(format!("invalid Prometheus metric name: {name:?}"));
         }
         if !names.insert(name.clone()) {
             return Err(format!("duplicate metric family: {name}"));
         }
-        let metric_type = ExpositionType::parse(required_string(metric, "type", &name)?)?;
-        let help = required_nonempty_string(metric, "help", &name)?.to_string();
-        let raw_series = metric
-            .get("series")
-            .and_then(serde_json::Value::as_array)
-            .ok_or_else(|| format!("metric {name} requires a series array"))?;
+        let metric_type = ExpositionType::from_wire(metric.metric_type());
+        let help = metric.help().to_string();
+        if help.is_empty() {
+            return Err(format!("{name} field help must not be empty"));
+        }
 
         let mut labelsets = BTreeSet::new();
         let mut family_label_keys = None;
-        let mut series = Vec::with_capacity(raw_series.len());
-        for raw in raw_series {
-            let parsed = parse_series(raw, metric_type, &name)?;
+        let mut series = Vec::new();
+        match metric {
+            MetricFamily::Counter { series: raw, .. } | MetricFamily::Gauge { series: raw, .. } => {
+                series.reserve(raw.len());
+                for raw in raw {
+                    let labels = parse_labels(&raw.labels, &name)?;
+                    series.push(ExpositionSeries::Value {
+                        labels,
+                        value: raw.value,
+                    });
+                }
+            }
+            MetricFamily::Histogram { series: raw, .. } => {
+                series.reserve(raw.len());
+                for raw in raw {
+                    let labels = parse_labels(&raw.labels, &name)?;
+                    let buckets = parse_buckets(&raw.buckets, &name)?;
+                    if !raw.sum.is_finite() {
+                        return Err(format!("metric {name} sum must be finite"));
+                    }
+                    series.push(ExpositionSeries::Histogram {
+                        labels,
+                        buckets,
+                        sum: raw.sum,
+                        count: raw.count,
+                    });
+                }
+            }
+        }
+        for parsed in &series {
             if !labelsets.insert(parsed.labels().clone()) {
                 return Err(format!("metric {name} contains a duplicate labelset"));
             }
@@ -324,7 +343,6 @@ fn parse_snapshot(root: &serde_json::Value) -> Result<Vec<ExpositionFamily>, Str
                 None => family_label_keys = Some(label_keys),
                 _ => {}
             }
-            series.push(parsed);
         }
         validate_exported_labelsets(&series, metric_type, &name)?;
         series.sort_by(|left, right| left.labels().cmp(right.labels()));
@@ -380,48 +398,7 @@ fn validate_histogram_namespaces(
     Ok(())
 }
 
-fn parse_series(
-    value: &serde_json::Value,
-    metric_type: ExpositionType,
-    metric_name: &str,
-) -> Result<ExpositionSeries, String> {
-    let object = value
-        .as_object()
-        .ok_or_else(|| format!("metric {metric_name} series must be an object"))?;
-    let labels = parse_labels(object.get("labels"), metric_name)?;
-    match metric_type {
-        ExpositionType::Counter | ExpositionType::Gauge => {
-            let value = object
-                .get("value")
-                .and_then(serde_json::Value::as_u64)
-                .ok_or_else(|| format!("metric {metric_name} value must be a u64"))?;
-            Ok(ExpositionSeries::Value { labels, value })
-        }
-        ExpositionType::Histogram => {
-            let buckets = parse_buckets(object.get("buckets"), metric_name)?;
-            let sum = object
-                .get("sum")
-                .and_then(serde_json::Value::as_f64)
-                .filter(|value| value.is_finite())
-                .ok_or_else(|| format!("metric {metric_name} sum must be finite"))?;
-            let count = object
-                .get("count")
-                .and_then(serde_json::Value::as_u64)
-                .ok_or_else(|| format!("metric {metric_name} count must be a u64"))?;
-            Ok(ExpositionSeries::Histogram {
-                labels,
-                buckets,
-                sum,
-                count,
-            })
-        }
-    }
-}
-
-fn parse_labels(value: Option<&serde_json::Value>, metric_name: &str) -> Result<Labels, String> {
-    let labels = value
-        .and_then(serde_json::Value::as_object)
-        .ok_or_else(|| format!("metric {metric_name} labels must be an object"))?;
+fn parse_labels(labels: &BTreeMap<String, String>, metric_name: &str) -> Result<Labels, String> {
     let mut parsed = Vec::with_capacity(labels.len());
     for (key, value) in labels {
         if !is_legacy_label_name(key) {
@@ -429,10 +406,7 @@ fn parse_labels(value: Option<&serde_json::Value>, metric_name: &str) -> Result<
                 "metric {metric_name} has invalid Prometheus label name: {key:?}"
             ));
         }
-        let value = value
-            .as_str()
-            .ok_or_else(|| format!("metric {metric_name} label {key} must be a string"))?;
-        parsed.push((key.clone(), value.to_string()));
+        parsed.push((key.clone(), value.clone()));
     }
     parsed.sort();
     Ok(parsed)
@@ -465,26 +439,12 @@ fn is_legacy_label_name(name: &str) -> bool {
                     .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_'))
 }
 
-fn parse_buckets(
-    value: Option<&serde_json::Value>,
-    metric_name: &str,
-) -> Result<Vec<(f64, u64)>, String> {
-    let raw = value
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| format!("metric {metric_name} buckets must be an array"))?;
+fn parse_buckets(raw: &[(f64, u64)], metric_name: &str) -> Result<Vec<(f64, u64)>, String> {
     let mut buckets = Vec::with_capacity(raw.len());
-    for bucket in raw {
-        let tuple = bucket
-            .as_array()
-            .filter(|tuple| tuple.len() == 2)
-            .ok_or_else(|| format!("metric {metric_name} bucket must be a pair"))?;
-        let bound = tuple[0]
-            .as_f64()
-            .filter(|bound| bound.is_finite())
-            .ok_or_else(|| format!("metric {metric_name} bucket bound must be finite"))?;
-        let count = tuple[1]
-            .as_u64()
-            .ok_or_else(|| format!("metric {metric_name} bucket count must be a u64"))?;
+    for &(bound, count) in raw {
+        if !bound.is_finite() {
+            return Err(format!("metric {metric_name} bucket bound must be finite"));
+        }
         if let Some((previous_bound, previous_count)) = buckets.last() {
             if previous_bound >= &bound {
                 return Err(format!(
@@ -500,30 +460,6 @@ fn parse_buckets(
         buckets.push((bound, count));
     }
     Ok(buckets)
-}
-
-fn required_string<'a>(
-    object: &'a serde_json::Map<String, serde_json::Value>,
-    field: &str,
-    context: &str,
-) -> Result<&'a str, String> {
-    object
-        .get(field)
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| format!("{context} requires string field {field}"))
-}
-
-fn required_nonempty_string<'a>(
-    object: &'a serde_json::Map<String, serde_json::Value>,
-    field: &str,
-    context: &str,
-) -> Result<&'a str, String> {
-    let value = required_string(object, field, context)?;
-    if value.is_empty() {
-        Err(format!("{context} field {field} must not be empty"))
-    } else {
-        Ok(value)
-    }
 }
 
 fn render_snapshot(families: &[ExpositionFamily]) -> String {
@@ -721,6 +657,15 @@ mod tests {
     use super::*;
     use tokio::io::AsyncReadExt;
     use tokio::net::{TcpStream, UnixListener};
+
+    #[test]
+    fn schema_v1_fixture_parses_through_the_shared_wire_dto() {
+        let fixture = include_str!("../../limpid-metrics-schema/tests/fixtures/schema-v1.json");
+        let shared: limpid_metrics_schema::MetricsSnapshot = serde_json::from_str(fixture).unwrap();
+        let expected = json_to_prometheus(fixture).unwrap();
+        let families = parse_snapshot(&shared).unwrap();
+        assert_eq!(render_snapshot(&families), expected);
+    }
 
     #[test]
     fn schema_v1_rejects_inconsistent_and_colliding_labelsets() {

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -6,7 +6,7 @@ description = "Log pipelines, limpid as intent."
 license.workspace = true
 
 [dependencies]
-limpid-metrics-schema = { version = "0.7.15", path = "../limpid-metrics-schema" }
+limpid-metrics-schema = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -6,6 +6,7 @@ description = "Log pipelines, limpid as intent."
 license.workspace = true
 
 [dependencies]
+limpid-metrics-schema = { version = "0.7.15", path = "../limpid-metrics-schema" }
 tokio = { version = "1", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -11,7 +11,10 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use serde::Serialize;
+pub(crate) use limpid_metrics_schema::MetricsSnapshot;
+use limpid_metrics_schema::{
+    HistogramSeries, MetricFamily as SnapshotFamily, ValueSeries as SnapshotValueSeries,
+};
 
 pub struct InputMetrics {
     /// Events actually received by the input module (network, socket, file, etc).
@@ -451,49 +454,11 @@ mod registry_core {
         }
     }
 
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
-    #[serde(rename_all = "lowercase")]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum MetricType {
         Counter,
         Gauge,
         Histogram,
-    }
-
-    #[derive(Serialize)]
-    pub(crate) struct MetricsSnapshot {
-        schema: u32,
-        metrics: Vec<MetricSnapshot>,
-    }
-
-    #[derive(Serialize)]
-    struct MetricSnapshot {
-        name: String,
-        #[serde(rename = "type")]
-        metric_type: MetricType,
-        help: String,
-        series: Vec<SeriesSnapshot>,
-    }
-
-    #[derive(Serialize)]
-    #[serde(untagged)]
-    enum SeriesSnapshot {
-        Value {
-            labels: BTreeMap<String, String>,
-            value: u64,
-        },
-        /// `buckets` carries cumulative Prometheus counts for the
-        /// finite upper bounds configured on the histogram. The
-        /// implicit `+Inf` bucket is intentionally absent from this
-        /// array; Prometheus translators must synthesise it as a
-        /// `+Inf` sample whose value equals `count`. `count` includes
-        /// observations above the last configured bound, so the
-        /// synthesised `+Inf` value stays authoritative.
-        Histogram {
-            labels: BTreeMap<String, String>,
-            buckets: Vec<(f64, u64)>,
-            sum: f64,
-            count: u64,
-        },
     }
 
     #[derive(Clone, PartialEq, Eq, Hash)]
@@ -573,17 +538,8 @@ mod registry_core {
                 .inner
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let metrics = inner
-                .families
-                .iter()
-                .map(|family| MetricSnapshot {
-                    name: family.name.clone(),
-                    metric_type: family.kind.metric_type(),
-                    help: family.help.clone(),
-                    series: snapshot_series(&family.kind),
-                })
-                .collect();
-            MetricsSnapshot { schema: 1, metrics }
+            let metrics = inner.families.iter().map(snapshot_family).collect();
+            MetricsSnapshot::new(metrics)
         }
 
         fn register_counter(
@@ -983,47 +939,72 @@ mod registry_core {
             })
     }
 
-    fn snapshot_series(kind: &FamilyKind) -> Vec<SeriesSnapshot> {
-        match kind {
-            FamilyKind::Counter(series) => series
-                .iter()
-                .map(|series| SeriesSnapshot::Value {
-                    labels: labels_map(&series.labels),
-                    value: series.handle.value.load(Ordering::Relaxed),
-                })
-                .collect(),
-            FamilyKind::Gauge(series) => series
-                .iter()
-                .map(|series| SeriesSnapshot::Value {
-                    labels: labels_map(&series.labels),
-                    value: series.handle.value.load(Ordering::Relaxed),
-                })
-                .collect(),
-            FamilyKind::Histogram(series) => series
-                .iter()
-                .map(|series| {
-                    // Fold the raw per-bucket counts into the
-                    // cumulative shape Prometheus expects (see the
-                    // `Histogram` doc for why storage stays raw).
-                    let mut cumulative = 0;
-                    let buckets = series
-                        .handle
-                        .boundaries
-                        .iter()
-                        .zip(&series.handle.bucket_counts)
-                        .map(|(boundary, count)| {
-                            cumulative += count.load(Ordering::Relaxed);
-                            (*boundary, cumulative)
-                        })
-                        .collect();
-                    SeriesSnapshot::Histogram {
-                        labels: labels_map(&series.labels),
-                        buckets,
-                        sum: f64::from_bits(series.handle.sum_bits.load(Ordering::Relaxed)),
-                        count: series.handle.count.load(Ordering::Relaxed),
-                    }
-                })
-                .collect(),
+    fn snapshot_family(family: &MetricFamily) -> SnapshotFamily {
+        match &family.kind {
+            FamilyKind::Counter(series) => SnapshotFamily::counter(
+                family.name.clone(),
+                family.help.clone(),
+                snapshot_value_series(series),
+            ),
+            FamilyKind::Gauge(series) => SnapshotFamily::gauge(
+                family.name.clone(),
+                family.help.clone(),
+                snapshot_value_series(series),
+            ),
+            FamilyKind::Histogram(series) => SnapshotFamily::histogram(
+                family.name.clone(),
+                family.help.clone(),
+                series
+                    .iter()
+                    .map(|series| {
+                        let mut cumulative = 0;
+                        let buckets = series
+                            .handle
+                            .boundaries
+                            .iter()
+                            .zip(&series.handle.bucket_counts)
+                            .map(|(boundary, count)| {
+                                cumulative += count.load(Ordering::Relaxed);
+                                (*boundary, cumulative)
+                            })
+                            .collect();
+                        HistogramSeries::new(
+                            labels_map(&series.labels),
+                            buckets,
+                            f64::from_bits(series.handle.sum_bits.load(Ordering::Relaxed)),
+                            series.handle.count.load(Ordering::Relaxed),
+                        )
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    fn snapshot_value_series<T>(series: &[ValueSeries<T>]) -> Vec<SnapshotValueSeries>
+    where
+        T: ValueHandle,
+    {
+        series
+            .iter()
+            .map(|series| {
+                SnapshotValueSeries::new(labels_map(&series.labels), series.handle.load_value())
+            })
+            .collect()
+    }
+
+    trait ValueHandle {
+        fn load_value(&self) -> u64;
+    }
+
+    impl ValueHandle for Counter {
+        fn load_value(&self) -> u64 {
+            self.value.load(Ordering::Relaxed)
+        }
+    }
+
+    impl ValueHandle for Gauge {
+        fn load_value(&self) -> u64 {
+            self.value.load(Ordering::Relaxed)
         }
     }
 
@@ -1033,7 +1014,7 @@ mod registry_core {
 }
 
 #[allow(unused_imports)]
-pub(crate) use registry_core::{MetricsError, MetricsSnapshot, Registry};
+pub(crate) use registry_core::{MetricsError, Registry};
 
 #[cfg(test)]
 mod registry_tests {
@@ -1151,6 +1132,28 @@ mod registry_tests {
     fn snapshot_json(registry: &Registry) -> Value {
         let snapshot: MetricsSnapshot = registry.snapshot();
         serde_json::to_value(snapshot).expect("snapshot must serialize")
+    }
+
+    #[test]
+    fn registry_snapshot_matches_the_shared_wire_dto() {
+        let registry = Registry::new();
+        build_ok(
+            registry
+                .counter("limpid_test_events_total")
+                .help("Test events.")
+                .label("source", "unit")
+                .build(),
+        )
+        .inc();
+
+        let shared: limpid_metrics_schema::MetricsSnapshot = registry.snapshot();
+        assert_eq!(
+            serde_json::to_string(&shared).unwrap(),
+            r#"{"schema":1,"metrics":[{"name":"limpid_test_events_total","type":"counter","help":"Test events.","series":[{"labels":{"source":"unit"},"value":1}]}]}"#
+        );
+        let produced = serde_json::to_value(&shared).unwrap();
+        assert_eq!(produced["schema"], 1);
+        assert_eq!(produced["metrics"][0]["name"], "limpid_test_events_total");
     }
 
     fn metric<'a>(snapshot: &'a Value, name: &str) -> &'a Value {

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -10,6 +10,7 @@ name = "limpidctl"
 path = "src/main.rs"
 
 [dependencies]
+limpid-metrics-schema = { version = "0.7.15", path = "../limpid-metrics-schema" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -10,7 +10,7 @@ name = "limpidctl"
 path = "src/main.rs"
 
 [dependencies]
-limpid-metrics-schema = { version = "0.7.15", path = "../limpid-metrics-schema" }
+limpid-metrics-schema = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -21,6 +21,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
+use limpid_metrics_schema::{MetricFamily, MetricType, MetricsSnapshot};
 
 const DEFAULT_SOCKET: &str = "/var/run/limpid/control.sock";
 
@@ -477,7 +478,10 @@ const OUTPUT_METRICS: [&str; 7] = [
 type MetricValues = BTreeMap<String, u64>;
 
 fn format_stats(json: &str) {
-    match render_default_stats(json) {
+    let rendered = serde_json::from_str::<MetricsSnapshot>(json)
+        .ok()
+        .and_then(|snapshot| render_default_stats(&snapshot));
+    match rendered {
         Some(rendered) => print!("{}", rendered),
         None => print!("{}", json),
     }
@@ -491,37 +495,31 @@ fn format_stats(json: &str) {
 /// family that fails validation returns `None`, so the caller falls
 /// back to the raw response rather than emit a partial table that
 /// omits or lies about a counter.
-fn render_default_stats(json: &str) -> Option<String> {
-    let snapshot: serde_json::Value = serde_json::from_str(json).ok()?;
-    if snapshot.get("schema")?.as_u64()? != 1 {
+fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+    if snapshot.schema != 1 {
         return None;
     }
-    let metrics = snapshot.get("metrics")?.as_array()?;
     let mut families = BTreeMap::<String, MetricValues>::new();
 
-    for metric in metrics {
-        let metric = metric.as_object()?;
-        let name = metric.get("name")?.as_str()?;
+    for metric in &snapshot.metrics {
+        let name = metric.name();
         let Some(label_name) = known_metric_label(name) else {
             continue;
         };
-        if metric.get("type")?.as_str()? != "counter" || families.contains_key(name) {
+        if metric.metric_type() != MetricType::Counter || families.contains_key(name) {
             return None;
         }
-        let series = metric.get("series")?.as_array()?;
+        let series = metric.value_series()?;
         if series.is_empty() {
             return None;
         }
         let mut values = MetricValues::new();
         for item in series {
-            let item = item.as_object()?;
-            let labels = item.get("labels")?.as_object()?;
-            if labels.len() != 1 {
+            if item.labels.len() != 1 {
                 return None;
             }
-            let scope = labels.get(label_name)?.as_str()?;
-            let value = item.get("value")?.as_u64()?;
-            if values.insert(scope.to_owned(), value).is_some() {
+            let scope = item.labels.get(label_name)?;
+            if values.insert(scope.clone(), item.value).is_some() {
                 return None;
             }
         }
@@ -663,20 +661,21 @@ struct HistogramDetail {
 }
 
 fn format_stats_details(json: &str) {
-    match render_stats_details(json) {
+    let rendered = serde_json::from_str::<MetricsSnapshot>(json)
+        .ok()
+        .and_then(|snapshot| render_stats_details(&snapshot));
+    match rendered {
         Some(rendered) => print!("{}", rendered),
         None => print!("{}", json),
     }
 }
 
-fn render_stats_details(json: &str) -> Option<String> {
-    let snapshot: serde_json::Value = serde_json::from_str(json).ok()?;
-    if snapshot.get("schema")?.as_u64()? != 1 {
+fn render_stats_details(snapshot: &MetricsSnapshot) -> Option<String> {
+    if snapshot.schema != 1 {
         return None;
     }
     let mut metrics: Vec<DetailMetric> = snapshot
-        .get("metrics")?
-        .as_array()?
+        .metrics
         .iter()
         .map(parse_detail_metric)
         .collect::<Option<_>>()?;
@@ -689,7 +688,7 @@ fn render_stats_details(json: &str) -> Option<String> {
     if metrics
         .iter()
         .any(|metric| known_metric_label(&metric.name).is_some())
-        && render_default_stats(json).is_none()
+        && render_default_stats(snapshot).is_none()
     {
         return None;
     }
@@ -737,28 +736,26 @@ impl DetailKind {
     }
 }
 
-fn parse_detail_metric(value: &serde_json::Value) -> Option<DetailMetric> {
-    let metric = value.as_object()?;
-    let name = metric.get("name")?.as_str()?.to_owned();
-    let help = metric.get("help")?.as_str()?.to_owned();
-    let series = metric.get("series")?.as_array()?;
-    let kind = match metric.get("type")?.as_str()? {
-        "counter" => DetailKind::Counter(parse_value_details(series)?),
-        "gauge" => DetailKind::Gauge(parse_value_details(series)?),
-        "histogram" => DetailKind::Histogram(parse_histogram_details(series)?),
-        _ => return None,
+fn parse_detail_metric(metric: &MetricFamily) -> Option<DetailMetric> {
+    let name = metric.name().to_owned();
+    let help = metric.help().to_owned();
+    let kind = match metric.metric_type() {
+        MetricType::Counter => DetailKind::Counter(parse_value_details(metric.value_series()?)?),
+        MetricType::Gauge => DetailKind::Gauge(parse_value_details(metric.value_series()?)?),
+        MetricType::Histogram => {
+            DetailKind::Histogram(parse_histogram_details(metric.histogram_series()?)?)
+        }
     };
     Some(DetailMetric { name, help, kind })
 }
 
-fn parse_value_details(series: &[serde_json::Value]) -> Option<Vec<ValueDetail>> {
+fn parse_value_details(series: &[limpid_metrics_schema::ValueSeries]) -> Option<Vec<ValueDetail>> {
     let mut parsed: Vec<ValueDetail> = series
         .iter()
         .map(|value| {
-            let value = value.as_object()?;
             Some(ValueDetail {
-                labels: parse_labels(value.get("labels")?)?,
-                value: value.get("value")?.as_u64()?,
+                labels: parse_labels(&value.labels),
+                value: value.value,
             })
         })
         .collect::<Option<_>>()?;
@@ -772,27 +769,16 @@ fn parse_value_details(series: &[serde_json::Value]) -> Option<Vec<ValueDetail>>
     Some(parsed)
 }
 
-fn parse_histogram_details(series: &[serde_json::Value]) -> Option<Vec<HistogramDetail>> {
+fn parse_histogram_details(
+    series: &[limpid_metrics_schema::HistogramSeries],
+) -> Option<Vec<HistogramDetail>> {
     let mut parsed: Vec<HistogramDetail> = series
         .iter()
         .map(|value| {
-            let value = value.as_object()?;
-            let buckets = value
-                .get("buckets")?
-                .as_array()?
-                .iter()
-                .map(|bucket| {
-                    let bucket = bucket.as_array()?;
-                    if bucket.len() != 2 {
-                        return None;
-                    }
-                    let bound = bucket[0].as_f64()?;
-                    if !bound.is_finite() {
-                        return None;
-                    }
-                    Some((bound, bucket[1].as_u64()?))
-                })
-                .collect::<Option<Vec<_>>>()?;
+            let buckets = value.buckets.clone();
+            if buckets.iter().any(|(bound, _)| !bound.is_finite()) {
+                return None;
+            }
             if buckets.windows(2).any(|pair| pair[0].0 >= pair[1].0) {
                 return None;
             }
@@ -803,15 +789,15 @@ fn parse_histogram_details(series: &[serde_json::Value]) -> Option<Vec<Histogram
             // independent atomics in the daemon, so observe ordering
             // permits a transient last-bucket count that exceeds the
             // total — do not reject on that inequality.
-            let sum = value.get("sum")?.as_f64()?;
+            let sum = value.sum;
             if !sum.is_finite() {
                 return None;
             }
             Some(HistogramDetail {
-                labels: parse_labels(value.get("labels")?)?,
+                labels: parse_labels(&value.labels),
                 buckets,
                 sum,
-                count: value.get("count")?.as_u64()?,
+                count: value.count,
             })
         })
         .collect::<Option<_>>()?;
@@ -825,14 +811,13 @@ fn parse_histogram_details(series: &[serde_json::Value]) -> Option<Vec<Histogram
     Some(parsed)
 }
 
-fn parse_labels(value: &serde_json::Value) -> Option<Vec<(String, String)>> {
+fn parse_labels(value: &BTreeMap<String, String>) -> Vec<(String, String)> {
     let mut labels: Vec<(String, String)> = value
-        .as_object()?
         .iter()
-        .map(|(key, value)| Some((key.clone(), value.as_str()?.to_owned())))
-        .collect::<Option<_>>()?;
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
     labels.sort();
-    Some(labels)
+    labels
 }
 
 fn format_labels(labels: &[(String, String)]) -> String {
@@ -1015,6 +1000,87 @@ impl ReplayState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn canonical_shared_snapshot(extra_family: bool) -> limpid_metrics_schema::MetricsSnapshot {
+        let mut metrics = PIPELINE_METRICS
+            .iter()
+            .map(|name| {
+                serde_json::json!({
+                    "name": name,
+                    "type": "counter",
+                    "help": "Pipeline counter.",
+                    "series": [{"labels": {"pipeline": "route"}, "value": 1}]
+                })
+            })
+            .chain(INPUT_METRICS.iter().map(|name| {
+                serde_json::json!({
+                    "name": name,
+                    "type": "counter",
+                    "help": "Input counter.",
+                    "series": [{"labels": {"input": "ingress"}, "value": 2}]
+                })
+            }))
+            .chain(OUTPUT_METRICS.iter().map(|name| {
+                serde_json::json!({
+                    "name": name,
+                    "type": "counter",
+                    "help": "Output counter.",
+                    "series": [{"labels": {"output": "egress"}, "value": 3}]
+                })
+            }))
+            .collect::<Vec<_>>();
+        if extra_family {
+            metrics.push(serde_json::json!({
+                "name": "future_metric",
+                "type": "gauge",
+                "help": "Future metric.",
+                "series": [{"labels": {"scope": "future"}, "value": 9}]
+            }));
+        }
+        serde_json::from_value(serde_json::json!({"schema": 1, "metrics": metrics})).unwrap()
+    }
+
+    #[test]
+    fn default_stats_renders_the_shared_snapshot_and_ignores_unknown_families() {
+        let shared = canonical_shared_snapshot(true);
+        let render: fn(&limpid_metrics_schema::MetricsSnapshot) -> Option<String> =
+            render_default_stats;
+        let rendered = render(&shared).unwrap();
+        assert!(rendered.contains("Pipelines:"));
+        assert!(rendered.contains("route"));
+        assert!(rendered.contains("Inputs:"));
+        assert!(rendered.contains("ingress"));
+        assert!(rendered.contains("Outputs:"));
+        assert!(rendered.contains("egress"));
+        assert!(!rendered.contains("future_metric"));
+    }
+
+    #[test]
+    fn default_stats_rejects_a_semantically_ambiguous_shared_snapshot() {
+        let mut fixture = serde_json::to_value(canonical_shared_snapshot(false)).unwrap();
+        let duplicate = fixture["metrics"][0]["series"][0].clone();
+        fixture["metrics"][0]["series"]
+            .as_array_mut()
+            .unwrap()
+            .push(duplicate);
+        let shared: limpid_metrics_schema::MetricsSnapshot =
+            serde_json::from_value(fixture).unwrap();
+        let render: fn(&limpid_metrics_schema::MetricsSnapshot) -> Option<String> =
+            render_default_stats;
+        assert!(render(&shared).is_none());
+    }
+
+    #[test]
+    fn details_render_all_shared_wire_family_types() {
+        let fixture = include_str!("../../limpid-metrics-schema/tests/fixtures/schema-v1.json");
+        let shared: limpid_metrics_schema::MetricsSnapshot = serde_json::from_str(fixture).unwrap();
+        let render: fn(&limpid_metrics_schema::MetricsSnapshot) -> Option<String> =
+            render_stats_details;
+        let rendered = render(&shared).unwrap();
+        assert!(rendered.contains("requests_total"));
+        assert!(rendered.contains("queue_depth"));
+        assert!(rendered.contains("latency_seconds"));
+    }
 
     #[test]
     fn valid_names_match_daemon_ident_grammar() {

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -59,6 +59,12 @@ bounds must be strictly increasing and counts must be nondecreasing. An empty
 bucket list is valid. `count` includes every observation, including values above
 the last finite bound; `sum` is the accumulated observation sum.
 
+Consumers ignore unknown fields at every level of the schema-v1 envelope,
+metric family, and value or histogram series so additive metadata remains
+forward-compatible. The documented fields above remain required and retain
+their exact types; ignoring an unknown field does not make a missing or
+malformed required field valid.
+
 Schema v1 deliberately does not contain an explicit `+Inf` bucket. A
 Prometheus consumer derives `le="+Inf"` from `count`. Bucket, sum, and count
 atomics are loaded independently, so a concurrent snapshot may transiently show


### PR DESCRIPTION
## Summary
- add a shared, wire-only schema-v1 metrics crate
- migrate the daemon producer, limpidctl, and limpid-prometheus to the shared typed representation
- keep rendering and validation policies local to each consumer

## Compatibility
- tolerate additive unknown fields at every schema-v1 object level while keeping required fields and known types strict
- preserve the established raw schema-v1 member order and limpidctl `stats --json` response bytes
- add no derived metadata, process metrics, configuration, or public runtime API

## Validation
- schema boundary, purity, and wire-contract tests
- daemon snapshot, limpidctl unit and integration, and limpid-prometheus tests
- workspace and Kafka-feature tests
- workspace and Kafka-feature clippy with `-D warnings`
- `cargo fmt --all -- --check` and diff checks
- `mdbook build docs`
- `cargo xtask lint-snippet-headers`
- `cargo xtask gen-snippet-inventory --check`
- `cargo deny check advisories bans sources licenses`
- focused mutation checks for mixed series shapes, additive fields, required fields, numeric widths, dependency boundaries, and legacy DTO bridges

The journal feature requires Linux systemd development libraries. Darwin validation covers the default and Kafka paths; the unchanged Ubuntu CI job owns the journal-enabled build and test boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared schema for versioned metrics snapshots, including counters, gauges, histograms, labels, and histogram data.
  * Updated metrics collection, export, and command-line rendering to use the shared schema.
  * Added forward compatibility for unknown fields in metric responses.

* **Documentation**
  * Documented schema-v1 compatibility and required field handling.

* **Bug Fixes**
  * Improved typed validation for metric values, labels, histogram bounds, sums, and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->