### PR TITLE
fix(dsl): reject recursive process calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — process call graphs must be acyclic (breaking)
+
+`def process` declarations may still call other named processes, but direct
+and mutual recursion are now rejected at config-load time. The same validation
+applies to calls nested in control-flow branches and to definitions merged from
+included files. Existing acyclic parser, normalizer, and composer chains are
+unchanged. Configurations that relied on recursive process calls must rewrite
+the flow as a finite process graph or use the bounded collection primitives for
+collection traversal.
+
 ### Changed — metrics use one self-describing schema-v1 registry
 
 The daemon now registers its existing input, pipeline, and output counters in a

--- a/crates/limpid/src/check/function.rs
+++ b/crates/limpid/src/check/function.rs
@@ -378,7 +378,7 @@ fn dfs_cycle<'a>(
                             ),
                             span: None,
                             help: Some(
-                                "use `def process` if you genuinely need recursion; otherwise rewrite the chain to be acyclic"
+                                "rewrite the function calls to form an acyclic graph"
                                     .to_string(),
                             ),
                         });

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -27,6 +27,7 @@
 //! - `expr_types`      — `Expr` → `FieldType` inference + arg-/op-checks
 //! - `outputs`         — output-side workspace reference checks
 //! - `parser_effects`  — parser `produces` → workspace merge
+//! - `process`         — process call-graph cycle rejection
 //! - `render`          — rustc-style snippet+caret diagnostic emit
 //! - `suggestions`     — Levenshtein "did you mean" hint
 //! - `recovery_readiness` — cross-cutting warning: recovery-worthy outputs without `error_log`
@@ -44,6 +45,7 @@ mod journal_match_format;
 mod module_props;
 mod outputs;
 mod parser_effects;
+mod process;
 mod recovery_readiness;
 pub mod render;
 pub mod suggestions;
@@ -286,6 +288,7 @@ pub fn analyze(config: &CompiledConfig, _source_map: &SourceMap) -> Vec<Diagnost
 
     let mut diagnostics = Vec::new();
     function::check_all_functions(config, &registry, &mut diagnostics);
+    process::check_process_cycles(config, &mut diagnostics);
     module_props::analyze_all(config, &module_registry, &mut diagnostics);
     global_props::analyze_all(config, &mut diagnostics);
     #[cfg(feature = "journal")]
@@ -1638,6 +1641,106 @@ def pipeline p { input i; output o }
         );
         let m = &cycle_errs[0].message;
         assert!(m.contains("a") && m.contains("b"), "got: {}", m);
