### PR TITLE
feat(metrics): unify dropped-event hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Changed — dropped metrics use one rooted hierarchy (breaking)
+
+`limpid_pipeline_events_dropped_total{pipeline}` is replaced by the
+`limpid_events_dropped_total{pipeline,step,process_path,process_name}` family.
+The pipeline frame is the hierarchy root and uses `step="0"`,
+`process_path="/"`, and an empty `process_name`; process frames retain their
+one-based root step and compiled invocation path. Dashboards and alerts using
+the old family name must migrate to the unified family and select the root or
+process paths they need.
+
+`limpid-prometheus` additionally exposes
+`limpid_events_dropped_own_total` with the same labels. It subtracts direct
+child totals at scrape time, so the root series reports drops executed directly
+in the pipeline body and process series report drops executed directly in that
+process body. The daemon's source counter remains the propagated total at each
+node.
+
 ### Changed — process call graphs must be acyclic (breaking)
 
 `def process` declarations may still call other named processes, but direct

--- a/crates/limpid-metrics-schema/src/lib.rs
+++ b/crates/limpid-metrics-schema/src/lib.rs
@@ -1,13 +1,65 @@
-//! Wire-only data transfer objects for schema-v1 metrics snapshots.
+//! Schema-v1 metric definitions and wire data transfer objects.
 //!
