### PR TITLE
feat(event): preserve immutable event identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Added — immutable event identity
+
+Every event now receives a UUIDv7 `key` before fan-out. The key is preserved
+through clones, queue persistence, dead-letter capture, and JSON replay, and is
+visible in `tap --json` without changing the default raw tap stream or the DSL.
+Pre-0.8 Event JSON without a key is assigned one when first read. The dead-letter
+record schema is now version 3 because its `event` object carries the key.
+
 ### Changed — dropped metrics use one rooted hierarchy (breaking)
 
 `limpid_pipeline_events_dropped_total{pipeline}` is replaced by the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -514,7 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1141,6 +1141,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "webpki-roots",
 ]
 
@@ -1294,7 +1295,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1417,7 +1418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1921,7 +1922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2228,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2296,7 +2297,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2682,6 +2683,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "rand",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -13,6 +13,7 @@ chrono-tz = "0.10"
 bytes = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+uuid = { version = "=1.20.0", features = ["v7", "fast-rng"] }
 pest = "2"
 pest_derive = "2"
 anyhow = "1"

--- a/crates/limpid/src/dsl/eval.rs
+++ b/crates/limpid/src/dsl/eval.rs
@@ -1126,15 +1126,12 @@ mod tests {
         let ev = make_event();
         let bev = ev.view_in(&arena);
         let f = make_funcs();
-        assert!(
-            eval_expr(
-                &e(ExprKind::Ident(vec!["typo_field".into()])),
-                &bev,
-                &f,
-                &arena
-            )
-            .is_err()
-        );
+        for ident in ["typo_field", "key"] {
+            assert!(
+                eval_expr(&e(ExprKind::Ident(vec![ident.into()])), &bev, &f, &arena).is_err(),
+                "{ident} must not be visible to the DSL"
+            );
+        }
     }
 
     #[test]

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -589,6 +589,7 @@ fn clone_borrowed_event<'bump>(
         workspace.push((*k, *v));
     }
     BorrowedEvent {
+        key: src.key,
         received_at: src.received_at,
         source: src.source,
         ingress: src.ingress.clone(),
@@ -603,6 +604,7 @@ mod tests {
     use bytes::Bytes;
     use std::net::SocketAddr;
 
+    use crate::dsl::arena::EventArena;
     use crate::dsl::exec::*;
     use crate::event::{BorrowedEvent, Event};
     use crate::functions::FunctionRegistry;
@@ -619,6 +621,19 @@ mod tests {
         let table_store = crate::functions::table::TableStore::from_configs(vec![]).unwrap();
         crate::functions::register_builtins(&mut reg, table_store);
         reg
+    }
+
+    #[test]
+    fn borrowed_event_clone_preserves_identity() {
+        let original = make_event();
+        let expected_key = original.key;
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let borrowed = original.view_in(&arena);
+
+        let cloned = clone_borrowed_event(&borrowed, &arena);
+
+        assert_eq!(cloned.key, expected_key);
     }
 
     /// Spanless [`Expr`] construction shortcut — see `eval_test::tests::e`.

--- a/crates/limpid/src/dsl/exec.rs
+++ b/crates/limpid/src/dsl/exec.rs
@@ -583,19 +583,7 @@ fn clone_borrowed_event<'bump>(
     src: &BorrowedEvent<'bump>,
     arena: &'bump EventArena<'bump>,
 ) -> BorrowedEvent<'bump> {
-    let mut workspace =
-        bumpalo::collections::Vec::with_capacity_in(src.workspace.len(), arena.bump());
-    for (k, v) in src.workspace.iter() {
-        workspace.push((*k, *v));
-    }
-    BorrowedEvent {
-        key: src.key,
-        received_at: src.received_at,
-        source: src.source,
-        ingress: src.ingress.clone(),
-        egress: src.egress.clone(),
-        workspace,
-    }
+    src.snapshot_in(arena)
 }
 
 #[cfg(test)]