+    }
+
+    #[test]
+    fn process_self_recursion_errors() {
+        let src = r#"
+def process rec {
+    process rec
+}
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; process rec; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            errors(&diags).iter().any(|e| {
+                e.message.contains("process call cycle detected")
+                    && e.message.contains("`rec` calls itself")
+            }),
+            "expected process self-recursion error, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn process_cycle_inside_all_branch_forms_errors_once() {
+        let src = r#"
+def process a {
+    if true {
+        process b
+    }
+}
+def process b {
+    switch "selected" {
+        "selected" { process c }
+    }
+}
+def process c {
+    try {
+        process a
+    } catch {
+        workspace.recovered = true
+    }
+}
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; process a; output o }
+"#;
+        let diags = analyze_str(src);
+        let cycle_errs: Vec<&Diagnostic> = errors(&diags)
+            .into_iter()
+            .filter(|e| e.message.contains("process call cycle detected"))
+            .collect();
+        assert_eq!(
+            cycle_errs.len(),
+            1,
+            "expected exactly one process cycle error, got: {:?}",
+            diags
+        );
+        let message = &cycle_errs[0].message;
+        assert!(
+            message.contains("a") && message.contains("b") && message.contains("c"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn unreachable_process_cycle_is_still_rejected() {
+        let src = r#"
+def process unused_a { process unused_b }
+def process unused_b { process unused_a }
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            errors(&diags)
+                .iter()
+                .any(|e| e.message.contains("process call cycle detected")),
+            "expected unreachable process cycle to be rejected, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn acyclic_process_calls_remain_valid() {
+        let src = r#"
+def process leaf { workspace.done = true }
+def process middle { process leaf }
+def process root { process middle }
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; process root; output o }
+"#;
+        let diags = analyze_str(src);
+        assert!(
+            errors(&diags).is_empty(),
+            "acyclic process graph must remain valid, got: {:?}",
+            diags
+        );
     }
 
     #[test]

--- a/crates/limpid/src/check/process.rs
+++ b/crates/limpid/src/check/process.rs
@@ -1,0 +1,154 @@
+//! Static call-graph validation for `def process` declarations.
+//!
+//! Process bodies may call other named processes, but the resulting
+//! graph must be acyclic. Rejecting cycles at config-load time keeps
+//! execution bounded by the compiled configuration and makes each
+//! invocation path a finite, statically known identity.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::dsl::ast::{BranchBody, ProcessStatement};
+use crate::pipeline::CompiledConfig;
+
+use super::{DiagKind, Diagnostic, Level};
+
+pub(super) fn check_process_cycles(config: &CompiledConfig, diagnostics: &mut Vec<Diagnostic>) {
+    let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
+    for (name, process) in &config.processes {
+        let mut callees = Vec::new();
+        collect_process_callees(&process.body, config, &mut callees);
+        callees.sort_unstable();
+        callees.dedup();
+        adjacency.insert(name.as_str(), callees);
+    }
+
+    let mut color: HashMap<&str, u8> = adjacency.keys().map(|name| (*name, 0)).collect();
+    let mut stack = Vec::new();
+    let mut reported = HashSet::new();
+    let mut names: Vec<&str> = adjacency.keys().copied().collect();
+    names.sort_unstable();
+    for name in names {
+        if color[&name] == 0 {
+            visit_process(
+                name,
+                &adjacency,
+                &mut color,
+                &mut stack,
+                &mut reported,
+                diagnostics,
+            );
+        }
+    }
+}
+
+fn collect_process_callees<'a>(
+    statements: &'a [ProcessStatement],
+    config: &'a CompiledConfig,
+    out: &mut Vec<&'a str>,
+) {
+    for statement in statements {
+        match statement {
+            ProcessStatement::ProcessCall(name) => {
+                if let Some((stored_name, _)) = config.processes.get_key_value(name) {
+                    out.push(stored_name.as_str());
+                }
+            }
+            ProcessStatement::If(chain) => {
+                for (_, body) in &chain.branches {
+                    collect_branch_callees(body, config, out);
+                }
+                if let Some(body) = &chain.else_body {
+                    collect_branch_callees(body, config, out);
+                }
+            }
+            ProcessStatement::Switch(_, arms) => {
+                for arm in arms {
+                    collect_branch_callees(&arm.body, config, out);
+                }
+            }
+            ProcessStatement::TryCatch(try_body, catch_body) => {
+                collect_process_callees(try_body, config, out);
+                collect_process_callees(catch_body, config, out);
+            }
+            ProcessStatement::Assign(_, _)
+            | ProcessStatement::LetBinding(_, _)
+            | ProcessStatement::Drop
+            | ProcessStatement::Error(_)
+            | ProcessStatement::ExprStmt(_) => {}
+        }
+    }
+}
+
+fn collect_branch_callees<'a>(
+    body: &'a [BranchBody],
+    config: &'a CompiledConfig,
+    out: &mut Vec<&'a str>,
+) {
+    for item in body {
+        if let BranchBody::Process(statement) = item {
+            collect_process_callees(std::slice::from_ref(statement), config, out);
+        }
+    }
+}
+
+fn visit_process<'a>(
+    node: &'a str,
+    adjacency: &HashMap<&'a str, Vec<&'a str>>,
+    color: &mut HashMap<&'a str, u8>,
+    stack: &mut Vec<&'a str>,
+    reported: &mut HashSet<Vec<String>>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    color.insert(node, 1);
+    stack.push(node);
+    if let Some(callees) = adjacency.get(node) {
+        for &callee in callees {
+            match color.get(callee).copied().unwrap_or(0) {
+                0 => visit_process(callee, adjacency, color, stack, reported, diagnostics),
+                1 => report_cycle(callee, stack, reported, diagnostics),
+                _ => {}
+            }
+        }
+    }
+    stack.pop();
+    color.insert(node, 2);
+}
+
+fn report_cycle(
+    callee: &str,
+    stack: &[&str],
+    reported: &mut HashSet<Vec<String>>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let position = stack.iter().position(|name| *name == callee).unwrap_or(0);
+    let cycle: Vec<String> = stack[position..]
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect();
+    let mut canonical = cycle.clone();
+    let first = canonical
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, name)| name.as_str())
+        .map(|(index, _)| index)
+        .unwrap_or(0);
+    canonical.rotate_left(first);
+    if !reported.insert(canonical) {
+        return;
+    }
+
+    let path = if cycle.len() == 1 {
+        format!("`{}` calls itself", cycle[0])
+    } else {
+        format!("`{}` → `{}`", cycle.join("` → `"), cycle[0])
+    };
+    diagnostics.push(Diagnostic {
+        level: Level::Error,
+        kind: DiagKind::Other,
+        message: format!(
+            "process call cycle detected: {path}; recursion in `def process` is not supported"
+        ),
+        span: None,
+        help: Some("rewrite the process calls to form an acyclic graph".to_owned()),
+    });
+}