-//! These wire DTOs keep the daemon's runtime state out of consumer
-//! dependency graphs. Serde is the crate's only production dependency,
-//! and architecture tests enforce that boundary.
+//! The well-known dropped hierarchy, process metric vocabulary, and path
+//! helpers are pure schema definitions. The wire DTOs keep the daemon's
+//! runtime state out of consumer dependency graphs. Serde is the crate's only
+//! production dependency, and architecture tests enforce that boundary.
 
 use std::collections::BTreeMap;
 
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
+
+pub const PROCESS_EVENTS_IN_TOTAL: &str = "limpid_process_events_in_total";
+pub const PROCESS_EVENTS_OUT_TOTAL: &str = "limpid_process_events_out_total";
+pub const PROCESS_EVENTS_ERRORED_TOTAL: &str = "limpid_process_events_errored_total";
+pub const EVENTS_DROPPED_TOTAL: &str = "limpid_events_dropped_total";
+pub const EVENTS_DROPPED_OWN_TOTAL: &str = "limpid_events_dropped_own_total";
+
+pub const PROCESS_LABEL_PIPELINE: &str = "pipeline";
+pub const PROCESS_LABEL_STEP: &str = "step";
+pub const PROCESS_LABEL_PATH: &str = "process_path";
+pub const PROCESS_LABEL_NAME: &str = "process_name";
+
+pub const PROCESS_PATH_SEPARATOR: char = '/';
+pub const PROCESS_PATH_ROOT: &str = "/";
+pub const DROPPED_ROOT_STEP: &str = "0";
+pub const DROPPED_ROOT_PROCESS_NAME: &str = "";
+
+pub fn process_path_leaf(path: &str) -> Option<&str> {
+    if !is_process_path(path) || path == PROCESS_PATH_ROOT {
+        return None;
+    }
+    path.rsplit_once(PROCESS_PATH_SEPARATOR)
+        .map(|(_, leaf)| leaf)
+}
+
+pub fn process_path_parent(path: &str) -> Option<&str> {
+    if !is_process_path(path) || path == PROCESS_PATH_ROOT {
+        return None;
+    }
+    let (parent, _) = path.rsplit_once(PROCESS_PATH_SEPARATOR)?;
+    Some(if parent.is_empty() {
+        PROCESS_PATH_ROOT
+    } else {
+        parent
+    })
+}
+
+pub fn is_direct_child(parent: &str, child: &str) -> bool {
+    is_process_path(parent)
+        && is_process_path(child)
+        && process_path_parent(child).is_some_and(|candidate| candidate == parent)
+}
+
+fn is_process_path(path: &str) -> bool {
+    path == PROCESS_PATH_ROOT
+        || path
+            .strip_prefix(PROCESS_PATH_SEPARATOR)
+            .is_some_and(|suffix| {
+                !suffix.is_empty() && suffix.split('/').all(|part| !part.is_empty())
+            })
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MetricsSnapshot {

--- a/crates/limpid-metrics-schema/tests/purity.rs
+++ b/crates/limpid-metrics-schema/tests/purity.rs
@@ -113,13 +113,6 @@ impl<'ast> Visit<'ast> for RuntimeReferences {
         }
         syn::visit::visit_attribute(self, attribute);
     }
-
-    fn visit_lit_str(&mut self, literal: &'ast syn::LitStr) {
-        if literal.value().starts_with("limpid_") {
-            self.hits.push(literal.value());
-        }
-        syn::visit::visit_lit_str(self, literal);
-    }
 }
 
 fn inspect_serde_meta(
@@ -185,7 +178,7 @@ fn schema_crate_has_only_serde_as_a_normal_dependency() {
 }
 
 #[test]
-fn every_schema_source_file_is_free_of_runtime_types_and_semantics() {
+fn every_schema_source_file_is_free_of_runtime_implementation_types() {
     let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut files = Vec::new();
     rust_sources(&source_root, &mut files);
@@ -199,9 +192,10 @@ fn every_schema_source_file_is_free_of_runtime_types_and_semantics() {
 }
 
 #[test]
-fn purity_guard_allows_wire_collections_and_serde_derives() {
+fn purity_guard_allows_schema_definitions_wire_collections_and_serde_derives() {
     let source = r#"
         // std::sync::Arc and limpid::metrics::Registry in comments are inert.
+        const PROCESS_FAMILY: &str = "limpid_process_events_in_total";
         #[derive(serde::Serialize, serde::Deserialize)]
         struct WireValue {
             labels: std::collections::BTreeMap<String, String>,
@@ -237,7 +231,6 @@ fn purity_guard_detects_each_forbidden_runtime_reference() {
         "#[serde(default, rename = \"wire\", deny_unknown_fields)] struct Closed;",
         "#[serde(rename(serialize = \"out\", deserialize = \"in\"), deny_unknown_fields)] struct Closed;",
         "#[serde(bound(deserialize = \"T: serde::Deserialize<'de>\"), deny_unknown_fields)] struct Closed<T>(T);",
-        "const FAMILY: &str = \"limpid_runtime_total\";",
     ] {
         assert!(!inspect(source).is_empty(), "{source}");
     }

--- a/crates/limpid-metrics-schema/tests/wire_contract.rs
+++ b/crates/limpid-metrics-schema/tests/wire_contract.rs
@@ -1,4 +1,10 @@
-use limpid_metrics_schema::MetricsSnapshot;
+use limpid_metrics_schema::{
+    DROPPED_ROOT_PROCESS_NAME, DROPPED_ROOT_STEP, EVENTS_DROPPED_OWN_TOTAL, EVENTS_DROPPED_TOTAL,
+    MetricsSnapshot, PROCESS_EVENTS_ERRORED_TOTAL, PROCESS_EVENTS_IN_TOTAL,
+    PROCESS_EVENTS_OUT_TOTAL, PROCESS_LABEL_NAME, PROCESS_LABEL_PATH, PROCESS_LABEL_PIPELINE,
+    PROCESS_LABEL_STEP, PROCESS_PATH_ROOT, PROCESS_PATH_SEPARATOR, is_direct_child,
+    process_path_leaf, process_path_parent,
+};
 use serde_json::{Value, json};
 
 const FIXTURE: &str = include_str!("fixtures/schema-v1.json");
@@ -185,4 +191,82 @@ fn an_empty_histogram_bucket_list_is_valid() {
     let mut candidate = fixture();
     candidate["metrics"][2]["series"][0]["buckets"] = json!([]);
     assert!(serde_json::from_value::<MetricsSnapshot>(candidate).is_ok());
+}
+
+#[test]
+fn dropped_hierarchy_and_process_metric_names_are_the_well_known_schema_v1_vocabulary() {
+    assert_eq!(
+        [
+            PROCESS_EVENTS_IN_TOTAL,
+            PROCESS_EVENTS_OUT_TOTAL,
+            EVENTS_DROPPED_TOTAL,
+            PROCESS_EVENTS_ERRORED_TOTAL,
+            EVENTS_DROPPED_OWN_TOTAL,
+        ],
+        [
+            "limpid_process_events_in_total",
+            "limpid_process_events_out_total",
+            "limpid_events_dropped_total",
+            "limpid_process_events_errored_total",
+            "limpid_events_dropped_own_total",
+        ]
+    );
+    assert_eq!(
+        [
+            PROCESS_LABEL_PIPELINE,
+            PROCESS_LABEL_STEP,
+            PROCESS_LABEL_PATH,
+            PROCESS_LABEL_NAME,
+        ],
+        ["pipeline", "step", "process_path", "process_name"]
+    );
+    assert_eq!(PROCESS_PATH_SEPARATOR, '/');
+    assert_eq!(PROCESS_PATH_ROOT, "/");
+    assert_eq!(DROPPED_ROOT_STEP, "0");
+    assert_eq!(DROPPED_ROOT_PROCESS_NAME, "");
+}
+
+#[test]
+fn process_path_leaf_and_parent_follow_the_rooted_invocation_hierarchy() {
+    let cases = [
+        ("/dispatch/leaf", Some("leaf"), Some("/dispatch")),
+        ("/dispatch", Some("dispatch"), Some("/")),
+        ("/(inline)", Some("(inline)"), Some("/")),
+        ("/", None, None),
+        ("", None, None),
+        ("dispatch", None, None),
+        ("/dispatch/", None, None),
+        ("/dispatch//leaf", None, None),
+    ];
+
+    for (path, leaf, parent) in cases {
+        assert_eq!(process_path_leaf(path), leaf, "leaf for {path:?}");
+        assert_eq!(process_path_parent(path), parent, "parent for {path:?}");
+    }
+}
+
+#[test]
+fn direct_child_requires_exactly_one_valid_path_segment() {
+    for (parent, child) in [
+        ("/", "/dispatch"),
+        ("/dispatch", "/dispatch/leaf"),
+        ("/dispatch", "/dispatch/(inline)"),
+    ] {
+        assert!(is_direct_child(parent, child), "{parent:?} -> {child:?}");
+    }
+
+    for (parent, child) in [
+        ("/", "/dispatch/leaf"),
+        ("/dispatch", "/dispatch"),
+        ("/dispatch", "/dispatcher/leaf"),
+        ("/dispatch", "/dispatch/leaf/grandchild"),
+        ("/dispatch", "/dispatch/"),
+        ("/dispatch", "/dispatch//leaf"),
+        ("dispatch", "dispatch/leaf"),
+    ] {
+        assert!(
+            !is_direct_child(parent, child),
+            "{parent:?} must not own {child:?}"
+        );
+    }
 }

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -28,7 +28,11 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use limpid_metrics_schema::{MetricFamily, MetricType, MetricsSnapshot};
+use limpid_metrics_schema::{
+    EVENTS_DROPPED_OWN_TOTAL, EVENTS_DROPPED_TOTAL, MetricFamily, MetricType, MetricsSnapshot,
+    PROCESS_LABEL_NAME, PROCESS_LABEL_PATH, PROCESS_LABEL_PIPELINE, PROCESS_PATH_ROOT,
+    process_path_parent,
+};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, UnixStream};
@@ -63,6 +67,9 @@ const CONNECTION_TIMEOUT: Duration = Duration::from_secs(15);
 /// as an in-flight one finishes — paired with `CONNECTION_TIMEOUT`,
 /// so an idle-forever peer can't perma-hold its slot.
 const MAX_CONCURRENT_CONNECTIONS: usize = 8;
+
+const DROPPED_OWN_HELP: &str =
+    "Total events dropped directly at this processing node, excluding direct child drops.";
 
 #[derive(Parser)]
 #[command(name = "limpid-prometheus", about = "Prometheus exporter for limpid")]
@@ -354,8 +361,93 @@ fn parse_snapshot(root: &MetricsSnapshot) -> Result<Vec<ExpositionFamily>, Strin
         });
     }
     validate_histogram_namespaces(&families, &names)?;
+    if let Some(derived) = derive_dropped_own(&families) {
+        families.push(derived);
+    }
     families.sort_by(|left, right| left.name.cmp(&right.name));
     Ok(families)
+}
+
+fn derive_dropped_own(families: &[ExpositionFamily]) -> Option<ExpositionFamily> {
+    let source = families
+        .iter()
+        .find(|family| family.name == EVENTS_DROPPED_TOTAL)?;
+    if !matches!(source.metric_type, ExpositionType::Counter) {
+        return None;
+    }
+
+    let dimensions = |labels: &Labels| {
+        labels
+            .iter()
+            .filter(|(key, _)| key != PROCESS_LABEL_PATH && key != PROCESS_LABEL_NAME)
+            .cloned()
+            .collect::<Labels>()
+    };
+    let mut root_indices = BTreeMap::new();
+    let mut parent_indices = BTreeMap::new();
+    let mut series = Vec::with_capacity(source.series.len());
+    for source_series in &source.series {
+        let ExpositionSeries::Value {
+            labels,
+            value: source_value,
+        } = source_series
+        else {
+            return None;
+        };
+        if let Some(path) = label_value(labels, PROCESS_LABEL_PATH) {
+            if path == PROCESS_PATH_ROOT {
+                if let Some(pipeline) = label_value(labels, PROCESS_LABEL_PIPELINE) {
+                    root_indices.insert(pipeline.to_string(), series.len());
+                }
+            } else {
+                parent_indices.insert((dimensions(labels), path.to_string()), series.len());
+            }
+        }
+        series.push(ExpositionSeries::Value {
+            labels: labels.clone(),
+            value: *source_value,
+        });
+    }
+
+    for child in &source.series {
+        let ExpositionSeries::Value {
+            labels,
+            value: child_value,
+        } = child
+        else {
+            return None;
+        };
+        let Some(parent_path) =
+            label_value(labels, PROCESS_LABEL_PATH).and_then(process_path_parent)
+        else {
+            continue;
+        };
+        let parent_index = if parent_path == PROCESS_PATH_ROOT {
+            label_value(labels, PROCESS_LABEL_PIPELINE)
+                .and_then(|pipeline| root_indices.get(pipeline))
+        } else {
+            parent_indices.get(&(dimensions(labels), parent_path.to_string()))
+        };
+        let Some(parent_index) = parent_index else {
+            continue;
+        };
+        if let Some(ExpositionSeries::Value { value: own, .. }) = series.get_mut(*parent_index) {
+            *own = own.saturating_sub(*child_value);
+        }
+    }
+
+    Some(ExpositionFamily {
+        name: EVENTS_DROPPED_OWN_TOTAL.to_string(),
+        metric_type: ExpositionType::Counter,
+        help: DROPPED_OWN_HELP.to_string(),
+        series,
+    })
+}
+
+fn label_value<'a>(labels: &'a Labels, name: &str) -> Option<&'a str> {
+    labels
+        .iter()
+        .find_map(|(key, value)| (key == name).then_some(value.as_str()))
 }
 
 fn validate_exported_labelsets(
@@ -657,6 +749,69 @@ mod tests {
     use super::*;
     use tokio::io::AsyncReadExt;
     use tokio::net::{TcpStream, UnixListener};
+
+    const DROPPED_FAMILY: &str = "limpid_events_dropped_total";
+    const DROPPED_OWN_FAMILY: &str = "limpid_events_dropped_own_total";
+
+    fn dropped_series(
+        pipeline: &str,
+        step: &str,
+        path: &str,
+        name: &str,
+        value: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "labels": {
+                "pipeline": pipeline,
+                "step": step,
+                "process_path": path,
+                "process_name": name,
+            },
+            "value": value,
+        })
+    }
+
+    fn dropped_snapshot(series: Vec<serde_json::Value>) -> serde_json::Value {
+        serde_json::json!({
+            "schema": 1,
+            "metrics": [{
+                "name": DROPPED_FAMILY,
+                "type": "counter",
+                "help": "Total events whose drop propagated through this processing node.",
+                "series": series,
+            }]
+        })
+    }
+
+    fn derived_own_samples(snapshot: &serde_json::Value) -> Vec<String> {
+        let output = json_to_prometheus(&snapshot.to_string()).unwrap();
+        let help_prefix = format!("# HELP {DROPPED_OWN_FAMILY} ");
+        let help = output
+            .lines()
+            .find(|line| line.starts_with(&help_prefix))
+            .expect("derived family must include HELP metadata")
+            .to_ascii_lowercase();
+        assert!(help.contains("dropped"));
+        assert!(help.contains("direct child"));
+        assert!(output.contains(&format!("# TYPE {DROPPED_OWN_FAMILY} counter\n")));
+
+        let sample_prefix = format!("{DROPPED_OWN_FAMILY}{{");
+        let mut samples = output
+            .lines()
+            .filter(|line| line.starts_with(&sample_prefix))
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        samples.sort();
+        samples
+    }
+
+    fn without_derived_own_family(output: &str) -> String {
+        let help_prefix = format!("# HELP {DROPPED_OWN_FAMILY} ");
+        output
+            .split_inclusive("\n\n")
+            .filter(|family| !family.starts_with(&help_prefix))
+            .collect()
+    }
 
     #[test]
     fn schema_v1_fixture_parses_through_the_shared_wire_dto() {
@@ -1162,7 +1317,7 @@ metric_zeta_seconds_count{az="two",le_="source-zero",le__="source-one",le___="so
                     }]
                 },
                 {
-                    "name": "limpid_process_events_dropped_total",
+                    "name": "limpid_events_dropped_total",
                     "type": "counter",
                     "help": "Process invocations dropped.",
                     "series": [{
@@ -1191,9 +1346,9 @@ metric_zeta_seconds_count{az="two",le_="source-zero",le__="source-one",le___="so
                 }
             ]
         });
