### PR TITLE
feat(metrics): expose node build information

### DIFF
--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -668,6 +668,31 @@ mod tests {
     }
 
     #[test]
+    fn build_info_translates_through_the_generic_schema_v1_path() {
+        let snapshot = serde_json::json!({
+            "schema": 1,
+            "metrics": [{
+                "name": "limpid_build_info",
+                "type": "gauge",
+                "help": "Build information for the running limpid node.",
+                "series": [{
+                    "labels": {"node_id": "edge-a", "version": "0.7.15"},
+                    "value": 1
+                }]
+            }]
+        });
+
+        assert_eq!(
+            json_to_prometheus(&snapshot.to_string()).unwrap(),
+            concat!(
+                "# HELP limpid_build_info Build information for the running limpid node.\n",
+                "# TYPE limpid_build_info gauge\n",
+                "limpid_build_info{node_id=\"edge-a\",version=\"0.7.15\"} 1\n\n"
+            )
+        );
+    }
+
+    #[test]
     fn schema_v1_rejects_inconsistent_and_colliding_labelsets() {
         let cases = [
             (

--- a/crates/limpid/src/config.rs
+++ b/crates/limpid/src/config.rs
@@ -143,6 +143,7 @@ fn load_recursive(
         // earlier parent. Returning an empty config keeps duplication
         // out of the merged AST.
         return Ok(Config {
+            node_id: None,
             definitions: Vec::new(),
             global_blocks: Vec::new(),
             includes: Vec::new(),
@@ -197,6 +198,11 @@ fn load_recursive(
 
             let inc_config =
                 load_recursive(&inc_path, canonical_root, state, depth + 1, source_map)?;
+            if let Some(included_node_id) = inc_config.node_id
+                && config.node_id.replace(included_node_id).is_some()
+            {
+                bail!("duplicate node_id");
+            }
             config.definitions.extend(inc_config.definitions);
             config.global_blocks.extend(inc_config.global_blocks);
         }
@@ -368,6 +374,62 @@ mod tests {
             1,
             "shared.limpid should contribute its single definition exactly once"
         );
+    }
+
+    #[test]
+    fn included_node_id_is_retained_in_the_merged_config() {
+        let dir = TempDir::new().unwrap();
+        let main_conf = dir.path().join("main.conf");
+        let included = dir.path().join("included.limpid");
+
+        fs::write(&included, "node_id \"included-node\"").unwrap();
+        fs::write(&main_conf, "include \"included.limpid\"").unwrap();
+
+        let config = load_config(&main_conf).unwrap();
+        assert_eq!(config.node_id.as_deref(), Some("included-node"));
+    }
+
+    #[test]
+    fn distinct_node_id_declarations_across_includes_are_rejected() {
+        let dir = TempDir::new().unwrap();
+        let included_a = dir.path().join("a.limpid");
+        let included_b = dir.path().join("b.limpid");
+        fs::write(&included_a, "node_id \"included-a\"").unwrap();
+        fs::write(&included_b, "node_id \"included-b\"").unwrap();
+
+        for (case, source) in [
+            ("main-and-include", "node_id \"main\"\ninclude \"a.limpid\""),
+            ("two-includes", "include \"a.limpid\"\ninclude \"b.limpid\""),
+        ] {
+            let main_conf = dir.path().join(format!("{case}.conf"));
+            fs::write(&main_conf, source).unwrap();
+            let error = load_config(&main_conf).expect_err("duplicate node_id must fail");
+            assert!(
+                format!("{error:#}").contains("duplicate node_id"),
+                "{case} must report the semantic duplicate"
+            );
+        }
+    }
+
+    #[test]
+    fn diamond_included_node_id_is_adopted_once() {
+        let dir = TempDir::new().unwrap();
+        let shared = dir.path().join("shared.limpid");
+        let parent_a = dir.path().join("parent_a.limpid");
+        let parent_b = dir.path().join("parent_b.limpid");
+        let main_conf = dir.path().join("main.conf");
+
+        fs::write(&shared, "node_id \"shared-node\"").unwrap();
+        fs::write(&parent_a, "include \"shared.limpid\"").unwrap();
+        fs::write(&parent_b, "include \"shared.limpid\"").unwrap();
+        fs::write(
+            &main_conf,
+            "include \"parent_a.limpid\"\ninclude \"parent_b.limpid\"",
+        )
+        .unwrap();
+
+        let config = load_config(&main_conf).unwrap();
+        assert_eq!(config.node_id.as_deref(), Some("shared-node"));
     }
 
     #[test]

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1262,6 +1262,8 @@ def pipeline p { input i; output o }
             .build()
             .expect("test metric registration must succeed");
         received.inc();
+        crate::metrics::register_build_info(&metrics, "0.7.15", "control-node")
+            .expect("build info registration must succeed");
 
         let server = ControlServer::new(
             Some(socket_path.to_string_lossy().into_owned()),
@@ -1343,6 +1345,22 @@ def pipeline p { input i; output o }
         assert_eq!(family["type"], "counter");
         assert_eq!(family["series"][0]["labels"]["input"], "control_test");
         assert_eq!(family["series"][0]["value"], 1);
+        let build_info = metrics
+            .iter()
+            .find(|metric| metric["name"] == "limpid_build_info")
+            .expect("stats must include build info");
+        assert_eq!(build_info["type"], "gauge");
+        assert_eq!(
+            build_info["help"],
+            "Build information for the running limpid node."
+        );
+        assert_eq!(
+            build_info["series"],
+            serde_json::json!([{
+                "labels": {"node_id": "control-node", "version": "0.7.15"},
+                "value": 1
+            }])
+        );
         assert!(parsed.get("inputs").is_none());
         assert!(parsed.get("pipelines").is_none());
         assert!(parsed.get("outputs").is_none());

--- a/crates/limpid/src/dsl/ast.rs
+++ b/crates/limpid/src/dsl/ast.rs
@@ -8,6 +8,9 @@ use super::span::Span;
 /// A complete configuration file.
 #[derive(Debug, Clone)]
 pub struct Config {
+    /// Optional operator-supplied node identity. The runtime resolves
+    /// the host name once at startup when this is absent.
+    pub(crate) node_id: Option<String>,
     pub definitions: Vec<Definition>,
     /// Global config blocks (e.g. `geoip { ... }`, `control { ... }`)
     pub global_blocks: Vec<GlobalBlock>,

--- a/crates/limpid/src/dsl/limpid.pest
+++ b/crates/limpid/src/dsl/limpid.pest
@@ -9,12 +9,18 @@ config = { SOI ~ top_level_item* ~ EOI }
 top_level_item = {
     definition
   | include_directive
+  | node_id_directive
   | global_block
 }
 
 // Include directive: `include "inputs/*.limpid"`
 include_directive = {
     kw_include ~ string_lit
+}
+
+// Optional stable identity exported by `limpid_build_info`.
+node_id_directive = {
+    kw_node_id ~ expr
 }
 
 definition = {
@@ -27,7 +33,7 @@ definition = {
 
 // Global config block: `name { key value ... }` (no `def` keyword)
 global_block = {
-    !kw_def ~ !kw_include ~ ident ~ "{" ~ property* ~ "}"
+    !kw_def ~ !kw_include ~ !kw_node_id ~ ident ~ "{" ~ property* ~ "}"
 }
 
 // -- Comments & whitespace ---------------------------------------------------
@@ -58,6 +64,7 @@ kw_true     = _{ "true" }
 kw_false    = _{ "false" }
 kw_null     = _{ "null" }
 kw_include  = _{ "include" }
+kw_node_id  = @{ "node_id" ~ !(ASCII_ALPHANUMERIC | "_") }
 kw_let      = _{ "let" }
 kw_function = _{ "function" }
 

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -34,6 +34,7 @@ pub fn parse_config_with_file_id(input: &str, file_id: u32) -> Result<Config> {
     let mut definitions = Vec::new();
     let mut global_blocks = Vec::new();
     let mut includes = Vec::new();
+    let mut node_id = None;
 
     for pair in config_pair.into_inner() {
         match pair.as_rule() {
@@ -69,6 +70,24 @@ pub fn parse_config_with_file_id(input: &str, file_id: u32) -> Result<Config> {
                         let path_pair = first_inner(inner)?;
                         includes.push(parse_string_lit(&path_pair));
                     }
+                    Rule::node_id_directive => {
+                        let mut directive = inner.into_inner();
+                        let keyword = directive.next().expect("pest grammar invariant");
+                        debug_assert_eq!(keyword.as_rule(), Rule::kw_node_id);
+                        let value = parse_expr_from_pair(
+                            directive.next().expect("pest grammar invariant"),
+                            file_id,
+                        )?;
+                        let ExprKind::StringLit(value) = value.kind else {
+                            bail!("node_id requires a string value");
+                        };
+                        if value.is_empty() {
+                            bail!("node_id must be non-empty");
+                        }
+                        if node_id.replace(value).is_some() {
+                            bail!("duplicate node_id");
+                        }
+                    }
                     Rule::global_block => {
                         global_blocks.push(parse_global_block(inner, file_id)?);
                     }
@@ -81,6 +100,7 @@ pub fn parse_config_with_file_id(input: &str, file_id: u32) -> Result<Config> {
     }
 
     Ok(Config {
+        node_id,
         definitions,
         global_blocks,
         includes,

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -16,6 +16,21 @@ use limpid_metrics_schema::{
     HistogramSeries, MetricFamily as SnapshotFamily, ValueSeries as SnapshotValueSeries,
 };
 
+pub(crate) fn register_build_info(
+    registry: &Registry,
+    version: &str,
+    node_id: &str,
+) -> Result<(), MetricsError> {
+    let build_info = registry
+        .gauge("limpid_build_info")
+        .label("version", version)
+        .label("node_id", node_id)
+        .help("Build information for the running limpid node.")
+        .build()?;
+    build_info.set(1);
+    Ok(())
+}
+
 pub struct InputMetrics {
     /// Events actually received by the input module (network, socket, file, etc).
     /// Injected events are NOT counted here — see `events_injected`.
@@ -1218,6 +1233,29 @@ mod registry_tests {
         let produced = serde_json::to_value(&shared).unwrap();
         assert_eq!(produced["schema"], 1);
         assert_eq!(produced["metrics"][0]["name"], "limpid_test_events_total");
+    }
+
+    #[test]
+    fn build_info_is_one_prepopulated_gauge_with_fixed_labels() {
+        let registry = Registry::new();
+        super::register_build_info(&registry, "0.7.15", "node-a")
+            .expect("build info must register");
+
+        let snapshot = snapshot_json(&registry);
+        let family = metric(&snapshot, "limpid_build_info");
+        assert_eq!(family["type"], "gauge");
+        assert_eq!(
+            family["help"],
+            "Build information for the running limpid node."
+        );
+        assert_eq!(
+            family["series"],
+            serde_json::json!([{
+                "labels": {"node_id": "node-a", "version": "0.7.15"},
+                "value": 1
+            }])
+        );
+        assert_eq!(snapshot["metrics"].as_array().unwrap().len(), 1);
     }
 
     fn metric<'a>(snapshot: &'a Value, name: &str) -> &'a Value {

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -39,6 +39,7 @@ use crate::tap::TapRegistry;
 /// A fully resolved configuration ready for execution.
 #[derive(Clone)]
 pub struct CompiledConfig {
+    pub(crate) node_id: Option<String>,
     pub inputs: HashMap<String, InputDef>,
     pub outputs: HashMap<String, OutputDef>,
     pub processes: HashMap<String, ProcessDef>,
@@ -100,6 +101,7 @@ impl CompiledConfig {
         }
 
         let compiled = Self {
+            node_id: config.node_id,
             inputs,
             outputs,
             processes,

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -40,6 +40,24 @@ impl Runtime {
         config_file: PathBuf,
         metrics_registry: Arc<Registry>,
     ) -> Result<Self> {
+        Self::start_with_registry_and_node_id_resolver(
+            config,
+            config_file,
+            metrics_registry,
+            || Ok(gethostname::gethostname().to_string_lossy().into_owned()),
+        )
+        .await
+    }
+
+    pub(crate) async fn start_with_registry_and_node_id_resolver<F>(
+        config: CompiledConfig,
+        config_file: PathBuf,
+        metrics_registry: Arc<Registry>,
+        resolve_hostname: F,
+    ) -> Result<Self>
+    where
+        F: FnOnce() -> Result<String>,
+    {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
@@ -56,6 +74,15 @@ impl Runtime {
         let func_registry = Arc::new(func_registry);
 
         config.validate()?;
+        let node_id = match &config.node_id {
+            Some(node_id) => node_id.clone(),
+            None => resolve_hostname()?,
+        };
+        crate::metrics::register_build_info(
+            &metrics_registry,
+            env!("CARGO_PKG_VERSION"),
+            &node_id,
+        )?;
         let registry = Arc::new(registry);
 
         let tap = TapRegistry::new();
@@ -2087,6 +2114,123 @@ def pipeline p { process a; finish }
             .await
             .expect("public start must use the working registry-wired startup path");
         runtime.shutdown().await;
+    }
+
+    async fn assert_startup_build_info(
+        configured_node_id: Option<&str>,
+        expected_node_id: &str,
+        expected_resolver_calls: usize,
+    ) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
+            .expect("secure control parent");
+        let socket = dir.path().join("control.sock");
+        let node_id = configured_node_id
+            .map(|node_id| format!("node_id \"{node_id}\"\n"))
+            .unwrap_or_default();
+        let source = format!(
+            "{node_id}control {{ socket {:?} }}",
+            socket.display().to_string()
+        );
+        let config = compiled_config(&source);
+        let registry = Arc::new(Registry::new());
+        let resolver_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls = Arc::clone(&resolver_calls);
+
+        let runtime = Runtime::start_with_registry_and_node_id_resolver(
+            config,
+            PathBuf::from("build-info-startup-test.limpid"),
+            Arc::clone(&registry),
+            move || {
+                let call = calls.fetch_add(1, Ordering::Relaxed) + 1;
+                Ok(format!("resolved-host-{call}"))
+            },
+        )
+        .await
+        .expect("runtime must start");
+
+        let labels = [
+            ("node_id", expected_node_id),
+            ("version", env!("CARGO_PKG_VERSION")),
+        ];
+        assert_eq!(series_value(&registry, "limpid_build_info", &labels), 1);
+        assert_eq!(metric_series(&registry, "limpid_build_info").len(), 1);
+        assert_eq!(
+            resolver_calls.load(Ordering::Relaxed),
+            expected_resolver_calls,
+            "startup must resolve hostname exactly when node_id is omitted"
+        );
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn startup_with_explicit_node_id_skips_hostname_and_registers_that_value() {
+        assert_startup_build_info(Some("configured-node"), "configured-node", 0).await;
+    }
+
+    #[tokio::test]
+    async fn startup_without_node_id_resolves_hostname_once_and_registers_that_value() {
+        assert_startup_build_info(None, "resolved-host-1", 1).await;
+    }
+
+    #[tokio::test]
+    async fn startup_propagates_duplicate_build_info_from_the_actual_registry() {
+        let config = compiled_config("node_id \"configured-node\"");
+        let registry = Arc::new(Registry::new());
+        crate::metrics::register_build_info(
+            &registry,
+            env!("CARGO_PKG_VERSION"),
+            "configured-node",
+        )
+        .expect("preseed build info");
+        let resolver_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls = Arc::clone(&resolver_calls);
+
+        let error = match Runtime::start_with_registry_and_node_id_resolver(
+            config,
+            PathBuf::from("duplicate-build-info-startup-test.limpid"),
+            Arc::clone(&registry),
+            move || {
+                calls.fetch_add(1, Ordering::Relaxed);
+                Ok("unexpected-hostname".to_owned())
+            },
+        )
+        .await
+        {
+            Ok(runtime) => {
+                runtime.shutdown().await;
+                panic!("duplicate build-info registration must fail startup");
+            }
+            Err(error) => error,
+        };
+
+        let metrics_error = error
+            .downcast_ref::<MetricsError>()
+            .expect("startup error must retain MetricsError");
+        let expected_labelset = vec![
+            ("node_id".to_owned(), "configured-node".to_owned()),
+            ("version".to_owned(), env!("CARGO_PKG_VERSION").to_owned()),
+        ];
+        match metrics_error {
+            MetricsError::DuplicateSeries { name, labelset } => {
+                assert_eq!(name, "limpid_build_info");
+                assert_eq!(labelset, &expected_labelset);
+            }
+            other => panic!("expected DuplicateSeries, got {other:?}"),
+        }
+        let diagnostic = error.to_string();
+        assert!(
+            diagnostic.contains(&format!("name={:?}", "limpid_build_info")),
+            "diagnostic must identify the metric family: {diagnostic}"
+        );
+        assert!(
+            diagnostic.contains(&format!("labelset={expected_labelset:?}")),
+            "diagnostic must include the complete labelset: {diagnostic}"
+        );
+        assert_eq!(resolver_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(metric_series(&registry, "limpid_build_info").len(), 1);
     }
 
     #[test]

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -61,6 +61,77 @@ def pipeline p { input i; output o }
 }
 
 #[test]
+fn check_accepts_explicit_or_omitted_node_id() {
+    for (case, node_id) in [("explicit", "node_id \"edge-a\"\n"), ("omitted", "")] {
+        let dir = TempDir::new().unwrap();
+        let conf = dir.path().join(format!("node-id-{case}.conf"));
+        fs::write(
+            &conf,
+            format!(
+                r#"{node_id}def input i {{ type syslog_tcp bind "0.0.0.0:514" }}
+def output o {{ type stdout }}
+def pipeline p {{ input i; output o }}
+"#
+            ),
+        )
+        .unwrap();
+
+        let out = run_check(&conf);
+        assert!(
+            out.status.success(),
+            "{case} node_id must be accepted: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+fn assert_node_id_rejected(case: &str, node_id: &str, diagnostic: &str) {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join(format!("node-id-{case}.conf"));
+    fs::write(
+        &conf,
+        format!(
+            r#"{node_id}def input i {{ type syslog_tcp bind "0.0.0.0:514" }}
+def output o {{ type stdout }}
+def pipeline p {{ input i; output o }}
+"#
+        ),
+    )
+    .unwrap();
+
+    let out = run_check(&conf);
+    assert!(!out.status.success(), "{case} node_id must be rejected");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains(diagnostic),
+        "{case} diagnostic must contain {diagnostic:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn check_rejects_empty_node_id_with_semantic_diagnostic() {
+    assert_node_id_rejected("empty", "node_id \"\"\n", "node_id must be non-empty");
+}
+
+#[test]
+fn check_rejects_non_string_node_id_with_semantic_diagnostic() {
+    assert_node_id_rejected(
+        "wrong-type",
+        "node_id 42\n",
+        "node_id requires a string value",
+    );
+}
+
+#[test]
+fn check_rejects_duplicate_node_id_with_semantic_diagnostic() {
+    assert_node_id_rejected(
+        "duplicate",
+        "node_id \"one\"\nnode_id \"two\"\n",
+        "duplicate node_id",
+    );
+}
+
+#[test]
 fn check_with_warning_still_exits_zero_and_mentions_warnings() {
     // `lower(workspace.count)` where count is bound as Int → analyzer
     // emits a warning but no error, so exit is 0.

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -779,6 +779,40 @@ fn default_ignores_unknown_families_but_details_includes_them() {
 }
 
 #[test]
+fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
+    let mut payload = canonical_snapshot(false);
+    payload["metrics"].as_array_mut().unwrap().push(json!({
+        "name": "limpid_build_info",
+        "type": "gauge",
+        "help": "Build information for the running limpid node.",
+        "series": [{
+            "labels": {"node_id": "edge-a", "version": "0.7.15"},
+            "value": 1
+        }]
+    }));
+    let response = format!("{payload}\n");
+
+    let default_output = run_stats(&response, &[]);
+    assert!(default_output.status.success(), "{default_output:?}");
+    assert_eq!(stdout(&default_output), expected_default_table());
+    assert!(!stdout(&default_output).contains("limpid_build_info"));
+
+    let details_output = run_stats(&response, &["--details"]);
+    assert!(details_output.status.success(), "{details_output:?}");
+    let details = stdout(&details_output);
+    assert!(details.contains("limpid_build_info"));
+    assert!(details.contains("gauge"));
+    assert!(details.contains("Build information for the running limpid node."));
+    assert!(details.contains("node_id=\"edge-a\""));
+    assert!(details.contains("version=\"0.7.15\""));
+    assert!(details.contains("value: 1"));
+
+    let json_output = run_stats(&response, &["--json"]);
+    assert!(json_output.status.success(), "{json_output:?}");
+    assert_eq!(json_output.stdout, response.as_bytes());
+}
+
+#[test]
 fn malformed_known_families_fall_back_to_the_raw_response() {
     let canonical = canonical_snapshot(false);
     let mut cases = Vec::new();

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -29,6 +29,22 @@ Rules:
 - Nested includes are supported — an included file may itself contain `include` directives. The same file is loaded only once even if multiple parents reference it (diamond-safe). Cycles are detected and reported as a parse error.
 - Glob patterns are supported.
 
+## Node identity
+
+The optional top-level `node_id` identifies this daemon in build-information
+metrics:
+
+```limpid
+node_id "edge-a"
+```
+
+When it is omitted, limpid resolves the host name once during startup and uses
+that value for the lifetime of the runtime. Set `node_id` explicitly when an
+operator needs to distinguish multiple limpid instances on the same host. If
+multiple instances omit it, they expose the same host-derived identity;
+assigning distinct identities in that deployment is the operator's
+responsibility.
+
 ## Global blocks
 
 ### control

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -6,7 +6,7 @@ series. The daemon exposes a read-only snapshot through the existing `stats`
 control command; `limpidctl` and `limpid-prometheus` are consumers of that
 snapshot, not alternate metric stores.
 
-The current runtime metrics are counters. Schema v1 also defines gauge and
+The current runtime metrics are counters and gauges. Schema v1 also defines
 histogram series so consumers can render any registered family without a list
 of hard-coded names.
 
@@ -84,6 +84,15 @@ These are the current metric families registered by the daemon. Their labels
 are fixed from the compiled configuration at registration time, so cardinality
 is bounded by that configuration. Process-family cardinality follows distinct
 compiled invocation paths rather than only process definition count.
+
+### Build information
+
+`limpid_build_info{version,node_id}` is a gauge with value `1`. `version` is
+the running limpid package version. `node_id` is the explicit top-level
+configuration value when set; otherwise it is the host name resolved once at
+startup. The series is registered before the control server starts and remains
+stable for that runtime. See [Node identity](../configuration.md#node-identity)
+for the same-host multi-instance deployment caveat.
 
 ### Pipelines
 


### PR DESCRIPTION
## Summary

- Add an optional top-level `node_id` setting and expose `limpid_build_info{version,node_id}`.
- Resolve an omitted node ID from the hostname once during startup and keep that identity stable for the process lifetime.
- Preserve the shared schema-v1 boundary: limpidctl and limpid-prometheus consume the new gauge through their existing generic paths.

## Semantics

- An explicit non-empty `node_id` is used verbatim. When omitted, limpid resolves the hostname exactly once at startup. Operators running multiple instances on the same host are responsible for assigning distinct explicit IDs when distinct identities are required.
- `limpid_build_info{version,node_id}` is a single startup-registered gauge with value `1`; `version` is the running package version and `node_id` is the startup-stable resolved identity.
- Registration happens against the runtime registry before the control task starts. Duplicate registration remains a startup error.
- This change does not revise schema v1, add dependencies or public runtime APIs, or include Stage C derived metadata or LTP work.

## Validation

- Focused node-ID parsing, include topology, startup resolution, duplicate-registration propagation, registry snapshot, control, limpidctl, and Prometheus tests.
- `cargo test -p limpid`, `cargo test -p limpid --all-targets --features kafka`, and `cargo test --workspace`.
- `cargo clippy -p limpid --all-targets --features kafka -- -D warnings` and `cargo clippy --workspace -- -D warnings`.
- `cargo fmt --all -- --check`, `mdbook build docs`, snippet header/inventory checks, and Cargo deny advisories/bans/sources/licenses checks.
- Darwin keeps the existing journal/libsystemd platform boundary; Ubuntu CI owns journal-enabled coverage.
- Canonical aarch64 Ubuntu playground benchmark, release builds, workloads A-D, three runs per comparison arm (48 integrity-checked raw runs total):
  - Phase 1 final -> candidate median throughput ratios: A `99.8617%`, B `101.1107%`, C `99.7596%`, D `100.8854%`; worst regression `0.2404%`.
  - Current release -> candidate isolated ratios: A `99.5731%`, B `96.5609%`, C `99.6267%`, D `104.697%`; worst regression `3.4391%`.
  - Both comparisons remain below the `5%` regression guard. Raw benchmark archive SHA-256: `b6a55b0cd150390bf06de3e7a5c39a53812ede12eaa4ddde9d9268bd3c3183`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional top-level `node_id` configuration with validation and hostname fallback.
  * Exposed stable `limpid_build_info` metrics containing version and node identity.
  * Included build information in detailed statistics output and Prometheus metrics.

* **Bug Fixes**
  * Prevented conflicting node IDs across included configurations.
  * Improved validation for empty, non-string, and duplicate node IDs.

* **Documentation**
  * Documented node identity configuration, hostname fallback, uniqueness requirements, and build information metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->