--- a/crates/limpid/src/dsl/ast.rs
+++ b/crates/limpid/src/dsl/ast.rs
@@ -150,9 +150,8 @@ pub enum ProcessStatement {
 /// without an Event in hand.
 ///
 /// Recursion (direct or mutual) is rejected at analyzer time; this
-/// keeps the type-inference step a simple post-order traversal and
-/// avoids the small set of patterns where recursion would be useful
-/// (those belong in `def process`).
+/// keeps the type-inference step a simple post-order traversal. Process
+/// call graphs are likewise required to be acyclic.
 #[derive(Debug, Clone)]
 pub struct FunctionDef {
     pub name: String,

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -51,9 +51,8 @@ pub trait ProcessRegistry {
 /// Registry extension that accepts a metric token pre-resolved at
 /// startup. The token identifies the metric node independently of
 /// the process name — the same name at different call sites
-/// (including recursion) resolves to distinct or shared nodes decided
-/// at compile time — so the event path only needs one `Vec` index
-/// instead of walking the process tree.
+/// resolves to nodes decided at compile time — so the event path only
+/// needs one `Vec` index instead of walking the process tree.
 pub(crate) trait CompiledProcessRegistry: ProcessRegistry {
     fn call_pre_resolved<'bump>(
         &self,

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -396,6 +396,9 @@ mod registry_core {
             existing: String,
             requested: String,
         },
+        /// Defensive guard for callers that compile process metrics
+        /// without first running the config analyzer.
+        ProcessCallCycle { path: Vec<String> },
     }
 
     impl fmt::Display for MetricsError {
@@ -432,6 +435,11 @@ mod registry_core {
                 } => write!(
                     formatter,
                     "metric family metadata conflict: name={name:?}, existing={existing}, requested={requested}"
+                ),
+                Self::ProcessCallCycle { path } => write!(
+                    formatter,
+                    "process call cycle reached metric compilation: {}",
+                    path.join(" -> ")
                 ),
             }
         }

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -876,13 +876,10 @@ impl ProcessMetricPlanValidator<'_> {
     ) -> anyhow::Result<()> {
         match (statement, metric) {
             (ProcessStatement::ProcessCall(name), ProcessMetricStatement::Call(token)) => {
-                let expected = if let Some((_, ancestor)) = ancestors
-                    .iter()
-                    .rev()
-                    .find(|(ancestor, _)| ancestor == name)
-                {
-                    *ancestor
-                } else if let Some(existing) = self.edges.get(&(parent, name.clone())) {
+                if ancestors.iter().any(|(ancestor, _)| ancestor == name) {
+                    anyhow::bail!("compiled process metric plan contains a recursive process call");
+                }
+                let expected = if let Some(existing) = self.edges.get(&(parent, name.clone())) {
                     *existing
                 } else {
                     let identity = self.raw.identities.get(*token).ok_or_else(|| {
@@ -1153,14 +1150,17 @@ impl ProcessMetricsBuilder<'_> {
             ProcessStatement::ProcessCall(name) => {
                 let child = if let Some(child) = self.children[parent].get(name) {
                     *child
-                } else if let Some((_, ancestor)) = ancestors
+                } else if let Some((position, _)) = ancestors
                     .iter()
-                    .rev()
-                    .find(|(ancestor, _)| ancestor == name)
+                    .enumerate()
+                    .find(|(_, (ancestor, _))| ancestor == name)
                 {
-                    let child = *ancestor;
-                    self.children[parent].insert(name.clone(), child);
-                    child
+                    let mut path: Vec<String> = ancestors[position..]
+                        .iter()
+                        .map(|(ancestor, _)| ancestor.clone())
+                        .collect();
+                    path.push(name.clone());
+                    return Err(crate::metrics::MetricsError::ProcessCallCycle { path });
                 } else {
                     let body = self
                         .processes

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -1155,14 +1155,12 @@ def pipeline topology {
     }
 
     #[test]
-    fn process_metrics_fold_same_call_site_and_collapse_recursive_back_edges() {
+    fn process_metrics_reuse_same_callee_calls_within_one_parent() {
         let config = compiled_config(
             r#"
-def process a { process b }
-def process b { process a }
 def process leaf { egress = ingress }
 def process dispatch { process leaf; process leaf }
-def pipeline bounded { process a; process dispatch }
+def pipeline bounded { process dispatch }
 "#,
         );
         let registry = Registry::new();
@@ -1174,9 +1172,7 @@ def pipeline bounded { process a; process dispatch }
             .iter()
             .map(|series| series["labels"]["process_path"].as_str().expect("path"))
             .collect();
-        assert_eq!(series.len(), 4);
-        assert_eq!(paths.iter().filter(|path| **path == "/a").count(), 1);
-        assert_eq!(paths.iter().filter(|path| **path == "/a/b").count(), 1);
+        assert_eq!(series.len(), 2);
         assert_eq!(paths.iter().filter(|path| **path == "/dispatch").count(), 1);
         assert_eq!(
             paths
@@ -1185,7 +1181,6 @@ def pipeline bounded { process a; process dispatch }
                 .count(),
             1
         );
-        assert!(!paths.contains(&"/a/b/a"));
     }
 
     #[tokio::test]
@@ -1196,13 +1191,10 @@ def process leaf { egress = ingress }
 def process parent_one { process leaf }
 def process parent_two { process leaf }
 def process dispatch { process leaf; process leaf }
-def process a { process b }
-def process b { process a }
 def pipeline p {
     process parent_one
     process parent_two
     process dispatch
-    process a
 }
 "#,
         );
@@ -1218,7 +1210,6 @@ def pipeline p {
         let parent_one = plan.root_token_for_testing(1).expect("parent_one token");
         let parent_two = plan.root_token_for_testing(2).expect("parent_two token");
         let dispatch = plan.root_token_for_testing(3).expect("dispatch token");
-        let a = plan.root_token_for_testing(4).expect("a token");
         let parent_one_leaf = plan
             .child_token_for_testing(parent_one, 0)
             .expect("parent_one leaf token");
@@ -1234,13 +1225,6 @@ def pipeline p {
             plan.child_token_for_testing(dispatch, 1),
             "same-parent calls to the same callee must reuse one frame token"
         );
-        let b = plan.child_token_for_testing(a, 0).expect("a-to-b token");
-        assert_eq!(
-            plan.child_token_for_testing(b, 0),
-            Some(a),
-            "an ancestor back-edge must reuse the ancestor token"
-        );
-
         let execution_config = compiled_config(
             r#"
 def process leaf { egress = ingress }
@@ -1961,53 +1945,31 @@ def pipeline nested { process outer; finish }
         assert_process_conservation(&nested);
     }
 
-    #[tokio::test]
-    async fn recursive_invocations_reuse_the_ancestor_series_without_dynamic_growth() {
-        let mut event = fixture_event();
-        event
-            .workspace
-            .insert("depth".to_owned(), crate::dsl::value::OwnedValue::Int(0));
-        let registry = run_process_metric_fixture(
+    #[test]
+    fn process_metric_compilation_rejects_recursion_if_analysis_is_bypassed() {
+        let config = compiled_config(
             r#"
-def process a {
-    if workspace.depth < 2 {
-        workspace.depth = workspace.depth + 1
-        process b
-    }
-}
+def process a { process b }
 def process b { process a }
-def pipeline p { process a; finish }
+def pipeline p { process a }
 "#,
-            "p",
-            event,
-        )
-        .await;
-        assert_process_vector(
+        );
+        let registry = Registry::new();
+        let def = config.pipelines.get("p").expect("pipeline");
+        let error = match PipelineWorker::compile_process_metric_plan_for_testing(
+            def,
+            &config.processes,
             &registry,
-            &[
-                ("pipeline", "p"),
-                ("step", "1"),
-                ("process_path", "/a"),
-                ("process_name", "a"),
-            ],
-            [3, 3, 0, 0],
-        );
-        assert_process_vector(
-            &registry,
-            &[
-                ("pipeline", "p"),
-                ("step", "1"),
-                ("process_path", "/a/b"),
-                ("process_name", "b"),
-            ],
-            [2, 2, 0, 0],
-        );
-        assert_eq!(
-            metric_series(&registry, "limpid_process_events_in_total").len(),
-            2,
-            "recursive calls must not register runtime series"
-        );
-        assert_process_conservation(&registry);
+        ) {
+            Ok(_) => panic!("metric compilation must reject a recursive process graph"),
+            Err(error) => error,
+        };
+        match error {
+            crate::metrics::MetricsError::ProcessCallCycle { path } => {
+                assert_eq!(path, ["a", "b", "a"]);
+            }
+            other => panic!("unexpected metric compilation error: {other}"),
+        };
     }
 
     #[tokio::test]

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -944,8 +944,7 @@ def pipeline p { input i; output o }
     assert!(!out.status.success(), "process cycle must fail --check");
     assert!(
         stderr.contains("process call cycle detected")
-            && stderr.contains("first")
-            && stderr.contains("second"),
+            && stderr.contains("`first` → `second` → `first`"),
         "stderr: {stderr}"
     );
 }

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -919,6 +919,37 @@ fn check_self_inclusion_is_rejected() {
     assert!(stderr.contains("cycle"), "stderr: {}", stderr);
 }
 
+#[test]
+fn check_rejects_process_cycle_across_included_files() {
+    let dir = TempDir::new().unwrap();
+    let first = dir.path().join("first.limpid");
+    let second = dir.path().join("second.limpid");
+    let main = dir.path().join("main.conf");
+    fs::write(&first, "def process first { process second }").unwrap();
+    fs::write(&second, "def process second { process first }").unwrap();
+    fs::write(
+        &main,
+        r#"
+include "first.limpid"
+include "second.limpid"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; output o }
+"#,
+    )
+    .unwrap();
+
+    let out = run_check(&main);
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(!out.status.success(), "process cycle must fail --check");
+    assert!(
+        stderr.contains("process call cycle detected")
+            && stderr.contains("first")
+            && stderr.contains("second"),
+        "stderr: {stderr}"
+    );
+}
+
 // ---- daemon startup analyzer enforcement -----------------------------
 //
 // `--check` and daemon startup share the same compile-validate-analyze
@@ -1065,6 +1096,34 @@ def pipeline p { input i; output o }
         stderr.contains("egress") && stderr.contains("pipeline-mutable state"),
         "expected pipeline-mutable diagnostic; stderr: {}",
         stderr
+    );
+}
+
+#[test]
+fn daemon_startup_rejects_recursive_process_graph() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("daemon_process_cycle.conf");
+    fs::write(
+        &conf,
+        r#"
+def process a { process b }
+def process b { process a }
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p { input i; process a; output o }
+"#,
+    )
+    .unwrap();
+
+    let out = run_daemon_attempt(&conf);
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        !out.status.success(),
+        "daemon must reject process recursion"
+    );
+    assert!(
+        stderr.contains("process call cycle detected") && stderr.contains("rejected by analyzer"),
+        "stderr: {stderr}"
     );
 }
 

--- a/docs/src/functions/user-defined.md
+++ b/docs/src/functions/user-defined.md
@@ -140,7 +140,7 @@ The body **may not**:
 
 - **read from the Event** — `ingress`, `egress`, `source`, `received_at`, `error`, and any `workspace.*` path are rejected. Functions are pure transformations of their arguments; coupling them to the surrounding pipeline context defeats the point.
 - **invoke any routing op** — `process foo`, `drop`, [`error`](../processing/user-defined.md#error), `output` are all rejected. A function returns a value; routing decisions belong at pipeline level, and the side effects of a `def process` body don't fit the function contract. (`finish` is a pipeline-only statement and is not reachable from a function body even in principle — listed here for completeness.)
-- **recurse**, directly or mutually. The analyzer detects cycles in the function-to-function call graph and rejects them at config-load time. If you genuinely need recursion, write a `def process` instead.
+- **recurse**, directly or mutually. The analyzer detects cycles in the function-to-function call graph and rejects them at config-load time. Process call graphs are also required to be acyclic.
 - **call an unknown function** — every function call inside the body must resolve to either a built-in primitive, a user-defined `def function`, or (if a block-arg primitive's block) the block parameters. Calls to names that don't exist (typos, references to removed primitives) are rejected, with a near-match hint when available.
 
 ```
@@ -187,7 +187,7 @@ The analyzer's cycle check catches mutual recursion across any chain length.
 | Any assignment (`x = …`) | ❌ | ✅ allowed |
 | `drop` / `error` / `output foo` / `process foo` | ❌ | ✅ allowed |
 | Calls another `def function` | ✅ | ✅ |
-| Recursion | ❌ | ✅ allowed (operator-responsible) |
+| Recursion | ❌ | ❌ |
 | Composable in expressions / HashLit | ✅ | ❌ (statement only) |
 
 Rule of thumb: **if the result is a single value the caller wants to embed somewhere**, write a function. **If the result is a side effect on the Event**, write a process.

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -129,11 +129,11 @@ The four process counter families use the labels `pipeline`, `step`,
 These are invocation counters, not event counters. `step` is the root process
 site's one-based, pipeline-wide source-order position; nested calls share that
 root step. A named root has a path such as `/dispatch`, a nested call extends it
-to `/dispatch/leaf`, and an inline root uses `/(inline)`. Recursive back-edges
-reuse their ancestor series. Each distinct compiled invocation node owns four
-counter series; reusing a helper under different parents creates distinct path
-series, while ancestor recursion reuses the ancestor node and cannot grow the
-topology at runtime. Every configured series is prepopulated with zero.
+to `/dispatch/leaf`, and an inline root uses `/(inline)`. Process call graphs
+must be acyclic, so every invocation path is finite and known at config-load
+time. Each distinct compiled invocation node owns four counter series; reusing
+a helper under different parents creates distinct path series. Every
+configured series is prepopulated with zero.
 
 Each frame records exactly one terminal result, so for an individual series
 `in = out + dropped + errored`. A nested drop propagates through its active

--- a/docs/src/processing/design-guide.md
+++ b/docs/src/processing/design-guide.md
@@ -210,7 +210,7 @@ The question "function or process?" has a clean answer:
 | Depends on a specific schema spec (RFC 5424, CEF, OCSF, …) | A namespaced built-in (`syslog.xxx`) if shipping with the daemon, otherwise a `def process` in a snippet |
 | Reads or writes `egress`, `workspace`, or `ingress` directly | A `def process` |
 | Can `drop`, or must run multiple statements in sequence | A `def process` |
-| Recursive | A `def process` (`def function` rejects recursion at `--check` time) |
+| Recursive | Not supported; both function and process call graphs must be acyclic |
 | Operator-specific policy (facility rewrite, vendor filter, site-specific routing) | Always a `def process`, defined close to the pipeline that uses it |
 
 A snippet library (the `functions/*.limpid` + `parsers/parse_*.limpid` + `composers/compose_*.limpid` collection that ships under `/usr/share/limpid/snippets/`) mixes the three: `def function` files under `functions/` for vendor-agnostic mappings (severity, proto, action), `def process` files under `parsers/parse_*` for vendor parsers and under `composers/compose_*` for the per-class composer bodies that consume Event state and write to `workspace.lsis.parsed` / `workspace.lsis.composed.<slot>`, and built-in primitives (`syslog.parse`, `cef.parse`, `to_json`, `regex_*`) as the building blocks underneath.

--- a/docs/src/processing/user-defined.md
+++ b/docs/src/processing/user-defined.md
@@ -252,3 +252,5 @@ def process enrich_and_tag {
 ```
 
 Each call runs the named process's body against the same event in sequence. Only the named single-call form works here — the `|`-chain shape (`process strip_headers | enrich`) and inline anonymous processes (`process { ... }`) are pipeline-side composition primitives, not process-body statements. See [Pipelines → Routing](../pipelines/routing.md) for those.
+
+Process calls must form an acyclic graph. Direct recursion and mutual recursion are rejected at config-load time, including cycles that cross included files or appear only inside `if`, `switch`, or `try` / `catch` branches. Repetition over event collections belongs in bounded collection primitives such as `map`, `filter`, and `reduce`; process calls compose a finite parser and transformation graph.


### PR DESCRIPTION
## Summary

- reject direct and mutual `def process` recursion at config-load time
- analyze the complete merged process namespace, including calls inside control-flow branches and included files
- remove recursive metric back-edge collapsing and fail defensively if metric compilation bypasses analysis

## Behavior

Process call graphs must now be acyclic. Existing finite parser, normalizer, and composer chains are unchanged. Collection traversal remains available through bounded collection primitives such as `map`, `filter`, and `reduce`.

This is a pre-1.0 DSL breaking change. The shipped snippet corpus contains no recursive process graph.

## Validation

- `cargo test --workspace`
- `cargo test -p limpid --all-targets --features kafka`
- workspace and Kafka all-target Clippy with `-D warnings`
- `cargo fmt --all -- --check`
- `mdbook build docs`
- uchgs full push gate: 9/9 PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Recursive process calls are now rejected during configuration loading, including direct, mutual, cross-file, and branch-contained cycles.
  - Affected configurations report the complete recursive call path and fail validation or startup.
  - Rewrite recursive flows as acyclic graphs or use bounded operations such as `map`, `filter`, and `reduce`.

- **Documentation**
  - Updated recursion and process-metrics guidance to describe the acyclic-call requirement and finite invocation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->