-        let expected = r#"# HELP limpid_process_events_dropped_total Process invocations dropped.
-# TYPE limpid_process_events_dropped_total counter
-limpid_process_events_dropped_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="2"} 1
+        let expected = r#"# HELP limpid_events_dropped_total Process invocations dropped.
+# TYPE limpid_events_dropped_total counter
+limpid_events_dropped_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="2"} 1
 
 # HELP limpid_process_events_errored_total Process invocations errored.
 # TYPE limpid_process_events_errored_total counter
@@ -1208,6 +1363,314 @@ limpid_process_events_in_total{pipeline="main",process_name="leaf",process_path=
 limpid_process_events_out_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="2"} 5
 
 "#;
+        let output = json_to_prometheus(&snapshot.to_string()).unwrap();
+        assert_eq!(without_derived_own_family(&output), expected);
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"2\"} 1"
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_subtracts_the_direct_child_in_a_chain() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "1", "/dispatch", "dispatch", 10),
+            dropped_series("main", "1", "/dispatch/leaf", "leaf", 4),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 6",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"1\"} 4",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_treats_pipeline_root_as_the_parent_of_every_root_process_step() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "0", "/", "", 20),
+            dropped_series("main", "1", "/dispatch", "dispatch", 10),
+            dropped_series("main", "1", "/dispatch/leaf", "leaf", 4),
+            dropped_series("main", "2", "/normalize", "normalize", 6),
+            dropped_series("other", "0", "/", "", 5),
+            dropped_series("other", "1", "/dispatch", "dispatch", 3),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"\",process_path=\"/\",step=\"0\"} 4",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 6",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"1\"} 4",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"normalize\",process_path=\"/normalize\",step=\"2\"} 6",
+                "limpid_events_dropped_own_total{pipeline=\"other\",process_name=\"\",process_path=\"/\",step=\"0\"} 2",
+                "limpid_events_dropped_own_total{pipeline=\"other\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 3",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_subtracts_every_direct_child_in_a_branch() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "1", "/dispatch", "dispatch", 10),
+            dropped_series("main", "1", "/dispatch/alpha", "alpha", 3),
+            dropped_series("main", "1", "/dispatch/beta", "beta", 4),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"alpha\",process_path=\"/dispatch/alpha\",step=\"1\"} 3",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"beta\",process_path=\"/dispatch/beta\",step=\"1\"} 4",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 3",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_indexes_a_high_cardinality_branch_exactly() {
+        const CHILDREN: usize = 256;
+
+        let mut source = Vec::with_capacity(CHILDREN + 1);
+        source.push(dropped_series("main", "1", "/dispatch", "dispatch", 1_000));
+        let mut expected = Vec::with_capacity(CHILDREN + 1);
+        expected.push(
+            "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 744"
+                .to_string(),
+        );
+        for child in 0..CHILDREN {
+            let name = format!("leaf-{child:03}");
+            let path = format!("/dispatch/{name}");
+            source.push(dropped_series("main", "1", &path, &name, 1));
+            expected.push(format!(
+                "limpid_events_dropped_own_total{{pipeline=\"main\",process_name=\"{name}\",process_path=\"{path}\",step=\"1\"}} 1"
+            ));
+        }
+        expected.sort();
+
+        assert_eq!(derived_own_samples(&dropped_snapshot(source)), expected);
+    }
+
+    #[test]
+    fn dropped_own_clamps_when_direct_child_total_exceeds_u64() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "1", "/dispatch", "dispatch", u64::MAX),
+            dropped_series("main", "1", "/dispatch/alpha", "alpha", u64::MAX),
+            dropped_series("main", "1", "/dispatch/beta", "beta", 1),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"alpha\",process_path=\"/dispatch/alpha\",step=\"1\"} 18446744073709551615",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"beta\",process_path=\"/dispatch/beta\",step=\"1\"} 1",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 0",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_clamps_snapshot_skew_at_zero() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "1", "/dispatch", "dispatch", 2),
+            dropped_series("main", "1", "/dispatch/leaf", "leaf", 5),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 0",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"1\"} 5",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_subtracts_only_direct_children_at_each_depth() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "1", "/dispatch", "dispatch", 10),
+            dropped_series("main", "1", "/dispatch/leaf", "leaf", 7),
+            dropped_series("main", "1", "/dispatch/leaf/grandchild", "grandchild", 2),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 3",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"grandchild\",process_path=\"/dispatch/leaf/grandchild\",step=\"1\"} 2",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"1\"} 5",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_does_not_bridge_a_missing_intermediate_path() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "1", "/dispatch", "dispatch", 10),
+            dropped_series("main", "1", "/dispatch/missing/leaf", "leaf", 4),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 10",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/missing/leaf\",step=\"1\"} 4",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_own_scopes_child_subtraction_by_pipeline_and_root_step() {
+        let snapshot = dropped_snapshot(vec![
+            dropped_series("main", "1", "/dispatch", "dispatch", 10),
+            dropped_series("main", "1", "/dispatch/leaf", "leaf", 4),
+            dropped_series("main", "2", "/dispatch", "dispatch", 8),
+            dropped_series("main", "2", "/dispatch/leaf", "leaf", 3),
+            dropped_series("other", "1", "/dispatch", "dispatch", 7),
+            dropped_series("other", "1", "/dispatch/leaf", "leaf", 2),
+        ]);
+
+        assert_eq!(
+            derived_own_samples(&snapshot),
+            [
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 6",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"2\"} 5",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"1\"} 4",
+                "limpid_events_dropped_own_total{pipeline=\"main\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"2\"} 3",
+                "limpid_events_dropped_own_total{pipeline=\"other\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 5",
+                "limpid_events_dropped_own_total{pipeline=\"other\",process_name=\"leaf\",process_path=\"/dispatch/leaf\",step=\"1\"} 2",
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshots_without_dropped_hierarchy_do_not_gain_a_derived_family() {
+        let snapshot = serde_json::json!({
+            "schema": 1,
+            "metrics": [{
+                "name": "legacy_counter_total",
+                "type": "counter",
+                "help": "Legacy counter.",
+                "series": [{"labels": {"scope": "one"}, "value": 3}]
+            }]
+        });
+        let expected = concat!(
+            "# HELP legacy_counter_total Legacy counter.\n",
+            "# TYPE legacy_counter_total counter\n",
+            "legacy_counter_total{scope=\"one\"} 3\n\n"
+        );
+
+        assert_eq!(json_to_prometheus(&snapshot.to_string()).unwrap(), expected);
+    }
+
+    #[test]
+    fn non_counter_dropped_hierarchy_renders_without_a_derived_family() {
+        let snapshot = serde_json::json!({
+            "schema": 1,
+            "metrics": [{
+                "name": DROPPED_FAMILY,
+                "type": "gauge",
+                "help": "A generic gauge using the well-known family name.",
+                "series": [{
+                    "labels": {
+                        "pipeline": "main",
+                        "step": "1",
+                        "process_path": "/dispatch",
+                        "process_name": "dispatch"
+                    },
+                    "value": 3
+                }]
+            }]
+        });
+        let expected = concat!(
+            "# HELP limpid_events_dropped_total A generic gauge using the well-known family name.\n",
+            "# TYPE limpid_events_dropped_total gauge\n",
+            "limpid_events_dropped_total{pipeline=\"main\",process_name=\"dispatch\",process_path=\"/dispatch\",step=\"1\"} 3\n\n"
+        );
+
+        assert_eq!(json_to_prometheus(&snapshot.to_string()).unwrap(), expected);
+    }
+
+    #[test]
+    fn dropped_own_preserves_source_and_renders_the_full_canonical_exposition() {
+        let snapshot = serde_json::json!({
+            "schema": 1,
+            "metrics": [
+                {
+                    "name": "zeta_total",
+                    "type": "counter",
+                    "help": "A later family.",
+                    "series": [{"labels": {"scope": "z"}, "value": 9}]
+                },
+                {
+                    "name": DROPPED_FAMILY,
+                    "type": "counter",
+                    "help": "Total events whose drop propagated through this processing node.",
+                    "series": [
+                        {
+                            "labels": {
+                                "process_name": "",
+                                "pipeline": "main",
+                                "step": "0",
+                                "process_path": "/"
+                            },
+                            "value": 12
+                        },
+                        {
+                            "labels": {
+                                "step": "7",
+                                "process_path": "/dispatch/leaf",
+                                "pipeline": "main",
+                                "process_name": "leaf"
+                            },
+                            "value": 4
+                        },
+                        {
+                            "labels": {
+                                "process_name": "dispatch",
+                                "pipeline": "main",
+                                "step": "7",
+                                "process_path": "/dispatch"
+                            },
+                            "value": 10
+                        },
+                        {
+                            "labels": {
+                                "process_path": "opaque",
+                                "process_name": "opaque",
+                                "step": "8",
+                                "pipeline": "main"
+                            },
+                            "value": 3
+                        }
+                    ]
+                }
+            ]
+        });
+        let expected = r#"# HELP limpid_events_dropped_own_total Total events dropped directly at this processing node, excluding direct child drops.
+# TYPE limpid_events_dropped_own_total counter
+limpid_events_dropped_own_total{pipeline="main",process_name="",process_path="/",step="0"} 2
+limpid_events_dropped_own_total{pipeline="main",process_name="dispatch",process_path="/dispatch",step="7"} 6
+limpid_events_dropped_own_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="7"} 4
+limpid_events_dropped_own_total{pipeline="main",process_name="opaque",process_path="opaque",step="8"} 3
+
+# HELP limpid_events_dropped_total Total events whose drop propagated through this processing node.
+# TYPE limpid_events_dropped_total counter
+limpid_events_dropped_total{pipeline="main",process_name="",process_path="/",step="0"} 12
+limpid_events_dropped_total{pipeline="main",process_name="dispatch",process_path="/dispatch",step="7"} 10
+limpid_events_dropped_total{pipeline="main",process_name="leaf",process_path="/dispatch/leaf",step="7"} 4
+limpid_events_dropped_total{pipeline="main",process_name="opaque",process_path="opaque",step="8"} 3
+
+# HELP zeta_total A later family.
+# TYPE zeta_total counter
+zeta_total{scope="z"} 9
+
+"#;
+
         assert_eq!(json_to_prometheus(&snapshot.to_string()).unwrap(), expected);
     }
 

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -13,7 +13,10 @@ use std::sync::{Arc, Mutex};
 
 pub(crate) use limpid_metrics_schema::MetricsSnapshot;
 use limpid_metrics_schema::{
-    HistogramSeries, MetricFamily as SnapshotFamily, ValueSeries as SnapshotValueSeries,
+    DROPPED_ROOT_PROCESS_NAME, DROPPED_ROOT_STEP, EVENTS_DROPPED_TOTAL, HistogramSeries,
+    MetricFamily as SnapshotFamily, PROCESS_EVENTS_ERRORED_TOTAL, PROCESS_EVENTS_IN_TOTAL,
+    PROCESS_EVENTS_OUT_TOTAL, PROCESS_LABEL_NAME, PROCESS_LABEL_PATH, PROCESS_LABEL_PIPELINE,
+    PROCESS_LABEL_STEP, PROCESS_PATH_ROOT, ValueSeries as SnapshotValueSeries,
 };
 
 pub(crate) fn register_build_info(
@@ -132,10 +135,14 @@ impl PipelineMetrics {
                 "limpid_pipeline_events_finished_total",
                 "Total events that finished pipeline processing."
             ),
-            events_dropped: counter!(
-                "limpid_pipeline_events_dropped_total",
-                "Total events dropped by the pipeline."
-            ),
+            events_dropped: registry
+                .counter(EVENTS_DROPPED_TOTAL)
+                .label(PROCESS_LABEL_PIPELINE, pipeline)
+                .label(PROCESS_LABEL_STEP, DROPPED_ROOT_STEP)
+                .label(PROCESS_LABEL_PATH, PROCESS_PATH_ROOT)
+                .label(PROCESS_LABEL_NAME, DROPPED_ROOT_PROCESS_NAME)
+                .help("Total events whose drop propagated through this processing node.")
+                .build()?,
             events_discarded: counter!(
                 "limpid_pipeline_events_discarded_total",
                 "Total events discarded by pipeline routing."
@@ -182,28 +189,28 @@ impl ProcessCounters {
         let counter = |name, help| {
             registry
                 .counter(name)
-                .label("pipeline", pipeline)
-                .label("step", &step)
-                .label("process_path", process_path)
-                .label("process_name", process_name)
+                .label(PROCESS_LABEL_PIPELINE, pipeline)
+                .label(PROCESS_LABEL_STEP, &step)
+                .label(PROCESS_LABEL_PATH, process_path)
+                .label(PROCESS_LABEL_NAME, process_name)
                 .help(help)
                 .build()
         };
         Ok(Self {
             incoming: counter(
-                "limpid_process_events_in_total",
+                PROCESS_EVENTS_IN_TOTAL,
                 "Total process invocation frames started.",
             )?,
             outgoing: counter(
-                "limpid_process_events_out_total",
+                PROCESS_EVENTS_OUT_TOTAL,
                 "Total process invocation frames that continued successfully.",
             )?,
             dropped: counter(
-                "limpid_process_events_dropped_total",
-                "Total process invocation frames terminated by a drop.",
+                EVENTS_DROPPED_TOTAL,
+                "Total events whose drop propagated through this processing node.",
             )?,
             errored: counter(
-                "limpid_process_events_errored_total",
+                PROCESS_EVENTS_ERRORED_TOTAL,
                 "Total process invocation frames terminated by an error.",
             )?,
         })
@@ -1821,12 +1828,6 @@ mod registry_tests {
                 5,
             ),
             (
-                "limpid_pipeline_events_dropped_total",
-                "pipeline",
-                "route",
-                6,
-            ),
-            (
                 "limpid_pipeline_events_discarded_total",
                 "pipeline",
                 "route",
@@ -1891,6 +1892,24 @@ mod registry_tests {
             );
             assert_eq!(series["value"], value);
         }
+
+        let dropped = metric(&snapshot, "limpid_events_dropped_total");
+        assert_eq!(dropped["type"], "counter");
+        assert_eq!(
+            dropped["help"],
+            "Total events whose drop propagated through this processing node."
+        );
+        assert_eq!(dropped["series"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            dropped["series"][0]["labels"],
+            serde_json::json!({
+                "pipeline": "route",
+                "step": "0",
+                "process_path": "/",
+                "process_name": "",
+            })
+        );
+        assert_eq!(dropped["series"][0]["value"], 6);
 
         let expected_gauges = [
             ("limpid_pipeline_inflight", "pipeline", "route", 2),

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -1106,7 +1106,6 @@ def pipeline topology {
         let process_families = [
             "limpid_process_events_in_total",
             "limpid_process_events_out_total",
-            "limpid_process_events_dropped_total",
             "limpid_process_events_errored_total",
         ];
         let expected = [
@@ -1145,13 +1144,36 @@ def pipeline topology {
             }
         }
 
-        let dropped = metric_series(&registry, "limpid_pipeline_events_dropped_total");
-        assert_eq!(dropped.len(), 1);
+        let dropped = metric_series(&registry, "limpid_events_dropped_total");
+        assert_eq!(dropped.len(), expected.len() + 1);
         assert_eq!(
-            dropped[0]["labels"],
-            serde_json::json!({"pipeline": "topology"})
+            series_value(
+                &registry,
+                "limpid_events_dropped_total",
+                &[
+                    ("pipeline", "topology"),
+                    ("step", "0"),
+                    ("process_path", "/"),
+                    ("process_name", ""),
+                ],
+            ),
+            0
         );
-        assert_eq!(dropped[0]["value"], 0);
+        for (step, path, name) in expected {
+            assert_eq!(
+                series_value(
+                    &registry,
+                    "limpid_events_dropped_total",
+                    &[
+                        ("pipeline", "topology"),
+                        ("step", step),
+                        ("process_path", path),
+                        ("process_name", name),
+                    ],
+                ),
+                0
+            );
+        }
     }
 
     #[test]
@@ -1434,8 +1456,13 @@ def pipeline execute { process dispatch; finish }
         assert_eq!(
             series_value(
                 &registry,
-                "limpid_pipeline_events_dropped_total",
-                &[("pipeline", pipeline)],
+                "limpid_events_dropped_total",
+                &[
+                    ("pipeline", pipeline),
+                    ("step", "0"),
+                    ("process_path", "/"),
+                    ("process_name", ""),
+                ],
             ),
             0,
             "the process body's drop side effect must not run during validation"
@@ -1638,8 +1665,12 @@ def pipeline p_fallback {
         let _worker = PipelineWorker::new_with_process_metrics(def, &config.processes, &registry)
             .expect("register metrics");
         let snapshot = serde_json::to_value(registry.snapshot()).expect("snapshot");
-        for suffix in ["in", "out", "dropped", "errored"] {
-            let name = format!("limpid_process_events_{suffix}_total");
+        for name in [
+            "limpid_process_events_in_total",
+            "limpid_process_events_out_total",
+            "limpid_events_dropped_total",
+            "limpid_process_events_errored_total",
+        ] {
             let family = snapshot["metrics"]
                 .as_array()
                 .unwrap()
@@ -1702,7 +1733,7 @@ def pipeline p_fallback {
         let family_names = [
             "limpid_process_events_in_total",
             "limpid_process_events_out_total",
-            "limpid_process_events_dropped_total",
+            "limpid_events_dropped_total",
             "limpid_process_events_errored_total",
         ];
         let label_sets: Vec<std::collections::BTreeSet<Vec<(String, String)>>> = family_names
@@ -1710,6 +1741,7 @@ def pipeline p_fallback {
             .map(|family| {
                 metric_series(registry, family)
                     .into_iter()
+                    .filter(|series| series["labels"]["process_path"] != "/")
                     .map(|series| {
                         series["labels"]
                             .as_object()
@@ -1744,11 +1776,12 @@ def pipeline p_fallback {
             let terminal: u64 = ["out", "dropped", "errored"]
                 .into_iter()
                 .map(|suffix| {
-                    series_value(
-                        registry,
-                        &format!("limpid_process_events_{suffix}_total"),
-                        &labels,
-                    )
+                    let family = if suffix == "dropped" {
+                        "limpid_events_dropped_total".to_owned()
+                    } else {
+                        format!("limpid_process_events_{suffix}_total")
+                    };
+                    series_value(registry, &family, &labels)
                 })
                 .sum();
             assert_eq!(input, terminal, "non-conserving process series {labels:?}");
@@ -1757,11 +1790,12 @@ def pipeline p_fallback {
 
     fn assert_process_vector(registry: &Registry, labels: &[(&str, &str)], expected: [u64; 4]) {
         let actual = ["in", "out", "dropped", "errored"].map(|suffix| {
-            series_value(
-                registry,
-                &format!("limpid_process_events_{suffix}_total"),
-                labels,
-            )
+            let family = if suffix == "dropped" {
+                "limpid_events_dropped_total".to_owned()
+            } else {
+                format!("limpid_process_events_{suffix}_total")
+            };
+            series_value(registry, &family, labels)
         });
         assert_eq!(actual, expected, "wrong process vector for {labels:?}");
     }
@@ -1811,8 +1845,13 @@ def pipeline p { process dispatch; finish }
         assert_eq!(
             series_value(
                 &dropped,
-                "limpid_pipeline_events_dropped_total",
-                &[("pipeline", "p")],
+                "limpid_events_dropped_total",
+                &[
+                    ("pipeline", "p"),
+                    ("step", "0"),
+                    ("process_path", "/"),
+                    ("process_name", ""),
+                ],
             ),
             1
         );
@@ -1891,23 +1930,27 @@ def pipeline p { process outer; finish }
     }
 
     #[tokio::test]
-    async fn pipeline_drop_counter_stays_event_based_while_process_drops_propagate_by_frame() {
+    async fn dropped_events_share_one_rooted_pipeline_and_process_hierarchy() {
         for body in ["drop", "process { drop }", "process named"] {
             let source =
                 format!("def process named {{ drop }} def pipeline p {{ {body}; finish }}");
             let registry = run_process_metric_fixture(&source, "p", fixture_event()).await;
-            let dropped = metric_series(&registry, "limpid_pipeline_events_dropped_total");
-            assert_eq!(dropped.len(), 1, "{body}");
-            assert_eq!(dropped[0]["labels"], serde_json::json!({"pipeline": "p"}));
+            let dropped = metric_series(&registry, "limpid_events_dropped_total");
             assert_eq!(
                 series_value(
                     &registry,
-                    "limpid_pipeline_events_dropped_total",
-                    &[("pipeline", "p")],
+                    "limpid_events_dropped_total",
+                    &[
+                        ("pipeline", "p"),
+                        ("step", "0"),
+                        ("process_path", "/"),
+                        ("process_name", ""),
+                    ],
                 ),
                 1,
-                "each dropped event must increment the plain pipeline counter once: {body}"
+                "each dropped event must increment the hierarchy root once: {body}"
             );
+            assert_eq!(dropped.len(), if body == "drop" { 1 } else { 2 }, "{body}");
             if body != "drop" {
                 assert_process_conservation(&registry);
             }
@@ -1923,13 +1966,21 @@ def pipeline nested { process outer; finish }
             fixture_event(),
         )
         .await;
-        let dropped = metric_series(&nested, "limpid_pipeline_events_dropped_total");
-        assert_eq!(dropped.len(), 1);
+        let dropped = metric_series(&nested, "limpid_events_dropped_total");
+        assert_eq!(dropped.len(), 3);
         assert_eq!(
-            dropped[0]["labels"],
-            serde_json::json!({"pipeline": "nested"})
+            series_value(
+                &nested,
+                "limpid_events_dropped_total",
+                &[
+                    ("pipeline", "nested"),
+                    ("step", "0"),
+                    ("process_path", "/"),
+                    ("process_name", ""),
+                ],
+            ),
+            1
         );
-        assert_eq!(dropped[0]["value"], 1);
         for (path, name) in [("/outer", "outer"), ("/outer/leaf", "leaf")] {
             assert_process_vector(
                 &nested,

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -23,7 +23,7 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use limpid_metrics_schema::{
     DROPPED_ROOT_PROCESS_NAME, DROPPED_ROOT_STEP, EVENTS_DROPPED_TOTAL, MetricFamily, MetricType,
-    MetricsSnapshot, PROCESS_PATH_ROOT, process_path_leaf,
+    MetricsSnapshot, PROCESS_PATH_ROOT,
 };
 
 const DEFAULT_SOCKET: &str = "/var/run/limpid/control.sock";
@@ -564,7 +564,7 @@ fn render_default_stats_inner(
                     }
                     let process_path = item.labels.get("process_path")?.clone();
                     let process_name = item.labels.get("process_name")?.clone();
-                    if process_path_leaf(&process_path)? != process_name {
+                    if limpid_metrics_schema::process_path_leaf(&process_path)? != process_name {
                         return None;
                     }
                     let identity = ProcessIdentity {

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -23,7 +23,7 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use limpid_metrics_schema::{
     DROPPED_ROOT_PROCESS_NAME, DROPPED_ROOT_STEP, EVENTS_DROPPED_TOTAL, MetricFamily, MetricType,
-    MetricsSnapshot, PROCESS_PATH_ROOT,
+    MetricsSnapshot, PROCESS_PATH_ROOT, process_path_leaf,
 };
 
 const DEFAULT_SOCKET: &str = "/var/run/limpid/control.sock";
@@ -562,11 +562,16 @@ fn render_default_stats_inner(
                     if item.labels.len() != 4 {
                         return None;
                     }
+                    let process_path = item.labels.get("process_path")?.clone();
+                    let process_name = item.labels.get("process_name")?.clone();
+                    if process_path_leaf(&process_path)? != process_name {
+                        return None;
+                    }
                     let identity = ProcessIdentity {
                         pipeline: item.labels.get("pipeline")?.clone(),
                         step: item.labels.get("step")?.parse().ok()?,
-                        process_path: item.labels.get("process_path")?.clone(),
-                        process_name: item.labels.get("process_name")?.clone(),
+                        process_path,
+                        process_name,
                     };
                     if process_values.insert(identity, item.value).is_some() {
                         return None;

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -21,7 +21,10 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
-use limpid_metrics_schema::{MetricFamily, MetricType, MetricsSnapshot};
+use limpid_metrics_schema::{
+    DROPPED_ROOT_PROCESS_NAME, DROPPED_ROOT_STEP, EVENTS_DROPPED_TOTAL, MetricFamily, MetricType,
+    MetricsSnapshot, PROCESS_PATH_ROOT,
+};
 
 const DEFAULT_SOCKET: &str = "/var/run/limpid/control.sock";
 
@@ -455,7 +458,7 @@ fn format_duration(secs: u64) -> String {
 const PIPELINE_METRICS: [&str; 6] = [
     "limpid_pipeline_events_received_total",
     "limpid_pipeline_events_finished_total",
-    "limpid_pipeline_events_dropped_total",
+    "limpid_events_dropped_total",
     "limpid_pipeline_events_discarded_total",
     "limpid_pipeline_events_errored_total",
     "limpid_pipeline_events_errored_unwritable_total",
@@ -477,9 +480,10 @@ const OUTPUT_METRICS: [&str; 7] = [
 const PROCESS_METRICS: [&str; 4] = [
     "limpid_process_events_in_total",
     "limpid_process_events_out_total",
-    "limpid_process_events_dropped_total",
+    DROPPED_EVENTS_METRIC,
     "limpid_process_events_errored_total",
 ];
+const DROPPED_EVENTS_METRIC: &str = EVENTS_DROPPED_TOTAL;
 
 type MetricValues = BTreeMap<String, u64>;
 
@@ -527,6 +531,57 @@ fn render_default_stats_inner(
 
     for metric in &snapshot.metrics {
         let name = metric.name();
+        if name == DROPPED_EVENTS_METRIC {
+            if metric.metric_type() != MetricType::Counter
+                || families.contains_key(name)
+                || process_families.contains_key(name)
+            {
+                return None;
+            }
+            let series = metric.value_series()?;
+            if series.is_empty() {
+                return None;
+            }
+            let mut pipeline_values = MetricValues::new();
+            let mut process_values = ProcessMetricValues::new();
+            for item in series {
+                if item.labels.get("process_path").map(String::as_str) == Some(PROCESS_PATH_ROOT) {
+                    if item.labels.len() != 4 {
+                        return None;
+                    }
+                    let pipeline = item.labels.get("pipeline")?.clone();
+                    let step = item.labels.get("step")?;
+                    let process_name = item.labels.get("process_name")?;
+                    if step != DROPPED_ROOT_STEP || process_name != DROPPED_ROOT_PROCESS_NAME {
+                        return None;
+                    }
+                    if pipeline_values.insert(pipeline, item.value).is_some() {
+                        return None;
+                    }
+                } else if validate_process_families {
+                    if item.labels.len() != 4 {
+                        return None;
+                    }
+                    let identity = ProcessIdentity {
+                        pipeline: item.labels.get("pipeline")?.clone(),
+                        step: item.labels.get("step")?.parse().ok()?,
+                        process_path: item.labels.get("process_path")?.clone(),
+                        process_name: item.labels.get("process_name")?.clone(),
+                    };
+                    if process_values.insert(identity, item.value).is_some() {
+                        return None;
+                    }
+                }
+            }
+            if pipeline_values.is_empty() {
+                return None;
+            }
+            families.insert(name.to_owned(), pipeline_values);
+            if validate_process_families && !process_values.is_empty() {
+                process_families.insert(name.to_owned(), process_values);
+            }
+            continue;
+        }
         if validate_process_families && PROCESS_METRICS.contains(&name) {
             if metric.metric_type() != MetricType::Counter || process_families.contains_key(name) {
                 return None;
@@ -1102,11 +1157,21 @@ mod tests {
         let mut metrics = PIPELINE_METRICS
             .iter()
             .map(|name| {
+                let labels = if *name == DROPPED_EVENTS_METRIC {
+                    serde_json::json!({
+                        "pipeline": "route",
+                        "step": "0",
+                        "process_path": "/",
+                        "process_name": ""
+                    })
+                } else {
+                    serde_json::json!({"pipeline": "route"})
+                };
                 serde_json::json!({
                     "name": name,
                     "type": "counter",
                     "help": "Pipeline counter.",
-                    "series": [{"labels": {"pipeline": "route"}, "value": 1}]
+                    "series": [{"labels": labels, "value": 1}]
                 })
             })
             .chain(INPUT_METRICS.iter().map(|name| {

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -130,6 +130,32 @@ fn counter_family(
     json!({"name": name, "type": "counter", "help": help, "series": series})
 }
 
+fn dropped_root_family(values: &[(&str, u64)], reverse_series: bool) -> Value {
+    let mut series: Vec<Value> = values
+        .iter()
+        .map(|(pipeline, value)| {
+            json!({
+                "labels": {
+                    "pipeline": pipeline,
+                    "step": "0",
+                    "process_path": "/",
+                    "process_name": ""
+                },
+                "value": value
+            })
+        })
+        .collect();
+    if reverse_series {
+        series.reverse();
+    }
+    json!({
+        "name": "limpid_events_dropped_total",
+        "type": "counter",
+        "help": "Total events whose drop propagated through this processing node.",
+        "series": series
+    })
+}
+
 fn histogram_snapshot(buckets: Value) -> String {
     format!(
         "{}\n",
@@ -174,10 +200,7 @@ fn canonical_snapshot(reverse: bool) -> Value {
             ],
             false,
         ),
-        counter_family(
-            "limpid_pipeline_events_dropped_total",
-            "pipeline",
-            "dropped",
+        dropped_root_family(
             &[("unwritable_only", 0), ("compact", 1), ("errored_only", 0)],
             false,
         ),
@@ -355,7 +378,6 @@ fn process_snapshot() -> Value {
     for (name, root_value, leaf_value) in [
         ("limpid_process_events_in_total", 4, 3),
         ("limpid_process_events_out_total", 4, 1),
-        ("limpid_process_events_dropped_total", 0, 1),
         ("limpid_process_events_errored_total", 0, 1),
     ] {
         payload["metrics"].as_array_mut().unwrap().push(json!({
@@ -384,6 +406,29 @@ fn process_snapshot() -> Value {
             ]
         }));
     }
+    family_mut(&mut payload, "limpid_events_dropped_total")["series"]
+        .as_array_mut()
+        .unwrap()
+        .extend([
+            json!({
+                "labels": {
+                    "pipeline": "compact",
+                    "step": "10",
+                    "process_path": "/dispatch/leaf",
+                    "process_name": "leaf"
+                },
+                "value": 1
+            }),
+            json!({
+                "labels": {
+                    "pipeline": "compact",
+                    "step": "2",
+                    "process_path": "/dispatch",
+                    "process_name": "dispatch"
+                },
+                "value": 0
+            }),
+        ]);
     payload
 }
 
@@ -400,11 +445,20 @@ fn for_each_process_family_mut(payload: &mut Value, mut update: impl FnMut(&mut 
     for name in [
         "limpid_process_events_in_total",
         "limpid_process_events_out_total",
-        "limpid_process_events_dropped_total",
+        "limpid_events_dropped_total",
         "limpid_process_events_errored_total",
     ] {
         update(family_mut(payload, name));
     }
+}
+
+fn first_process_series_mut(family: &mut Value) -> &mut Value {
+    family["series"]
+        .as_array_mut()
+        .expect("series")
+        .iter_mut()
+        .find(|series| series["labels"]["process_path"] != "/")
+        .expect("process series")
 }
 
 fn process_default_validator_only_defects() -> Vec<(&'static str, Value)> {
@@ -412,7 +466,7 @@ fn process_default_validator_only_defects() -> Vec<(&'static str, Value)> {
 
     let mut missing_label = process_snapshot();
     for_each_process_family_mut(&mut missing_label, |family| {
-        family["series"][0]["labels"]
+        first_process_series_mut(family)["labels"]
             .as_object_mut()
             .unwrap()
             .remove("process_name");
@@ -421,7 +475,7 @@ fn process_default_validator_only_defects() -> Vec<(&'static str, Value)> {
 
     let mut extra_label = process_snapshot();
     for_each_process_family_mut(&mut extra_label, |family| {
-        family["series"][0]["labels"]
+        first_process_series_mut(family)["labels"]
             .as_object_mut()
             .unwrap()
             .insert("extra".to_owned(), json!("x"));
@@ -430,7 +484,7 @@ fn process_default_validator_only_defects() -> Vec<(&'static str, Value)> {
 
     let mut non_numeric_step = process_snapshot();
     for_each_process_family_mut(&mut non_numeric_step, |family| {
-        family["series"][0]["labels"]["step"] = json!("ten");
+        first_process_series_mut(family)["labels"]["step"] = json!("ten");
     });
     cases.push(("non-numeric step", non_numeric_step));
 
@@ -528,7 +582,7 @@ fn process_counters_render_a_numerically_sorted_default_invocation_table() {
     for name in [
         "limpid_process_events_in_total",
         "limpid_process_events_out_total",
-        "limpid_process_events_dropped_total",
+        "limpid_events_dropped_total",
         "limpid_process_events_errored_total",
     ] {
         assert!(details.contains(name), "missing {name}");
@@ -596,6 +650,36 @@ fn malformed_process_families_fall_back_to_the_whole_raw_response() {
         did_not_fall_back.is_empty(),
         "each single defect must cause a whole raw fallback; rendered: {did_not_fall_back:?}"
     );
+}
+
+#[test]
+fn malformed_dropped_hierarchy_roots_fall_back_to_the_raw_response() {
+    let mut wrong_step = process_snapshot();
+    family_mut(&mut wrong_step, "limpid_events_dropped_total")["series"][0]["labels"]["step"] =
+        json!("1");
+
+    let mut nonempty_name = process_snapshot();
+    family_mut(&mut nonempty_name, "limpid_events_dropped_total")["series"][0]["labels"]["process_name"] =
+        json!("pipeline");
+
+    let mut missing_root = process_snapshot();
+    family_mut(&mut missing_root, "limpid_events_dropped_total")["series"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|series| series["labels"]["process_path"] != "/");
+
+    for (name, payload) in [
+        ("wrong root step", wrong_step),
+        ("non-empty root process name", nonempty_name),
+        ("missing root", missing_root),
+    ] {
+        let response = format!("{payload}\n");
+        for args in [&[][..], &["--details"][..]] {
+            let output = run_stats(&response, args);
+            assert!(output.status.success(), "{name}: {output:?}");
+            assert_eq!(output.stdout, response.as_bytes(), "{name}: {args:?}");
+        }
+    }
 }
 
 #[test]

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -488,6 +488,18 @@ fn process_default_validator_only_defects() -> Vec<(&'static str, Value)> {
     });
     cases.push(("non-numeric step", non_numeric_step));
 
+    let mut malformed_path = process_snapshot();
+    for_each_process_family_mut(&mut malformed_path, |family| {
+        first_process_series_mut(family)["labels"]["process_path"] = json!("/dispatch//leaf");
+    });
+    cases.push(("malformed process path", malformed_path));
+
+    let mut mismatched_leaf = process_snapshot();
+    for_each_process_family_mut(&mut mismatched_leaf, |family| {
+        first_process_series_mut(family)["labels"]["process_name"] = json!("other");
+    });
+    cases.push(("process name differs from path leaf", mismatched_leaf));
+
     cases
 }
 

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -65,6 +65,11 @@ forward-compatible. The documented fields above remain required and retain
 their exact types; ignoring an unknown field does not make a missing or
 malformed required field valid.
 
+The shared schema-v1 crate also defines the well-known dropped hierarchy,
+process family and label names, and the `/`-separated process-path relationship
+used by current consumers. These definitions do not add fields to the wire
+envelope.
+
 Schema v1 deliberately does not contain an explicit `+Inf` bucket. A
 Prometheus consumer derives `le="+Inf"` from `count`. Bucket, sum, and count
 atomics are loaded independently, so a concurrent snapshot may transiently show
@@ -100,7 +105,6 @@ for the same-host multi-instance deployment caveat.
 | --- | --- | --- |
 | `limpid_pipeline_events_received_total` | `pipeline` | Events entering the pipeline. |
 | `limpid_pipeline_events_finished_total` | `pipeline` | Events that reached at least one output. |
-| `limpid_pipeline_events_dropped_total` | `pipeline` | Events explicitly discarded by `drop`. |
 | `limpid_pipeline_events_discarded_total` | `pipeline` | Events that completed without reaching any output. |
 | `limpid_pipeline_events_errored_total` | `pipeline` | Events that failed at a pipeline-side producer site and were routed to the [error log](./error-log.md). |
 | `limpid_pipeline_events_errored_unwritable_total` | `pipeline` | Pipeline-side error-log writes that failed. |
@@ -118,31 +122,69 @@ original event is preserved when the configured error-log write succeeds; see
 
 ### Process invocations
 
-The four process counter families use the labels `pipeline`, `step`,
+The three process-only counter families use the labels `pipeline`, `step`,
 `process_path`, and `process_name`:
 
 - `limpid_process_events_in_total` counts frame entry.
 - `limpid_process_events_out_total` counts frames that return `Continue`.
-- `limpid_process_events_dropped_total` counts frames terminated by `Drop`.
 - `limpid_process_events_errored_total` counts frames terminated by an error.
 
 These are invocation counters, not event counters. `step` is the root process
 site's one-based, pipeline-wide source-order position; nested calls share that
-root step. A named root has a path such as `/dispatch`, a nested call extends it
-to `/dispatch/leaf`, and an inline root uses `/(inline)`. Process call graphs
-must be acyclic, so every invocation path is finite and known at config-load
-time. Each distinct compiled invocation node owns four counter series; reusing
-a helper under different parents creates distinct path series. Every
-configured series is prepopulated with zero.
+root step. `process_path` is a `/`-separated invocation hierarchy whose leaf is
+`process_name`: a named root has a path such as `/dispatch`, a nested call
+extends it to `/dispatch/leaf`, and an inline root uses `/(inline)`. Process
+call graphs must be acyclic, so every invocation path is finite and known at
+config-load time. Each distinct compiled invocation node owns three
+process-only counter series; reusing a helper under different parents creates
+distinct path series. Every configured series is prepopulated with zero.
 
 Each frame records exactly one terminal result, so for an individual series
 `in = out + dropped + errored`. A nested drop propagates through its active
 caller frames. A nested error counts as errored for that frame even when a
 caller's catch block recovers and the caller returns normally. Consequently,
 summing process series double-counts nested invocations and is not an event
-flow total. The pipeline event families above remain the authoritative event
-flow: in particular, `limpid_pipeline_events_dropped_total{pipeline}` retains
-its existing single-label event semantics.
+flow total.
+
+### Dropped-event hierarchy
+
+`limpid_events_dropped_total` is one counter family for both the pipeline
+frame and its process frames. Every series has the labels `pipeline`, `step`,
+`process_path`, and `process_name`. The pipeline frame is the root node and is
+represented by `step="0"`, `process_path="/"`, and an empty `process_name`.
+Its value is the number of events dropped from that pipeline. Process nodes
+use their ordinary one-based root step and invocation path. Their values count
+drops that propagated through that process frame.
+
+A drop therefore increments one finite path from the node that executed
+`drop` through every active caller to the pipeline root. Process call graphs
+are acyclic, so this hierarchy is fully known at config-load time. The source
+family exposes propagated totals at every node; its root is the authoritative
+pipeline dropped-event total.
+
+`limpid-prometheus` additionally synthesizes the counter
+`limpid_events_dropped_own_total` at scrape time. It has the same
+`pipeline`, `step`, `process_path`, and `process_name` labels as the source
+dropped family, with help text `Total events dropped directly at this
+processing node, excluding direct child drops.` For each source series it
+reports `max(0, parent - sum(direct children))`. A root process is a direct
+child of `/` when its `pipeline` matches; its one-based `step` identifies the
+root call site and does not have to match the root's reserved step `0`. Below a
+process node, a direct child's `process_path` is the parent path extended by
+`/` and exactly one non-empty segment, and all labels other than
+`process_path` and `process_name` must be equal. Missing intermediate paths are
+not bridged. The clamp accommodates independently read counter snapshots and
+arithmetic overflow without changing or rejecting the source family. If the
+source dropped family is absent, the derived family is absent too.
+
+The derived value at `/` counts drops executed directly in the pipeline body.
+At a process node it counts drops executed directly in that process body.
+
+Only dropped frames propagate through every active caller, making direct-child
+subtraction meaningful. Continue and error outcomes do not have that
+propagation invariant, so no corresponding `own` families are synthesized.
+The derived family is a sidecar exposition view rather than another daemon
+registry series; `limpid_events_dropped_total` remains authoritative.
 
 ### Inputs
 


### PR DESCRIPTION
## Summary

- unify pipeline and process drop counters as `limpid_events_dropped_total{pipeline,step,process_path,process_name}`
- represent the pipeline frame as the hierarchy root with `step="0"`, `process_path="/"`, and an empty `process_name`
- derive `limpid_events_dropped_own_total` in `limpid-prometheus` by subtracting direct-child propagated totals
- publish the well-known dropped hierarchy vocabulary from `limpid-metrics-schema` without changing the schema-v1 wire DTO

## Semantics

- a drop increments the finite path from the executing process frame through active callers to the pipeline root
- process call graphs are acyclic, so direct-child subtraction is well-defined
- the derived family uses `max(0, parent - sum(direct children))` and leaves the daemon source family unchanged
- pipeline roots remain strict in `limpidctl`; `--details` keeps generic rendering for process-only semantic defects
- this is a breaking metric-family migration from the v0.7 pipeline dropped counter and is documented in the changelog and metrics guide

## Validation

- `cargo test --workspace --all-targets`
- Kafka all-target tests
- workspace and Kafka Clippy with `-D warnings`
- schema boundary, purity, and wire-contract suites
- `limpid-prometheus` derived-hierarchy tests, including 257-series branching and overflow clamping
- `limpidctl` unit and schema-v1 integration suites
- `cargo fmt --all -- --check`
- mdBook, snippet header and inventory checks
- cargo-deny and cargo-audit
- native push gate: 9/9 scopes PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Consolidated dropped-event metrics into `limpid_events_dropped_total` with pipeline and process hierarchy labels.
  * Removed separate pipeline and process dropped metric names.

* **New Features**
  * Added Prometheus-only `limpid_events_dropped_own_total` metrics for direct drops.
  * Added validation and handling for rooted process paths and dropped-event metric hierarchies.

* **Documentation**
  * Updated metrics documentation and migration guidance for dashboards and alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->