@@ -626,14 +614,14 @@ mod tests {
     #[test]
     fn borrowed_event_clone_preserves_identity() {
         let original = make_event();
-        let expected_key = original.key;
+        let expected_key = original.key();
         let bump = bumpalo::Bump::new();
         let arena = EventArena::new(&bump);
         let borrowed = original.view_in(&arena);
 
         let cloned = clone_borrowed_event(&borrowed, &arena);
 
-        assert_eq!(cloned.key, expected_key);
+        assert_eq!(cloned.key(), expected_key);
     }
 
     /// Spanless [`Expr`] construction shortcut — see `eval_test::tests::e`.

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -1,11 +1,11 @@
 //! Dead-letter queue (DLQ) writer for events that fail their main-flow
 //! disposition.
 //!
-//! Records are sum-typed (`schema_version: 2`): every record carries a
+//! Records are sum-typed (`schema_version: 3`): every record carries a
 //! `kind` discriminator (`"process"` or `"output"`) and a per-kind block
 //! (`process: { name }` or `output: { name }`) naming the failure site.
 //! The Output flavor additionally carries the rendered `egress` in
-//! `event.egress`; the Process flavor only has `event.{source,
+//! `event.egress`; the Process flavor only has `event.{key, source,
 //! received_at, ingress}`.
 //!
 //! Seven producer sites map to the two flavors:
@@ -96,7 +96,7 @@ impl ErroredEventContext {
     ///
     /// ```text
     /// {
-    ///   "schema_version": 2,
+    ///   "schema_version": 3,
     ///   "timestamp": "<RFC3339 nanos UTC>",
     ///   "reason": "<error msg>",
     ///   "pipeline": "<def pipeline name or empty>",
@@ -104,6 +104,7 @@ impl ErroredEventContext {
     ///   "process": { "name": "<process_name>" },   // kind=process only
     ///   "output":  { "name": "<output_name>" },    // kind=output only
     ///   "event": {
+    ///     "key": "<UUIDv7>",
     ///     "source": { "ip": ..., "port": ... },
     ///     "received_at": <unix nanos>,
     ///     "ingress": "...",
@@ -112,8 +113,8 @@ impl ErroredEventContext {
     /// }
     /// ```
     ///
-    /// `schema_version: 2` is the operator-visible discriminator for
-    /// the v0.7.8 schema break. Output records intentionally carry
+    /// `schema_version: 3` is the operator-visible discriminator for
+    /// immutable event identity. Output records intentionally carry
     /// *only* `{ name }` — no address, dest, path, key, topic,
     /// partition, endpoint, URL, peer, target, or workspace. Replay
     /// (`limpidctl inject output <name>`) hands the event back to the
@@ -125,7 +126,7 @@ impl ErroredEventContext {
     /// construct it, but the JSONL shape is `error_log`'s to own.
     pub fn to_jsonl(&self) -> String {
         // Rebuild a minimal Event so we can reuse the canonical
-        // `to_json_value` serialiser for source / received_at /
+        // `to_json_value` serialiser for key / source / received_at /
         // ingress / egress. We construct it from the snapshot rather
         // than carrying a full OwnedEvent so we never accidentally
         // leak workspace fragments into the DLQ.
@@ -138,6 +139,7 @@ impl ErroredEventContext {
                 event,
             } => {
                 let ev = OwnedEvent {
+                    key: event.key,
                     received_at: event.received_at,
                     source: event.source,
                     ingress: event.ingress.clone(),
@@ -174,6 +176,7 @@ impl ErroredEventContext {
                 event,
             } => {
                 let ev = OwnedEvent {
+                    key: event.key,
                     received_at: event.received_at,
                     source: event.source,
                     ingress: event.ingress.clone(),
@@ -205,7 +208,7 @@ impl ErroredEventContext {
         // Merge kind discriminator block + per-kind name block into
         // the top-level record. Using a Map keeps key ordering stable.
         let mut record = serde_json::Map::new();
-        record.insert("schema_version".into(), serde_json::json!(2));
+        record.insert("schema_version".into(), serde_json::json!(3));
         record.insert(
             "timestamp".into(),
             serde_json::Value::String(
@@ -1041,15 +1044,16 @@ mod tests {
         assert_eq!(lines.len(), 2);
         for line in &lines {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
-            assert_eq!(v["schema_version"], 2);
+            assert_eq!(v["schema_version"], 3);
             assert_eq!(v["kind"], "process");
             assert_eq!(v["pipeline"], "p");
             assert_eq!(v["process"]["name"], "wrap");
             assert!(v["output"].is_null());
             assert!(v["reason"].as_str().unwrap().contains("timestamp"));
-            // event sub-object keeps only source / received_at / ingress
+            // event sub-object keeps only key / source / received_at / ingress
             // for Process records — egress and workspace are omitted.
             let event = &v["event"];
+            assert!(event.get("key").is_some());
             assert!(event.get("source").is_some());
             assert!(event.get("received_at").is_some());
             assert!(event.get("ingress").is_some());
@@ -1542,7 +1546,7 @@ mod tests {
     // to_jsonl wire-format tests
     // -----------------------------------------------------------------
     //
-    // The JSONL shape (schema_version = 2, `Process`/`Output` sum
+    // The JSONL shape (schema_version = 3, `Process`/`Output` sum
     // discriminants, forbidden routing fields on Output, event sub-object
     // replayable through `Event::from_json`) is `error_log`'s to own —
     // that contract is what `limpidctl inject --json` and any downstream
@@ -1562,22 +1566,25 @@ mod tests {
 
     #[test]
     fn process_variant_jsonl_has_no_egress_no_output_block() {
+        let event = sample_owned_event();
+        let expected_key = event.key;
         let ctx = ErroredEventContext::Process {
             timestamp: chrono::DateTime::from_timestamp_nanos(1_700_000_000_000_000_000),
             pipeline: "p".into(),
             site: "wrap".into(),
             reason: "boom".into(),
-            event: crate::pipeline::ProcessEvent::from_owned(&sample_owned_event()),
+            event: crate::pipeline::ProcessEvent::from_owned(&event),
         };
         let line = ctx.to_jsonl();
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
-        assert_eq!(v["schema_version"], 2);
+        assert_eq!(v["schema_version"], 3);
         assert_eq!(v["kind"], "process");
         assert_eq!(v["pipeline"], "p");
         assert_eq!(v["reason"], "boom");
         assert_eq!(v["process"]["name"], "wrap");
         assert!(v["output"].is_null(), "Process must not carry output block");
         assert_eq!(v["event"]["ingress"], "hello");
+        assert_eq!(v["event"]["key"], expected_key.hyphenated().to_string());
         assert!(
             v["event"]["egress"].is_null(),
             "Process event must omit egress"
@@ -1587,17 +1594,19 @@ mod tests {
 
     #[test]
     fn output_variant_jsonl_carries_egress_and_output_block() {
+        let event = sample_owned_event();
+        let expected_key = event.key;
         let ctx = ErroredEventContext::Output {
             timestamp: chrono::DateTime::from_timestamp_nanos(1_700_000_000_000_000_000),
             pipeline: String::new(),
             site: "sink enqueue".into(),
             reason: "queue closed".into(),
             output_name: "sink".into(),
-            event: crate::pipeline::OutputEvent::from_owned(&sample_owned_event()),
+            event: crate::pipeline::OutputEvent::from_owned(&event),
         };
         let line = ctx.to_jsonl();
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
-        assert_eq!(v["schema_version"], 2);
+        assert_eq!(v["schema_version"], 3);
         assert_eq!(v["kind"], "output");
         assert_eq!(v["pipeline"], "");
         assert_eq!(v["output"]["name"], "sink");
@@ -1607,15 +1616,17 @@ mod tests {
         );
         assert_eq!(v["event"]["ingress"], "hello");
         assert_eq!(v["event"]["egress"], "goodbye");
+        assert_eq!(v["event"]["key"], expected_key.hyphenated().to_string());
         assert!(v["event"]["workspace"].is_null());
     }
 
     #[test]
     fn output_variant_jsonl_must_not_carry_sink_routing_metadata() {
         // Pin the DLQ no-address contract: the Output record carries
-        // ONLY `{ name }`. No address, dest, path, key, topic,
-        // partition, endpoint, url, peer, target, or workspace at any
-        // level.
+        // ONLY `{ name }`. No address, dest, path, routing key, topic,
+        // partition, endpoint, url, peer, target, or workspace at the
+        // top level or in the output block. The event sub-object carries
+        // its unrelated immutable event identity under `key`.
         let ctx = ErroredEventContext::Output {
             timestamp: chrono::Utc::now(),
             pipeline: "p".into(),
@@ -1630,7 +1641,6 @@ mod tests {
             "address",
             "dest",
             "path",
-            "key",
             "topic",
             "partition",
             "endpoint",
@@ -1652,10 +1662,12 @@ mod tests {
             );
             assert!(
                 v["event"].get(f).is_none(),
-                "event block must not carry forbidden field {}",
-                f
+                "event block must not carry {f}"
             );
         }
+        assert!(v.get("key").is_none());
+        assert!(v["output"].get("key").is_none());
+        assert!(v["event"].get("key").is_some());
         // output block must have *only* `name`.
         let obj = v["output"].as_object().expect("output is an object");
         assert_eq!(obj.len(), 1, "output block must carry only `name`");
@@ -1667,13 +1679,15 @@ mod tests {
         // The Output event sub-object must be replayable through
         // `Event::from_json` so `limpidctl inject output --json` can
         // reconstruct the egress payload end-to-end.
+        let event = sample_owned_event();
+        let expected_key = event.key;
         let ctx = ErroredEventContext::Output {
             timestamp: chrono::Utc::now(),
             pipeline: String::new(),
             site: "sink enqueue".into(),
             reason: "queue closed".into(),
             output_name: "sink".into(),
-            event: crate::pipeline::OutputEvent::from_owned(&sample_owned_event()),
+            event: crate::pipeline::OutputEvent::from_owned(&event),
         };
         let line = ctx.to_jsonl();
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
@@ -1682,16 +1696,19 @@ mod tests {
             crate::event::Event::from_json(&event_str).expect("event sub-object must replay");
         assert_eq!(&replayed.ingress[..], b"hello");
         assert_eq!(&replayed.egress[..], b"goodbye");
+        assert_eq!(replayed.key, expected_key);
     }
 
     #[test]
     fn process_variant_round_trip_via_event_from_json() {
+        let event = sample_owned_event();
+        let expected_key = event.key;
         let ctx = ErroredEventContext::Process {
             timestamp: chrono::Utc::now(),
             pipeline: "p".into(),
             site: "wrap".into(),
             reason: "boom".into(),
-            event: crate::pipeline::ProcessEvent::from_owned(&sample_owned_event()),
+            event: crate::pipeline::ProcessEvent::from_owned(&event),
         };
         let line = ctx.to_jsonl();
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
@@ -1703,6 +1720,7 @@ mod tests {
         // sees a self-consistent starting state.
         assert_eq!(&replayed.ingress[..], b"hello");
         assert_eq!(&replayed.egress[..], b"hello");
+        assert_eq!(replayed.key, expected_key);
     }
 
     #[tokio::test]

--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -92,7 +92,7 @@ use crate::pipeline::ErroredEventContext;
 impl ErroredEventContext {
     /// Serialise as a single-line JSON record for the dead-letter queue.
     ///
-    /// Layout (v2 — hard break from v1):
+    /// Layout (v3):
     ///
     /// ```text
     /// {
@@ -115,7 +115,7 @@ impl ErroredEventContext {
     ///
     /// `schema_version: 3` is the operator-visible discriminator for
     /// immutable event identity. Output records intentionally carry
-    /// *only* `{ name }` — no address, dest, path, key, topic,
+    /// *only* `{ name }` — no address, dest, path, routing key, topic,
     /// partition, endpoint, URL, peer, target, or workspace. Replay
     /// (`limpidctl inject output <name>`) hands the event back to the
     /// sink's `consume()`, which re-routes internally.
@@ -138,15 +138,13 @@ impl ErroredEventContext {
                 reason,
                 event,
             } => {
-                let ev = OwnedEvent {
-                    key: event.key,
-                    received_at: event.received_at,
-                    source: event.source,
-                    ingress: event.ingress.clone(),
-                    egress: event.ingress.clone(),
-                    workspace: std::collections::HashMap::new(),
-                    ack: None,
-                };
+                let ev = OwnedEvent::from_persisted_parts(
+                    event.key(),
+                    event.received_at,
+                    event.source,
+                    event.ingress.clone(),
+                    event.ingress.clone(),
+                );
                 let mut event_json = ev.to_json_value();
                 if let serde_json::Value::Object(ref mut map) = event_json {
                     // ProcessEvent has no egress concept — strip it so
@@ -175,15 +173,13 @@ impl ErroredEventContext {
                 output_name,
                 event,
             } => {
-                let ev = OwnedEvent {
-                    key: event.key,
-                    received_at: event.received_at,
-                    source: event.source,
-                    ingress: event.ingress.clone(),
-                    egress: event.egress.clone(),
-                    workspace: std::collections::HashMap::new(),
-                    ack: None,
-                };
+                let ev = OwnedEvent::from_persisted_parts(
+                    event.key(),
+                    event.received_at,
+                    event.source,
+                    event.ingress.clone(),
+                    event.egress.clone(),
+                );
                 let mut event_json = ev.to_json_value();
                 if let serde_json::Value::Object(ref mut map) = event_json {
                     // Output records must never carry workspace —
@@ -1567,7 +1563,7 @@ mod tests {
     #[test]
     fn process_variant_jsonl_has_no_egress_no_output_block() {
         let event = sample_owned_event();
-        let expected_key = event.key;
+        let expected_key = event.key();
         let ctx = ErroredEventContext::Process {
             timestamp: chrono::DateTime::from_timestamp_nanos(1_700_000_000_000_000_000),
             pipeline: "p".into(),
@@ -1595,7 +1591,7 @@ mod tests {
     #[test]
     fn output_variant_jsonl_carries_egress_and_output_block() {
         let event = sample_owned_event();
-        let expected_key = event.key;
+        let expected_key = event.key();
         let ctx = ErroredEventContext::Output {
             timestamp: chrono::DateTime::from_timestamp_nanos(1_700_000_000_000_000_000),
             pipeline: String::new(),
@@ -1680,7 +1676,7 @@ mod tests {
         // `Event::from_json` so `limpidctl inject output --json` can
         // reconstruct the egress payload end-to-end.
         let event = sample_owned_event();
-        let expected_key = event.key;
+        let expected_key = event.key();
         let ctx = ErroredEventContext::Output {
             timestamp: chrono::Utc::now(),
             pipeline: String::new(),
@@ -1696,13 +1692,13 @@ mod tests {
             crate::event::Event::from_json(&event_str).expect("event sub-object must replay");
         assert_eq!(&replayed.ingress[..], b"hello");
         assert_eq!(&replayed.egress[..], b"goodbye");
-        assert_eq!(replayed.key, expected_key);
+        assert_eq!(replayed.key(), expected_key);
     }
 
     #[test]
     fn process_variant_round_trip_via_event_from_json() {
         let event = sample_owned_event();
-        let expected_key = event.key;
+        let expected_key = event.key();
         let ctx = ErroredEventContext::Process {
             timestamp: chrono::Utc::now(),
             pipeline: "p".into(),
@@ -1720,7 +1716,7 @@ mod tests {
         // sees a self-consistent starting state.
         assert_eq!(&replayed.ingress[..], b"hello");
         assert_eq!(&replayed.egress[..], b"hello");
-        assert_eq!(replayed.key, expected_key);
+        assert_eq!(replayed.key(), expected_key);
     }
 
     #[tokio::test]

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -170,7 +170,7 @@ impl Drop for AckHandle {
 pub struct OwnedEvent {
     /// Immutable event identity, minted once at the input boundary before
     /// fan-out and retained by clones, persistence, and replay.
-    pub key: uuid::Uuid,
+    key: uuid::Uuid,
     /// Wall-clock time at which this hop received the event. Set once
     /// by the input layer (`OwnedEvent::new` → `Utc::now()`); never
     /// overwritten from payload contents (Principle 2: input is dumb
@@ -227,6 +227,30 @@ impl OwnedEvent {
         }
     }
 
+    /// Return this event's immutable identity.
+    pub fn key(&self) -> uuid::Uuid {
+        self.key
+    }
+
+    /// Reconstruct an event from persisted fields while retaining its identity.
+    pub(crate) fn from_persisted_parts(
+        key: uuid::Uuid,
+        received_at: DateTime<Utc>,
+        source: SocketAddr,
+        ingress: Bytes,
+        egress: Bytes,
+    ) -> Self {
+        Self {
+            key,
+            received_at,
+            source,
+            ingress,
+            egress,
+            workspace: HashMap::new(),
+            ack: None,
+        }
+    }
+
     /// Copy this owned event into `arena` and return a [`BorrowedEvent`]
     /// view. Workspace string keys are alloc'd into the arena and each
     /// value is recursively viewed (see [`OwnedValue::view_in`]).
@@ -240,7 +264,7 @@ impl OwnedEvent {
             workspace.push((arena.alloc_str(k), v.view_in(arena)));
         }
         BorrowedEvent {
-            key: self.key,
+            key: self.key(),
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -418,7 +442,7 @@ pub type Event = OwnedEvent;
 ///   hash + entry-table indirection on a per-event basis (see the
 ///   v0.6.0 baseline — `IndexMap` ops were 11.8% on-CPU).
 pub struct BorrowedEvent<'bump> {
-    pub key: uuid::Uuid,
+    key: uuid::Uuid,
     pub received_at: DateTime<Utc>,
     pub source: SocketAddr,
     pub ingress: Bytes,
@@ -427,6 +451,11 @@ pub struct BorrowedEvent<'bump> {
 }
 
 impl<'bump> BorrowedEvent<'bump> {
+    /// Return this event's immutable identity.
+    pub fn key(&self) -> uuid::Uuid {
+        self.key
+    }
+
     /// Heap-allocate a fresh [`OwnedEvent`] from this borrowed view.
     /// Called at `run_pipeline` exit and at error path setup
     /// (`ErroredEventContext` holds an `OwnedEvent` because the DLQ
@@ -437,7 +466,7 @@ impl<'bump> BorrowedEvent<'bump> {
             workspace.insert((*k).to_string(), v.to_owned_value());
         }
         OwnedEvent {
-            key: self.key,
+            key: self.key(),
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -479,7 +508,7 @@ impl<'bump> BorrowedEvent<'bump> {
     /// of `to_owned` / `to_owned_without_workspace` to invoke.
     pub fn to_owned_without_workspace(&self) -> OwnedEvent {
         OwnedEvent {
-            key: self.key,
+            key: self.key(),
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -527,7 +556,7 @@ impl<'bump> BorrowedEvent<'bump> {
             workspace.push(*entry);
         }
         BorrowedEvent {
-            key: self.key,
+            key: self.key(),
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -870,8 +899,8 @@ mod boundary_tests {
         let third = OwnedEvent::with_ack(Bytes::from_static(b"third"), source, Arc::clone(&ack));
         let fourth = OwnedEvent::with_ack(Bytes::from_static(b"fourth"), source, ack);
 
-        let _: uuid::Uuid = first.key;
-        let keys = [first.key, second.key, third.key, fourth.key];
+        let _: uuid::Uuid = first.key();
+        let keys = [first.key(), second.key(), third.key(), fourth.key()];
         assert!(keys.iter().all(|key| key.get_version_num() == 7));
         assert!(
             keys.iter()

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -1,10 +1,10 @@
 //! Event: the internal message representation flowing through pipelines.
 //!
-//! Each event carries an immutable `ingress` (bytes as received from
-//! the input) and a mutable `egress` (bytes that will be handed to the
-//! output), plus typed metadata and a free-form `workspace` (pipeline-
-//! local scratch namespace). `ingress` / `egress` frame the hop
-//! contract: what came in, what goes out.
+//! Each event carries an immutable UUIDv7 `key`, an immutable `ingress`
+//! (bytes as received from the input), and a mutable `egress` (bytes that
+//! will be handed to the output), plus typed metadata and a free-form
+//! `workspace` (pipeline-local scratch namespace). `ingress` / `egress`
+//! frame the hop contract: what came in, what goes out.
 //!
 //! Two representations live side by side:
 //!
@@ -168,6 +168,9 @@ impl Drop for AckHandle {
 
 #[derive(Debug, Clone)]
 pub struct OwnedEvent {
+    /// Immutable event identity, minted once at the input boundary before
+    /// fan-out and retained by clones, persistence, and replay.
+    pub key: uuid::Uuid,
     /// Wall-clock time at which this hop received the event. Set once
     /// by the input layer (`OwnedEvent::new` → `Utc::now()`); never
     /// overwritten from payload contents (Principle 2: input is dumb
@@ -196,6 +199,7 @@ pub struct OwnedEvent {
 impl OwnedEvent {
     pub fn new(ingress: Bytes, source: SocketAddr) -> Self {
         Self {
+            key: uuid::Uuid::now_v7(),
             received_at: Utc::now(),
             source,
             egress: ingress.clone(),
@@ -213,6 +217,7 @@ impl OwnedEvent {
     /// the end of `runtime::process_event`.
     pub fn with_ack(ingress: Bytes, source: SocketAddr, ack: Arc<AckHandle>) -> Self {
         Self {
+            key: uuid::Uuid::now_v7(),
             received_at: Utc::now(),
             source,
             egress: ingress.clone(),
@@ -235,6 +240,7 @@ impl OwnedEvent {
             workspace.push((arena.alloc_str(k), v.view_in(arena)));
         }
         BorrowedEvent {
+            key: self.key,
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -267,6 +273,10 @@ impl OwnedEvent {
 
     fn to_json_value_with(&self, include_workspace: bool) -> JsonValue {
         let mut map = serde_json::Map::new();
+        map.insert(
+            "key".into(),
+            JsonValue::String(self.key.hyphenated().to_string()),
+        );
         // Wire form is unix nanoseconds (i64) — matches OTLP
         // `time_unix_nano` and is lossless against RFC3339. Receivers
         // (`inject --json`, downstream tooling) parse the integer back
@@ -313,6 +323,20 @@ impl OwnedEvent {
     /// `OwnedValue::Bytes`.
     pub fn from_json(json_str: &str) -> Option<Self> {
         let v: JsonValue = serde_json::from_str(json_str).ok()?;
+        let key = match v.get("key") {
+            Some(JsonValue::String(raw)) => {
+                let parsed = uuid::Uuid::parse_str(raw).ok()?;
+                if parsed.get_version_num() != 7
+                    || parsed.get_variant() != uuid::Variant::RFC4122
+                    || parsed.hyphenated().to_string() != *raw
+                {
+                    return None;
+                }
+                parsed
+            }
+            Some(_) => return None,
+            None => uuid::Uuid::now_v7(),
+        };
         let ingress = json_to_bytes(v.get("ingress")?)?;
         // Source is the v0.5.6+ object form `{ip, port}` — matches the
         // DSL ident shape and what `to_json_value` emits. The legacy
@@ -338,6 +362,7 @@ impl OwnedEvent {
             .unwrap_or_else(|| ingress.clone());
 
         let mut event = Self {
+            key,
             received_at,
             source,
             ingress,
@@ -380,7 +405,7 @@ pub type Event = OwnedEvent;
 ///
 /// Semantics mirror [`OwnedEvent`]:
 ///
-/// - `received_at` / `source` — typed metadata, scalar, copy-cheap.
+/// - `key` / `received_at` / `source` — typed metadata, scalar, copy-cheap.
 /// - `ingress` / `egress` — `bytes::Bytes`. These are reference-counted
 ///   buffers, so handing them across the boundary is a refcount bump,
 ///   not a copy. They are NOT alloc'd inside `arena`, by design — the
@@ -393,6 +418,7 @@ pub type Event = OwnedEvent;
 ///   hash + entry-table indirection on a per-event basis (see the
 ///   v0.6.0 baseline — `IndexMap` ops were 11.8% on-CPU).
 pub struct BorrowedEvent<'bump> {
+    pub key: uuid::Uuid,
     pub received_at: DateTime<Utc>,
     pub source: SocketAddr,
     pub ingress: Bytes,
@@ -411,6 +437,7 @@ impl<'bump> BorrowedEvent<'bump> {
             workspace.insert((*k).to_string(), v.to_owned_value());
         }
         OwnedEvent {
+            key: self.key,
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -435,7 +462,7 @@ impl<'bump> BorrowedEvent<'bump> {
     /// `consume` reads `egress` (with `file`'s dynamic path evaluator
     /// reading `source` / `received_at` and `kafka`'s optional key
     /// reading `source.ip`), the DLQ record projection stores only
-    /// `OutputEvent`'s four fields, and the analyzer rejects
+    /// `OutputEvent`'s five fields, and the analyzer rejects
     /// `workspace` on the output config side at load time. Skipping
     /// the workspace deep-clone here avoids the per-event `HashMap<
     /// String, OwnedValue>` allocation + string-key allocations +
@@ -452,6 +479,7 @@ impl<'bump> BorrowedEvent<'bump> {
     /// of `to_owned` / `to_owned_without_workspace` to invoke.
     pub fn to_owned_without_workspace(&self) -> OwnedEvent {
         OwnedEvent {
+            key: self.key,
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -499,6 +527,7 @@ impl<'bump> BorrowedEvent<'bump> {
             workspace.push(*entry);
         }
         BorrowedEvent {
+            key: self.key,
             received_at: self.received_at,
             source: self.source,
             ingress: self.ingress.clone(),
@@ -608,6 +637,7 @@ mod boundary_tests {
         let arena = EventArena::new(&bump);
         let borrowed = original.view_in(&arena);
         let recovered: OwnedEvent = borrowed.to_owned();
+        assert_eq!(recovered.key, original.key);
         assert_eq!(recovered.received_at, original.received_at);
         assert_eq!(recovered.source, original.source);
         assert_eq!(recovered.ingress, original.ingress);
@@ -628,9 +658,14 @@ mod boundary_tests {
         // routes through the `$bytes_b64` escape pathway).
         let original = sample_event();
         let json = original.to_json_value();
+        assert_eq!(
+            json["key"].as_str(),
+            Some(original.key.hyphenated().to_string().as_str())
+        );
         let serialized = serde_json::to_string(&json).unwrap();
         let recovered =
             OwnedEvent::from_json(&serialized).expect("from_json must accept its own to_json");
+        assert_eq!(recovered.key, original.key);
         assert_eq!(recovered.received_at, original.received_at);
         assert_eq!(recovered.source, original.source);
         assert_eq!(recovered.ingress, original.ingress);
@@ -685,6 +720,7 @@ mod boundary_tests {
         let borrowed = original.view_in(&arena);
         let light = borrowed.to_owned_without_workspace();
         assert!(light.workspace.is_empty(), "workspace must be empty");
+        assert_eq!(light.key, original.key);
         // Every other DLQ / sink-relevant field must survive verbatim,
         // matching the same round-trip guarantees as `to_owned`.
         assert_eq!(light.received_at, original.received_at);
@@ -721,6 +757,7 @@ mod boundary_tests {
         let arena = EventArena::new(&bump);
         let mut view = original.view_in(&arena);
         let snapshot = view.snapshot_in(&arena);
+        assert_eq!(snapshot.key, original.key);
 
         // Mutate the source view after snapshotting.
         view.workspace_set_str(&arena, "added_after_snapshot", Value::Int(42));
@@ -814,5 +851,85 @@ mod boundary_tests {
             recovered.received_at.timestamp_nanos_opt(),
             original.received_at.timestamp_nanos_opt()
         );
+    }
+
+    #[test]
+    fn constructors_mint_distinct_version_7_keys_before_fan_out() {
+        let source = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
+        let first = OwnedEvent::new(Bytes::from_static(b"first"), source);
+        let second = OwnedEvent::new(Bytes::from_static(b"second"), source);
+
+        let (ack_tx, _ack_rx) = tokio::sync::mpsc::unbounded_channel();
+        let ack = Arc::new(AckHandle::new(
+            AckPosition::Offset {
+                generation: 1,
+                offset: 2,
+            },
+            ack_tx,
+        ));
+        let third = OwnedEvent::with_ack(Bytes::from_static(b"third"), source, Arc::clone(&ack));
+        let fourth = OwnedEvent::with_ack(Bytes::from_static(b"fourth"), source, ack);
+
+        let _: uuid::Uuid = first.key;
+        let keys = [first.key, second.key, third.key, fourth.key];
+        assert!(keys.iter().all(|key| key.get_version_num() == 7));
+        assert!(
+            keys.iter()
+                .all(|key| key.get_variant() == uuid::Variant::RFC4122)
+        );
+        assert_eq!(
+            keys.into_iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            4
+        );
+        assert_eq!(first.clone().key, first.key);
+    }
+
+    #[test]
+    fn legacy_json_without_key_mints_one_on_first_read() {
+        let original = sample_event();
+        let mut json = original.to_json_value();
+        json.as_object_mut().unwrap().remove("key");
+
+        let encoded = serde_json::to_string(&json).unwrap();
+        let first = OwnedEvent::from_json(&encoded).unwrap();
+        let second = OwnedEvent::from_json(&encoded).unwrap();
+        assert_eq!(first.key.get_version_num(), 7);
+        assert_eq!(second.key.get_version_num(), 7);
+        assert_ne!(first.key, original.key);
+        assert_ne!(second.key, original.key);
+        assert_ne!(first.key, second.key);
+    }
+
+    #[test]
+    fn present_event_key_must_be_a_canonical_version_7_uuid() {
+        let original = sample_event();
+        let mut json = original.to_json_value();
+
+        json["key"] = JsonValue::String("not-a-uuid".into());
+        assert!(OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).is_none());
+
+        json["key"] = JsonValue::String("550e8400-e29b-41d4-a716-446655440000".into());
+        assert!(OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).is_none());
+
+        json["key"] = JsonValue::String(original.key.simple().to_string());
+        assert!(OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).is_none());
+
+        json["key"] = JsonValue::String("0198A3B4-4D7E-7C20-8B11-9F4E6A2D1357".into());
+        assert!(OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).is_none());
+
+        json["key"] = JsonValue::String("0198a3b4-4d7e-7c20-0b11-9f4e6a2d1357".into());
+        assert!(OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).is_none());
+
+        for invalid in [
+            JsonValue::Null,
+            JsonValue::Number(7.into()),
+            JsonValue::Bool(true),
+            serde_json::json!({ "uuid": original.key.hyphenated().to_string() }),
+        ] {
+            json["key"] = invalid;
+            assert!(OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).is_none());
+        }
     }
 }

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -1354,9 +1354,10 @@ mod tests {
         assert_eq!(lines.len(), 2);
         for line in &lines {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
-            assert_eq!(v["schema_version"], 2);
+            assert_eq!(v["schema_version"], 3);
             assert_eq!(v["kind"], "output");
             assert_eq!(v["output"]["name"], "myout");
+            assert!(v["event"]["key"].is_string());
             assert!(v["event"]["ingress"].is_string() || v["event"]["ingress"].is_object());
             assert!(
                 v["event"]["egress"].is_string() || v["event"]["egress"].is_object(),

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -1321,13 +1321,15 @@ mod tests {
         props
     }
 
-    async fn buffer_two(output: &OtlpGrpcOutput) {
+    async fn buffer_two(output: &OtlpGrpcOutput) -> [uuid::Uuid; 2] {
+        let mut keys = Vec::with_capacity(2);
         for ts in [1u64, 2u64] {
-            consume(output, &event_with_egress(singleton_bytes(ts)))
-                .await
-                .unwrap();
+            let event = event_with_egress(singleton_bytes(ts));
+            keys.push(event.key());
+            consume(output, &event).await.unwrap();
         }
         assert_eq!(output.sink.inner.batch.lock().await.len(), 2);
+        keys.try_into().unwrap()
     }
 
     #[tokio::test]
@@ -1344,7 +1346,7 @@ mod tests {
             ..crate::modules::BuildContext::for_testing()
         };
         let output = OtlpGrpcOutput::from_properties("myout", &mp(&props), &ctx).unwrap();
-        buffer_two(&output).await;
+        let expected_keys = buffer_two(&output).await;
 
         output.shutdown(Some(&writer)).await.unwrap();
         assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
@@ -1352,12 +1354,12 @@ mod tests {
         let body = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = body.lines().collect();
         assert_eq!(lines.len(), 2);
-        for line in &lines {
+        for (line, expected_key) in lines.iter().zip(expected_keys) {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
             assert_eq!(v["schema_version"], 3);
             assert_eq!(v["kind"], "output");
             assert_eq!(v["output"]["name"], "myout");
-            assert!(v["event"]["key"].is_string());
+            assert_eq!(v["event"]["key"], expected_key.hyphenated().to_string());
             assert!(v["event"]["ingress"].is_string() || v["event"]["ingress"].is_object());
             assert!(
                 v["event"]["egress"].is_string() || v["event"]["egress"].is_object(),

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -1977,13 +1977,15 @@ def output o {{
         props
     }
 
-    async fn buffer_two(output: &OtlpHttpOutput) {
+    async fn buffer_two(output: &OtlpHttpOutput) -> [uuid::Uuid; 2] {
+        let mut keys = Vec::with_capacity(2);
         for ts in [1u64, 2u64] {
-            consume(output, &event_with_egress(singleton_bytes(ts)))
-                .await
-                .unwrap();
+            let event = event_with_egress(singleton_bytes(ts));
+            keys.push(event.key());
+            consume(output, &event).await.unwrap();
         }
         assert_eq!(output.sink.inner.batch.lock().await.len(), 2);
+        keys.try_into().unwrap()
     }
 
     #[tokio::test]
@@ -1997,7 +1999,7 @@ def output o {{
             ..crate::modules::BuildContext::for_testing()
         };
         let output = OtlpHttpOutput::from_properties("myout", &mp(&props), &ctx).unwrap();
-        buffer_two(&output).await;
+        let expected_keys = buffer_two(&output).await;
 
         output.shutdown(Some(&writer)).await.unwrap();
         assert_eq!(output.sink.inner.batch.lock().await.len(), 0);
@@ -2005,12 +2007,12 @@ def output o {{
         let body = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = body.lines().collect();
         assert_eq!(lines.len(), 2);
-        for line in &lines {
+        for (line, expected_key) in lines.iter().zip(expected_keys) {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
             assert_eq!(v["schema_version"], 3);
             assert_eq!(v["kind"], "output");
             assert_eq!(v["output"]["name"], "myout");
-            assert!(v["event"]["key"].is_string());
+            assert_eq!(v["event"]["key"], expected_key.hyphenated().to_string());
             // The reason carries the underlying transport error from
             // `flush_events`; the exact wording is implementation
             // detail.

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -2007,9 +2007,10 @@ def output o {{
         assert_eq!(lines.len(), 2);
         for line in &lines {
             let v: serde_json::Value = serde_json::from_str(line).unwrap();
-            assert_eq!(v["schema_version"], 2);
+            assert_eq!(v["schema_version"], 3);
             assert_eq!(v["kind"], "output");
             assert_eq!(v["output"]["name"], "myout");
+            assert!(v["event"]["key"].is_string());
             // The reason carries the underlying transport error from
             // `flush_events`; the exact wording is implementation
             // detail.

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -317,7 +317,7 @@ pub enum ErroredEventContext {
 /// point it may hold partial output of an earlier process step.
 #[derive(Debug, Clone)]
 pub struct ProcessEvent {
-    pub key: uuid::Uuid,
+    key: uuid::Uuid,
     pub source: std::net::SocketAddr,
     pub received_at: chrono::DateTime<chrono::Utc>,
     pub ingress: bytes::Bytes,
@@ -331,7 +331,7 @@ pub struct ProcessEvent {
 /// re-rendering / re-shipping.
 #[derive(Debug, Clone)]
 pub struct OutputEvent {
-    pub key: uuid::Uuid,
+    key: uuid::Uuid,
     pub source: std::net::SocketAddr,
     pub received_at: chrono::DateTime<chrono::Utc>,
     pub ingress: bytes::Bytes,
@@ -342,11 +342,16 @@ impl ProcessEvent {
     /// Snapshot the process-flavor fields from an [`OwnedEvent`].
     pub fn from_owned(ev: &OwnedEvent) -> Self {
         Self {
-            key: ev.key,
+            key: ev.key(),
             source: ev.source,
             received_at: ev.received_at,
             ingress: ev.ingress.clone(),
         }
+    }
+
+    /// Return the immutable identity of the captured event.
+    pub fn key(&self) -> uuid::Uuid {
+        self.key
     }
 }
 
@@ -354,12 +359,17 @@ impl OutputEvent {
     /// Snapshot the output-flavor fields from an [`OwnedEvent`].
     pub fn from_owned(ev: &OwnedEvent) -> Self {
         Self {
-            key: ev.key,
+            key: ev.key(),
             source: ev.source,
             received_at: ev.received_at,
             ingress: ev.ingress.clone(),
             egress: ev.egress.clone(),
         }
+    }
+
+    /// Return the immutable identity of the captured event.
+    pub fn key(&self) -> uuid::Uuid {
+        self.key
     }
 }
 

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -250,7 +250,7 @@ pub enum PipelineTermination {
 /// - [`Process`](ErroredEventContext::Process) — a `process` step (named
 ///   `def process` invocation, inline `process { ... }` block, or a
 ///   top-level `error` statement) failed during pipeline execution.
-///   The captured [`ProcessEvent`] holds the original ingress / source /
+///   The captured [`ProcessEvent`] holds the original key / ingress / source /
 ///   received_at; egress is not snapshotted because at the failure
 ///   point it may hold partial output of an earlier process in the
 ///   chain, which would confuse replay. Replay re-runs the pipeline
@@ -285,7 +285,7 @@ pub enum ErroredEventContext {
         site: String,
         /// Stringified `ProcessError` / `anyhow::Error` from the failure.
         reason: String,
-        /// Pre-failure event snapshot (ingress / source / received_at only).
+        /// Pre-failure event snapshot (key / ingress / source / received_at only).
         event: ProcessEvent,
     },
     Output {
@@ -304,7 +304,7 @@ pub enum ErroredEventContext {
         /// Output name — the *only* sink-routing metadata captured.
         /// Replay = `limpidctl inject output <output_name>`.
         output_name: String,
-        /// Event snapshot (ingress + egress + source + received_at).
+        /// Event snapshot (key + ingress + egress + source + received_at).
         event: OutputEvent,
     },
 }
@@ -317,6 +317,7 @@ pub enum ErroredEventContext {
 /// point it may hold partial output of an earlier process step.
 #[derive(Debug, Clone)]
 pub struct ProcessEvent {
+    pub key: uuid::Uuid,
     pub source: std::net::SocketAddr,
     pub received_at: chrono::DateTime<chrono::Utc>,
     pub ingress: bytes::Bytes,
@@ -330,6 +331,7 @@ pub struct ProcessEvent {
 /// re-rendering / re-shipping.
 #[derive(Debug, Clone)]
 pub struct OutputEvent {
+    pub key: uuid::Uuid,
     pub source: std::net::SocketAddr,
     pub received_at: chrono::DateTime<chrono::Utc>,
     pub ingress: bytes::Bytes,
@@ -340,6 +342,7 @@ impl ProcessEvent {
     /// Snapshot the process-flavor fields from an [`OwnedEvent`].
     pub fn from_owned(ev: &OwnedEvent) -> Self {
         Self {
+            key: ev.key,
             source: ev.source,
             received_at: ev.received_at,
             ingress: ev.ingress.clone(),
@@ -351,6 +354,7 @@ impl OutputEvent {
     /// Snapshot the output-flavor fields from an [`OwnedEvent`].
     pub fn from_owned(ev: &OwnedEvent) -> Self {
         Self {
+            key: ev.key,
             source: ev.source,
             received_at: ev.received_at,
             ingress: ev.ingress.clone(),
@@ -1885,7 +1889,7 @@ fn exec_pipeline_stmt<'bump>(
             //   the `workspace` (via `to_owned_without_workspace`).
             //   The downstream sink reads `egress` (and, for `file`
             //   and `kafka`, `source` / `received_at` / `source.ip`),
-            //   the DLQ path projects to `OutputEvent`'s four fields,
+            //   the DLQ path projects to `OutputEvent`'s five fields,
             //   and the output-flavor `tap` strips `workspace` on the
             //   emit side too — so nobody observes the missing
             //   workspace.
@@ -2123,7 +2127,7 @@ def pipeline p {
         }
         assert!(result.outputs.is_empty());
         let line = ctx.to_jsonl();
-        assert!(line.contains("\"schema_version\":2"));
+        assert!(line.contains("\"schema_version\":3"));
         assert!(line.contains("\"kind\":\"process\""));
         assert!(line.contains("\"pipeline\":\"p\""));
         assert!(line.contains("\"name\":\"wrap\""));

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -676,6 +676,7 @@ mod tests {
     #[test]
     fn test_event_roundtrip() {
         let mut event = make_event("<134>test");
+        let expected_key = event.key;
         event
             .workspace
             .insert("key".into(), crate::dsl::OwnedValue::String("val".into()));
@@ -684,6 +685,7 @@ mod tests {
         let json_str = serde_json::to_string(&json).unwrap();
         let recovered = Event::from_json(&json_str).unwrap();
 
+        assert_eq!(recovered.key, expected_key);
         assert_eq!(String::from_utf8_lossy(&recovered.ingress), "<134>test");
         assert_eq!(
             recovered.workspace["key"],
@@ -727,14 +729,20 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (tx, mut rx) = create_disk_queue(dir.path().to_str().unwrap(), 0).unwrap();
 
-        tx.send(make_event("<134>msg1")).await.unwrap();
-        tx.send(make_event("<134>msg2")).await.unwrap();
+        let first = make_event("<134>msg1");
+        let second = make_event("<134>msg2");
+        let first_key = first.key;
+        let second_key = second.key;
+        tx.send(first).await.unwrap();
+        tx.send(second).await.unwrap();
 
         let (e1, _p1) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>msg1");
+        assert_eq!(e1.key, first_key);
 
         let (e2, _p2) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>msg2");
+        assert_eq!(e2.key, second_key);
     }
 
     #[test]

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn test_event_roundtrip() {
         let mut event = make_event("<134>test");
-        let expected_key = event.key;
+        let expected_key = event.key();
         event
             .workspace
             .insert("key".into(), crate::dsl::OwnedValue::String("val".into()));
@@ -685,7 +685,7 @@ mod tests {
         let json_str = serde_json::to_string(&json).unwrap();
         let recovered = Event::from_json(&json_str).unwrap();
 
-        assert_eq!(recovered.key, expected_key);
+        assert_eq!(recovered.key(), expected_key);
         assert_eq!(String::from_utf8_lossy(&recovered.ingress), "<134>test");
         assert_eq!(
             recovered.workspace["key"],
@@ -731,18 +731,18 @@ mod tests {
 
         let first = make_event("<134>msg1");
         let second = make_event("<134>msg2");
-        let first_key = first.key;
-        let second_key = second.key;
+        let first_key = first.key();
+        let second_key = second.key();
         tx.send(first).await.unwrap();
         tx.send(second).await.unwrap();
 
         let (e1, _p1) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>msg1");
-        assert_eq!(e1.key, first_key);
+        assert_eq!(e1.key(), first_key);
 
         let (e2, _p2) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>msg2");
-        assert_eq!(e2.key, second_key);
+        assert_eq!(e2.key(), second_key);
     }
 
     #[test]

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -738,7 +738,7 @@ async fn run_pipeline_with_outputs_inner(
     let outputs = std::mem::take(&mut result.outputs);
     // Each failed enqueue carries a per-output snapshot of just the
     // fields the DLQ record actually stores (`OutputEvent`:
-    // `source`, `received_at`, `ingress`, `egress` — the same shape
+    // `key`, `source`, `received_at`, `ingress`, `egress` — the same shape
     // `inject output` replay needs). Snapshotting `OutputEvent` here
     // rather than the whole `OwnedEvent` avoids the workspace
     // `HashMap<String, OwnedValue>` deep clone on every success:
@@ -755,7 +755,7 @@ async fn run_pipeline_with_outputs_inner(
     for (output_name, event) in outputs {
         if let Some(sender) = ctx.output_senders.get(&output_name) {
             // Snapshot the DLQ-relevant fields before the send
-            // consumes `event`. Cheap: four Copy scalars + two
+            // consumes `event`. Cheap: five Copy scalars + two
             // `Bytes` refcount bumps; workspace is not touched.
             let snapshot = crate::pipeline::OutputEvent::from_owned(&event);
             if let Err(e) = sender.send(event).await {

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -103,7 +103,7 @@ A pipeline-side failure (process body raised, pipeline-skeleton eval failed, exp
   "event": {
     "key": "0198a3b4-4d7e-7c20-8b11-9f4e6a2d1357",
     "source": {"ip": "10.0.0.1", "port": 514},
-    "received_at": 1745719719178046000,
+    "received_at": 1777260519178046000,
     "ingress": "<134>1 2026-04-27T03:28:39Z host app 1234 - - hello"
   }
 }
@@ -124,7 +124,7 @@ A sink-side failure (retry budget exhausted, batched-output shutdown drain, runt
   "event": {
     "key": "0198a3b4-4d7e-7c20-8b11-9f4e6a2d1357",
     "source": {"ip": "10.0.0.1", "port": 514},
-    "received_at": 1745719719178046000,
+    "received_at": 1777260519178046000,
     "ingress": "<134>1 2026-04-27T03:28:39Z host app 1234 - - hello",
     "egress": "<134>1 2026-04-27T03:28:39Z host app 1234 - - hello\n"
   }
@@ -183,7 +183,7 @@ The `reason` field distinguishes sites 5 / 6 / 7 within a single output name: re
 
 ### Address-free Output records
 
-The Output record carries `output: { name }` and nothing more. No peer address, endpoint URL, partition, topic, path, target, key, or workspace fragment leaks into the recovery record.
+The Output record carries `output: { name }` and nothing more. No peer address, endpoint URL, partition, topic, path, target, routing key, or workspace fragment leaks into the recovery record.
 
 Why: replay calls `limpidctl inject output <name>`, which hands the event back to the sink. The sink re-routes via the same `consume()` path it uses for live traffic — round-robin peer selection, retry budget, batching, headers, all of it. There is no "send this exact record to this exact peer" mode; the sink owns routing. Carrying address details on the record would create two failure modes: (a) replay vs. live diverging when the operator updates the sink config between failure and replay, and (b) sensitive routing metadata (peer hostnames, internal endpoint URLs) leaking into the DLQ file.
 

--- a/docs/src/operations/error-log.md
+++ b/docs/src/operations/error-log.md
@@ -20,7 +20,7 @@ Three behaviours were considered:
 - **Discard** makes the bug visible (counter goes up) but is itself a strong failure mode: a security telemetry pipeline that drops events to a config typo is the wrong default.
 - **DLQ** preserves the data and the bug signal: `events_errored` ticks up *and* the original event is recoverable. This is the Logstash / Fluentd `@ERROR` pattern.
 
-The runtime cannot guess what the operator intended at the failure point — `egress` may have been partially rewritten by earlier processes in the chain, the next process expected a workspace key that was never produced, etc. So the DLQ deliberately preserves only the *original* event (ingress / source / received_at) for the Process flavor, and the pre-rendered wire payload (with `egress`) for the Output flavor, and lets the operator re-run from the appropriate boundary after the fix.
+The runtime cannot guess what the operator intended at the failure point — `egress` may have been partially rewritten by earlier processes in the chain, the next process expected a workspace key that was never produced, etc. So the DLQ deliberately preserves only the *original* event (key / ingress / source / received_at) for the Process flavor, and the pre-rendered wire payload (with `egress`) for the Output flavor, and lets the operator re-run from the appropriate boundary after the fix.
 
 ## Configuring the DLQ
 
@@ -86,7 +86,7 @@ Operators with stricter retention needs (compliance: hold N days of forensic-qua
 
 ## Record format
 
-Each line is a sum-typed JSON record. Since 0.7.8 the record carries an explicit `schema_version: 2` and a `kind` discriminator (`"process"` or `"output"`) that selects a per-kind block at the top level. Process flavor records carry `process: { name }` and a minimal event (ingress only); Output flavor records carry `output: { name }` and the pre-rendered `event.egress`.
+Each line is a sum-typed JSON record. The current format is `schema_version: 3`; the `kind` discriminator (`"process"` or `"output"`) selects a per-kind block at the top level. Both flavors carry the immutable event key. Process flavor records carry `process: { name }` and a minimal event (ingress only); Output flavor records carry `output: { name }` and the pre-rendered `event.egress`.
 
 ### Process flavor
 
@@ -94,13 +94,14 @@ A pipeline-side failure (process body raised, pipeline-skeleton eval failed, exp
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "timestamp": "2026-04-27T03:28:39.178046123Z",
   "reason": "unknown identifier: timestamp",
   "pipeline": "journal_forward",
   "kind": "process",
   "process": { "name": "wrap_journal" },
   "event": {
+    "key": "0198a3b4-4d7e-7c20-8b11-9f4e6a2d1357",
     "source": {"ip": "10.0.0.1", "port": 514},
     "received_at": 1745719719178046000,
     "ingress": "<134>1 2026-04-27T03:28:39Z host app 1234 - - hello"
@@ -114,13 +115,14 @@ A sink-side failure (retry budget exhausted, batched-output shutdown drain, runt
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "timestamp": "2026-04-27T03:31:02.998742000Z",
   "reason": "output write failed after 5 attempts: connection refused",
   "pipeline": "",
   "kind": "output",
   "output": { "name": "mysink" },
   "event": {
+    "key": "0198a3b4-4d7e-7c20-8b11-9f4e6a2d1357",
     "source": {"ip": "10.0.0.1", "port": 514},
     "received_at": 1745719719178046000,
     "ingress": "<134>1 2026-04-27T03:28:39Z host app 1234 - - hello",
@@ -133,11 +135,12 @@ A sink-side failure (retry budget exhausted, batched-output shutdown drain, runt
 
 | Field | Meaning |
 |-------|---------|
-| `schema_version` | Integer `2`. Identifies the v2 sum-typed shape; v1 is a hard break (see [Schema migration v1 → v2](#schema-migration-v1--v2) below). |
+| `schema_version` | Integer `3`. Identifies the event-identity shape; v2 records omit `event.key` (see [Schema migration v2 → v3](#schema-migration-v2--v3) below). |
 | `timestamp` | RFC3339 with nanosecond precision; wall-clock at which the failure was raised. |
 | `reason` | Stringified failure reason. Stable enough for `grep` / classification but not a stable API. The runbook below maps reason patterns back to producer sites. |
 | `pipeline` | Pipeline name (`def pipeline <name>`). Populated for every Process record; for Output records it carries the originating pipeline only when the failure happened *at the pipeline → output boundary* (= enqueue failure). Retry-exhausted and shutdown-drain Output records have an empty `pipeline` field because the event had already left its source pipeline by then. |
 | `kind` | Discriminator: `"process"` or `"output"`. Selects which per-kind block is present and which `event.*` fields are populated. |
+| `event.key` | Canonical hyphenated lowercase UUIDv7. Immutable across fan-out, capture, and replay. |
 | `event.source` | Originating peer as `{ip, port}` object. Same shape as `tap --json` and as the DSL `source` ident. |
 | `event.received_at` | i64 unix nanoseconds (matches OTLP `time_unix_nano`). Same shape as `tap --json`. |
 | `event.ingress` | Original wire bytes. UTF-8-clean payloads serialise as a JSON string; non-UTF-8 payloads use the `$bytes_b64` marker the rest of the JSON layer already uses for `tap --json`. |
@@ -148,7 +151,7 @@ A sink-side failure (retry budget exhausted, batched-output shutdown drain, runt
 |-------|---------|
 | `process` | `{ "name": "<site>" }` block. `name` is the failing `def process` name, `(inline)` for an inline `process { ... }` block, `(pipeline)` for a pipeline-statement `error <expr>`, or `(pipeline body)` for a pipeline-skeleton expression failure (`if` condition, `switch` scrutinee, `error <expr>` argument, or a body expression evaluated inside the pipeline). |
 
-`event` carries only `{ source, received_at, ingress }` — no `egress`, no `workspace`. Replay re-runs the pipeline from scratch on `ingress`.
+`event` carries only `{ key, source, received_at, ingress }` — no `egress`, no `workspace`. Replay re-runs the pipeline from scratch on `ingress` while retaining the same event identity.
 
 ### Output-flavor extras
 
@@ -173,7 +176,7 @@ Process flavor (4 sites — replay via `inject input`):
 Output flavor (3 sites — replay via `inject output`):
 
 5. **`<output_name>`** — the output exhausted its `retry { ... }` budget against the destination. A batched output's per-event render failure inside `flush()` is also routed here with `reason = "render failed during batch flush: ..."`. `pipeline` is empty.
-6. **`<output_name> shutdown`** — a batched output (`http`, `otlp_http`, `otlp_grpc`) was **gracefully shut down** (`SIGTERM`, `SIGHUP` reload, `systemctl stop`, or an explicit `shutdown()` API call) with events still buffered and the bounded final drain failed. The drain runs one flush attempt per payload bounded by `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` (3 s) plus a per-actor in-flight cancel; transport timeout, in-flight cancel, or retry exhaustion all route here. The `shutdown()` impl walks the remaining `(Event, QueueAckHandle)` buffer entries (one record per parked event) through this writer. `pipeline` is empty. The per-event `source`, `received_at`, `ingress`, and `egress` come from the original `Event` that was parked in the buffer at `consume()` time; nothing is synthesised. (Earlier 0.7.7 drafts of this flavor carried synthetic shutdown-time metadata; the 0.7.8 ack-lifecycle work parks the source `Event` alongside the ack handle so each shutdown-drain record now reflects the real per-event provenance.) **`SIGKILL` (`kill -9`) cannot reach this path** — actor tasks are aborted and the stack-local buffer is lost without an error_log write. Production deployments must not send `SIGKILL` directly to the daemon; keep systemd's `KillSignal=SIGTERM` default.
+6. **`<output_name> shutdown`** — a batched output (`http`, `otlp_http`, `otlp_grpc`) was **gracefully shut down** (`SIGTERM`, `SIGHUP` reload, `systemctl stop`, or an explicit `shutdown()` API call) with events still buffered and the bounded final drain failed. The drain runs one flush attempt per payload bounded by `SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT` (3 s) plus a per-actor in-flight cancel; transport timeout, in-flight cancel, or retry exhaustion all route here. The `shutdown()` impl walks the remaining `(Event, QueueAckHandle)` buffer entries (one record per parked event) through this writer. `pipeline` is empty. The per-event `key`, `source`, `received_at`, `ingress`, and `egress` come from the original `Event` that was parked in the buffer at `consume()` time; nothing is synthesised. (Earlier 0.7.7 drafts of this flavor carried synthetic shutdown-time metadata; the 0.7.8 ack-lifecycle work parks the source `Event` alongside the ack handle so each shutdown-drain record now reflects the real per-event provenance.) **`SIGKILL` (`kill -9`) cannot reach this path** — actor tasks are aborted and the stack-local buffer is lost without an error_log write. Production deployments must not send `SIGKILL` directly to the daemon; keep systemd's `KillSignal=SIGTERM` default.
 7. **`<output_name> enqueue`** — `runtime.rs` could not hand an event to the named output's queue (queue closed, disk-queue write error, unknown output). `pipeline` is the name of the originating pipeline — the only Output-flavor site that keeps it populated. Per-failed-output split: a single pipeline-eval result with N failed-output enqueues produces N records (one per failing output).
 
 The `reason` field distinguishes sites 5 / 6 / 7 within a single output name: retry exhaustion uses `"output write failed after N attempts: ..."`, shutdown drain uses `"shutdown flush failed: ..."`, enqueue failure uses `"output enqueue failed (queue closed, disk write error, or unknown output)"`. A batched output's per-event render failure inside `flush()` uses `"render failed during batch flush: ..."`. The runbook's [root-cause heuristics table](#step-3--root-cause-heuristics-by-site) lists the full patterns.
@@ -188,7 +191,7 @@ The trade-off: an operator who needs to know *which peer failed* for an `<output
 
 ### Schema stability
 
-`schema_version: 2` is the operator-visible discriminator. Pre-1.0, the schema may add fields to existing kinds, or add new kinds, both of which bump `schema_version`. Field renames within an existing kind also bump it. After 1.0 the format will be locked under semantic versioning.
+`schema_version: 3` is the operator-visible discriminator. Pre-1.0, the schema may add fields to existing kinds, or add new kinds, both of which bump `schema_version`. Field renames within an existing kind also bump it. After 1.0 the format will be locked under semantic versioning.
 
 `event.source` changed shape from a flat `"ip:port"` string to a `{ip, port}` object in v0.5.6 (independent of `schema_version`, but worth knowing if you're reading captures from that era).
 
@@ -360,7 +363,7 @@ jq -c 'select(.kind == "process" and (.reason | test("parse_json"))) | .event' \
     | limpidctl inject input <input_name> --json
 ```
 
-**Shutdown-drain caveat.** Output-flavor records with `reason` starting with `shutdown flush failed: ...` are *per-event* records, not per-batch — the batched output's shutdown helper walks every still-buffered `(Event, QueueAckHandle)` entry and writes one record per parked event, so `event.source`, `event.received_at`, `event.ingress`, and `event.egress` all reflect the original per-event provenance (no synthetic shutdown-time metadata). `event.egress` carries the per-event pre-rendered payload (= the bytes the output had built for the wire on each event, before the unsent batch wrapper was applied), so `inject output <name>` is the correct replay path — the sink takes the per-event pre-rendered bytes and re-routes via its `consume()` path, applying the current batch wrapper / headers / compression as if the event had just been enqueued. Do **not** route shutdown-drain records through `inject input <name>`: doing so feeds the per-event pre-rendered payload back into the pipeline as raw `ingress`, which is almost never what you want.
+**Shutdown-drain caveat.** Output-flavor records with `reason` starting with `shutdown flush failed: ...` are *per-event* records, not per-batch — the batched output's shutdown helper walks every still-buffered `(Event, QueueAckHandle)` entry and writes one record per parked event, so `event.key`, `event.source`, `event.received_at`, `event.ingress`, and `event.egress` all reflect the original per-event provenance (no synthetic shutdown-time metadata). `event.egress` carries the per-event pre-rendered payload (= the bytes the output had built for the wire on each event, before the unsent batch wrapper was applied), so `inject output <name>` is the correct replay path — the sink takes the per-event pre-rendered bytes and re-routes via its `consume()` path, applying the current batch wrapper / headers / compression as if the event had just been enqueued. Do **not** route shutdown-drain records through `inject input <name>`: doing so feeds the per-event pre-rendered payload back into the pipeline as raw `ingress`, which is almost never what you want.
 
 **OTLP `partial_success` attribution caveat.** For `output otlp_http` and `output otlp_grpc`, Output-flavor records with `reason == "collector reported partial_success rejection"` are an **approximate** attribution of a batch-level rejection: the OTLP response carries a rejected *count*, not the identity of each rejected log record. limpid splits the batch into Delivered + Recovered along the trailing N entries (where N = `rejected_log_records`) and writes one DLQ record per Recovered tail entry, but the collector did not identify those exact events. Metric totals (`events_written`, `events_failed`) are accurate; per-event provenance in `event.*` is correct (it is the original Event); the *attribution* — which specific event was rejected — is not. For replay purposes treat these records as a batch-level rejection split into per-event records, not as proof of which records the collector rejected. `inject output <name>` still works the same way; if the underlying cause is a payload-shape issue, the rejection will simply re-occur on the rejected subset of the replay (and the same approximate split will apply on the new response).
 
@@ -441,7 +444,7 @@ $ echo 'sample event' \
 [input] → ingress: <134>sample event
 [process]  wrap_journal → error: process failed: unknown identifier: timestamp (event → error_log)
 
-[error_log]  {"schema_version":2,"timestamp":"...","reason":"...","pipeline":"journal_forward","kind":"process","process":{"name":"wrap_journal"},"event":{"source":{"ip":"127.0.0.1","port":0},"received_at":...,"ingress":"<134>sample event"}}
+[error_log]  {"schema_version":3,"timestamp":"...","reason":"...","pipeline":"journal_forward","kind":"process","process":{"name":"wrap_journal"},"event":{"key":"0198a3b4-4d7e-7c20-8b11-9f4e6a2d1357","source":{"ip":"127.0.0.1","port":0},"received_at":...,"ingress":"<134>sample event"}}
 ```
 
 This is useful for confirming the JSONL shape, the `kind` / per-kind name discriminator, and that the original ingress is captured correctly — all without booting the daemon or touching any file. The Output-flavor shape can be observed by triggering a sink retry exhaustion against an unroutable peer; `--test-pipeline` does not directly emit Output records (it stops at pipeline-side disposition).
@@ -514,6 +517,19 @@ Two boundaries the shutdown drain does not cover. Both are protocol-level and bo
 Both limitations are surfaced deliberately. `events_failed` on the output ticks for every event that took the DLQ path; the DLQ record captures the payload. Neither is treated as an excuse for further silent gaps inside the runtime.
 
 **`SIGKILL` (`kill -9`) still bypasses the entire graceful-shutdown path.** Actor tasks are aborted with their handles unresolved, and batched outputs lose whatever was mid-flush. Production deployments must keep systemd's `KillSignal=SIGTERM` default and give the daemon its 10 s budget.
+
+## Schema migration v2 → v3
+
+Version 3 adds `event.key`, the immutable UUIDv7 shared with `tap --json` and
+the queue persistence format. New records retain the same key when replayed,
+so a failure can be correlated with observations made before and after the
+DLQ boundary.
+
+Version 2 records remain replayable: their event object has no key, so limpid
+assigns a UUIDv7 when it first reads that event object. No rewrite is required
+unless external tooling validates `schema_version`; such tooling should accept both
+versions during migration and treat a missing v2 key as unavailable rather
+than synthesising one independently.
 
 ## Schema migration v1 → v2
 

--- a/docs/src/operations/tap.md
+++ b/docs/src/operations/tap.md
@@ -18,7 +18,7 @@ sudo limpidctl tap process enrich_fortigate
 sudo limpidctl list
 ```
 
-By default, tap emits each event's `egress` bytes as a line of text. Add `--json` to emit the Event as one JSON object per line. Top-level keys are always `received_at`, `source`, `ingress`, and `egress`. `workspace` inclusion depends on the tap point:
+By default, tap emits each event's `egress` bytes as a line of text. Add `--json` to emit the Event as one JSON object per line. Top-level keys are always `key`, `received_at`, `source`, `ingress`, and `egress`. `key` is the event's immutable UUIDv7 identity; it is minted before fan-out and survives queue persistence, DLQ capture, and JSON replay. `workspace` inclusion depends on the tap point:
 
 - **`tap process <name> --json`** — `workspace` is included when non-empty. This is the tap point that shows workspace state, because process bodies are the only DSL construct that mutates it.
 - **`tap input <name> --json`** — `workspace` is always absent (input events start with an empty workspace).
@@ -30,6 +30,9 @@ sudo limpidctl tap output ama --json | jq -r '[.source.ip, .egress] | @tsv'
 
 # Workspace state after a named process
 sudo limpidctl tap process enrich_fortigate --json | jq '.workspace'
+
+# Correlate the same event across tap points
+sudo limpidctl tap process enrich_fortigate --json | jq -r '.key'
 ```
 
 ## How it works
@@ -76,6 +79,10 @@ limpidctl inject output ama < messages.log
 limpidctl inject input fw_syslog --json < events.jsonl
 limpidctl inject output ama --json < events.jsonl
 ```
+
+JSON captured before 0.8.0 has no `key`. On its first read, limpid assigns a
+new UUIDv7; JSON that already contains a key must use the canonical hyphenated
+lowercase UUIDv7 form. Replaying a current capture preserves its existing key.
 
 On success, `limpidctl inject` prints the number of events injected:
 


### PR DESCRIPTION
## Summary

- assign every event an immutable UUIDv7 identity before fan-out
- preserve the key through clones, queues, dead-letter capture, and JSON replay
- expose the key in JSON tap output while keeping the default raw tap stream and DSL unchanged
- update dead-letter records to schema version 3, with compatibility for older keyless event JSON
- pin the UUID dependency to the tested fast-rng release without duplicate dependency versions

## Validation

- workspace tests and Clippy
- Kafka and journal-enabled workspace tests
- formatting, documentation, snippet inventory, dependency policy, and vulnerability audit
- formal A-D event-throughput benchmarks; all median results remained within the accepted regression threshold


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Events now include immutable UUIDv7 keys for reliable identification and correlation.
  - Keys are preserved through cloning, queues, fan-out, persistence, dead-letter capture, replay, and tap output.
  - Legacy event JSON without a key receives a new key when read.
- **Bug Fixes**
  - Event identity is retained during borrowed-event cloning and JSON round trips.
- **Documentation**
  - Updated event, tap, replay, and dead-letter guidance with key handling and schema version 3 details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->