### PR TITLE
feat(metrics): report process invocation counters

### DIFF
--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -1104,6 +1104,89 @@ metric_zeta_seconds_count{az="two",le_="source-zero",le__="source-one",le___="so
     }
 
     #[test]
+    fn schema_v1_translation_accepts_process_dimensions_generically() {
+        let snapshot = serde_json::json!({
+            "schema": 1,
+            "metrics": [
+                {
+                    "name": "limpid_process_events_in_total",
+                    "type": "counter",
+                    "help": "Process invocations started.",
+                    "series": [{
+                        "labels": {
+                            "step": "2",
+                            "pipeline": "main",
+                            "process_name": "leaf",
+                            "process_path": "/dispatch/leaf"
+                        },
+                        "value": 7
+                    }]
+                },
+                {
+                    "name": "limpid_process_events_out_total",
+                    "type": "counter",
+                    "help": "Process invocations continued.",
+                    "series": [{
+                        "labels": {
+                            "pipeline": "main",
+                            "step": "2",
+                            "process_path": "/dispatch/leaf",
+                            "process_name": "leaf"
+                        },
+                        "value": 5
+                    }]
+                },
+                {
+                    "name": "limpid_process_events_dropped_total",
+                    "type": "counter",
+                    "help": "Process invocations dropped.",
+                    "series": [{
+                        "labels": {
+                            "pipeline": "main",
+                            "step": "2",
+                            "process_path": "/dispatch/leaf",
+                            "process_name": "leaf"
+                        },
+                        "value": 1
+                    }]
+                },
+                {
+                    "name": "limpid_process_events_errored_total",
+                    "type": "counter",
+                    "help": "Process invocations errored.",
+                    "series": [{
+                        "labels": {
+                            "pipeline": "main",
+                            "step": "2",
+                            "process_path": "/dispatch/leaf",
+                            "process_name": "leaf"
+                        },
+                        "value": 1
+                    }]
+                }
+            ]
+        });
+        let expected = r#"# HELP limpid_process_events_dropped_total Process invocations dropped.
+# TYPE limpid_process_events_dropped_total counter
+limpid_process_events_dropped_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="2"} 1
+
+# HELP limpid_process_events_errored_total Process invocations errored.
+# TYPE limpid_process_events_errored_total counter
+limpid_process_events_errored_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="2"} 1
+
+# HELP limpid_process_events_in_total Process invocations started.
+# TYPE limpid_process_events_in_total counter
+limpid_process_events_in_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="2"} 7
+
+# HELP limpid_process_events_out_total Process invocations continued.
+# TYPE limpid_process_events_out_total counter
+limpid_process_events_out_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="2"} 5
+
+"#;
+        assert_eq!(json_to_prometheus(&snapshot.to_string()).unwrap(), expected);
+    }
+
+    #[test]
     fn schema_v1_translation_rejects_legacy_unsupported_and_partial_snapshots() {
         let cases = [
             ("invalid json", "{"),

--- a/crates/limpid/src/dsl/eval.rs
+++ b/crates/limpid/src/dsl/eval.rs
@@ -774,20 +774,32 @@ pub fn values_match(left: &Value<'_>, right: &Value<'_>) -> bool {
 /// responsible for executing the returned body. Lets the pipeline and
 /// process executors share one first-match algorithm without coupling
 /// to either context.
+#[allow(dead_code)]
 pub fn select_switch_arm<'bump, 'a, F>(
     disc_val: &Value<'bump>,
     arms: &'a [SwitchStmtArm],
-    mut eval_pattern: F,
+    eval_pattern: F,
 ) -> Result<Option<&'a [BranchBody]>>
 where
     F: FnMut(&Expr) -> Result<Value<'bump>>,
 {
-    for arm in arms {
+    Ok(select_switch_arm_with_ordinal(disc_val, arms, eval_pattern)?.map(|(_, body)| body))
+}
+
+pub(crate) fn select_switch_arm_with_ordinal<'bump, 'a, F>(
+    disc_val: &Value<'bump>,
+    arms: &'a [SwitchStmtArm],
+    mut eval_pattern: F,
+) -> Result<Option<(usize, &'a [BranchBody])>>
+where
+    F: FnMut(&Expr) -> Result<Value<'bump>>,
+{
+    for (ordinal, arm) in arms.iter().enumerate() {
         let Some(pattern) = arm.pattern.as_ref() else {
-            return Ok(Some(&arm.body));
+            return Ok(Some((ordinal, &arm.body)));
         };
         if values_match(disc_val, &eval_pattern(pattern)?) {
-            return Ok(Some(&arm.body));
+            return Ok(Some((ordinal, &arm.body)));
         }
     }
     Ok(None)
@@ -802,19 +814,44 @@ where
 ///
 /// Same pure-dispatch shape as [`select_switch_arm`]: the caller
 /// supplies `eval_condition` and executes the returned body.
+#[allow(dead_code)]
 pub fn select_if_branch<'bump, 'a, F>(
     chain: &'a IfChain,
-    mut eval_condition: F,
+    eval_condition: F,
 ) -> Result<Option<&'a [BranchBody]>>
 where
     F: FnMut(&Expr) -> Result<Value<'bump>>,
 {
-    for (condition, body) in &chain.branches {
+    Ok(select_if_branch_with_ordinal(chain, eval_condition)?.map(|selection| selection.body))
+}
+
+/// Chosen branch plus its zero-based ordinal, so the caller can
+/// index the parallel metric plan without re-matching AST branches.
+/// `ordinal` is `None` for the else branch.
+pub(crate) struct SelectedIfBranch<'a> {
+    pub(crate) ordinal: Option<usize>,
+    pub(crate) body: &'a [BranchBody],
+}
+
+pub(crate) fn select_if_branch_with_ordinal<'bump, 'a, F>(
+    chain: &'a IfChain,
+    mut eval_condition: F,
+) -> Result<Option<SelectedIfBranch<'a>>>
+where
+    F: FnMut(&Expr) -> Result<Value<'bump>>,
+{
+    for (ordinal, (condition, body)) in chain.branches.iter().enumerate() {
         if eval_condition(condition)?.is_truthy() {
-            return Ok(Some(body));
+            return Ok(Some(SelectedIfBranch {
+                ordinal: Some(ordinal),
+                body,
+            }));
         }
     }
-    Ok(chain.else_body.as_deref())
+    Ok(chain.else_body.as_deref().map(|body| SelectedIfBranch {
+        ordinal: None,
+        body,
+    }))
 }
 
 /// String coercion used by templates, format() placeholders, and any

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -12,7 +12,8 @@ use thiserror::Error;
 use super::arena::EventArena;
 use super::ast::*;
 use super::eval::{
-    LocalScope, eval_expr_with_scope, select_if_branch, select_switch_arm, value_to_string,
+    LocalScope, eval_expr_with_scope, select_if_branch_with_ordinal,
+    select_switch_arm_with_ordinal, value_to_string,
 };
 use super::value::Value;
 use crate::event::BorrowedEvent;
@@ -47,6 +48,75 @@ pub trait ProcessRegistry {
     ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError>;
 }
 
+/// Registry extension that accepts a metric token pre-resolved at
+/// startup. The token identifies the metric node independently of
+/// the process name — the same name at different call sites
+/// (including recursion) resolves to distinct or shared nodes decided
+/// at compile time — so the event path only needs one `Vec` index
+/// instead of walking the process tree.
+pub(crate) trait CompiledProcessRegistry: ProcessRegistry {
+    fn call_pre_resolved<'bump>(
+        &self,
+        name: &str,
+        metric_token: usize,
+        event: BorrowedEvent<'bump>,
+        arena: &'bump EventArena<'bump>,
+    ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError>;
+}
+
+pub(crate) enum ProcessMetricStatement {
+    None,
+    Call(usize),
+    If {
+        branches: Vec<Vec<Self>>,
+        else_body: Option<Vec<Self>>,
+    },
+    Switch(Vec<Vec<Self>>),
+    TryCatch {
+        try_body: Vec<Self>,
+        catch_body: Vec<Self>,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum ProcessRegistryDispatch<'a> {
+    Plain(&'a dyn ProcessRegistry),
+    Compiled(&'a dyn CompiledProcessRegistry),
+}
+
+impl ProcessRegistryDispatch<'_> {
+    fn is_compiled(self) -> bool {
+        matches!(self, Self::Compiled(_))
+    }
+
+    fn call<'bump>(
+        self,
+        name: &str,
+        event: BorrowedEvent<'bump>,
+        arena: &'bump EventArena<'bump>,
+    ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError> {
+        match self {
+            Self::Plain(registry) => registry.call(name, event, arena),
+            Self::Compiled(registry) => registry.call(name, event, arena),
+        }
+    }
+
+    fn call_pre_resolved<'bump>(
+        self,
+        name: &str,
+        metric_token: usize,
+        event: BorrowedEvent<'bump>,
+        arena: &'bump EventArena<'bump>,
+    ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError> {
+        match self {
+            Self::Plain(registry) => registry.call(name, event, arena),
+            Self::Compiled(registry) => {
+                registry.call_pre_resolved(name, metric_token, event, arena)
+            }
+        }
+    }
+}
+
 /// Execute a sequence of process statements against an event.
 ///
 /// Each call starts with a fresh [`LocalScope`] — `let` bindings do not
@@ -61,8 +131,52 @@ pub fn exec_process_body<'bump>(
     funcs: &FunctionRegistry,
     arena: &'bump EventArena<'bump>,
 ) -> Result<ExecResult<'bump>> {
+    exec_process_body_inner(
+        stmts,
+        None,
+        event,
+        ProcessRegistryDispatch::Plain(registry),
+        funcs,
+        arena,
+    )
+}
+
+pub(crate) fn exec_process_body_with_metric_plan<'bump>(
+    stmts: &[ProcessStatement],
+    metric_stmts: &[ProcessMetricStatement],
+    event: BorrowedEvent<'bump>,
+    registry: &dyn CompiledProcessRegistry,
+    funcs: &FunctionRegistry,
+    arena: &'bump EventArena<'bump>,
+) -> Result<ExecResult<'bump>> {
+    exec_process_body_inner(
+        stmts,
+        Some(metric_stmts),
+        event,
+        ProcessRegistryDispatch::Compiled(registry),
+        funcs,
+        arena,
+    )
+}
+
+fn exec_process_body_inner<'bump>(
+    stmts: &[ProcessStatement],
+    metric_stmts: Option<&[ProcessMetricStatement]>,
+    event: BorrowedEvent<'bump>,
+    registry: ProcessRegistryDispatch<'_>,
+    funcs: &FunctionRegistry,
+    arena: &'bump EventArena<'bump>,
+) -> Result<ExecResult<'bump>> {
     let mut scope = LocalScope::new();
-    exec_stmts_with_scope(stmts, event, registry, funcs, &mut scope, arena)
+    exec_stmts_with_scope(
+        stmts,
+        metric_stmts,
+        event,
+        registry,
+        funcs,
+        &mut scope,
+        arena,
+    )
 }
 
 /// Run statements with the given local scope. `let` bindings mutate
@@ -73,14 +187,30 @@ pub fn exec_process_body<'bump>(
 /// semantics and matches how users read the code top-to-bottom.
 fn exec_stmts_with_scope<'bump>(
     stmts: &[ProcessStatement],
+    metric_stmts: Option<&[ProcessMetricStatement]>,
     mut event: BorrowedEvent<'bump>,
-    registry: &dyn ProcessRegistry,
+    registry: ProcessRegistryDispatch<'_>,
     funcs: &FunctionRegistry,
     scope: &mut LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<ExecResult<'bump>> {
-    for stmt in stmts {
-        match exec_process_stmt(stmt, event, registry, funcs, scope, arena)? {
+    if registry.is_compiled() {
+        let metric_stmts = metric_stmts
+            .ok_or_else(|| anyhow::anyhow!("compiled process metric plan is missing"))?;
+        if metric_stmts.len() != stmts.len() {
+            bail!("compiled process metric plan length does not match the process body");
+        }
+    }
+    for (index, stmt) in stmts.iter().enumerate() {
+        let metric_stmt = match registry {
+            ProcessRegistryDispatch::Compiled(_) => Some(
+                metric_stmts
+                    .and_then(|metrics| metrics.get(index))
+                    .ok_or_else(|| anyhow::anyhow!("compiled process metric entry is missing"))?,
+            ),
+            ProcessRegistryDispatch::Plain(_) => None,
+        };
+        match exec_process_stmt(stmt, metric_stmt, event, registry, funcs, scope, arena)? {
             ExecResult::Continue(e) => event = e,
             ExecResult::Dropped => return Ok(ExecResult::Dropped),
         }
@@ -90,8 +220,9 @@ fn exec_stmts_with_scope<'bump>(
 
 fn exec_process_stmt<'bump>(
     stmt: &ProcessStatement,
+    metric_stmt: Option<&ProcessMetricStatement>,
     mut event: BorrowedEvent<'bump>,
-    registry: &dyn ProcessRegistry,
+    registry: ProcessRegistryDispatch<'_>,
     funcs: &FunctionRegistry,
     scope: &mut LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
@@ -151,8 +282,17 @@ fn exec_process_stmt<'bump>(
             // `try`/`catch` arm below catches Err and runs the
             // recovery body with the original error message exposed
             // via `workspace._error`.
-            registry
-                .call(name, event, arena)
+            let result = match (registry, metric_stmt) {
+                (
+                    ProcessRegistryDispatch::Compiled(_),
+                    Some(ProcessMetricStatement::Call(token)),
+                ) => registry.call_pre_resolved(name, *token, event, arena),
+                (ProcessRegistryDispatch::Compiled(_), _) => {
+                    bail!("compiled process call token is missing or invalid")
+                }
+                (ProcessRegistryDispatch::Plain(_), _) => registry.call(name, event, arena),
+            };
+            result
                 .map(|opt_event| match opt_event {
                     Some(e) => ExecResult::Continue(e),
                     None => ExecResult::Dropped,
@@ -161,20 +301,60 @@ fn exec_process_stmt<'bump>(
         }
 
         ProcessStatement::If(if_chain) => {
-            match select_if_branch(if_chain, |c| {
+            match select_if_branch_with_ordinal(if_chain, |c| {
                 eval_expr_with_scope(c, &event, funcs, scope, arena)
             })? {
-                Some(body) => exec_branch_body_process(body, event, registry, funcs, scope, arena),
+                Some(selection) => {
+                    let metric_body = match (registry, metric_stmt) {
+                        (
+                            ProcessRegistryDispatch::Compiled(_),
+                            Some(ProcessMetricStatement::If {
+                                branches,
+                                else_body,
+                            }),
+                        ) => match selection.ordinal {
+                            Some(ordinal) => branches.get(ordinal).map(Vec::as_slice),
+                            None => else_body.as_deref(),
+                        },
+                        (ProcessRegistryDispatch::Compiled(_), _) => None,
+                        (ProcessRegistryDispatch::Plain(_), _) => None,
+                    };
+                    exec_branch_body_process(
+                        selection.body,
+                        metric_body,
+                        event,
+                        registry,
+                        funcs,
+                        scope,
+                        arena,
+                    )
+                }
                 None => Ok(ExecResult::Continue(event)),
             }
         }
 
         ProcessStatement::Switch(discriminant, arms) => {
             let disc_val = eval_expr_with_scope(discriminant, &event, funcs, scope, arena)?;
-            match select_switch_arm(&disc_val, arms, |e| {
+            match select_switch_arm_with_ordinal(&disc_val, arms, |e| {
                 eval_expr_with_scope(e, &event, funcs, scope, arena)
             })? {
-                Some(body) => exec_branch_body_process(body, event, registry, funcs, scope, arena),
+                Some((ordinal, body)) => {
+                    let metric_body = match metric_stmt {
+                        Some(ProcessMetricStatement::Switch(arms_metrics)) => {
+                            arms_metrics.get(ordinal).map(Vec::as_slice)
+                        }
+                        _ => None,
+                    };
+                    exec_branch_body_process(
+                        body,
+                        metric_body,
+                        event,
+                        registry,
+                        funcs,
+                        scope,
+                        arena,
+                    )
+                }
                 None => Ok(ExecResult::Continue(event)),
             }
         }
@@ -186,7 +366,15 @@ fn exec_process_stmt<'bump>(
             // scope the try started with.
             let event_backup = clone_borrowed_event(&event, arena);
             let scope_backup = scope.clone();
-            match exec_stmts_with_scope(try_body, event, registry, funcs, scope, arena) {
+            let (try_metrics, catch_metrics) = match metric_stmt {
+                Some(ProcessMetricStatement::TryCatch {
+                    try_body,
+                    catch_body,
+                }) => (Some(try_body.as_slice()), Some(catch_body.as_slice())),
+                _ => (None, None),
+            };
+            match exec_stmts_with_scope(try_body, try_metrics, event, registry, funcs, scope, arena)
+            {
                 Ok(result) => Ok(result),
                 Err(e) => {
                     *scope = scope_backup;
@@ -197,8 +385,15 @@ fn exec_process_stmt<'bump>(
                     let mut recovered = event_backup;
                     let msg = arena.alloc_str(&e.to_string());
                     recovered.workspace_set_str(arena, "_error", Value::String(msg));
-                    let mut result =
-                        exec_stmts_with_scope(catch_body, recovered, registry, funcs, scope, arena);
+                    let mut result = exec_stmts_with_scope(
+                        catch_body,
+                        catch_metrics,
+                        recovered,
+                        registry,
+                        funcs,
+                        scope,
+                        arena,
+                    );
                     // Clean up _error after catch body
                     if let Ok(ExecResult::Continue(ref mut evt)) = result {
                         evt.workspace_remove("_error");
@@ -245,16 +440,32 @@ fn exec_process_stmt<'bump>(
 
 fn exec_branch_body_process<'bump>(
     body: &[BranchBody],
+    metric_body: Option<&[ProcessMetricStatement]>,
     mut event: BorrowedEvent<'bump>,
-    registry: &dyn ProcessRegistry,
+    registry: ProcessRegistryDispatch<'_>,
     funcs: &FunctionRegistry,
     scope: &mut LocalScope<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> Result<ExecResult<'bump>> {
-    for item in body {
+    if registry.is_compiled() {
+        let metric_body = metric_body
+            .ok_or_else(|| anyhow::anyhow!("compiled process branch plan is missing"))?;
+        if metric_body.len() != body.len() {
+            bail!("compiled process branch plan length does not match the selected body");
+        }
+    }
+    for (index, item) in body.iter().enumerate() {
+        let metric_stmt = match registry {
+            ProcessRegistryDispatch::Compiled(_) => Some(
+                metric_body
+                    .and_then(|metrics| metrics.get(index))
+                    .ok_or_else(|| anyhow::anyhow!("compiled process branch entry is missing"))?,
+            ),
+            ProcessRegistryDispatch::Plain(_) => None,
+        };
         match item {
             BranchBody::Process(stmt) => {
-                match exec_process_stmt(stmt, event, registry, funcs, scope, arena)? {
+                match exec_process_stmt(stmt, metric_stmt, event, registry, funcs, scope, arena)? {
                     ExecResult::Continue(e) => event = e,
                     ExecResult::Dropped => return Ok(ExecResult::Dropped),
                 }

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -147,6 +147,70 @@ impl PipelineMetrics {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct ProcessCounters {
+    incoming: Arc<registry_core::Counter>,
+    outgoing: Arc<registry_core::Counter>,
+    dropped: Arc<registry_core::Counter>,
+    errored: Arc<registry_core::Counter>,
+}
+
+impl ProcessCounters {
+    pub(crate) fn register(
+        registry: &Registry,
+        pipeline: &str,
+        step: usize,
+        process_path: &str,
+        process_name: &str,
+    ) -> Result<Self, MetricsError> {
+        let step = step.to_string();
+        let counter = |name, help| {
+            registry
+                .counter(name)
+                .label("pipeline", pipeline)
+                .label("step", &step)
+                .label("process_path", process_path)
+                .label("process_name", process_name)
+                .help(help)
+                .build()
+        };
+        Ok(Self {
+            incoming: counter(
+                "limpid_process_events_in_total",
+                "Total process invocation frames started.",
+            )?,
+            outgoing: counter(
+                "limpid_process_events_out_total",
+                "Total process invocation frames that continued successfully.",
+            )?,
+            dropped: counter(
+                "limpid_process_events_dropped_total",
+                "Total process invocation frames terminated by a drop.",
+            )?,
+            errored: counter(
+                "limpid_process_events_errored_total",
+                "Total process invocation frames terminated by an error.",
+            )?,
+        })
+    }
+
+    pub(crate) fn start(&self) {
+        self.incoming.inc();
+    }
+
+    pub(crate) fn continued(&self) {
+        self.outgoing.inc();
+    }
+
+    pub(crate) fn dropped(&self) {
+        self.dropped.inc();
+    }
+
+    pub(crate) fn errored(&self) {
+        self.errored.inc();
+    }
+}
+
 pub struct OutputMetrics {
     /// Total events that entered this output's queue (from pipelines + injects).
     /// `events_received - events_injected` = events delivered via pipelines.

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -508,19 +508,30 @@ impl PipelineProcessMetrics {
     }
 
     fn select_node(&self, token: usize) -> Option<&ProcessMetricNode> {
+        #[cfg(test)]
+        let armed = self
+            .selection_trap
+            .armed
+            .load(std::sync::atomic::Ordering::Relaxed);
+        #[cfg(test)]
+        if armed {
+            self.selection_trap
+                .total_attempts
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
         let node = self.nodes.get(token);
         #[cfg(test)]
-        if node.is_none()
-            && self
-                .selection_trap
-                .armed
-                .load(std::sync::atomic::Ordering::Relaxed)
-        {
+        if armed && node.is_none() {
             self.selection_trap
-                .attempts
+                .invalid_attempts
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         node
+    }
+
+    #[cfg(test)]
+    pub(crate) fn select_node_for_testing(&self, token: usize) -> bool {
+        self.select_node(token).is_some()
     }
 }
 
@@ -958,7 +969,8 @@ impl ProcessMetricPlanValidator<'_> {
 #[derive(Default)]
 struct MetricNodeSelectionTrapState {
     armed: std::sync::atomic::AtomicBool,
-    attempts: std::sync::atomic::AtomicUsize,
+    total_attempts: std::sync::atomic::AtomicUsize,
+    invalid_attempts: std::sync::atomic::AtomicUsize,
 }
 
 #[cfg(test)]
@@ -972,8 +984,16 @@ impl MetricNodeSelectionTrap {
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
-    pub(crate) fn metric_node_lookup_attempts_for_testing(&self) -> usize {
-        self.0.attempts.load(std::sync::atomic::Ordering::Relaxed)
+    pub(crate) fn total_token_selections_for_testing(&self) -> usize {
+        self.0
+            .total_attempts
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn invalid_token_selections_for_testing(&self) -> usize {
+        self.0
+            .invalid_attempts
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -14,15 +14,20 @@
 //! sends, DLQ persistence) keeps the same `OwnedEvent` shape it had
 //! before v0.6.0.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Result, bail};
 use tracing::trace;
 
 use crate::dsl::arena::EventArena;
 use crate::dsl::ast::*;
-use crate::dsl::eval::{eval_expr, select_if_branch, select_switch_arm, value_to_string};
-use crate::dsl::exec::{ExecResult, ProcessError, ProcessRegistry, exec_process_body};
+use crate::dsl::eval::{
+    eval_expr, select_if_branch_with_ordinal, select_switch_arm_with_ordinal, value_to_string,
+};
+use crate::dsl::exec::{
+    CompiledProcessRegistry, ExecResult, ProcessError, ProcessMetricStatement, ProcessRegistry,
+    exec_process_body, exec_process_body_with_metric_plan,
+};
 use crate::event::{BorrowedEvent, OwnedEvent};
 use crate::functions::FunctionRegistry;
 use crate::tap::TapRegistry;
@@ -418,6 +423,803 @@ pub struct PipelineRunResult {
     pub errored: Vec<ErroredEventContext>,
 }
 
+/// Pre-compiled metric plan for a pipeline's process invocations.
+/// The plan is validated once at startup, so event execution uses
+/// only O(1) token lookups. Validation rejects shape or identity
+/// mismatches before worker construction; defensive checked access
+/// returns an internal error instead of silently attributing an
+/// invocation to the wrong metric series.
+pub(crate) struct PipelineProcessMetrics {
+    nodes: Vec<ProcessMetricNode>,
+    statements: Vec<PipelineMetricStatement>,
+    #[cfg(test)]
+    selection_trap: std::sync::Arc<MetricNodeSelectionTrapState>,
+}
+
+struct ProcessMetricNode {
+    counters: crate::metrics::ProcessCounters,
+    body_plan: Vec<ProcessMetricStatement>,
+    #[cfg(test)]
+    call_sites: Vec<usize>,
+}
+
+pub(crate) struct RawPipelineProcessMetrics {
+    nodes: Vec<ProcessMetricNode>,
+    identities: Vec<ProcessMetricNodeIdentity>,
+    statements: Vec<PipelineMetricStatement>,
+    #[cfg(test)]
+    selection_trap: std::sync::Arc<MetricNodeSelectionTrapState>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ProcessMetricNodeIdentity {
+    parent: Option<usize>,
+    step: usize,
+    kind: ProcessMetricNodeKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ProcessMetricNodeKind {
+    Named(String),
+    Inline,
+}
+
+enum PipelineMetricStatement {
+    None,
+    ProcessChain(Vec<usize>),
+    If {
+        branches: Vec<Vec<PipelineMetricStatement>>,
+        else_body: Option<Vec<PipelineMetricStatement>>,
+    },
+    Switch(Vec<Vec<PipelineMetricStatement>>),
+}
+
+impl PipelineProcessMetrics {
+    pub(crate) fn register(
+        pipeline: &PipelineDef,
+        processes: &HashMap<String, ProcessDef>,
+        registry: &crate::metrics::Registry,
+    ) -> anyhow::Result<Self> {
+        Self::compile_raw(pipeline, processes, registry)?.validate(pipeline, processes)
+    }
+
+    pub(crate) fn compile_raw(
+        pipeline: &PipelineDef,
+        processes: &HashMap<String, ProcessDef>,
+        registry: &crate::metrics::Registry,
+    ) -> Result<RawPipelineProcessMetrics, crate::metrics::MetricsError> {
+        let mut builder = ProcessMetricsBuilder {
+            pipeline: &pipeline.name,
+            processes,
+            registry,
+            nodes: Vec::new(),
+            identities: Vec::new(),
+            children: Vec::new(),
+            next_step: 1,
+        };
+        let statements = builder.pipeline_body(&pipeline.body)?;
+        Ok(RawPipelineProcessMetrics {
+            nodes: builder.nodes,
+            identities: builder.identities,
+            statements,
+            #[cfg(test)]
+            selection_trap: std::sync::Arc::new(MetricNodeSelectionTrapState::default()),
+        })
+    }
+
+    fn select_node(&self, token: usize) -> Option<&ProcessMetricNode> {
+        let node = self.nodes.get(token);
+        #[cfg(test)]
+        if node.is_none()
+            && self
+                .selection_trap
+                .armed
+                .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            self.selection_trap
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        node
+    }
+}
+
+impl RawPipelineProcessMetrics {
+    pub(crate) fn validate(
+        self,
+        pipeline: &PipelineDef,
+        processes: &HashMap<String, ProcessDef>,
+    ) -> anyhow::Result<PipelineProcessMetrics> {
+        let mut validator = ProcessMetricPlanValidator {
+            raw: &self,
+            processes,
+            next_step: 1,
+            edges: HashMap::new(),
+            validated_nodes: HashSet::new(),
+        };
+        validator.pipeline_body(&pipeline.body, &self.statements)?;
+        if validator.validated_nodes.len() != self.nodes.len() {
+            anyhow::bail!("compiled process metric plan contains unreachable nodes");
+        }
+        Ok(PipelineProcessMetrics {
+            nodes: self.nodes,
+            statements: self.statements,
+            #[cfg(test)]
+            selection_trap: self.selection_trap,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn root_token_for_testing(&self, step: usize) -> Option<usize> {
+        self.identities
+            .iter()
+            .position(|identity| identity.parent.is_none() && identity.step == step)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn child_token_for_testing(&self, parent: usize, ordinal: usize) -> Option<usize> {
+        self.nodes.get(parent)?.call_sites.get(ordinal).copied()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn metric_node_selection_trap_for_testing(&self) -> MetricNodeSelectionTrap {
+        MetricNodeSelectionTrap(std::sync::Arc::clone(&self.selection_trap))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remove_root_plan_for_testing(&mut self) {
+        self.statements.clear();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replace_first_root_plan_with_none_for_testing(&mut self) {
+        if let Some(statement) = self.statements.first_mut() {
+            *statement = PipelineMetricStatement::None;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn invalidate_first_root_token_for_testing(&mut self) {
+        for statement in &mut self.statements {
+            if let PipelineMetricStatement::ProcessChain(tokens) = statement
+                && let Some(token) = tokens.first_mut()
+            {
+                *token = usize::MAX;
+                return;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn swap_first_two_root_tokens_for_testing(&mut self) {
+        for statement in &mut self.statements {
+            if let PipelineMetricStatement::ProcessChain(tokens) = statement
+                && tokens.len() >= 2
+            {
+                tokens.swap(0, 1);
+                return;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn invalidate_first_nested_token_for_testing(&mut self) {
+        for node in &mut self.nodes {
+            if let Some(ProcessMetricStatement::Call(token)) = node
+                .body_plan
+                .iter_mut()
+                .find(|statement| matches!(statement, ProcessMetricStatement::Call(_)))
+            {
+                *token = usize::MAX;
+                return;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn swap_first_two_nested_tokens_for_testing(&mut self) {
+        let positions: Vec<(usize, usize)> = self
+            .nodes
+            .iter()
+            .enumerate()
+            .flat_map(|(node_index, node)| {
+                node.body_plan
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, statement)| matches!(statement, ProcessMetricStatement::Call(_)))
+                    .map(move |(statement_index, _)| (node_index, statement_index))
+            })
+            .take(2)
+            .collect();
+        if let [(left_node, left_statement), (right_node, right_statement)] = positions.as_slice() {
+            let left = match self.nodes[*left_node].body_plan[*left_statement] {
+                ProcessMetricStatement::Call(token) => token,
+                _ => unreachable!(),
+            };
+            let right = match self.nodes[*right_node].body_plan[*right_statement] {
+                ProcessMetricStatement::Call(token) => token,
+                _ => unreachable!(),
+            };
+            self.nodes[*left_node].body_plan[*left_statement] = ProcessMetricStatement::Call(right);
+            self.nodes[*right_node].body_plan[*right_statement] =
+                ProcessMetricStatement::Call(left);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn invalidate_first_inline_token_for_testing(&mut self) {
+        for statement in &mut self.statements {
+            if let PipelineMetricStatement::ProcessChain(tokens) = statement
+                && let Some(token) = tokens.first_mut()
+            {
+                *token = usize::MAX;
+                return;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replace_first_process_body_plan_with_none_for_testing(&mut self) {
+        for node in &mut self.nodes {
+            if let Some(statement) = node
+                .body_plan
+                .iter_mut()
+                .find(|statement| matches!(statement, ProcessMetricStatement::Call(_)))
+            {
+                *statement = ProcessMetricStatement::None;
+                return;
+            }
+        }
+    }
+}
+
+struct ProcessMetricPlanValidator<'a> {
+    raw: &'a RawPipelineProcessMetrics,
+    processes: &'a HashMap<String, ProcessDef>,
+    next_step: usize,
+    edges: HashMap<(usize, String), usize>,
+    validated_nodes: HashSet<usize>,
+}
+
+impl ProcessMetricPlanValidator<'_> {
+    fn pipeline_body(
+        &mut self,
+        statements: &[PipelineStatement],
+        plan: &[PipelineMetricStatement],
+    ) -> anyhow::Result<()> {
+        if statements.len() != plan.len() {
+            anyhow::bail!("compiled pipeline metric plan length mismatch");
+        }
+        for (statement, metric) in statements.iter().zip(plan) {
+            self.pipeline_statement(statement, metric)?;
+        }
+        Ok(())
+    }
+
+    fn pipeline_branch(
+        &mut self,
+        body: &[BranchBody],
+        plan: &[PipelineMetricStatement],
+    ) -> anyhow::Result<()> {
+        if body.len() != plan.len() {
+            anyhow::bail!("compiled pipeline branch metric plan length mismatch");
+        }
+        for (item, metric) in body.iter().zip(plan) {
+            let BranchBody::Pipeline(statement) = item else {
+                anyhow::bail!("process statement found in pipeline metric plan");
+            };
+            self.pipeline_statement(statement, metric)?;
+        }
+        Ok(())
+    }
+
+    fn pipeline_statement(
+        &mut self,
+        statement: &PipelineStatement,
+        metric: &PipelineMetricStatement,
+    ) -> anyhow::Result<()> {
+        match (statement, metric) {
+            (
+                PipelineStatement::ProcessChain(chain),
+                PipelineMetricStatement::ProcessChain(tokens),
+            ) => {
+                if chain.len() != tokens.len() {
+                    anyhow::bail!("compiled root process token count mismatch");
+                }
+                for (site, token) in chain.iter().zip(tokens) {
+                    let step = self.next_step;
+                    self.next_step += 1;
+                    let expected_kind = match site {
+                        ProcessChainElement::Named(name) => {
+                            ProcessMetricNodeKind::Named(name.clone())
+                        }
+                        ProcessChainElement::Inline(_) => ProcessMetricNodeKind::Inline,
+                    };
+                    let identity = self.raw.identities.get(*token).ok_or_else(|| {
+                        anyhow::anyhow!("compiled root process token is out of range")
+                    })?;
+                    if identity.parent.is_some()
+                        || identity.step != step
+                        || identity.kind != expected_kind
+                    {
+                        anyhow::bail!("compiled root process token identity mismatch");
+                    }
+                    match site {
+                        ProcessChainElement::Named(name) => {
+                            let body = self
+                                .processes
+                                .get(name)
+                                .map(|process| process.body.as_slice())
+                                .unwrap_or_default();
+                            self.process_body(*token, body, &mut vec![(name.clone(), *token)])?;
+                        }
+                        ProcessChainElement::Inline(body) => {
+                            self.process_body(*token, body, &mut Vec::new())?;
+                        }
+                    }
+                }
+            }
+            (
+                PipelineStatement::If(chain),
+                PipelineMetricStatement::If {
+                    branches,
+                    else_body,
+                },
+            ) => {
+                if chain.branches.len() != branches.len()
+                    || chain.else_body.is_some() != else_body.is_some()
+                {
+                    anyhow::bail!("compiled pipeline if metric plan shape mismatch");
+                }
+                for ((_, body), branch_plan) in chain.branches.iter().zip(branches) {
+                    self.pipeline_branch(body, branch_plan)?;
+                }
+                if let (Some(body), Some(branch_plan)) =
+                    (chain.else_body.as_deref(), else_body.as_deref())
+                {
+                    self.pipeline_branch(body, branch_plan)?;
+                }
+            }
+            (PipelineStatement::Switch(_, arms), PipelineMetricStatement::Switch(metric_arms)) => {
+                if arms.len() != metric_arms.len() {
+                    anyhow::bail!("compiled pipeline switch metric plan shape mismatch");
+                }
+                for (arm, arm_plan) in arms.iter().zip(metric_arms) {
+                    self.pipeline_branch(&arm.body, arm_plan)?;
+                }
+            }
+            (
+                PipelineStatement::Input(_)
+                | PipelineStatement::Output(_)
+                | PipelineStatement::Drop
+                | PipelineStatement::Finish
+                | PipelineStatement::Error(_),
+                PipelineMetricStatement::None,
+            ) => {}
+            _ => anyhow::bail!("compiled pipeline metric statement variant mismatch"),
+        }
+        Ok(())
+    }
+
+    fn process_body(
+        &mut self,
+        parent: usize,
+        statements: &[ProcessStatement],
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> anyhow::Result<()> {
+        if !self.validated_nodes.insert(parent) {
+            return Ok(());
+        }
+        let plan = &self
+            .raw
+            .nodes
+            .get(parent)
+            .ok_or_else(|| anyhow::anyhow!("compiled process node is out of range"))?
+            .body_plan;
+        self.process_statements(parent, statements, plan, ancestors)
+    }
+
+    fn process_statements(
+        &mut self,
+        parent: usize,
+        statements: &[ProcessStatement],
+        plan: &[ProcessMetricStatement],
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> anyhow::Result<()> {
+        if statements.len() != plan.len() {
+            anyhow::bail!("compiled process metric plan length mismatch");
+        }
+        for (statement, metric) in statements.iter().zip(plan) {
+            self.process_statement(parent, statement, metric, ancestors)?;
+        }
+        Ok(())
+    }
+
+    fn process_branch(
+        &mut self,
+        parent: usize,
+        body: &[BranchBody],
+        plan: &[ProcessMetricStatement],
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> anyhow::Result<()> {
+        if body.len() != plan.len() {
+            anyhow::bail!("compiled process branch metric plan length mismatch");
+        }
+        for (item, metric) in body.iter().zip(plan) {
+            let BranchBody::Process(statement) = item else {
+                anyhow::bail!("pipeline statement found in process metric plan");
+            };
+            self.process_statement(parent, statement, metric, ancestors)?;
+        }
+        Ok(())
+    }
+
+    fn process_statement(
+        &mut self,
+        parent: usize,
+        statement: &ProcessStatement,
+        metric: &ProcessMetricStatement,
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> anyhow::Result<()> {
+        match (statement, metric) {
+            (ProcessStatement::ProcessCall(name), ProcessMetricStatement::Call(token)) => {
+                let expected = if let Some((_, ancestor)) = ancestors
+                    .iter()
+                    .rev()
+                    .find(|(ancestor, _)| ancestor == name)
+                {
+                    *ancestor
+                } else if let Some(existing) = self.edges.get(&(parent, name.clone())) {
+                    *existing
+                } else {
+                    let identity = self.raw.identities.get(*token).ok_or_else(|| {
+                        anyhow::anyhow!("compiled nested process token is out of range")
+                    })?;
+                    let parent_identity = self.raw.identities.get(parent).ok_or_else(|| {
+                        anyhow::anyhow!("compiled parent process token is out of range")
+                    })?;
+                    if identity.parent != Some(parent)
+                        || identity.step != parent_identity.step
+                        || identity.kind != ProcessMetricNodeKind::Named(name.clone())
+                    {
+                        anyhow::bail!("compiled nested process token identity mismatch");
+                    }
+                    self.edges.insert((parent, name.clone()), *token);
+                    *token
+                };
+                if *token != expected {
+                    anyhow::bail!("compiled process call-site token identity mismatch");
+                }
+                if !self.validated_nodes.contains(token) {
+                    let body = self
+                        .processes
+                        .get(name)
+                        .map(|process| process.body.as_slice())
+                        .unwrap_or_default();
+                    ancestors.push((name.clone(), *token));
+                    self.process_body(*token, body, ancestors)?;
+                    ancestors.pop();
+                }
+            }
+            (
+                ProcessStatement::If(chain),
+                ProcessMetricStatement::If {
+                    branches,
+                    else_body,
+                },
+            ) => {
+                if chain.branches.len() != branches.len()
+                    || chain.else_body.is_some() != else_body.is_some()
+                {
+                    anyhow::bail!("compiled process if metric plan shape mismatch");
+                }
+                for ((_, body), branch_plan) in chain.branches.iter().zip(branches) {
+                    self.process_branch(parent, body, branch_plan, ancestors)?;
+                }
+                if let (Some(body), Some(branch_plan)) =
+                    (chain.else_body.as_deref(), else_body.as_deref())
+                {
+                    self.process_branch(parent, body, branch_plan, ancestors)?;
+                }
+            }
+            (ProcessStatement::Switch(_, arms), ProcessMetricStatement::Switch(metric_arms)) => {
+                if arms.len() != metric_arms.len() {
+                    anyhow::bail!("compiled process switch metric plan shape mismatch");
+                }
+                for (arm, arm_plan) in arms.iter().zip(metric_arms) {
+                    self.process_branch(parent, &arm.body, arm_plan, ancestors)?;
+                }
+            }
+            (
+                ProcessStatement::TryCatch(try_body, catch_body),
+                ProcessMetricStatement::TryCatch {
+                    try_body: try_plan,
+                    catch_body: catch_plan,
+                },
+            ) => {
+                self.process_statements(parent, try_body, try_plan, ancestors)?;
+                self.process_statements(parent, catch_body, catch_plan, ancestors)?;
+            }
+            (
+                ProcessStatement::Assign(_, _)
+                | ProcessStatement::LetBinding(_, _)
+                | ProcessStatement::Drop
+                | ProcessStatement::Error(_)
+                | ProcessStatement::ExprStmt(_),
+                ProcessMetricStatement::None,
+            ) => {}
+            _ => anyhow::bail!("compiled process metric statement variant mismatch"),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct MetricNodeSelectionTrapState {
+    armed: std::sync::atomic::AtomicBool,
+    attempts: std::sync::atomic::AtomicUsize,
+}
+
+#[cfg(test)]
+pub(crate) struct MetricNodeSelectionTrap(std::sync::Arc<MetricNodeSelectionTrapState>);
+
+#[cfg(test)]
+impl MetricNodeSelectionTrap {
+    pub(crate) fn arm_for_testing(&self) {
+        self.0
+            .armed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn metric_node_lookup_attempts_for_testing(&self) -> usize {
+        self.0.attempts.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+struct ProcessMetricsBuilder<'a> {
+    pipeline: &'a str,
+    processes: &'a HashMap<String, ProcessDef>,
+    registry: &'a crate::metrics::Registry,
+    nodes: Vec<ProcessMetricNode>,
+    identities: Vec<ProcessMetricNodeIdentity>,
+    children: Vec<HashMap<String, usize>>,
+    next_step: usize,
+}
+
+impl ProcessMetricsBuilder<'_> {
+    fn pipeline_body(
+        &mut self,
+        body: &[PipelineStatement],
+    ) -> Result<Vec<PipelineMetricStatement>, crate::metrics::MetricsError> {
+        body.iter()
+            .map(|statement| self.pipeline_statement(statement))
+            .collect()
+    }
+
+    fn pipeline_branch(
+        &mut self,
+        body: &[BranchBody],
+    ) -> Result<Vec<PipelineMetricStatement>, crate::metrics::MetricsError> {
+        body.iter()
+            .map(|item| match item {
+                BranchBody::Pipeline(statement) => self.pipeline_statement(statement),
+                BranchBody::Process(_) => Ok(PipelineMetricStatement::None),
+            })
+            .collect()
+    }
+
+    fn pipeline_statement(
+        &mut self,
+        statement: &PipelineStatement,
+    ) -> Result<PipelineMetricStatement, crate::metrics::MetricsError> {
+        match statement {
+            PipelineStatement::ProcessChain(chain) => {
+                let mut nodes = Vec::with_capacity(chain.len());
+                for element in chain {
+                    let step = self.next_step;
+                    self.next_step += 1;
+                    let (name, kind, body) = match element {
+                        ProcessChainElement::Named(name) => (
+                            name.as_str(),
+                            ProcessMetricNodeKind::Named(name.clone()),
+                            self.processes
+                                .get(name)
+                                .map(|process| process.body.as_slice()),
+                        ),
+                        ProcessChainElement::Inline(body) => (
+                            "(inline)",
+                            ProcessMetricNodeKind::Inline,
+                            Some(body.as_slice()),
+                        ),
+                    };
+                    nodes.push(self.add_node(
+                        ProcessMetricNodeIdentity {
+                            parent: None,
+                            step,
+                            kind,
+                        },
+                        name,
+                        format!("/{name}"),
+                        body,
+                        &mut Vec::new(),
+                    )?);
+                }
+                Ok(PipelineMetricStatement::ProcessChain(nodes))
+            }
+            PipelineStatement::If(chain) => {
+                let branches = chain
+                    .branches
+                    .iter()
+                    .map(|(_, body)| self.pipeline_branch(body))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let else_body = chain
+                    .else_body
+                    .as_deref()
+                    .map(|body| self.pipeline_branch(body))
+                    .transpose()?;
+                Ok(PipelineMetricStatement::If {
+                    branches,
+                    else_body,
+                })
+            }
+            PipelineStatement::Switch(_, arms) => Ok(PipelineMetricStatement::Switch(
+                arms.iter()
+                    .map(|arm| self.pipeline_branch(&arm.body))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            _ => Ok(PipelineMetricStatement::None),
+        }
+    }
+
+    fn add_node(
+        &mut self,
+        identity: ProcessMetricNodeIdentity,
+        name: &str,
+        path: String,
+        body: Option<&[ProcessStatement]>,
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> Result<usize, crate::metrics::MetricsError> {
+        let id = self.nodes.len();
+        let step = identity.step;
+        self.nodes.push(ProcessMetricNode {
+            counters: crate::metrics::ProcessCounters::register(
+                self.registry,
+                self.pipeline,
+                step,
+                &path,
+                name,
+            )?,
+            body_plan: Vec::new(),
+            #[cfg(test)]
+            call_sites: Vec::new(),
+        });
+        self.identities.push(identity);
+        self.children.push(HashMap::new());
+        ancestors.push((name.to_owned(), id));
+        if let Some(body) = body {
+            self.nodes[id].body_plan = self.process_body(id, &path, step, body, ancestors)?;
+        }
+        ancestors.pop();
+        Ok(id)
+    }
+
+    fn process_body(
+        &mut self,
+        parent: usize,
+        parent_path: &str,
+        step: usize,
+        body: &[ProcessStatement],
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> Result<Vec<ProcessMetricStatement>, crate::metrics::MetricsError> {
+        body.iter()
+            .map(|statement| {
+                self.process_statement(parent, parent_path, step, statement, ancestors)
+            })
+            .collect()
+    }
+
+    fn process_statement(
+        &mut self,
+        parent: usize,
+        parent_path: &str,
+        step: usize,
+        statement: &ProcessStatement,
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> Result<ProcessMetricStatement, crate::metrics::MetricsError> {
+        match statement {
+            ProcessStatement::ProcessCall(name) => {
+                let child = if let Some(child) = self.children[parent].get(name) {
+                    *child
+                } else if let Some((_, ancestor)) = ancestors
+                    .iter()
+                    .rev()
+                    .find(|(ancestor, _)| ancestor == name)
+                {
+                    let child = *ancestor;
+                    self.children[parent].insert(name.clone(), child);
+                    child
+                } else {
+                    let body = self
+                        .processes
+                        .get(name)
+                        .map(|process| process.body.as_slice());
+                    let child = self.add_node(
+                        ProcessMetricNodeIdentity {
+                            parent: Some(parent),
+                            step,
+                            kind: ProcessMetricNodeKind::Named(name.clone()),
+                        },
+                        name,
+                        format!("{parent_path}/{name}"),
+                        body,
+                        ancestors,
+                    )?;
+                    self.children[parent].insert(name.clone(), child);
+                    child
+                };
+                #[cfg(test)]
+                self.nodes[parent].call_sites.push(child);
+                Ok(ProcessMetricStatement::Call(child))
+            }
+            ProcessStatement::If(chain) => {
+                let branches = chain
+                    .branches
+                    .iter()
+                    .map(|(_, body)| {
+                        self.process_branch(parent, parent_path, step, body, ancestors)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let else_body = chain
+                    .else_body
+                    .as_deref()
+                    .map(|body| self.process_branch(parent, parent_path, step, body, ancestors))
+                    .transpose()?;
+                Ok(ProcessMetricStatement::If {
+                    branches,
+                    else_body,
+                })
+            }
+            ProcessStatement::Switch(_, arms) => Ok(ProcessMetricStatement::Switch(
+                arms.iter()
+                    .map(|arm| self.process_branch(parent, parent_path, step, &arm.body, ancestors))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            ProcessStatement::TryCatch(try_body, catch_body) => {
+                Ok(ProcessMetricStatement::TryCatch {
+                    try_body: self.process_body(parent, parent_path, step, try_body, ancestors)?,
+                    catch_body: self.process_body(
+                        parent,
+                        parent_path,
+                        step,
+                        catch_body,
+                        ancestors,
+                    )?,
+                })
+            }
+            _ => Ok(ProcessMetricStatement::None),
+        }
+    }
+
+    fn process_branch(
+        &mut self,
+        parent: usize,
+        parent_path: &str,
+        step: usize,
+        body: &[BranchBody],
+        ancestors: &mut Vec<(String, usize)>,
+    ) -> Result<Vec<ProcessMetricStatement>, crate::metrics::MetricsError> {
+        body.iter()
+            .map(|item| match item {
+                BranchBody::Process(statement) => {
+                    self.process_statement(parent, parent_path, step, statement, ancestors)
+                }
+                BranchBody::Pipeline(_) => Ok(ProcessMetricStatement::None),
+            })
+            .collect()
+    }
+}
+
 /// A process registry backed by compiled DSL process definitions.
 ///
 /// Only user-defined `def process { ... }` blocks resolve here.
@@ -428,6 +1230,7 @@ struct DslProcessRegistry<'a> {
     processes: &'a HashMap<String, ProcessDef>,
     funcs: &'a FunctionRegistry,
     tap: Option<&'a TapRegistry>,
+    process_metrics: Option<&'a PipelineProcessMetrics>,
 }
 
 impl<'a> DslProcessRegistry<'a> {
@@ -435,11 +1238,82 @@ impl<'a> DslProcessRegistry<'a> {
         processes: &'a HashMap<String, ProcessDef>,
         funcs: &'a FunctionRegistry,
         tap: Option<&'a TapRegistry>,
+        process_metrics: Option<&'a PipelineProcessMetrics>,
     ) -> Self {
         Self {
             processes,
             funcs,
             tap,
+            process_metrics,
+        }
+    }
+
+    fn call_node<'bump>(
+        &self,
+        metric_token: Option<usize>,
+        name: &str,
+        event: BorrowedEvent<'bump>,
+        arena: &'bump EventArena<'bump>,
+    ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError> {
+        let metric_node = match (self.process_metrics, metric_token) {
+            (Some(metrics), Some(token)) => Some(metrics.select_node(token).ok_or_else(|| {
+                ProcessError::Failed("compiled process metric token is out of range".to_owned())
+            })?),
+            (Some(_), None) => {
+                return Err(ProcessError::Failed(
+                    "compiled process metric token is missing".to_owned(),
+                ));
+            }
+            (None, _) => None,
+        };
+        if let Some(node) = metric_node {
+            node.counters.start();
+        }
+
+        let result = if let Some(process_def) = self.processes.get(name) {
+            trace!("process '{}' (user-defined): executing", name);
+            match metric_node {
+                Some(node) => exec_process_body_with_metric_plan(
+                    &process_def.body,
+                    &node.body_plan,
+                    event,
+                    self,
+                    self.funcs,
+                    arena,
+                ),
+                None => exec_process_body(&process_def.body, event, self, self.funcs, arena),
+            }
+            .map_err(|error| ProcessError::Failed(error.to_string()))
+        } else {
+            tracing::warn!(
+                "unknown process '{}', passing event through unchanged",
+                name
+            );
+            Ok(ExecResult::Continue(event))
+        };
+
+        match result {
+            Ok(ExecResult::Continue(event)) => {
+                if let Some(node) = metric_node {
+                    node.counters.continued();
+                }
+                trace!("process '{}': ok", name);
+                self.emit_tap(name, &event);
+                Ok(Some(event))
+            }
+            Ok(ExecResult::Dropped) => {
+                if let Some(node) = metric_node {
+                    node.counters.dropped();
+                }
+                trace!("process '{}': dropped", name);
+                Ok(None)
+            }
+            Err(error) => {
+                if let Some(node) = metric_node {
+                    node.counters.errored();
+                }
+                Err(error)
+            }
         }
     }
 }
@@ -451,30 +1325,19 @@ impl ProcessRegistry for DslProcessRegistry<'_> {
         event: BorrowedEvent<'bump>,
         arena: &'bump EventArena<'bump>,
     ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError> {
-        if let Some(process_def) = self.processes.get(name) {
-            trace!("process '{}' (user-defined): executing", name);
-            return match exec_process_body(&process_def.body, event, self, self.funcs, arena) {
-                Ok(ExecResult::Continue(e)) => {
-                    trace!("process '{}': ok", name);
-                    self.emit_tap(name, &e);
-                    Ok(Some(e))
-                }
-                Ok(ExecResult::Dropped) => {
-                    trace!("process '{}': dropped", name);
-                    Ok(None)
-                }
-                Err(e) => Err(ProcessError::Failed(e.to_string())),
-            };
-        }
+        self.call_node(None, name, event, arena)
+    }
+}
 
-        // Unknown process — warn and pass through. Config validation in
-        // `CompiledConfig::validate` catches this up front; this branch
-        // is a safety net for paths that skip validation.
-        tracing::warn!(
-            "unknown process '{}', passing event through unchanged",
-            name
-        );
-        Ok(Some(event))
+impl CompiledProcessRegistry for DslProcessRegistry<'_> {
+    fn call_pre_resolved<'bump>(
+        &self,
+        name: &str,
+        metric_token: usize,
+        event: BorrowedEvent<'bump>,
+        arena: &'bump EventArena<'bump>,
+    ) -> std::result::Result<Option<BorrowedEvent<'bump>>, ProcessError> {
+        self.call_node(Some(metric_token), name, event, arena)
     }
 }
 
@@ -521,7 +1384,57 @@ pub fn run_pipeline(
     output_capture: OutputCapturePolicy<'_>,
     bump: &mut bumpalo::Bump,
 ) -> Result<PipelineRunResult> {
-    let registry = DslProcessRegistry::new(&config.processes, funcs, tap);
+    run_pipeline_inner(
+        pipeline,
+        event,
+        config,
+        funcs,
+        tap,
+        trace,
+        output_capture,
+        bump,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_pipeline_with_process_metrics(
+    pipeline: &PipelineDef,
+    event: &OwnedEvent,
+    config: &CompiledConfig,
+    funcs: &FunctionRegistry,
+    tap: Option<&TapRegistry>,
+    trace: Option<&mut Vec<TraceEntry>>,
+    output_capture: OutputCapturePolicy<'_>,
+    bump: &mut bumpalo::Bump,
+    process_metrics: &PipelineProcessMetrics,
+) -> Result<PipelineRunResult> {
+    run_pipeline_inner(
+        pipeline,
+        event,
+        config,
+        funcs,
+        tap,
+        trace,
+        output_capture,
+        bump,
+        Some(process_metrics),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_pipeline_inner(
+    pipeline: &PipelineDef,
+    event: &OwnedEvent,
+    config: &CompiledConfig,
+    funcs: &FunctionRegistry,
+    tap: Option<&TapRegistry>,
+    trace: Option<&mut Vec<TraceEntry>>,
+    output_capture: OutputCapturePolicy<'_>,
+    bump: &mut bumpalo::Bump,
+    process_metrics: Option<&PipelineProcessMetrics>,
+) -> Result<PipelineRunResult> {
+    let registry = DslProcessRegistry::new(&config.processes, funcs, tap, process_metrics);
     let mut trace = trace;
     let mut outputs = Vec::new();
 
@@ -565,7 +1478,13 @@ pub fn run_pipeline(
         outputs: &mut outputs,
         errored: &mut errored,
     };
-    let (_, termination) = exec_pipeline_body(&pipeline.body, bevent, &exec_ctx, &mut exec_out)?;
+    let (_, termination) = exec_pipeline_body(
+        &pipeline.body,
+        process_metrics.map(|metrics| metrics.statements.as_slice()),
+        bevent,
+        &exec_ctx,
+        &mut exec_out,
+    )?;
 
     let had_outputs = !outputs.is_empty();
     Ok(PipelineRunResult {
@@ -690,12 +1609,28 @@ impl PipelineExecOut<'_> {
 /// Returns (remaining event if any, how the pipeline terminated).
 fn exec_pipeline_body<'bump>(
     stmts: &[PipelineStatement],
+    metric_stmts: Option<&[PipelineMetricStatement]>,
     mut event: BorrowedEvent<'bump>,
     ctx: &PipelineExecCtx<'_, 'bump>,
     out: &mut PipelineExecOut<'_>,
 ) -> Result<(Option<BorrowedEvent<'bump>>, PipelineTermination)> {
-    for stmt in stmts {
-        match exec_pipeline_stmt(stmt, event, ctx, out)? {
+    if ctx.registry.process_metrics.is_some() {
+        let metric_stmts = metric_stmts
+            .ok_or_else(|| anyhow::anyhow!("compiled pipeline metric plan is missing"))?;
+        if metric_stmts.len() != stmts.len() {
+            bail!("compiled pipeline metric plan length does not match the pipeline body");
+        }
+    }
+    for (index, stmt) in stmts.iter().enumerate() {
+        let metric_stmt = match ctx.registry.process_metrics {
+            Some(_) => Some(
+                metric_stmts
+                    .and_then(|metrics| metrics.get(index))
+                    .ok_or_else(|| anyhow::anyhow!("compiled pipeline metric entry is missing"))?,
+            ),
+            None => None,
+        };
+        match exec_pipeline_stmt(stmt, metric_stmt, event, ctx, out)? {
             (Some(e), _) => event = e,
             (None, term) => return Ok((None, term)),
         }
@@ -705,6 +1640,7 @@ fn exec_pipeline_body<'bump>(
 
 fn exec_pipeline_stmt<'bump>(
     stmt: &PipelineStatement,
+    metric_stmt: Option<&PipelineMetricStatement>,
     event: BorrowedEvent<'bump>,
     ctx: &PipelineExecCtx<'_, 'bump>,
     out: &mut PipelineExecOut<'_>,
@@ -749,7 +1685,12 @@ fn exec_pipeline_stmt<'bump>(
 
         PipelineStatement::ProcessChain(chain) => {
             let mut current = event;
-            for element in chain {
+            let metric_nodes = match metric_stmt {
+                Some(PipelineMetricStatement::ProcessChain(nodes)) => Some(nodes.as_slice()),
+                _ => None,
+            };
+            for (index, element) in chain.iter().enumerate() {
+                let metric_token = metric_nodes.and_then(|nodes| nodes.get(index)).copied();
                 match element {
                     ProcessChainElement::Named(name) => {
                         // Snapshot the pre-call view before the registry
@@ -771,7 +1712,17 @@ fn exec_pipeline_stmt<'bump>(
                         // Err arm below, where the DLQ record's owned
                         // event has to cross the arena boundary anyway.
                         let backup_view = current.snapshot_in(ctx.arena);
-                        match ctx.registry.call(name, current, ctx.arena) {
+                        let call_result = match ctx.registry.process_metrics {
+                            Some(_) => {
+                                let token = metric_token.ok_or_else(|| {
+                                    anyhow::anyhow!("compiled root process token is missing")
+                                })?;
+                                ctx.registry
+                                    .call_pre_resolved(name, token, current, ctx.arena)
+                            }
+                            None => ctx.registry.call(name, current, ctx.arena),
+                        };
+                        match call_result {
                             Ok(Some(e)) => {
                                 out.push_trace(|| TraceEntry {
                                     stage: "process".into(),
@@ -819,8 +1770,38 @@ fn exec_pipeline_stmt<'bump>(
                         // shallow snapshot for the DLQ Err path; the
                         // heap materialization happens only on failure.
                         let backup_view = current.snapshot_in(ctx.arena);
-                        match exec_process_body(body, current, ctx.registry, ctx.funcs, ctx.arena) {
+                        let metric_node = match ctx.registry.process_metrics {
+                            Some(metrics) => {
+                                let token = metric_token.ok_or_else(|| {
+                                    anyhow::anyhow!("compiled inline process token is missing")
+                                })?;
+                                Some(metrics.select_node(token).ok_or_else(|| {
+                                    anyhow::anyhow!("compiled inline process token is out of range")
+                                })?)
+                            }
+                            None => None,
+                        };
+                        if let Some(node) = metric_node {
+                            node.counters.start();
+                        }
+                        let result = match metric_node {
+                            Some(node) => exec_process_body_with_metric_plan(
+                                body,
+                                &node.body_plan,
+                                current,
+                                ctx.registry,
+                                ctx.funcs,
+                                ctx.arena,
+                            ),
+                            None => {
+                                exec_process_body(body, current, ctx.registry, ctx.funcs, ctx.arena)
+                            }
+                        };
+                        match result {
                             Ok(ExecResult::Continue(e)) => {
+                                if let Some(node) = metric_node {
+                                    node.counters.continued();
+                                }
                                 out.push_trace(|| TraceEntry {
                                     stage: "process".into(),
                                     label: "(inline)".into(),
@@ -829,6 +1810,9 @@ fn exec_pipeline_stmt<'bump>(
                                 current = e;
                             }
                             Ok(ExecResult::Dropped) => {
+                                if let Some(node) = metric_node {
+                                    node.counters.dropped();
+                                }
                                 out.push_trace(|| TraceEntry {
                                     stage: "process".into(),
                                     label: "(inline)".into(),
@@ -837,6 +1821,9 @@ fn exec_pipeline_stmt<'bump>(
                                 return dropped();
                             }
                             Err(e) => {
+                                if let Some(node) = metric_node {
+                                    node.counters.errored();
+                                }
                                 tracing::warn!("inline process: {} — event routed to error_log", e);
                                 out.push_trace(|| TraceEntry {
                                     stage: "process".into(),
@@ -920,18 +1907,40 @@ fn exec_pipeline_stmt<'bump>(
         }
 
         PipelineStatement::If(if_chain) => {
-            match select_if_branch(if_chain, |c| eval_expr(c, &event, ctx.funcs, ctx.arena))? {
-                Some(body) => exec_pipeline_branch_body(body, event, ctx, out),
+            match select_if_branch_with_ordinal(if_chain, |c| {
+                eval_expr(c, &event, ctx.funcs, ctx.arena)
+            })? {
+                Some(selection) => {
+                    let metric_body = match metric_stmt {
+                        Some(PipelineMetricStatement::If {
+                            branches,
+                            else_body,
+                        }) => match selection.ordinal {
+                            Some(ordinal) => branches.get(ordinal).map(Vec::as_slice),
+                            None => else_body.as_deref(),
+                        },
+                        _ => None,
+                    };
+                    exec_pipeline_branch_body(selection.body, metric_body, event, ctx, out)
+                }
                 None => cont(event),
             }
         }
 
         PipelineStatement::Switch(discriminant, arms) => {
             let disc_val = eval_expr(discriminant, &event, ctx.funcs, ctx.arena)?;
-            match select_switch_arm(&disc_val, arms, |e| {
+            match select_switch_arm_with_ordinal(&disc_val, arms, |e| {
                 eval_expr(e, &event, ctx.funcs, ctx.arena)
             })? {
-                Some(body) => exec_pipeline_branch_body(body, event, ctx, out),
+                Some((ordinal, body)) => {
+                    let metric_body = match metric_stmt {
+                        Some(PipelineMetricStatement::Switch(metrics)) => {
+                            metrics.get(ordinal).map(Vec::as_slice)
+                        }
+                        _ => None,
+                    };
+                    exec_pipeline_branch_body(body, metric_body, event, ctx, out)
+                }
                 None => cont(event),
             }
         }
@@ -940,16 +1949,34 @@ fn exec_pipeline_stmt<'bump>(
 
 fn exec_pipeline_branch_body<'bump>(
     body: &[BranchBody],
+    metric_body: Option<&[PipelineMetricStatement]>,
     mut event: BorrowedEvent<'bump>,
     ctx: &PipelineExecCtx<'_, 'bump>,
     out: &mut PipelineExecOut<'_>,
 ) -> Result<(Option<BorrowedEvent<'bump>>, PipelineTermination)> {
-    for item in body {
+    if ctx.registry.process_metrics.is_some() {
+        let metric_body = metric_body
+            .ok_or_else(|| anyhow::anyhow!("compiled pipeline branch plan is missing"))?;
+        if metric_body.len() != body.len() {
+            bail!("compiled pipeline branch plan length does not match the selected body");
+        }
+    }
+    for (index, item) in body.iter().enumerate() {
+        let metric_stmt = match ctx.registry.process_metrics {
+            Some(_) => Some(
+                metric_body
+                    .and_then(|metrics| metrics.get(index))
+                    .ok_or_else(|| anyhow::anyhow!("compiled pipeline branch entry is missing"))?,
+            ),
+            None => None,
+        };
         match item {
-            BranchBody::Pipeline(stmt) => match exec_pipeline_stmt(stmt, event, ctx, out)? {
-                (Some(e), _) => event = e,
-                (None, term) => return Ok((None, term)),
-            },
+            BranchBody::Pipeline(stmt) => {
+                match exec_pipeline_stmt(stmt, metric_stmt, event, ctx, out)? {
+                    (Some(e), _) => event = e,
+                    (None, term) => return Ok((None, term)),
+                }
+            }
             BranchBody::Process(_) => {
                 bail!("process statement found in pipeline context")
             }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -1233,9 +1233,9 @@ def pipeline execute { process dispatch; finish }
             &execution_registry,
         )
         .expect("compile executable process metric plan");
-        // This trap is owned by the metric-node selection seam used by execution,
-        // rather than by the test facade. Arming it after compilation permits the
-        // definition registry lookup but rejects per-event metric-node lookup.
+        // This probe is owned by the metric-node selection seam used by execution,
+        // rather than by the test facade. Arming it after compilation measures the
+        // exact token-selection path without counting definition-registry lookups.
         let selection_trap = execution_plan.metric_node_selection_trap_for_testing();
         let worker = Arc::new(
             PipelineWorker::new_with_compiled_process_metrics_for_testing(
@@ -1264,9 +1264,14 @@ def pipeline execute { process dispatch; finish }
         )
         .await;
         assert_eq!(
-            selection_trap.metric_node_lookup_attempts_for_testing(),
+            selection_trap.total_token_selections_for_testing(),
+            3,
+            "dispatch once plus leaf twice must perform three token selections"
+        );
+        assert_eq!(
+            selection_trap.invalid_token_selections_for_testing(),
             0,
-            "execution must select pre-resolved metric frames by call-site token"
+            "compiled token selection must not access an invalid node"
         );
         assert_process_vector(
             &execution_registry,
@@ -1289,6 +1294,40 @@ def pipeline execute { process dispatch; finish }
             [2, 2, 0, 0],
         );
         assert_process_conservation(&execution_registry);
+    }
+
+    #[test]
+    fn process_metric_selection_probe_separates_total_and_invalid_tokens() {
+        let config = compiled_config(
+            "def process pass { egress = ingress } def pipeline p { process pass }",
+        );
+        let registry = Registry::new();
+        let def = config.pipelines.get("p").expect("pipeline").clone();
+        let plan = PipelineWorker::compile_process_metric_plan_for_testing(
+            &def,
+            &config.processes,
+            &registry,
+        )
+        .expect("compile process metric plan");
+        let probe = plan.metric_node_selection_trap_for_testing();
+        let worker = PipelineWorker::new_with_compiled_process_metrics_for_testing(
+            def,
+            &config.processes,
+            plan,
+        )
+        .expect("construct worker");
+        probe.arm_for_testing();
+
+        assert!(
+            !worker
+                .process_metrics
+                .as_ref()
+                .expect("process metrics")
+                .select_node_for_testing(usize::MAX),
+            "out-of-range token must not resolve"
+        );
+        assert_eq!(probe.total_token_selections_for_testing(), 1);
+        assert_eq!(probe.invalid_token_selections_for_testing(), 1);
     }
 
     async fn run_compiled_process_metric_fixture(
@@ -1359,6 +1398,8 @@ def pipeline execute { process dispatch; finish }
         )
         .expect("compile raw process metric plan");
         mutate(plan.process_metrics_mut_for_testing());
+        let selection_probe = plan.metric_node_selection_trap_for_testing();
+        selection_probe.arm_for_testing();
         assert!(
             PipelineWorker::new_with_compiled_process_metrics_for_testing(
                 def,
@@ -1368,6 +1409,8 @@ def pipeline execute { process dispatch; finish }
             .is_err(),
             "invalid raw plan must be rejected during worker construction"
         );
+        assert_eq!(selection_probe.total_token_selections_for_testing(), 0);
+        assert_eq!(selection_probe.invalid_token_selections_for_testing(), 0);
         assert_eq!(
             series_value(
                 &registry,
@@ -1448,10 +1491,19 @@ def pipeline p { process parent_one; process parent_two }
         expected: &[(&str, &str, &str, [u64; 4])],
     ) {
         let (registry, trap) = run_compiled_process_metric_fixture(source, pipeline, |_| {}).await;
+        let expected_selections = expected
+            .iter()
+            .map(|(_, _, _, vector)| vector[0] as usize)
+            .sum::<usize>();
         assert_eq!(
-            trap.metric_node_lookup_attempts_for_testing(),
+            trap.total_token_selections_for_testing(),
+            expected_selections,
+            "each invoked process frame must consume one compiled token"
+        );
+        assert_eq!(
+            trap.invalid_token_selections_for_testing(),
             0,
-            "branch execution must consume compiled ordinal plans without lookup"
+            "compiled branch selection must not access an invalid node"
         );
         for (step, path, name, vector) in expected {
             assert_process_vector(

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -213,8 +213,9 @@ impl Runtime {
         let mut input_pipelines: HashMap<String, Vec<Arc<PipelineWorker>>> = HashMap::new();
 
         for pipeline_def in config.pipelines.values() {
-            let worker = Arc::new(PipelineWorker::new(
+            let worker = Arc::new(PipelineWorker::new_with_process_metrics(
                 pipeline_def.clone(),
+                &config.processes,
                 &metrics_registry,
             )?);
             let input_names = get_pipeline_inputs(pipeline_def);
@@ -488,12 +489,90 @@ struct PipelineContext {
 struct PipelineWorker {
     def: PipelineDef,
     metrics: Arc<PipelineMetrics>,
+    process_metrics: Option<Arc<crate::pipeline::PipelineProcessMetrics>>,
 }
 
 impl PipelineWorker {
+    #[cfg(test)]
     fn new(def: PipelineDef, registry: &Registry) -> Result<Self, crate::metrics::MetricsError> {
         let metrics = PipelineMetrics::register(registry, &def.name)?;
-        Ok(Self { def, metrics })
+        Ok(Self {
+            def,
+            metrics,
+            process_metrics: None,
+        })
+    }
+
+    fn new_with_process_metrics(
+        def: PipelineDef,
+        processes: &HashMap<String, crate::dsl::ast::ProcessDef>,
+        registry: &Registry,
+    ) -> anyhow::Result<Self> {
+        let metrics = PipelineMetrics::register(registry, &def.name)?;
+        let process_metrics = Arc::new(crate::pipeline::PipelineProcessMetrics::register(
+            &def, processes, registry,
+        )?);
+        Ok(Self {
+            def,
+            metrics,
+            process_metrics: Some(process_metrics),
+        })
+    }
+
+    #[cfg(test)]
+    fn compile_process_metric_plan_for_testing(
+        def: &PipelineDef,
+        processes: &HashMap<String, crate::dsl::ast::ProcessDef>,
+        registry: &Registry,
+    ) -> Result<CompiledProcessMetricPlan, crate::metrics::MetricsError> {
+        Ok(CompiledProcessMetricPlan {
+            pipeline_metrics: PipelineMetrics::register(registry, &def.name)?,
+            process_metrics: crate::pipeline::PipelineProcessMetrics::compile_raw(
+                def, processes, registry,
+            )?,
+        })
+    }
+
+    #[cfg(test)]
+    fn new_with_compiled_process_metrics_for_testing(
+        def: PipelineDef,
+        processes: &HashMap<String, crate::dsl::ast::ProcessDef>,
+        plan: CompiledProcessMetricPlan,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            process_metrics: Some(Arc::new(plan.process_metrics.validate(&def, processes)?)),
+            def,
+            metrics: plan.pipeline_metrics,
+        })
+    }
+}
+
+#[cfg(test)]
+struct CompiledProcessMetricPlan {
+    pipeline_metrics: Arc<PipelineMetrics>,
+    process_metrics: crate::pipeline::RawPipelineProcessMetrics,
+}
+
+#[cfg(test)]
+impl CompiledProcessMetricPlan {
+    fn process_metrics_mut_for_testing(
+        &mut self,
+    ) -> &mut crate::pipeline::RawPipelineProcessMetrics {
+        &mut self.process_metrics
+    }
+
+    fn root_token_for_testing(&self, step: usize) -> Option<usize> {
+        self.process_metrics.root_token_for_testing(step)
+    }
+
+    fn child_token_for_testing(&self, parent: usize, ordinal: usize) -> Option<usize> {
+        self.process_metrics
+            .child_token_for_testing(parent, ordinal)
+    }
+
+    fn metric_node_selection_trap_for_testing(&self) -> crate::pipeline::MetricNodeSelectionTrap {
+        self.process_metrics
+            .metric_node_selection_trap_for_testing()
     }
 }
 
@@ -575,8 +654,19 @@ async fn run_pipeline_workers(
     info!("pipeline worker for input '{}' stopped", input_name);
 }
 
+#[cfg(test)]
 async fn run_pipeline_with_outputs(
     pipeline: &PipelineDef,
+    event: &Event,
+    ctx: &PipelineContext,
+    bump: &mut bumpalo::Bump,
+) -> Result<crate::pipeline::PipelineRunResult> {
+    run_pipeline_with_outputs_inner(pipeline, None, event, ctx, bump).await
+}
+
+async fn run_pipeline_with_outputs_inner(
+    pipeline: &PipelineDef,
+    process_metrics: Option<&crate::pipeline::PipelineProcessMetrics>,
     event: &Event,
     ctx: &PipelineContext,
     bump: &mut bumpalo::Bump,
@@ -585,16 +675,29 @@ async fn run_pipeline_with_outputs(
     // passing `None` skips every trace push (and the `format!` /
     // `to_string` work behind it) in `run_pipeline`, since nothing
     // here reads `PipelineRunResult::trace`.
-    let mut result = crate::pipeline::run_pipeline(
-        pipeline,
-        event,
-        &ctx.config,
-        &ctx.funcs,
-        Some(&ctx.tap),
-        None,
-        crate::pipeline::OutputCapturePolicy::DiskOnly(&ctx.disk_outputs),
-        bump,
-    )?;
+    let mut result = match process_metrics {
+        Some(process_metrics) => crate::pipeline::run_pipeline_with_process_metrics(
+            pipeline,
+            event,
+            &ctx.config,
+            &ctx.funcs,
+            Some(&ctx.tap),
+            None,
+            crate::pipeline::OutputCapturePolicy::DiskOnly(&ctx.disk_outputs),
+            bump,
+            process_metrics,
+        )?,
+        None => crate::pipeline::run_pipeline(
+            pipeline,
+            event,
+            &ctx.config,
+            &ctx.funcs,
+            Some(&ctx.tap),
+            None,
+            crate::pipeline::OutputCapturePolicy::DiskOnly(&ctx.disk_outputs),
+            bump,
+        )?,
+    };
 
     // Drain the per-event outputs vec into the queues. After this
     // change every output statement enqueues a plain `OwnedEvent`
@@ -716,7 +819,15 @@ async fn process_event(
             bump.reset();
         }
         worker.metrics.inflight.inc();
-        match run_pipeline_with_outputs(&worker.def, event, ctx, bump).await {
+        match run_pipeline_with_outputs_inner(
+            &worker.def,
+            worker.process_metrics.as_deref(),
+            event,
+            ctx,
+            bump,
+        )
+        .await
+        {
             Ok(result) => {
                 use crate::pipeline::PipelineTermination;
                 match result.termination {
@@ -899,6 +1010,981 @@ mod tests {
             }
         }
         panic!("no pipeline in src");
+    }
+
+    fn compiled_config(src: &str) -> CompiledConfig {
+        CompiledConfig::from_config(parse_config(src).expect("parse config"))
+            .expect("compile config")
+    }
+
+    fn metric_series(registry: &Registry, name: &str) -> Vec<serde_json::Value> {
+        let snapshot = serde_json::to_value(registry.snapshot()).expect("serialize snapshot");
+        snapshot["metrics"]
+            .as_array()
+            .expect("metrics array")
+            .iter()
+            .find(|family| family["name"] == name)
+            .unwrap_or_else(|| panic!("missing metric family {name}"))["series"]
+            .as_array()
+            .expect("series array")
+            .clone()
+    }
+
+    fn series_value(registry: &Registry, family: &str, labels: &[(&str, &str)]) -> u64 {
+        let expected: serde_json::Map<String, serde_json::Value> = labels
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), serde_json::json!(value)))
+            .collect();
+        metric_series(registry, family)
+            .into_iter()
+            .find(|series| series["labels"].as_object() == Some(&expected))
+            .unwrap_or_else(|| panic!("missing {family} series for {expected:?}"))["value"]
+            .as_u64()
+            .expect("counter value")
+    }
+
+    #[test]
+    fn process_metrics_prepopulate_exact_static_dfs_topology() {
+        let config = compiled_config(
+            r#"
+def process leaf { egress = ingress }
+def process parent_one { process leaf }
+def process parent_two { process leaf }
+def process repeated { egress = ingress }
+def process dispatch { process leaf; process leaf; drop }
+def process branch_then { egress = ingress }
+def process branch_else { egress = ingress }
+def process arm_first { egress = ingress }
+def process arm_default { egress = ingress }
+def pipeline topology {
+    process parent_one | parent_two
+    process repeated
+    process repeated
+    process dispatch
+    if true { process branch_then } else { process branch_else }
+    switch "first" {
+        "first" { process arm_first }
+        default { process arm_default }
+    }
+    process { drop }
+    drop
+}
+"#,
+        );
+        let registry = Registry::new();
+        let def = config.pipelines.get("topology").expect("pipeline").clone();
+        let _worker = PipelineWorker::new_with_process_metrics(def, &config.processes, &registry)
+            .expect("register pipeline and process metrics");
+
+        let process_families = [
+            "limpid_process_events_in_total",
+            "limpid_process_events_out_total",
+            "limpid_process_events_dropped_total",
+            "limpid_process_events_errored_total",
+        ];
+        let expected = [
+            ("1", "/parent_one", "parent_one"),
+            ("1", "/parent_one/leaf", "leaf"),
+            ("2", "/parent_two", "parent_two"),
+            ("2", "/parent_two/leaf", "leaf"),
+            ("3", "/repeated", "repeated"),
+            ("4", "/repeated", "repeated"),
+            ("5", "/dispatch", "dispatch"),
+            ("5", "/dispatch/leaf", "leaf"),
+            ("6", "/branch_then", "branch_then"),
+            ("7", "/branch_else", "branch_else"),
+            ("8", "/arm_first", "arm_first"),
+            ("9", "/arm_default", "arm_default"),
+            ("10", "/(inline)", "(inline)"),
+        ];
+        for family in process_families {
+            let series = metric_series(&registry, family);
+            assert_eq!(series.len(), expected.len(), "{family}");
+            for (step, path, name) in expected {
+                assert_eq!(
+                    series_value(
+                        &registry,
+                        family,
+                        &[
+                            ("pipeline", "topology"),
+                            ("step", step),
+                            ("process_path", path),
+                            ("process_name", name),
+                        ],
+                    ),
+                    0,
+                    "{family} must be prepopulated"
+                );
+            }
+        }
+
+        let dropped = metric_series(&registry, "limpid_pipeline_events_dropped_total");
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(
+            dropped[0]["labels"],
+            serde_json::json!({"pipeline": "topology"})
+        );
+        assert_eq!(dropped[0]["value"], 0);
+    }
+
+    #[test]
+    fn process_metrics_fold_same_call_site_and_collapse_recursive_back_edges() {
+        let config = compiled_config(
+            r#"
+def process a { process b }
+def process b { process a }
+def process leaf { egress = ingress }
+def process dispatch { process leaf; process leaf }
+def pipeline bounded { process a; process dispatch }
+"#,
+        );
+        let registry = Registry::new();
+        let def = config.pipelines.get("bounded").expect("pipeline").clone();
+        let _worker = PipelineWorker::new_with_process_metrics(def, &config.processes, &registry)
+            .expect("register bounded process topology");
+        let series = metric_series(&registry, "limpid_process_events_in_total");
+        let paths: Vec<&str> = series
+            .iter()
+            .map(|series| series["labels"]["process_path"].as_str().expect("path"))
+            .collect();
+        assert_eq!(series.len(), 4);
+        assert_eq!(paths.iter().filter(|path| **path == "/a").count(), 1);
+        assert_eq!(paths.iter().filter(|path| **path == "/a/b").count(), 1);
+        assert_eq!(paths.iter().filter(|path| **path == "/dispatch").count(), 1);
+        assert_eq!(
+            paths
+                .iter()
+                .filter(|path| **path == "/dispatch/leaf")
+                .count(),
+            1
+        );
+        assert!(!paths.contains(&"/a/b/a"));
+    }
+
+    #[tokio::test]
+    async fn process_metric_call_sites_compile_to_opaque_tokens_consumed_by_execution() {
+        let config = compiled_config(
+            r#"
+def process leaf { egress = ingress }
+def process parent_one { process leaf }
+def process parent_two { process leaf }
+def process dispatch { process leaf; process leaf }
+def process a { process b }
+def process b { process a }
+def pipeline p {
+    process parent_one
+    process parent_two
+    process dispatch
+    process a
+}
+"#,
+        );
+        let registry = Registry::new();
+        let def = config.pipelines.get("p").expect("pipeline").clone();
+        let plan = PipelineWorker::compile_process_metric_plan_for_testing(
+            &def,
+            &config.processes,
+            &registry,
+        )
+        .expect("compile process metric plan");
+
+        let parent_one = plan.root_token_for_testing(1).expect("parent_one token");
+        let parent_two = plan.root_token_for_testing(2).expect("parent_two token");
+        let dispatch = plan.root_token_for_testing(3).expect("dispatch token");
+        let a = plan.root_token_for_testing(4).expect("a token");
+        let parent_one_leaf = plan
+            .child_token_for_testing(parent_one, 0)
+            .expect("parent_one leaf token");
+        let parent_two_leaf = plan
+            .child_token_for_testing(parent_two, 0)
+            .expect("parent_two leaf token");
+        assert_ne!(
+            parent_one_leaf, parent_two_leaf,
+            "different parents must have different pre-resolved child frames"
+        );
+        assert_eq!(
+            plan.child_token_for_testing(dispatch, 0),
+            plan.child_token_for_testing(dispatch, 1),
+            "same-parent calls to the same callee must reuse one frame token"
+        );
+        let b = plan.child_token_for_testing(a, 0).expect("a-to-b token");
+        assert_eq!(
+            plan.child_token_for_testing(b, 0),
+            Some(a),
+            "an ancestor back-edge must reuse the ancestor token"
+        );
+
+        let execution_config = compiled_config(
+            r#"
+def process leaf { egress = ingress }
+def process dispatch { process leaf; process leaf }
+def pipeline execute { process dispatch; finish }
+"#,
+        );
+        let execution_registry = Registry::new();
+        let execution_def = execution_config
+            .pipelines
+            .get("execute")
+            .expect("execution pipeline")
+            .clone();
+        let execution_plan = PipelineWorker::compile_process_metric_plan_for_testing(
+            &execution_def,
+            &execution_config.processes,
+            &execution_registry,
+        )
+        .expect("compile executable process metric plan");
+        // This trap is owned by the metric-node selection seam used by execution,
+        // rather than by the test facade. Arming it after compilation permits the
+        // definition registry lookup but rejects per-event metric-node lookup.
+        let selection_trap = execution_plan.metric_node_selection_trap_for_testing();
+        let worker = Arc::new(
+            PipelineWorker::new_with_compiled_process_metrics_for_testing(
+                execution_def,
+                &execution_config.processes,
+                execution_plan,
+            )
+            .expect("execution must consume the compiled token plan"),
+        );
+        selection_trap.arm_for_testing();
+        let ctx = PipelineContext {
+            output_senders: Arc::new(HashMap::new()),
+            disk_outputs: Arc::new(HashSet::new()),
+            config: Arc::new(execution_config),
+            funcs: Arc::new(FunctionRegistry::new()),
+            tap: TapRegistry::new(),
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+        };
+        process_event(
+            &fixture_event(),
+            &[worker],
+            &ctx,
+            "input compiled-plan",
+            &mut bumpalo::Bump::new(),
+        )
+        .await;
+        assert_eq!(
+            selection_trap.metric_node_lookup_attempts_for_testing(),
+            0,
+            "execution must select pre-resolved metric frames by call-site token"
+        );
+        assert_process_vector(
+            &execution_registry,
+            &[
+                ("pipeline", "execute"),
+                ("step", "1"),
+                ("process_path", "/dispatch"),
+                ("process_name", "dispatch"),
+            ],
+            [1, 1, 0, 0],
+        );
+        assert_process_vector(
+            &execution_registry,
+            &[
+                ("pipeline", "execute"),
+                ("step", "1"),
+                ("process_path", "/dispatch/leaf"),
+                ("process_name", "leaf"),
+            ],
+            [2, 2, 0, 0],
+        );
+        assert_process_conservation(&execution_registry);
+    }
+
+    async fn run_compiled_process_metric_fixture(
+        source: &str,
+        pipeline: &str,
+        mutate: impl FnOnce(&mut crate::pipeline::RawPipelineProcessMetrics),
+    ) -> (Registry, crate::pipeline::MetricNodeSelectionTrap) {
+        let config = compiled_config(source);
+        let registry = Registry::new();
+        let def = config
+            .pipelines
+            .get(pipeline)
+            .unwrap_or_else(|| panic!("missing pipeline {pipeline}"))
+            .clone();
+        let mut plan = PipelineWorker::compile_process_metric_plan_for_testing(
+            &def,
+            &config.processes,
+            &registry,
+        )
+        .expect("compile process metric plan");
+        mutate(plan.process_metrics_mut_for_testing());
+        let selection_trap = plan.metric_node_selection_trap_for_testing();
+        let worker = Arc::new(
+            PipelineWorker::new_with_compiled_process_metrics_for_testing(
+                def,
+                &config.processes,
+                plan,
+            )
+            .expect("construct worker from compiled metric plan"),
+        );
+        selection_trap.arm_for_testing();
+        let ctx = PipelineContext {
+            output_senders: Arc::new(HashMap::new()),
+            disk_outputs: Arc::new(HashSet::new()),
+            config: Arc::new(config),
+            funcs: Arc::new(FunctionRegistry::new()),
+            tap: TapRegistry::new(),
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+        };
+        process_event(
+            &fixture_event(),
+            &[worker],
+            &ctx,
+            "input compiled-plan",
+            &mut bumpalo::Bump::new(),
+        )
+        .await;
+        (registry, selection_trap)
+    }
+
+    fn assert_compiled_plan_rejected_before_execution(
+        source: &str,
+        pipeline: &str,
+        mutate: impl FnOnce(&mut crate::pipeline::RawPipelineProcessMetrics),
+    ) {
+        let config = compiled_config(source);
+        let registry = Registry::new();
+        let def = config
+            .pipelines
+            .get(pipeline)
+            .unwrap_or_else(|| panic!("missing pipeline {pipeline}"))
+            .clone();
+        let mut plan = PipelineWorker::compile_process_metric_plan_for_testing(
+            &def,
+            &config.processes,
+            &registry,
+        )
+        .expect("compile raw process metric plan");
+        mutate(plan.process_metrics_mut_for_testing());
+        assert!(
+            PipelineWorker::new_with_compiled_process_metrics_for_testing(
+                def,
+                &config.processes,
+                plan,
+            )
+            .is_err(),
+            "invalid raw plan must be rejected during worker construction"
+        );
+        assert_eq!(
+            series_value(
+                &registry,
+                "limpid_pipeline_events_errored_total",
+                &[("pipeline", pipeline)],
+            ),
+            0,
+            "startup rejection must happen before an event is executed"
+        );
+        assert_eq!(
+            series_value(
+                &registry,
+                "limpid_pipeline_events_dropped_total",
+                &[("pipeline", pipeline)],
+            ),
+            0,
+            "the process body's drop side effect must not run during validation"
+        );
+        for series in metric_series(&registry, "limpid_process_events_in_total") {
+            assert_eq!(series["value"], 0, "no process frame may start at startup");
+        }
+        assert_process_conservation(&registry);
+    }
+
+    #[test]
+    fn compiled_metric_plan_mismatches_fail_closed_during_worker_construction() {
+        const NAMED: &str = r#"
+def process leaf { drop }
+def process root { process leaf }
+def pipeline p { process root; finish }
+"#;
+        assert_compiled_plan_rejected_before_execution(NAMED, "p", |metrics| {
+            metrics.remove_root_plan_for_testing()
+        });
+        assert_compiled_plan_rejected_before_execution(NAMED, "p", |metrics| {
+            metrics.replace_first_root_plan_with_none_for_testing();
+        });
+        assert_compiled_plan_rejected_before_execution(NAMED, "p", |metrics| {
+            metrics.invalidate_first_root_token_for_testing();
+        });
+        assert_compiled_plan_rejected_before_execution(NAMED, "p", |metrics| {
+            metrics.replace_first_process_body_plan_with_none_for_testing();
+        });
+        assert_compiled_plan_rejected_before_execution(NAMED, "p", |metrics| {
+            metrics.invalidate_first_nested_token_for_testing();
+        });
+        assert_compiled_plan_rejected_before_execution(
+            "def pipeline p { process { drop }; finish }",
+            "p",
+            |metrics| metrics.invalidate_first_inline_token_for_testing(),
+        );
+
+        assert_compiled_plan_rejected_before_execution(
+            "def process a { drop } def process b { drop } def pipeline p { process a | b }",
+            "p",
+            |metrics| metrics.swap_first_two_root_tokens_for_testing(),
+        );
+        assert_compiled_plan_rejected_before_execution(
+            r#"
+def process leaf { drop }
+def process parent_one { process leaf }
+def process parent_two { process leaf }
+def pipeline p { process parent_one; process parent_two }
+"#,
+            "p",
+            |metrics| metrics.swap_first_two_nested_tokens_for_testing(),
+        );
+        assert_compiled_plan_rejected_before_execution(
+            "def process named { drop } def pipeline p { process named | { drop } }",
+            "p",
+            |metrics| metrics.swap_first_two_root_tokens_for_testing(),
+        );
+    }
+
+    async fn assert_compiled_branch_selection(
+        source: &str,
+        pipeline: &str,
+        expected: &[(&str, &str, &str, [u64; 4])],
+    ) {
+        let (registry, trap) = run_compiled_process_metric_fixture(source, pipeline, |_| {}).await;
+        assert_eq!(
+            trap.metric_node_lookup_attempts_for_testing(),
+            0,
+            "branch execution must consume compiled ordinal plans without lookup"
+        );
+        for (step, path, name, vector) in expected {
+            assert_process_vector(
+                &registry,
+                &[
+                    ("pipeline", pipeline),
+                    ("step", step),
+                    ("process_path", path),
+                    ("process_name", name),
+                ],
+                *vector,
+            );
+        }
+        assert_process_conservation(&registry);
+    }
+
+    #[tokio::test]
+    async fn compiled_process_branches_use_selected_ordinals_for_nonfirst_and_fallback_bodies() {
+        const SOURCE: &str = r#"
+def process first { egress = ingress }
+def process selected { egress = ingress }
+def process fallback { egress = ingress }
+def process nonfirst {
+    if false { process first } else if true { process selected } else { process fallback }
+    switch "second" {
+        "first" { process first }
+        "second" { process selected }
+        default { process fallback }
+    }
+}
+def process defaults {
+    if false { process first } else if false { process selected } else { process fallback }
+    switch "missing" {
+        "first" { process first }
+        "second" { process selected }
+        default { process fallback }
+    }
+}
+def pipeline p_nonfirst { process nonfirst; finish }
+def pipeline p_fallback { process defaults; finish }
+"#;
+        assert_compiled_branch_selection(
+            SOURCE,
+            "p_nonfirst",
+            &[
+                ("1", "/nonfirst", "nonfirst", [1, 1, 0, 0]),
+                ("1", "/nonfirst/first", "first", [0, 0, 0, 0]),
+                ("1", "/nonfirst/selected", "selected", [2, 2, 0, 0]),
+                ("1", "/nonfirst/fallback", "fallback", [0, 0, 0, 0]),
+            ],
+        )
+        .await;
+        assert_compiled_branch_selection(
+            SOURCE,
+            "p_fallback",
+            &[
+                ("1", "/defaults", "defaults", [1, 1, 0, 0]),
+                ("1", "/defaults/first", "first", [0, 0, 0, 0]),
+                ("1", "/defaults/selected", "selected", [0, 0, 0, 0]),
+                ("1", "/defaults/fallback", "fallback", [2, 2, 0, 0]),
+            ],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn compiled_pipeline_branches_use_selected_ordinals_for_nonfirst_and_fallback_bodies() {
+        const SOURCE: &str = r#"
+def process leaf { egress = ingress }
+def process parent { process leaf }
+def pipeline p_nonfirst {
+    if false { process parent } else if true { process parent } else { process parent }
+    switch "second" {
+        "first" { process parent }
+        "second" { process parent }
+        default { process parent }
+    }
+    finish
+}
+def pipeline p_fallback {
+    if false { process parent } else if false { process parent } else { process parent }
+    switch "missing" {
+        "first" { process parent }
+        "second" { process parent }
+        default { process parent }
+    }
+    finish
+}
+"#;
+        assert_compiled_branch_selection(
+            SOURCE,
+            "p_nonfirst",
+            &[
+                ("2", "/parent", "parent", [1, 1, 0, 0]),
+                ("2", "/parent/leaf", "leaf", [1, 1, 0, 0]),
+                ("5", "/parent", "parent", [1, 1, 0, 0]),
+                ("5", "/parent/leaf", "leaf", [1, 1, 0, 0]),
+            ],
+        )
+        .await;
+        assert_compiled_branch_selection(
+            SOURCE,
+            "p_fallback",
+            &[
+                ("3", "/parent", "parent", [1, 1, 0, 0]),
+                ("3", "/parent/leaf", "leaf", [1, 1, 0, 0]),
+                ("6", "/parent", "parent", [1, 1, 0, 0]),
+                ("6", "/parent/leaf", "leaf", [1, 1, 0, 0]),
+            ],
+        )
+        .await;
+    }
+
+    #[test]
+    fn process_metric_families_have_exact_counter_metadata_and_label_dimensions() {
+        let config = compiled_config(
+            "def process pass { egress = ingress } def pipeline p { process pass }",
+        );
+        let registry = Registry::new();
+        let def = config.pipelines.get("p").expect("pipeline").clone();
+        let _worker = PipelineWorker::new_with_process_metrics(def, &config.processes, &registry)
+            .expect("register metrics");
+        let snapshot = serde_json::to_value(registry.snapshot()).expect("snapshot");
+        for suffix in ["in", "out", "dropped", "errored"] {
+            let name = format!("limpid_process_events_{suffix}_total");
+            let family = snapshot["metrics"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|family| family["name"] == name)
+                .unwrap_or_else(|| panic!("missing {name}"));
+            assert_eq!(family["type"], "counter");
+            assert!(family["help"].as_str().is_some_and(|help| !help.is_empty()));
+            let labels = family["series"][0]["labels"].as_object().unwrap();
+            assert_eq!(
+                labels.keys().map(String::as_str).collect::<Vec<_>>(),
+                ["pipeline", "process_name", "process_path", "step"]
+            );
+        }
+    }
+
+    async fn run_process_metric_fixture(src: &str, pipeline: &str, mut event: Event) -> Registry {
+        let config = compiled_config(src);
+        let registry = Registry::new();
+        let def = config
+            .pipelines
+            .get(pipeline)
+            .unwrap_or_else(|| panic!("missing pipeline {pipeline}"))
+            .clone();
+        let worker = Arc::new(
+            PipelineWorker::new_with_process_metrics(def, &config.processes, &registry)
+                .expect("register process metrics"),
+        );
+        let ctx = PipelineContext {
+            output_senders: Arc::new(HashMap::new()),
+            disk_outputs: Arc::new(HashSet::new()),
+            config: Arc::new(config),
+            funcs: Arc::new(FunctionRegistry::new()),
+            tap: TapRegistry::new(),
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+        };
+        if event.egress.is_empty() {
+            event.egress = event.ingress.clone();
+        }
+        process_event(
+            &event,
+            &[worker],
+            &ctx,
+            "input fixture",
+            &mut bumpalo::Bump::new(),
+        )
+        .await;
+        registry
+    }
+
+    fn fixture_event() -> Event {
+        Event::new(
+            Bytes::from_static(b"payload"),
+            SocketAddr::from_str("127.0.0.1:0").unwrap(),
+        )
+    }
+
+    fn assert_process_conservation(registry: &Registry) {
+        let family_names = [
+            "limpid_process_events_in_total",
+            "limpid_process_events_out_total",
+            "limpid_process_events_dropped_total",
+            "limpid_process_events_errored_total",
+        ];
+        let label_sets: Vec<std::collections::BTreeSet<Vec<(String, String)>>> = family_names
+            .iter()
+            .map(|family| {
+                metric_series(registry, family)
+                    .into_iter()
+                    .map(|series| {
+                        series["labels"]
+                            .as_object()
+                            .expect("labels")
+                            .iter()
+                            .map(|(key, value)| {
+                                (key.clone(), value.as_str().expect("label value").to_owned())
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect();
+        for labels in &label_sets[1..] {
+            assert_eq!(
+                labels, &label_sets[0],
+                "all process terminal families must have the exact input label-set"
+            );
+        }
+
+        for input in metric_series(registry, "limpid_process_events_in_total") {
+            let labels = input["labels"].as_object().expect("labels");
+            let owned_labels: Vec<(String, String)> = labels
+                .iter()
+                .map(|(key, value)| (key.clone(), value.as_str().expect("label value").to_owned()))
+                .collect();
+            let labels: Vec<(&str, &str)> = owned_labels
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str()))
+                .collect();
+            let input = input["value"].as_u64().expect("input value");
+            let terminal: u64 = ["out", "dropped", "errored"]
+                .into_iter()
+                .map(|suffix| {
+                    series_value(
+                        registry,
+                        &format!("limpid_process_events_{suffix}_total"),
+                        &labels,
+                    )
+                })
+                .sum();
+            assert_eq!(input, terminal, "non-conserving process series {labels:?}");
+        }
+    }
+
+    fn assert_process_vector(registry: &Registry, labels: &[(&str, &str)], expected: [u64; 4]) {
+        let actual = ["in", "out", "dropped", "errored"].map(|suffix| {
+            series_value(
+                registry,
+                &format!("limpid_process_events_{suffix}_total"),
+                labels,
+            )
+        });
+        assert_eq!(actual, expected, "wrong process vector for {labels:?}");
+    }
+
+    #[tokio::test]
+    async fn process_invocations_conserve_continue_drop_and_caught_error_frames() {
+        let continued = run_process_metric_fixture(
+            r#"
+def process leaf { egress = ingress }
+def process dispatch { process leaf }
+def pipeline p { process dispatch; finish }
+"#,
+            "p",
+            fixture_event(),
+        )
+        .await;
+        for path in ["/dispatch", "/dispatch/leaf"] {
+            let labels = [
+                ("pipeline", "p"),
+                ("step", "1"),
+                ("process_path", path),
+                ("process_name", path.rsplit('/').next().unwrap()),
+            ];
+            assert_process_vector(&continued, &labels, [1, 1, 0, 0]);
+        }
+        assert_process_conservation(&continued);
+
+        let dropped = run_process_metric_fixture(
+            r#"
+def process leaf { drop }
+def process dispatch { process leaf }
+def pipeline p { process dispatch; finish }
+"#,
+            "p",
+            fixture_event(),
+        )
+        .await;
+        for (path, name) in [("/dispatch", "dispatch"), ("/dispatch/leaf", "leaf")] {
+            let labels = [
+                ("pipeline", "p"),
+                ("step", "1"),
+                ("process_path", path),
+                ("process_name", name),
+            ];
+            assert_process_vector(&dropped, &labels, [1, 0, 1, 0]);
+        }
+        assert_eq!(
+            series_value(
+                &dropped,
+                "limpid_pipeline_events_dropped_total",
+                &[("pipeline", "p")],
+            ),
+            1
+        );
+        assert_process_conservation(&dropped);
+
+        let caught = run_process_metric_fixture(
+            r#"
+def process fail { error "expected" }
+def process catcher { try { process fail } catch { egress = ingress } }
+def pipeline p { process catcher; finish }
+"#,
+            "p",
+            fixture_event(),
+        )
+        .await;
+        assert_process_vector(
+            &caught,
+            &[
+                ("pipeline", "p"),
+                ("step", "1"),
+                ("process_path", "/catcher"),
+                ("process_name", "catcher"),
+            ],
+            [1, 1, 0, 0],
+        );
+        assert_process_vector(
+            &caught,
+            &[
+                ("pipeline", "p"),
+                ("step", "1"),
+                ("process_path", "/catcher/fail"),
+                ("process_name", "fail"),
+            ],
+            [1, 0, 0, 1],
+        );
+        assert_eq!(
+            series_value(
+                &caught,
+                "limpid_pipeline_events_errored_total",
+                &[("pipeline", "p")],
+            ),
+            0,
+            "a caught process error must not become a pipeline error"
+        );
+        assert_process_conservation(&caught);
+
+        let uncaught = run_process_metric_fixture(
+            r#"
+def process fail { error "expected" }
+def process outer { process fail }
+def pipeline p { process outer; finish }
+"#,
+            "p",
+            fixture_event(),
+        )
+        .await;
+        for (path, name) in [("/outer", "outer"), ("/outer/fail", "fail")] {
+            let labels = [
+                ("pipeline", "p"),
+                ("step", "1"),
+                ("process_path", path),
+                ("process_name", name),
+            ];
+            assert_process_vector(&uncaught, &labels, [1, 0, 0, 1]);
+        }
+        assert_eq!(
+            series_value(
+                &uncaught,
+                "limpid_pipeline_events_errored_total",
+                &[("pipeline", "p")],
+            ),
+            1,
+            "one errored pipeline run is independent of its two errored frames"
+        );
+        assert_process_conservation(&uncaught);
+    }
+
+    #[tokio::test]
+    async fn pipeline_drop_counter_stays_event_based_while_process_drops_propagate_by_frame() {
+        for body in ["drop", "process { drop }", "process named"] {
+            let source =
+                format!("def process named {{ drop }} def pipeline p {{ {body}; finish }}");
+            let registry = run_process_metric_fixture(&source, "p", fixture_event()).await;
+            let dropped = metric_series(&registry, "limpid_pipeline_events_dropped_total");
+            assert_eq!(dropped.len(), 1, "{body}");
+            assert_eq!(dropped[0]["labels"], serde_json::json!({"pipeline": "p"}));
+            assert_eq!(
+                series_value(
+                    &registry,
+                    "limpid_pipeline_events_dropped_total",
+                    &[("pipeline", "p")],
+                ),
+                1,
+                "each dropped event must increment the plain pipeline counter once: {body}"
+            );
+            if body != "drop" {
+                assert_process_conservation(&registry);
+            }
+        }
+
+        let nested = run_process_metric_fixture(
+            r#"
+def process leaf { drop }
+def process outer { process leaf }
+def pipeline nested { process outer; finish }
+"#,
+            "nested",
+            fixture_event(),
+        )
+        .await;
+        let dropped = metric_series(&nested, "limpid_pipeline_events_dropped_total");
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(
+            dropped[0]["labels"],
+            serde_json::json!({"pipeline": "nested"})
+        );
+        assert_eq!(dropped[0]["value"], 1);
+        for (path, name) in [("/outer", "outer"), ("/outer/leaf", "leaf")] {
+            assert_process_vector(
+                &nested,
+                &[
+                    ("pipeline", "nested"),
+                    ("step", "1"),
+                    ("process_path", path),
+                    ("process_name", name),
+                ],
+                [1, 0, 1, 0],
+            );
+        }
+        assert_process_conservation(&nested);
+    }
+
+    #[tokio::test]
+    async fn recursive_invocations_reuse_the_ancestor_series_without_dynamic_growth() {
+        let mut event = fixture_event();
+        event
+            .workspace
+            .insert("depth".to_owned(), crate::dsl::value::OwnedValue::Int(0));
+        let registry = run_process_metric_fixture(
+            r#"
+def process a {
+    if workspace.depth < 2 {
+        workspace.depth = workspace.depth + 1
+        process b
+    }
+}
+def process b { process a }
+def pipeline p { process a; finish }
+"#,
+            "p",
+            event,
+        )
+        .await;
+        assert_process_vector(
+            &registry,
+            &[
+                ("pipeline", "p"),
+                ("step", "1"),
+                ("process_path", "/a"),
+                ("process_name", "a"),
+            ],
+            [3, 3, 0, 0],
+        );
+        assert_process_vector(
+            &registry,
+            &[
+                ("pipeline", "p"),
+                ("step", "1"),
+                ("process_path", "/a/b"),
+                ("process_name", "b"),
+            ],
+            [2, 2, 0, 0],
+        );
+        assert_eq!(
+            metric_series(&registry, "limpid_process_events_in_total").len(),
+            2,
+            "recursive calls must not register runtime series"
+        );
+        assert_process_conservation(&registry);
+    }
+
+    #[tokio::test]
+    async fn concurrent_tasks_share_prepopulated_process_handles_without_cardinality_growth() {
+        let config = compiled_config(
+            "def process pass { egress = ingress } def pipeline p { process pass; finish }",
+        );
+        let registry = Arc::new(Registry::new());
+        let def = config.pipelines.get("p").expect("pipeline").clone();
+        let worker = Arc::new(
+            PipelineWorker::new_with_process_metrics(def, &config.processes, &registry)
+                .expect("register metrics"),
+        );
+        let ctx = Arc::new(PipelineContext {
+            output_senders: Arc::new(HashMap::new()),
+            disk_outputs: Arc::new(HashSet::new()),
+            config: Arc::new(config),
+            funcs: Arc::new(FunctionRegistry::new()),
+            tap: TapRegistry::new(),
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+        });
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let worker = Arc::clone(&worker);
+            let ctx = Arc::clone(&ctx);
+            tasks.push(tokio::spawn(async move {
+                process_event(
+                    &fixture_event(),
+                    &[worker],
+                    &ctx,
+                    "input concurrent",
+                    &mut bumpalo::Bump::new(),
+                )
+                .await;
+            }));
+        }
+        for task in tasks {
+            tokio::time::timeout(Duration::from_secs(2), task)
+                .await
+                .expect("invocation must finish")
+                .expect("invocation task must not panic");
+        }
+        let labels = [
+            ("pipeline", "p"),
+            ("step", "1"),
+            ("process_path", "/pass"),
+            ("process_name", "pass"),
+        ];
+        assert_process_vector(&registry, &labels, [16, 16, 0, 0]);
+        assert_eq!(
+            metric_series(&registry, "limpid_process_events_in_total").len(),
+            1,
+            "shared pre-resolved handles must not grow metric cardinality"
+        );
+        assert_process_conservation(&registry);
     }
 
     #[tokio::test]

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -662,7 +662,7 @@ fn render_default_stats_inner(
         for identity in identities.keys() {
             writeln!(
                 rendered,
-                "  {}  {}  {}  {}  {} in  {} out  {} dropped  {} errored",
+                "  {:<16} {:>4}  {:<32} {:<16} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
                 identity.pipeline,
                 identity.step,
                 identity.process_path,

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -474,8 +474,24 @@ const OUTPUT_METRICS: [&str; 7] = [
     "limpid_output_events_wedged_total",
     "limpid_output_events_errored_unwritable_total",
 ];
+const PROCESS_METRICS: [&str; 4] = [
+    "limpid_process_events_in_total",
+    "limpid_process_events_out_total",
+    "limpid_process_events_dropped_total",
+    "limpid_process_events_errored_total",
+];
 
 type MetricValues = BTreeMap<String, u64>;
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+struct ProcessIdentity {
+    pipeline: String,
+    step: usize,
+    process_path: String,
+    process_name: String,
+}
+
+type ProcessMetricValues = BTreeMap<ProcessIdentity, u64>;
 
 fn format_stats(json: &str) {
     let rendered = serde_json::from_str::<MetricsSnapshot>(json)
@@ -496,13 +512,47 @@ fn format_stats(json: &str) {
 /// back to the raw response rather than emit a partial table that
 /// omits or lies about a counter.
 fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
+    render_default_stats_inner(snapshot, true)
+}
+
+fn render_default_stats_inner(
+    snapshot: &MetricsSnapshot,
+    validate_process_families: bool,
+) -> Option<String> {
     if snapshot.schema != 1 {
         return None;
     }
     let mut families = BTreeMap::<String, MetricValues>::new();
+    let mut process_families = BTreeMap::<String, ProcessMetricValues>::new();
 
     for metric in &snapshot.metrics {
         let name = metric.name();
+        if validate_process_families && PROCESS_METRICS.contains(&name) {
+            if metric.metric_type() != MetricType::Counter || process_families.contains_key(name) {
+                return None;
+            }
+            let series = metric.value_series()?;
+            if series.is_empty() {
+                return None;
+            }
+            let mut values = ProcessMetricValues::new();
+            for item in series {
+                if item.labels.len() != 4 {
+                    return None;
+                }
+                let identity = ProcessIdentity {
+                    pipeline: item.labels.get("pipeline")?.clone(),
+                    step: item.labels.get("step")?.parse().ok()?,
+                    process_path: item.labels.get("process_path")?.clone(),
+                    process_name: item.labels.get("process_name")?.clone(),
+                };
+                if values.insert(identity, item.value).is_some() {
+                    return None;
+                }
+            }
+            process_families.insert(name.to_owned(), values);
+            continue;
+        }
         let Some(label_name) = known_metric_label(name) else {
             continue;
         };
@@ -529,6 +579,11 @@ fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
     validate_metric_group(&families, &PIPELINE_METRICS)?;
     validate_metric_group(&families, &INPUT_METRICS)?;
     validate_metric_group(&families, &OUTPUT_METRICS)?;
+    let process_identities = if validate_process_families {
+        validate_process_metric_group(&process_families)?
+    } else {
+        None
+    };
 
     let mut rendered = String::new();
     writeln!(rendered, "Pipelines:").ok()?;
@@ -602,7 +657,49 @@ fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
         }
         rendered.push('\n');
     }
+    if let Some(identities) = process_identities {
+        writeln!(rendered, "\nProcesses:").ok()?;
+        for identity in identities.keys() {
+            writeln!(
+                rendered,
+                "  {}  {}  {}  {}  {} in  {} out  {} dropped  {} errored",
+                identity.pipeline,
+                identity.step,
+                identity.process_path,
+                identity.process_name,
+                process_metric_value(&process_families, PROCESS_METRICS[0], identity)?,
+                process_metric_value(&process_families, PROCESS_METRICS[1], identity)?,
+                process_metric_value(&process_families, PROCESS_METRICS[2], identity)?,
+                process_metric_value(&process_families, PROCESS_METRICS[3], identity)?,
+            )
+            .ok()?;
+        }
+    }
     Some(rendered)
+}
+
+fn validate_process_metric_group(
+    families: &BTreeMap<String, ProcessMetricValues>,
+) -> Option<Option<&ProcessMetricValues>> {
+    if families.is_empty() {
+        return Some(None);
+    }
+    let expected = families.get(PROCESS_METRICS[0])?;
+    for name in PROCESS_METRICS {
+        let values = families.get(name)?;
+        if !values.keys().eq(expected.keys()) {
+            return None;
+        }
+    }
+    Some(Some(expected))
+}
+
+fn process_metric_value(
+    families: &BTreeMap<String, ProcessMetricValues>,
+    metric: &str,
+    identity: &ProcessIdentity,
+) -> Option<u64> {
+    families.get(metric)?.get(identity).copied()
 }
 
 fn known_metric_label(name: &str) -> Option<&'static str> {
@@ -688,7 +785,7 @@ fn render_stats_details(snapshot: &MetricsSnapshot) -> Option<String> {
     if metrics
         .iter()
         .any(|metric| known_metric_label(&metric.name).is_some())
-        && render_default_stats(snapshot).is_none()
+        && render_default_stats_inner(snapshot, false).is_none()
     {
         return None;
     }

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -350,6 +350,262 @@ fn default_stats_maps_schema_v1_to_the_existing_sorted_table() {
     }
 }
 
+fn process_snapshot() -> Value {
+    let mut payload = canonical_snapshot(false);
+    for (name, root_value, leaf_value) in [
+        ("limpid_process_events_in_total", 4, 3),
+        ("limpid_process_events_out_total", 4, 1),
+        ("limpid_process_events_dropped_total", 0, 1),
+        ("limpid_process_events_errored_total", 0, 1),
+    ] {
+        payload["metrics"].as_array_mut().unwrap().push(json!({
+            "name": name,
+            "type": "counter",
+            "help": "Process invocation fixture.",
+            "series": [
+                {
+                    "labels": {
+                        "pipeline": "compact",
+                        "step": "10",
+                        "process_path": "/dispatch/leaf",
+                        "process_name": "leaf"
+                    },
+                    "value": leaf_value
+                },
+                {
+                    "labels": {
+                        "pipeline": "compact",
+                        "step": "2",
+                        "process_path": "/dispatch",
+                        "process_name": "dispatch"
+                    },
+                    "value": root_value
+                }
+            ]
+        }));
+    }
+    payload
+}
+
+fn family_mut<'a>(payload: &'a mut Value, name: &str) -> &'a mut Value {
+    payload["metrics"]
+        .as_array_mut()
+        .expect("metrics")
+        .iter_mut()
+        .find(|family| family["name"] == name)
+        .unwrap_or_else(|| panic!("missing {name}"))
+}
+
+fn for_each_process_family_mut(payload: &mut Value, mut update: impl FnMut(&mut Value)) {
+    for name in [
+        "limpid_process_events_in_total",
+        "limpid_process_events_out_total",
+        "limpid_process_events_dropped_total",
+        "limpid_process_events_errored_total",
+    ] {
+        update(family_mut(payload, name));
+    }
+}
+
+fn process_default_validator_only_defects() -> Vec<(&'static str, Value)> {
+    let mut cases = Vec::new();
+
+    let mut missing_label = process_snapshot();
+    for_each_process_family_mut(&mut missing_label, |family| {
+        family["series"][0]["labels"]
+            .as_object_mut()
+            .unwrap()
+            .remove("process_name");
+    });
+    cases.push(("missing label", missing_label));
+
+    let mut extra_label = process_snapshot();
+    for_each_process_family_mut(&mut extra_label, |family| {
+        family["series"][0]["labels"]
+            .as_object_mut()
+            .unwrap()
+            .insert("extra".to_owned(), json!("x"));
+    });
+    cases.push(("extra label", extra_label));
+
+    let mut non_numeric_step = process_snapshot();
+    for_each_process_family_mut(&mut non_numeric_step, |family| {
+        family["series"][0]["labels"]["step"] = json!("ten");
+    });
+    cases.push(("non-numeric step", non_numeric_step));
+
+    cases
+}
+
+fn line_tokens(text: &str, token: &str) -> Vec<String> {
+    text.lines()
+        .find(|line| line.split_whitespace().any(|part| part == token))
+        .unwrap_or_else(|| panic!("missing line containing {token:?} in {text:?}"))
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect()
+}
+
+#[test]
+fn process_counters_render_a_numerically_sorted_default_invocation_table() {
+    let payload = process_snapshot();
+    let response = format!("{payload}\n");
+
+    let default = run_stats(&response, &[]);
+    assert!(default.status.success(), "{default:?}");
+    let default = stdout(&default);
+    assert!(default.starts_with(&expected_default_table()));
+    let process_header = default
+        .lines()
+        .find(|line| line.trim() == "Processes:")
+        .expect("default output must include the process section")
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    assert_eq!(process_header, ["Processes:"]);
+    assert_eq!(
+        line_tokens(&default, "/dispatch"),
+        [
+            "compact",
+            "2",
+            "/dispatch",
+            "dispatch",
+            "4",
+            "in",
+            "4",
+            "out",
+            "0",
+            "dropped",
+            "0",
+            "errored",
+        ]
+    );
+    assert_eq!(
+        line_tokens(&default, "/dispatch/leaf"),
+        [
+            "compact",
+            "10",
+            "/dispatch/leaf",
+            "leaf",
+            "3",
+            "in",
+            "1",
+            "out",
+            "1",
+            "dropped",
+            "1",
+            "errored",
+        ]
+    );
+    let root = default.find("/dispatch ").expect("root row");
+    let leaf = default.find("/dispatch/leaf ").expect("leaf row");
+    assert!(root < leaf, "step 2 must sort before step 10 numerically");
+
+    let details = run_stats(&response, &["--details"]);
+    assert!(details.status.success(), "{details:?}");
+    let details = stdout(&details);
+    for name in [
+        "limpid_process_events_in_total",
+        "limpid_process_events_out_total",
+        "limpid_process_events_dropped_total",
+        "limpid_process_events_errored_total",
+    ] {
+        assert!(details.contains(name), "missing {name}");
+    }
+    assert!(details.contains(
+        r#"pipeline="compact", process_name="leaf", process_path="/dispatch/leaf", step="10""#
+    ));
+
+    let json = run_stats(&response, &["--json"]);
+    assert!(json.status.success(), "{json:?}");
+    assert_eq!(json.stdout, response.as_bytes());
+}
+
+#[test]
+fn malformed_process_families_fall_back_to_the_whole_raw_response() {
+    let mut cases = Vec::new();
+
+    let mut missing_family = process_snapshot();
+    missing_family["metrics"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|family| family["name"] != "limpid_process_events_errored_total");
+    cases.push(("missing family", missing_family));
+
+    let mut duplicate_series = process_snapshot();
+    let duplicate = duplicate_series["metrics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|family| family["name"] == "limpid_process_events_in_total")
+        .unwrap()["series"][0]
+        .clone();
+    family_mut(&mut duplicate_series, "limpid_process_events_in_total")["series"]
+        .as_array_mut()
+        .unwrap()
+        .push(duplicate);
+    cases.push(("duplicate exact series", duplicate_series));
+
+    let mut wrong_type = process_snapshot();
+    family_mut(&mut wrong_type, "limpid_process_events_out_total")["type"] = json!("gauge");
+    cases.push(("wrong family type", wrong_type));
+
+    cases.extend(process_default_validator_only_defects());
+
+    let mut mismatched_identity = process_snapshot();
+    family_mut(&mut mismatched_identity, "limpid_process_events_out_total")["series"][0]["labels"]
+        ["process_path"] = json!("/dispatch/other");
+    cases.push(("mismatched identities", mismatched_identity));
+
+    let mut invalid_value = process_snapshot();
+    family_mut(&mut invalid_value, "limpid_process_events_in_total")["series"][0]["value"] =
+        json!("3");
+    cases.push(("invalid value", invalid_value));
+
+    let mut did_not_fall_back = Vec::new();
+    for (name, payload) in cases {
+        let response = format!("{payload}\n");
+        let output = run_stats(&response, &[]);
+        assert!(output.status.success(), "{name}: {output:?}");
+        if output.stdout != response.as_bytes() {
+            did_not_fall_back.push(name);
+        }
+    }
+    assert!(
+        did_not_fall_back.is_empty(),
+        "each single defect must cause a whole raw fallback; rendered: {did_not_fall_back:?}"
+    );
+}
+
+#[test]
+fn details_remains_generic_for_process_default_validator_only_defects() {
+    for (name, payload) in process_default_validator_only_defects() {
+        let response = format!("{payload}\n");
+        let output = run_stats(&response, &["--details"]);
+        assert!(output.status.success(), "{name}: {output:?}");
+        assert_ne!(
+            output.stdout,
+            response.as_bytes(),
+            "{name} is DTO-valid and must remain generic in details mode"
+        );
+        assert!(stdout(&output).contains("limpid_process_events_in_total"));
+    }
+}
+
+#[test]
+fn details_remains_generic_when_process_families_are_incomplete() {
+    let mut payload = process_snapshot();
+    payload["metrics"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|family| family["name"] != "limpid_process_events_errored_total");
+    let response = format!("{payload}\n");
+
+    let output = run_stats(&response, &["--details"]);
+    assert!(output.status.success(), "{output:?}");
+    assert_ne!(output.stdout, response.as_bytes());
+    assert!(stdout(&output).contains("limpid_process_events_in_total"));
+}
+
 #[test]
 fn json_mode_preserves_the_complete_control_response() {
     let response = concat!(

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -462,6 +462,28 @@ fn process_counters_render_a_numerically_sorted_default_invocation_table() {
         .split_whitespace()
         .collect::<Vec<_>>();
     assert_eq!(process_header, ["Processes:"]);
+    let root_row = default
+        .lines()
+        .find(|line| line.contains("/dispatch "))
+        .expect("root process row");
+    assert_eq!(
+        root_row,
+        format!(
+            "  {:<16} {:>4}  {:<32} {:<16} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
+            "compact", 2, "/dispatch", "dispatch", 4, 4, 0, 0
+        )
+    );
+    let leaf_row = default
+        .lines()
+        .find(|line| line.contains("/dispatch/leaf "))
+        .expect("leaf process row");
+    assert_eq!(
+        leaf_row,
+        format!(
+            "  {:<16} {:>4}  {:<32} {:<16} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
+            "compact", 10, "/dispatch/leaf", "leaf", 3, 1, 1, 1
+        )
+    );
     assert_eq!(
         line_tokens(&default, "/dispatch"),
         [

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -80,9 +80,9 @@ daemon startup instead of being ignored.
 
 ## Current metric families
 
-These are the current metric families registered by the daemon. Each series
-has exactly the fixed label shown; the label value is the configured component
-name, so label cardinality is bounded by the configured components.
+These are the current metric families registered by the daemon. Their labels
+are fixed from the compiled configuration at registration time, so cardinality
+is bounded by configured components and process sites.
 
 ### Pipelines
 
@@ -105,6 +105,32 @@ completed the pipeline but was never sent anywhere.
 failures are counted under the corresponding output's `events_failed`. The
 original event is preserved when the configured error-log write succeeds; see
 [Error Log → Replay](./error-log.md#replay).
+
+### Process invocations
+
+The four process counter families use the labels `pipeline`, `step`,
+`process_path`, and `process_name`:
+
+- `limpid_process_events_in_total` counts frame entry.
+- `limpid_process_events_out_total` counts frames that return `Continue`.
+- `limpid_process_events_dropped_total` counts frames terminated by `Drop`.
+- `limpid_process_events_errored_total` counts frames terminated by an error.
+
+These are invocation counters, not event counters. `step` is the root process
+site's one-based, pipeline-wide source-order position; nested calls share that
+root step. A named root has a path such as `/dispatch`, a nested call extends it
+to `/dispatch/leaf`, and an inline root uses `/(inline)`. Recursive back-edges
+reuse their ancestor series, so registration remains bounded by the compiled
+configuration. Every configured series is prepopulated with zero.
+
+Each frame records exactly one terminal result, so for an individual series
+`in = out + dropped + errored`. A nested drop propagates through its active
+caller frames. A nested error counts as errored for that frame even when a
+caller's catch block recovers and the caller returns normally. Consequently,
+summing process series double-counts nested invocations and is not an event
+flow total. The pipeline event families above remain the authoritative event
+flow: in particular, `limpid_pipeline_events_dropped_total{pipeline}` retains
+its existing single-label event semantics.
 
 ### Inputs
 
@@ -205,7 +231,7 @@ confirmed by `send`.
 ## Viewing metrics with limpidctl
 
 ```bash
-# Operator-focused table: Pipelines, Inputs, then Outputs
+# Operator-focused table: Pipelines, Inputs, Outputs, then Processes when present
 sudo limpidctl stats
 
 # Generic human view of every schema-v1 family and series
@@ -215,11 +241,13 @@ sudo limpidctl stats --details
 sudo limpidctl stats --json
 ```
 
-The default table preserves the established 16-counter operator view. Component
+The default table preserves the established component-counter view and appends
+a `Processes` invocation table when all four process families are present and
+valid. Process rows sort by pipeline, numeric step, path, and name. Component
 names are sorted and alarm fields such as `wedged` and `errored_unwritable` are
 shown under their existing conditional rules. Unknown future families are
 ignored in this mode. If a known family is missing, duplicated, has the wrong
-type or value, or does not have exactly its fixed label, limpidctl prints the
+type or value, or does not have exactly its fixed labels, limpidctl prints the
 raw response rather than inventing a zero or a partial table.
 
 `--details` replaces the default table with a generic view. Families are sorted

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -82,7 +82,8 @@ daemon startup instead of being ignored.
 
 These are the current metric families registered by the daemon. Their labels
 are fixed from the compiled configuration at registration time, so cardinality
-is bounded by configured components and process sites.
+is bounded by that configuration. Process-family cardinality follows distinct
+compiled invocation paths rather than only process definition count.
 
 ### Pipelines
 
@@ -120,8 +121,10 @@ These are invocation counters, not event counters. `step` is the root process
 site's one-based, pipeline-wide source-order position; nested calls share that
 root step. A named root has a path such as `/dispatch`, a nested call extends it
 to `/dispatch/leaf`, and an inline root uses `/(inline)`. Recursive back-edges
-reuse their ancestor series, so registration remains bounded by the compiled
-configuration. Every configured series is prepopulated with zero.
+reuse their ancestor series. Each distinct compiled invocation node owns four
+counter series; reusing a helper under different parents creates distinct path
+series, while ancestor recursion reuses the ancestor node and cannot grow the
+topology at runtime. Every configured series is prepopulated with zero.
 
 Each frame records exactly one terminal result, so for an individual series
 `in = out + dropped + errored`. A nested drop propagates through its active


### PR DESCRIPTION
## Summary

- add `limpid_process_events_in_total`, `limpid_process_events_out_total`, `limpid_process_events_dropped_total`, and `limpid_process_events_errored_total`, each labeled by `pipeline`, `step`, `process_path`, and `process_name`
- prepopulate the configuration-bounded process topology at registration and publish it through schema-v1 for limpidctl and generic Prometheus translation
- compile and validate pre-resolved metric tokens at startup so event-path metric-node selection is an O(1) checked index operation

## Semantics

- count process invocation frames: `in` increments at frame entry and exactly one of `out`, `dropped`, or `errored` classifies its terminal result, preserving per-series conservation
- propagate nested drops and errors through active caller frames; sums across process series intentionally double-count nested invocations and are not event totals
- assign root `step` values by pipeline-wide source-order DFS, share the root step with nested frames, and build stable root/nested `process_path` values; same-parent calls fold and recursive back-edges reuse bounded prepopulated nodes
- keep the existing `limpid_pipeline_events_dropped_total{pipeline}` family and event-flow semantics unchanged
- add a validated `Processes:` table to limpidctl's default view while retaining generic details output and byte-exact raw JSON; limpid-prometheus remains a generic schema-v1 consumer
- make no schema version, configuration, dependency, or public API change, and add no Stage C derived metadata; the formal cumulative Phase 2 benchmark remains pinned to PR2.4

## Validation

- `cargo test -p limpid --bin limpid` (995 passed, 1 ignored)
- `cargo test -p limpid --all-targets --features kafka` (1024 passed, 1 ignored) and CLI integration (29 passed)
- `cargo test -p limpidctl --test stats_schema_v1` (12 passed)
- `cargo test -p limpid-prometheus` (14 passed)
- workspace tests and Kafka/workspace clippy with `-D warnings`
- `cargo fmt --all -- --check` and diff checks
- `cargo doc --workspace --no-deps` and `mdbook build docs`
- `cargo xtask lint-snippet-headers` and `cargo xtask gen-snippet-inventory --check`
- `cargo deny check advisories bans sources licenses`
- native nine-scope audit gate (9/9)

The journal feature requires `libsystemd` and is covered by Ubuntu CI; local Darwin validation stops at that existing platform boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added process-level metrics for tracking starts, successful continuations, drops, and errors.
  * Added a Processes section to default statistics output, with deterministic sorting and validation.
  * Added support for process metrics across nested calls, conditionals, switches, recursion, and concurrent execution.
  * Runtime errors and output enqueue failures now generate corresponding error metrics and dead-letter records.

* **Bug Fixes**
  * Improved shutdown handling to retain events from outstanding send operations.

* **Documentation**
  * Documented process metric families, labels, invocation behavior, sorting, and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->