### PR TITLE
feat(ltp): provision node identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Added — LTP node key provisioning
+
+The optional top-level `node_key` selects an Ed25519 PKCS#8 private-key file.
+Daemon startup and reload validate its owner, exact `0400`/`0600` mode, regular
+file type, and key format through one non-symlink-following file descriptor.
+`limpidctl ltp keygen <path>` creates a new `0600` key without overwriting an
+existing path and prints the matching RFC 8410 SPKI public key as one base64
+line.
+
 ### Added — immutable event identity
 
 Every event now receives a UUIDv7 `key` before fan-out. The key is preserved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,6 +1120,7 @@ dependencies = [
  "maxminddb",
  "md-5",
  "opentelemetry-proto",
+ "pem",
  "pest",
  "pest_derive",
  "pkg-config",
@@ -1128,6 +1129,7 @@ dependencies = [
  "rdkafka",
  "regex-lite",
  "reqwest",
+ "ring",
  "rustls",
  "serde",
  "serde_json",
@@ -1172,11 +1174,15 @@ dependencies = [
 name = "limpidctl"
 version = "0.7.15"
 dependencies = [
+ "base64",
  "chrono",
  "clap",
  "libc",
  "limpid-metrics-schema",
+ "pem",
+ "ring",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 limpid-metrics-schema = { version = "0.7.15", path = "crates/limpid-metrics-schema" }
+base64 = "0.22.1"
+pem = "3.0.6"
+ring = "0.17.14"

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -41,7 +41,9 @@ sha2 = "0.10"
 sha1 = "0.10"
 md-5 = "0.10"
 digest = "0.10"
-base64 = "0.22"
+base64 = { workspace = true }
+pem = { workspace = true }
+ring = { workspace = true }
 indexmap = { version = "2", features = ["serde"] }
 # Per-event bump arena for the DSL `Value` tree. Each event allocates
 # transient `Value::Object` / `Value::Array` / `Value::String` /

--- a/crates/limpid/src/config.rs
+++ b/crates/limpid/src/config.rs
@@ -144,6 +144,7 @@ fn load_recursive(
         // out of the merged AST.
         return Ok(Config {
             node_id: None,
+            node_key: None,
             definitions: Vec::new(),
             global_blocks: Vec::new(),
             includes: Vec::new(),
@@ -202,6 +203,11 @@ fn load_recursive(
                 && config.node_id.replace(included_node_id).is_some()
             {
                 bail!("duplicate node_id");
+            }
+            if let Some(included_node_key) = inc_config.node_key
+                && config.node_key.replace(included_node_key).is_some()
+            {
+                bail!("duplicate node_key");
             }
             config.definitions.extend(inc_config.definitions);
             config.global_blocks.extend(inc_config.global_blocks);
@@ -430,6 +436,65 @@ mod tests {
 
         let config = load_config(&main_conf).unwrap();
         assert_eq!(config.node_id.as_deref(), Some("shared-node"));
+    }
+
+    #[test]
+    fn included_node_key_is_retained_in_the_merged_config() {
+        let dir = TempDir::new().unwrap();
+        let main_conf = dir.path().join("main.conf");
+        let included = dir.path().join("included.limpid");
+
+        fs::write(&included, "node_key \"keys/node.pem\"").unwrap();
+        fs::write(&main_conf, "include \"included.limpid\"").unwrap();
+
+        let config = load_config(&main_conf).unwrap();
+        assert_eq!(config.node_key.as_deref(), Some("keys/node.pem"));
+    }
+
+    #[test]
+    fn distinct_node_key_declarations_across_includes_are_rejected() {
+        let dir = TempDir::new().unwrap();
+        let included_a = dir.path().join("a.limpid");
+        let included_b = dir.path().join("b.limpid");
+        fs::write(&included_a, "node_key \"a.pem\"").unwrap();
+        fs::write(&included_b, "node_key \"b.pem\"").unwrap();
+
+        for (case, source) in [
+            (
+                "main-and-include",
+                "node_key \"main.pem\"\ninclude \"a.limpid\"",
+            ),
+            ("two-includes", "include \"a.limpid\"\ninclude \"b.limpid\""),
+        ] {
+            let main_conf = dir.path().join(format!("node-key-{case}.conf"));
+            fs::write(&main_conf, source).unwrap();
+            let error = load_config(&main_conf).expect_err("duplicate node_key must fail");
+            assert!(
+                format!("{error:#}").contains("duplicate node_key"),
+                "{case} must report the semantic duplicate"
+            );
+        }
+    }
+
+    #[test]
+    fn diamond_included_node_key_is_adopted_once() {
+        let dir = TempDir::new().unwrap();
+        let shared = dir.path().join("shared.limpid");
+        let parent_a = dir.path().join("parent_a.limpid");
+        let parent_b = dir.path().join("parent_b.limpid");
+        let main_conf = dir.path().join("node-key-main.conf");
+
+        fs::write(&shared, "node_key \"shared.pem\"").unwrap();
+        fs::write(&parent_a, "include \"shared.limpid\"").unwrap();
+        fs::write(&parent_b, "include \"shared.limpid\"").unwrap();
+        fs::write(
+            &main_conf,
+            "include \"parent_a.limpid\"\ninclude \"parent_b.limpid\"",
+        )
+        .unwrap();
+
+        let config = load_config(&main_conf).unwrap();
+        assert_eq!(config.node_key.as_deref(), Some("shared.pem"));
     }
 
     #[test]

--- a/crates/limpid/src/dsl/ast.rs
+++ b/crates/limpid/src/dsl/ast.rs
@@ -11,6 +11,8 @@ pub struct Config {
     /// Optional operator-supplied node identity. The runtime resolves
     /// the host name once at startup when this is absent.
     pub(crate) node_id: Option<String>,
+    /// Optional path to the node's Ed25519 PKCS#8 private key.
+    pub(crate) node_key: Option<String>,
     pub definitions: Vec<Definition>,
     /// Global config blocks (e.g. `geoip { ... }`, `control { ... }`)
     pub global_blocks: Vec<GlobalBlock>,

--- a/crates/limpid/src/dsl/limpid.pest
+++ b/crates/limpid/src/dsl/limpid.pest
@@ -10,6 +10,7 @@ top_level_item = {
     definition
   | include_directive
   | node_id_directive
+  | node_key_directive
   | global_block
 }
 
@@ -23,6 +24,11 @@ node_id_directive = {
     kw_node_id ~ expr
 }
 
+// Optional Ed25519 identity key loaded by LTP-enabled runtimes.
+node_key_directive = {
+    kw_node_key ~ expr
+}
+
 definition = {
     def_input
   | def_output
@@ -33,7 +39,7 @@ definition = {
 
 // Global config block: `name { key value ... }` (no `def` keyword)
 global_block = {
-    !kw_def ~ !kw_include ~ !kw_node_id ~ ident ~ "{" ~ property* ~ "}"
+    !kw_def ~ !kw_include ~ !kw_node_id ~ !kw_node_key ~ ident ~ "{" ~ property* ~ "}"
 }
 
 // -- Comments & whitespace ---------------------------------------------------
@@ -65,6 +71,7 @@ kw_false    = _{ "false" }
 kw_null     = _{ "null" }
 kw_include  = _{ "include" }
 kw_node_id  = @{ "node_id" ~ !(ASCII_ALPHANUMERIC | "_") }
+kw_node_key = @{ "node_key" ~ !(ASCII_ALPHANUMERIC | "_") }
 kw_let      = _{ "let" }
 kw_function = _{ "function" }
 

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -35,6 +35,7 @@ pub fn parse_config_with_file_id(input: &str, file_id: u32) -> Result<Config> {
     let mut global_blocks = Vec::new();
     let mut includes = Vec::new();
     let mut node_id = None;
+    let mut node_key = None;
 
     for pair in config_pair.into_inner() {
         match pair.as_rule() {
@@ -88,6 +89,24 @@ pub fn parse_config_with_file_id(input: &str, file_id: u32) -> Result<Config> {
                             bail!("duplicate node_id");
                         }
                     }
+                    Rule::node_key_directive => {
+                        let mut directive = inner.into_inner();
+                        let keyword = directive.next().expect("pest grammar invariant");
+                        debug_assert_eq!(keyword.as_rule(), Rule::kw_node_key);
+                        let value = parse_expr_from_pair(
+                            directive.next().expect("pest grammar invariant"),
+                            file_id,
+                        )?;
+                        let ExprKind::StringLit(value) = value.kind else {
+                            bail!("node_key requires a string value");
+                        };
+                        if value.is_empty() {
+                            bail!("node_key must be non-empty");
+                        }
+                        if node_key.replace(value).is_some() {
+                            bail!("duplicate node_key");
+                        }
+                    }
                     Rule::global_block => {
                         global_blocks.push(parse_global_block(inner, file_id)?);
                     }
@@ -101,6 +120,7 @@ pub fn parse_config_with_file_id(input: &str, file_id: u32) -> Result<Config> {
 
     Ok(Config {
         node_id,
+        node_key,
         definitions,
         global_blocks,
         includes,
@@ -1113,6 +1133,30 @@ fn first_inner(pair: Pair<Rule>) -> Result<Pair<Rule>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn node_key_accepts_one_non_empty_string_and_preserves_the_path() {
+        let config = parse_config(r#"node_key "../identity/node.pem""#).unwrap();
+        assert_eq!(config.node_key.as_deref(), Some("../identity/node.pem"));
+    }
+
+    #[test]
+    fn node_key_rejects_empty_non_string_and_duplicate_values() {
+        for (source, expected) in [
+            (r#"node_key """#, "node_key must be non-empty"),
+            ("node_key 1", "node_key requires a string value"),
+            (
+                "node_key \"one.pem\"\nnode_key \"two.pem\"",
+                "duplicate node_key",
+            ),
+        ] {
+            let error = parse_config(source).expect_err("invalid node_key must fail");
+            assert!(
+                format!("{error:#}").contains(expected),
+                "{source:?} did not report {expected:?}: {error:#}"
+            );
+        }
+    }
 
     #[test]
     fn test_parse_input_def() {

--- a/crates/limpid/src/ltp.rs
+++ b/crates/limpid/src/ltp.rs
@@ -1,7 +1,13 @@
-//! LTP metadata and complete-frame wire encoding.
+//! LTP metadata, complete-frame wire encoding, and node-key preflight.
 
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
 use bytes::Bytes;
 use prost::Message;
+use ring::signature::Ed25519KeyPair;
 use thiserror::Error;
 
 pub(crate) const FRAME_MAGIC: &[u8; 4] = b"LTP\0";
@@ -122,9 +128,89 @@ pub(crate) fn decode_frame(frame: &Bytes) -> Result<(LtpMeta, Bytes), FrameError
     Ok((meta, frame.slice(payload_len_end..payload_end)))
 }
 
+/// Verifies an operator-declared node key before runtime tasks start.
+///
+/// The path is opened without following a final symlink. Every later
+/// operation (metadata and read) uses that same descriptor, so a path
+/// replacement cannot redirect validation to a different inode.
+pub(crate) fn preflight_node_key(path: &Path) -> Result<()> {
+    preflight_node_key_with_open_hook(path, || {})
+}
+
+fn preflight_node_key_with_open_hook<F>(path: &Path, after_open: F) -> Result<()>
+where
+    F: FnOnce(),
+{
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("node_key '{}': secure open failed", path.display()))?;
+
+    after_open();
+
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("node_key '{}': fstat failed", path.display()))?;
+    if !metadata.is_file() {
+        bail!("node_key '{}': not a regular file", path.display());
+    }
+
+    let euid = unsafe { libc::geteuid() };
+    if !node_key_owner_matches(metadata.uid(), euid) {
+        bail!(
+            "node_key '{}': owner uid {} does not match daemon euid {}",
+            path.display(),
+            metadata.uid(),
+            euid
+        );
+    }
+
+    let mode = metadata.permissions().mode() & 0o7777;
+    if mode != 0o400 && mode != 0o600 {
+        bail!(
+            "node_key '{}': mode 0o{:o} must be exactly 0o400 or 0o600",
+            path.display(),
+            mode
+        );
+    }
+
+    let mut encoded = Vec::new();
+    file.read_to_end(&mut encoded)
+        .with_context(|| format!("node_key '{}': read failed", path.display()))?;
+    let document = pem::parse(&encoded)
+        .map_err(|_| anyhow::anyhow!("node_key '{}': invalid PRIVATE KEY PEM", path.display()))?;
+    if document.tag() != "PRIVATE KEY" {
+        bail!("node_key '{}': expected PRIVATE KEY PEM", path.display());
+    }
+    Ed25519KeyPair::from_pkcs8_maybe_unchecked(document.contents()).map_err(|_| {
+        anyhow::anyhow!(
+            "node_key '{}': invalid Ed25519 PKCS#8 private key",
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn node_key_owner_matches(owner_uid: u32, daemon_euid: u32) -> bool {
+    owner_uid == daemon_euid
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
+    use std::fs;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use ring::rand::SystemRandom;
 
     fn sample_meta() -> LtpMeta {
         LtpMeta {
@@ -146,6 +232,132 @@ mod tests {
         frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
         frame.extend_from_slice(payload);
         Bytes::from(frame)
+    }
+
+    fn write_ed25519_key(path: &Path, mode: u32) {
+        let pkcs8 = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
+        fs::write(
+            path,
+            pem::encode(&pem::Pem::new("PRIVATE KEY", pkcs8.as_ref())),
+        )
+        .unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[test]
+    fn node_key_preflight_accepts_generated_ed25519_at_exact_modes() {
+        for mode in [0o400, 0o600] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join(format!("node-{mode:o}.pem"));
+            write_ed25519_key(&path, mode);
+            preflight_node_key(&path).unwrap();
+        }
+    }
+
+    #[test]
+    fn node_key_preflight_accepts_standard_pkcs8_v1_ed25519() {
+        // RFC 8032 section 7.1 test vector 1 seed, wrapped in the
+        // RFC 8410 version-1 PrivateKeyInfo structure.
+        let mut pkcs8 = vec![
+            0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22,
+            0x04, 0x20,
+        ];
+        pkcs8.extend_from_slice(&[
+            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
+            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
+            0x1c, 0xae, 0x7f, 0x60,
+        ]);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node-v1.pem");
+        fs::write(&path, pem::encode(&pem::Pem::new("PRIVATE KEY", pkcs8))).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+
+        preflight_node_key(&path).unwrap();
+    }
+
+    #[test]
+    fn node_key_preflight_rejects_symlinks_and_other_modes() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("node.pem");
+        write_ed25519_key(&key, 0o600);
+        let link = dir.path().join("node-link.pem");
+        symlink(&key, &link).unwrap();
+        assert!(
+            format!("{:#}", preflight_node_key(&link).unwrap_err()).contains("secure open failed")
+        );
+
+        for mode in [0o440, 0o644, 0o700, 0o4600] {
+            fs::set_permissions(&key, fs::Permissions::from_mode(mode)).unwrap();
+            let error = preflight_node_key(&key).unwrap_err();
+            assert!(
+                format!("{error:#}").contains("must be exactly 0o400 or 0o600"),
+                "mode {mode:o}: {error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn node_key_preflight_rejects_a_fifo_without_waiting_for_a_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node-key.fifo");
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) }, 0);
+
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            tx.send(preflight_node_key(&path)).unwrap();
+        });
+        let error = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("secure open must not block while opening a FIFO")
+            .unwrap_err();
+        handle.join().unwrap();
+        assert!(format!("{error:#}").contains("not a regular file"));
+    }
+
+    #[test]
+    fn node_key_owner_must_match_the_daemon_even_for_root() {
+        assert!(node_key_owner_matches(501, 501));
+        assert!(node_key_owner_matches(0, 0));
+        assert!(!node_key_owner_matches(0, 501));
+        assert!(!node_key_owner_matches(501, 0));
+    }
+
+    #[test]
+    fn node_key_preflight_rejects_garbage_and_wrong_algorithm_without_leaking_material() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("node.pem");
+        let secret = "DO-NOT-LEAK-PRIVATE-MATERIAL";
+        fs::write(&key, secret).unwrap();
+        fs::set_permissions(&key, fs::Permissions::from_mode(0o600)).unwrap();
+        let diagnostic = format!("{:#?}", preflight_node_key(&key).unwrap_err());
+        assert!(!diagnostic.contains(secret));
+        assert!(diagnostic.contains("invalid PRIVATE KEY PEM"));
+
+        let wrong = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+        fs::write(
+            &key,
+            pem::encode(&pem::Pem::new("PRIVATE KEY", wrong.serialize_der())),
+        )
+        .unwrap();
+        let diagnostic = format!("{:#?}", preflight_node_key(&key).unwrap_err());
+        assert!(diagnostic.contains("invalid Ed25519 PKCS#8 private key"));
+    }
+
+    #[test]
+    fn node_key_preflight_fstats_and_reads_the_open_descriptor() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("node.pem");
+        let moved = dir.path().join("opened-node.pem");
+        write_ed25519_key(&key, 0o600);
+
+        preflight_node_key_with_open_hook(&key, || {
+            fs::rename(&key, &moved).unwrap();
+            fs::write(&key, "replacement that is not a key").unwrap();
+            fs::set_permissions(&key, fs::Permissions::from_mode(0o644)).unwrap();
+        })
+        .expect("validation must stay bound to the originally opened key inode");
     }
 
     #[test]

--- a/crates/limpid/src/ltp.rs
+++ b/crates/limpid/src/ltp.rs
@@ -137,6 +137,24 @@ pub(crate) fn preflight_node_key(path: &Path) -> Result<()> {
     preflight_node_key_with_open_hook(path, || {})
 }
 
+const MAX_NODE_KEY_FILE_LEN: usize = 64 * 1024;
+
+fn read_node_key_bounded<R: Read>(reader: &mut R, path: &Path) -> Result<Vec<u8>> {
+    let mut encoded = Vec::new();
+    reader
+        .take((MAX_NODE_KEY_FILE_LEN + 1) as u64)
+        .read_to_end(&mut encoded)
+        .with_context(|| format!("node_key '{}': read failed", path.display()))?;
+    if encoded.len() > MAX_NODE_KEY_FILE_LEN {
+        bail!(
+            "node_key '{}': file exceeds {} bytes",
+            path.display(),
+            MAX_NODE_KEY_FILE_LEN
+        );
+    }
+    Ok(encoded)
+}
+
 fn preflight_node_key_with_open_hook<F>(path: &Path, after_open: F) -> Result<()>
 where
     F: FnOnce(),
@@ -179,9 +197,7 @@ where
         );
     }
 
-    let mut encoded = Vec::new();
-    file.read_to_end(&mut encoded)
-        .with_context(|| format!("node_key '{}': read failed", path.display()))?;
+    let encoded = read_node_key_bounded(&mut file, path)?;
     let document = pem::parse(&encoded)
         .map_err(|_| anyhow::anyhow!("node_key '{}': invalid PRIVATE KEY PEM", path.display()))?;
     if document.tag() != "PRIVATE KEY" {
@@ -211,6 +227,19 @@ mod tests {
     use std::time::Duration;
 
     use ring::rand::SystemRandom;
+
+    struct CountingReader<R> {
+        inner: R,
+        bytes_read: usize,
+    }
+
+    impl<R: Read> Read for CountingReader<R> {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let count = self.inner.read(buffer)?;
+            self.bytes_read += count;
+            Ok(count)
+        }
+    }
 
     fn sample_meta() -> LtpMeta {
         LtpMeta {
@@ -343,6 +372,34 @@ mod tests {
         .unwrap();
         let diagnostic = format!("{:#?}", preflight_node_key(&key).unwrap_err());
         assert!(diagnostic.contains("invalid Ed25519 PKCS#8 private key"));
+    }
+
+    #[test]
+    fn node_key_preflight_enforces_the_exact_64_kib_file_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("node.pem");
+        fs::write(&key, vec![b'x'; MAX_NODE_KEY_FILE_LEN]).unwrap();
+        fs::set_permissions(&key, fs::Permissions::from_mode(0o600)).unwrap();
+        let exact_limit = format!("{:#}", preflight_node_key(&key).unwrap_err());
+        assert!(exact_limit.contains("invalid PRIVATE KEY PEM"));
+        assert!(!exact_limit.contains("file exceeds"));
+
+        fs::write(&key, vec![b'x'; MAX_NODE_KEY_FILE_LEN + 1]).unwrap();
+        let over_limit = format!("{:#}", preflight_node_key(&key).unwrap_err());
+        assert!(over_limit.contains("file exceeds 65536 bytes"));
+    }
+
+    #[test]
+    fn node_key_bounded_reader_stops_after_limit_plus_one() {
+        let input = vec![b'x'; MAX_NODE_KEY_FILE_LEN + 4096];
+        let mut reader = CountingReader {
+            inner: std::io::Cursor::new(input),
+            bytes_read: 0,
+        };
+        let error = read_node_key_bounded(&mut reader, Path::new("counted.pem")).unwrap_err();
+
+        assert!(format!("{error:#}").contains("file exceeds 65536 bytes"));
+        assert_eq!(reader.bytes_read, MAX_NODE_KEY_FILE_LEN + 1);
     }
 
     #[test]

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -40,6 +40,7 @@ use crate::tap::TapRegistry;
 #[derive(Clone)]
 pub struct CompiledConfig {
     pub(crate) node_id: Option<String>,
+    pub(crate) node_key: Option<String>,
     pub inputs: HashMap<String, InputDef>,
     pub outputs: HashMap<String, OutputDef>,
     pub processes: HashMap<String, ProcessDef>,
@@ -102,6 +103,7 @@ impl CompiledConfig {
 
         let compiled = Self {
             node_id: config.node_id,
+            node_key: config.node_key,
             inputs,
             outputs,
             processes,
@@ -2028,6 +2030,12 @@ mod tests {
 
     fn compile(src: &str) -> Result<CompiledConfig> {
         CompiledConfig::from_config(parse_config(src)?)
+    }
+
+    #[test]
+    fn compile_preserves_node_key_path_without_normalizing_it() {
+        let config = compile(r#"node_key "../identity/node.pem""#).unwrap();
+        assert_eq!(config.node_key.as_deref(), Some("../identity/node.pem"));
     }
 
     #[test]

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -74,6 +74,9 @@ impl Runtime {
         let func_registry = Arc::new(func_registry);
 
         config.validate()?;
+        if let Some(node_key) = &config.node_key {
+            crate::ltp::preflight_node_key(Path::new(node_key))?;
+        }
         let node_id = match &config.node_id {
             Some(node_id) => node_id.clone(),
             None => resolve_hostname()?,
@@ -2186,6 +2189,87 @@ def pipeline p { process a }
     #[tokio::test]
     async fn startup_without_node_id_resolves_hostname_once_and_registers_that_value() {
         assert_startup_build_info(None, "resolved-host-1", 1).await;
+    }
+
+    #[tokio::test]
+    async fn startup_preflights_a_declared_node_key_and_ignores_an_omitted_one() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
+            .expect("secure control parent");
+        let socket = dir.path().join("control.sock");
+        let key = dir.path().join("node-key.pem");
+        let pkcs8 =
+            ring::signature::Ed25519KeyPair::generate_pkcs8(&ring::rand::SystemRandom::new())
+                .expect("generate key");
+        std::fs::write(
+            &key,
+            pem::encode(&pem::Pem::new("PRIVATE KEY", pkcs8.as_ref())),
+        )
+        .expect("write key");
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600))
+            .expect("secure key mode");
+
+        let source = format!(
+            "node_id \"node-a\"\nnode_key {:?}\ncontrol {{ socket {:?} }}",
+            key.display().to_string(),
+            socket.display().to_string()
+        );
+        let runtime = Runtime::start(
+            compiled_config(&source),
+            PathBuf::from("node-key-startup-test.limpid"),
+        )
+        .await
+        .expect("declared valid key must pass startup preflight");
+        runtime.shutdown().await;
+
+        let omitted_socket = dir.path().join("omitted-control.sock");
+        let omitted = format!(
+            "node_id \"node-a\"\ncontrol {{ socket {:?} }}",
+            omitted_socket.display().to_string()
+        );
+        let runtime = Runtime::start(
+            compiled_config(&omitted),
+            PathBuf::from("missing-path-is-not-consulted.limpid"),
+        )
+        .await
+        .expect("omitted node_key must not trigger filesystem preflight");
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn startup_fails_before_tasks_when_a_declared_node_key_is_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
+            .expect("secure control parent");
+        let socket = dir.path().join("control.sock");
+        let missing = dir.path().join("missing-node-key.pem");
+        let source = format!(
+            "node_id \"node-a\"\nnode_key {:?}\ncontrol {{ socket {:?} }}",
+            missing.display().to_string(),
+            socket.display().to_string()
+        );
+
+        let error = match Runtime::start(
+            compiled_config(&source),
+            PathBuf::from("node-key-failure-test.limpid"),
+        )
+        .await
+        {
+            Ok(runtime) => {
+                runtime.shutdown().await;
+                panic!("declared missing node_key must fail startup")
+            }
+            Err(error) => error,
+        };
+        assert!(format!("{error:#}").contains("secure open failed"));
+        assert!(
+            !socket.exists(),
+            "control task must not start before key preflight"
+        );
     }
 
     #[tokio::test]

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -85,6 +85,70 @@ def pipeline p {{ input i; output o }}
     }
 }
 
+#[test]
+fn check_accepts_node_key_without_accessing_the_filesystem() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("node-key-check.conf");
+    let missing = dir.path().join("intentionally-missing-private-key.pem");
+    fs::write(
+        &conf,
+        format!(
+            r#"node_key {:?}
+def input i {{ type syslog_tcp bind "0.0.0.0:514" }}
+def output o {{ type stdout }}
+def pipeline p {{ input i; output o }}
+"#,
+            missing.display().to_string()
+        ),
+    )
+    .unwrap();
+
+    let out = run_check(&conf);
+    assert!(
+        out.status.success(),
+        "--check must validate node_key syntax without filesystem preflight: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(!missing.exists());
+}
+
+#[test]
+fn check_rejects_invalid_node_key_declarations() {
+    for (case, declaration, diagnostic) in [
+        ("empty", "node_key \"\"\n", "node_key must be non-empty"),
+        (
+            "wrong-type",
+            "node_key 42\n",
+            "node_key requires a string value",
+        ),
+        (
+            "duplicate",
+            "node_key \"one.pem\"\nnode_key \"two.pem\"\n",
+            "duplicate node_key",
+        ),
+    ] {
+        let dir = TempDir::new().unwrap();
+        let conf = dir.path().join(format!("node-key-{case}.conf"));
+        fs::write(
+            &conf,
+            format!(
+                r#"{declaration}def input i {{ type syslog_tcp bind "0.0.0.0:514" }}
+def output o {{ type stdout }}
+def pipeline p {{ input i; output o }}
+"#
+            ),
+        )
+        .unwrap();
+        let out = run_check(&conf);
+        assert!(!out.status.success(), "{case} node_key must be rejected");
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains(diagnostic),
+            "{case} diagnostic: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
 fn assert_node_id_rejected(case: &str, node_id: &str, diagnostic: &str) {
     let dir = TempDir::new().unwrap();
     let conf = dir.path().join(format!("node-id-{case}.conf"));

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -14,6 +14,12 @@ limpid-metrics-schema = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
+base64 = { workspace = true }
+pem = { workspace = true }
+ring = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -17,9 +17,7 @@ serde_json = "1"
 base64 = { workspace = true }
 pem = { workspace = true }
 ring = { workspace = true }
+tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-[dev-dependencies]
-tempfile = "3"

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -340,40 +340,68 @@ fn generate_node_key(path: &std::path::Path) -> Result<String, String> {
 }
 
 fn write_new_private_key(path: &std::path::Path, contents: &[u8]) -> Result<(), String> {
-    write_new_private_key_with(path, contents, |file, contents| {
-        file.write_all(contents)?;
-        file.sync_all()
-    })
+    write_new_private_key_with(
+        path,
+        contents,
+        |file, contents| {
+            file.write_all(contents)?;
+            file.sync_all()
+        },
+        || Ok(()),
+        |parent| std::fs::File::open(parent)?.sync_all(),
+    )
 }
 
-fn write_new_private_key_with<F>(
+fn write_new_private_key_with<W, B, S>(
     path: &std::path::Path,
     contents: &[u8],
-    write_and_sync: F,
+    write_and_sync: W,
+    before_publish: B,
+    sync_parent: S,
 ) -> Result<(), String>
 where
-    F: FnOnce(&mut std::fs::File, &[u8]) -> std::io::Result<()>,
+    W: FnOnce(&mut std::fs::File, &[u8]) -> std::io::Result<()>,
+    B: FnOnce() -> std::io::Result<()>,
+    S: FnOnce(&std::path::Path) -> std::io::Result<()>,
 {
-    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::PermissionsExt;
 
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(path)
-        .map_err(|error| format!("cannot create node key '{}': {error}", path.display()))?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".limpid-node-key.")
+        .tempfile_in(parent)
+        .map_err(|error| {
+            format!(
+                "cannot create temporary node key beside '{}': {error}",
+                path.display()
+            )
+        })?;
 
-    let persisted = file
+    temporary
+        .as_file()
         .set_permissions(std::fs::Permissions::from_mode(0o600))
-        .and_then(|()| write_and_sync(&mut file, contents));
-    if let Err(error) = persisted {
-        drop(file);
-        let _ = std::fs::remove_file(path);
-        return Err(format!(
-            "failed to persist node key '{}': {error}",
+        .and_then(|()| write_and_sync(temporary.as_file_mut(), contents))
+        .map_err(|error| format!("failed to persist node key '{}': {error}", path.display()))?;
+    before_publish()
+        .map_err(|error| format!("failed to publish node key '{}': {error}", path.display()))?;
+
+    let final_file = temporary.persist_noclobber(path).map_err(|error| {
+        format!(
+            "cannot publish node key '{}': {}",
+            path.display(),
+            error.error
+        )
+    })?;
+    sync_parent(parent).map_err(|error| {
+        format!(
+            "node key '{}' was published but parent directory sync failed: {error}",
             path.display()
-        ));
-    }
+        )
+    })?;
+    drop(final_file);
     Ok(())
 }
 
@@ -1272,6 +1300,7 @@ mod tests {
             &spki[ED25519_SPKI_PREFIX.len()..],
             key_pair.public_key().as_ref()
         );
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
     }
 
     #[test]
@@ -1281,24 +1310,143 @@ mod tests {
         std::fs::write(&path, b"existing material").unwrap();
 
         let error = generate_node_key(&path).unwrap_err();
-        assert!(error.contains("cannot create node key"));
+        assert!(error.contains("cannot publish node key"));
         assert_eq!(std::fs::read(&path).unwrap(), b"existing material");
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
     }
 
     #[test]
-    fn keygen_removes_only_the_file_it_created_after_a_write_failure() {
+    fn keygen_cleans_temporary_files_after_write_and_file_sync_failures() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("failed.pem");
         let private_material = b"DO-NOT-LEAK-PRIVATE-MATERIAL";
-        let error = write_new_private_key_with(&path, private_material, |file, contents| {
-            file.write_all(&contents[..8])?;
-            Err(std::io::Error::other("injected sync failure"))
-        })
+        let write_path = dir.path().join("write-failed.pem");
+        let write_error = write_new_private_key_with(
+            &write_path,
+            private_material,
+            |_file, _contents| Err(std::io::Error::other("injected write failure")),
+            || Ok(()),
+            |_parent| Ok(()),
+        )
+        .unwrap_err();
+        assert!(write_error.contains("injected write failure"));
+        assert!(!write_error.contains(std::str::from_utf8(private_material).unwrap()));
+        assert!(!write_path.exists());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+
+        let sync_path = dir.path().join("sync-failed.pem");
+        let sync_error = write_new_private_key_with(
+            &sync_path,
+            private_material,
+            |file, contents| {
+                file.write_all(contents)?;
+                Err(std::io::Error::other("injected file sync failure"))
+            },
+            || Ok(()),
+            |_parent| Ok(()),
+        )
+        .unwrap_err();
+        assert!(sync_error.contains("injected file sync failure"));
+        assert!(!sync_error.contains(std::str::from_utf8(private_material).unwrap()));
+        assert!(!sync_path.exists());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn keygen_publish_never_replaces_a_competing_final_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("competing.pem");
+        let private_material = b"new private material";
+        let preserved = b"competing path contents";
+
+        let error = write_new_private_key_with(
+            &path,
+            private_material,
+            |file, contents| {
+                file.write_all(contents)?;
+                file.sync_all()
+            },
+            || std::fs::write(&path, preserved),
+            |_parent| Ok(()),
+        )
         .unwrap_err();
 
-        assert!(error.contains("injected sync failure"));
-        assert!(!error.contains(std::str::from_utf8(private_material).unwrap()));
-        assert!(!path.exists(), "failed keygen must remove its partial file");
+        assert!(error.contains("cannot publish node key"));
+        assert_eq!(std::fs::read(&path).unwrap(), preserved);
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn keygen_parent_sync_failure_preserves_the_published_key() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("published.pem");
+        let private_material = b"complete private material";
+
+        let error = write_new_private_key_with(
+            &path,
+            private_material,
+            |file, contents| {
+                file.write_all(contents)?;
+                file.sync_all()
+            },
+            || Ok(()),
+            |_parent| Err(std::io::Error::other("injected parent sync failure")),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("published but parent directory sync failed"));
+        assert_eq!(std::fs::read(&path).unwrap(), private_material);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o7777,
+            0o600
+        );
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn keygen_orders_file_sync_publish_and_parent_sync() {
+        use std::cell::RefCell;
+        use std::os::unix::fs::PermissionsExt;
+        use std::rc::Rc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ordered.pem");
+        let private_material = b"ordered private material";
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let write_events = Rc::clone(&events);
+        let publish_events = Rc::clone(&events);
+        let parent_events = Rc::clone(&events);
+
+        write_new_private_key_with(
+            &path,
+            private_material,
+            |file, contents| {
+                assert!(!path.exists());
+                assert_eq!(file.metadata()?.permissions().mode() & 0o7777, 0o600);
+                file.write_all(contents)?;
+                file.sync_all()?;
+                write_events.borrow_mut().push("file-sync");
+                Ok(())
+            },
+            || {
+                assert!(!path.exists());
+                publish_events.borrow_mut().push("before-publish");
+                Ok(())
+            },
+            |_parent| {
+                assert_eq!(std::fs::read(&path)?, private_material);
+                parent_events.borrow_mut().push("parent-sync");
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            events.borrow().as_slice(),
+            ["file-sync", "before-publish", "parent-sync"]
+        );
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
     }
 
     fn canonical_shared_snapshot(extra_family: bool) -> limpid_metrics_schema::MetricsSnapshot {

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -19,6 +19,7 @@ use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use limpid_metrics_schema::{
@@ -72,6 +73,17 @@ enum Command {
         #[command(subcommand)]
         kind: InjectKind,
     },
+    /// Manage LTP node identity material
+    Ltp {
+        #[command(subcommand)]
+        command: LtpCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum LtpCommand {
+    /// Generate a new Ed25519 node key without overwriting an existing path
+    Keygen { path: PathBuf },
 }
 
 #[derive(Subcommand)]
@@ -291,7 +303,78 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        Command::Ltp { command } => match command {
+            LtpCommand::Keygen { path } => match generate_node_key(&path) {
+                Ok(public_key) => {
+                    println!("{public_key}");
+                    eprintln!("generated Ed25519 node key at {}", path.display());
+                }
+                Err(error) => {
+                    eprintln!("error: {error}");
+                    std::process::exit(1);
+                }
+            },
+        },
     }
+}
+
+const ED25519_SPKI_PREFIX: [u8; 12] = [
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+];
+
+fn generate_node_key(path: &std::path::Path) -> Result<String, String> {
+    use ring::signature::KeyPair as _;
+
+    let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&ring::rand::SystemRandom::new())
+        .map_err(|_| "failed to generate Ed25519 private key".to_owned())?;
+    let key_pair = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref())
+        .map_err(|_| "generated Ed25519 private key failed validation".to_owned())?;
+    let private_pem = pem::encode(&pem::Pem::new("PRIVATE KEY", pkcs8.as_ref()));
+    write_new_private_key(path, private_pem.as_bytes())?;
+
+    let mut spki =
+        Vec::with_capacity(ED25519_SPKI_PREFIX.len() + key_pair.public_key().as_ref().len());
+    spki.extend_from_slice(&ED25519_SPKI_PREFIX);
+    spki.extend_from_slice(key_pair.public_key().as_ref());
+    Ok(base64::engine::general_purpose::STANDARD.encode(spki))
+}
+
+fn write_new_private_key(path: &std::path::Path, contents: &[u8]) -> Result<(), String> {
+    write_new_private_key_with(path, contents, |file, contents| {
+        file.write_all(contents)?;
+        file.sync_all()
+    })
+}
+
+fn write_new_private_key_with<F>(
+    path: &std::path::Path,
+    contents: &[u8],
+    write_and_sync: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&mut std::fs::File, &[u8]) -> std::io::Result<()>,
+{
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|error| format!("cannot create node key '{}': {error}", path.display()))?;
+
+    let persisted = file
+        .set_permissions(std::fs::Permissions::from_mode(0o600))
+        .and_then(|()| write_and_sync(&mut file, contents));
+    if let Err(error) = persisted {
+        drop(file);
+        let _ = std::fs::remove_file(path);
+        return Err(format!(
+            "failed to persist node key '{}': {error}",
+            path.display()
+        ));
+    }
+    Ok(())
 }
 
 fn run_tap(socket: &PathBuf, command: &str) {
@@ -1157,6 +1240,66 @@ impl ReplayState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn keygen_writes_a_signing_key_and_returns_matching_rfc8410_spki() {
+        use ring::signature::KeyPair as _;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node.pem");
+        let public_key = generate_node_key(&path).unwrap();
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o7777, 0o600);
+        let document = pem::parse(std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(document.tag(), "PRIVATE KEY");
+        let key_pair = ring::signature::Ed25519KeyPair::from_pkcs8(document.contents()).unwrap();
+        let message = b"limpid ltp node identity";
+        let signature = key_pair.sign(message);
+        ring::signature::UnparsedPublicKey::new(
+            &ring::signature::ED25519,
+            key_pair.public_key().as_ref(),
+        )
+        .verify(message, signature.as_ref())
+        .unwrap();
+
+        let spki = base64::engine::general_purpose::STANDARD
+            .decode(public_key)
+            .unwrap();
+        assert_eq!(&spki[..ED25519_SPKI_PREFIX.len()], &ED25519_SPKI_PREFIX);
+        assert_eq!(
+            &spki[ED25519_SPKI_PREFIX.len()..],
+            key_pair.public_key().as_ref()
+        );
+    }
+
+    #[test]
+    fn keygen_never_overwrites_an_existing_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("existing.pem");
+        std::fs::write(&path, b"existing material").unwrap();
+
+        let error = generate_node_key(&path).unwrap_err();
+        assert!(error.contains("cannot create node key"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"existing material");
+    }
+
+    #[test]
+    fn keygen_removes_only_the_file_it_created_after_a_write_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("failed.pem");
+        let private_material = b"DO-NOT-LEAK-PRIVATE-MATERIAL";
+        let error = write_new_private_key_with(&path, private_material, |file, contents| {
+            file.write_all(&contents[..8])?;
+            Err(std::io::Error::other("injected sync failure"))
+        })
+        .unwrap_err();
+
+        assert!(error.contains("injected sync failure"));
+        assert!(!error.contains(std::str::from_utf8(private_material).unwrap()));
+        assert!(!path.exists(), "failed keygen must remove its partial file");
+    }
 
     fn canonical_shared_snapshot(extra_family: bool) -> limpid_metrics_schema::MetricsSnapshot {
         let mut metrics = PIPELINE_METRICS

--- a/crates/limpidctl/tests/ltp_keygen.rs
+++ b/crates/limpidctl/tests/ltp_keygen.rs
@@ -112,6 +112,11 @@ fn keygen_removes_the_created_file_when_persisting_fails() {
         !path.exists(),
         "failed subprocess must not leave key residue"
     );
+    assert_eq!(
+        std::fs::read_dir(dir.path()).unwrap().count(),
+        0,
+        "failed subprocess must not leave a temporary file"
+    );
 }
 
 #[test]
@@ -136,4 +141,28 @@ fn keygen_enforces_mode_0600_even_under_a_restrictive_umask() {
         std::fs::metadata(&path).unwrap().permissions().mode() & 0o7777,
         0o600
     );
+}
+
+#[test]
+fn keygen_publishes_a_bare_relative_path_in_the_current_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_limpidctl"));
+    command
+        .current_dir(dir.path())
+        .arg("ltp")
+        .arg("keygen")
+        .arg("node.pem");
+
+    let output = command.output().expect("run relative-path keygen");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let path = dir.path().join("node.pem");
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().permissions().mode() & 0o7777,
+        0o600
+    );
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
 }

--- a/crates/limpidctl/tests/ltp_keygen.rs
+++ b/crates/limpidctl/tests/ltp_keygen.rs
@@ -1,0 +1,139 @@
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Output};
+
+use base64::Engine as _;
+use ring::signature::KeyPair as _;
+
+const ED25519_SPKI_PREFIX: [u8; 12] = [
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+];
+
+fn run_keygen(path: &std::path::Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_limpidctl"))
+        .arg("ltp")
+        .arg("keygen")
+        .arg(path)
+        .output()
+        .expect("run limpidctl ltp keygen")
+}
+
+#[test]
+fn keygen_stdout_is_exactly_the_matching_spki_base64_line() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("node.pem");
+    let output = run_keygen(&path);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.ends_with('\n'));
+    assert_eq!(stdout.lines().count(), 1);
+    let spki = base64::engine::general_purpose::STANDARD
+        .decode(stdout.trim_end())
+        .unwrap();
+    assert_eq!(&spki[..ED25519_SPKI_PREFIX.len()], &ED25519_SPKI_PREFIX);
+
+    let document = pem::parse(std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(document.tag(), "PRIVATE KEY");
+    let pair = ring::signature::Ed25519KeyPair::from_pkcs8(document.contents()).unwrap();
+    assert_eq!(
+        &spki[ED25519_SPKI_PREFIX.len()..],
+        pair.public_key().as_ref()
+    );
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().permissions().mode() & 0o7777,
+        0o600
+    );
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("generated Ed25519 node key at")
+    );
+}
+
+#[test]
+fn keygen_rejects_existing_dangling_and_missing_parent_paths_without_overwrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let existing = dir.path().join("existing.pem");
+    std::fs::write(&existing, b"preserve me").unwrap();
+    let output = run_keygen(&existing);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(std::fs::read(&existing).unwrap(), b"preserve me");
+
+    let dangling = dir.path().join("dangling.pem");
+    symlink(dir.path().join("missing-target.pem"), &dangling).unwrap();
+    let output = run_keygen(&dangling);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        std::fs::symlink_metadata(&dangling)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+
+    let missing_parent = dir.path().join("missing").join("node.pem");
+    let output = run_keygen(&missing_parent);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(!missing_parent.exists());
+    assert!(!missing_parent.parent().unwrap().exists());
+}
+
+#[test]
+fn keygen_removes_the_created_file_when_persisting_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write-failure.pem");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_limpidctl"));
+    command.arg("ltp").arg("keygen").arg(&path);
+    unsafe {
+        command.pre_exec(|| {
+            let limit = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::setrlimit(libc::RLIMIT_FSIZE, &limit) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            libc::signal(libc::SIGXFSZ, libc::SIG_IGN);
+            Ok(())
+        });
+    }
+    let output = command.output().expect("run limited keygen");
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("failed to persist node key"));
+    assert!(
+        !path.exists(),
+        "failed subprocess must not leave key residue"
+    );
+}
+
+#[test]
+fn keygen_enforces_mode_0600_even_under_a_restrictive_umask() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("restrictive-umask.pem");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_limpidctl"));
+    command.arg("ltp").arg("keygen").arg(&path);
+    unsafe {
+        command.pre_exec(|| {
+            libc::umask(0o777);
+            Ok(())
+        });
+    }
+    let output = command.output().expect("run keygen with restrictive umask");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().permissions().mode() & 0o7777,
+        0o600
+    );
+}

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -45,6 +45,28 @@ multiple instances omit it, they expose the same host-derived identity;
 assigning distinct identities in that deployment is the operator's
 responsibility.
 
+## LTP node key
+
+The optional top-level `node_key` names an Ed25519 private-key file without
+rewriting or resolving the configured path:
+
+```limpid
+node_key "/etc/limpid/node-key.pem"
+```
+
+When declared, daemon startup and reload open the final path without following
+a symlink and require a regular file owned by the daemon's effective user with
+mode exactly `0400` or `0600`. The file must contain an Ed25519 PKCS#8
+`PRIVATE KEY` PEM. Validation and reading stay bound to the same open file
+descriptor. A failure stops startup; `limpid --check` validates only the
+configuration syntax and does not access the key file.
+
+Generate a new key with `limpidctl ltp keygen <path>`. The command creates the
+private-key file at mode `0600` without creating parent directories or
+overwriting any existing path. Its single stdout line is the RFC 8410 SPKI DER
+public key encoded as base64; the human-readable creation message is written to
+stderr.
+
 ## Global blocks
 
 ### control

--- a/docs/src/operations/cli.md
+++ b/docs/src/operations/cli.md
@@ -110,6 +110,9 @@ limpidctl stats --json
 # Health check
 limpidctl health
 limpidctl health --json
+
+# Create a new 0600 Ed25519 private key and print its SPKI public key as base64
+limpidctl ltp keygen /etc/limpid/node-key.pem
 ```
 
 `limpidctl stats` renders the established operator table from the schema-v1
@@ -118,6 +121,12 @@ family and series in deterministic human-readable order. `stats --json` prints
 the complete control-socket response unchanged. `--details` and `--json` are
 mutually exclusive. See [Metrics](./metrics.md#viewing-metrics-with-limpidctl)
 for the formatting, validation, and raw-fallback contracts.
+
+`limpidctl ltp keygen` never overwrites an existing path and does not create a
+missing parent directory. Stdout contains only the base64 SPKI public key line,
+so it can be redirected safely; status and errors are emitted on stderr. See
+[LTP node key](../configuration.md#ltp-node-key) for the daemon-side startup
+checks.
 
 ### Global options
 


### PR DESCRIPTION
## Summary

- add top-level `node_key` configuration with include/compile propagation
- add `limpidctl ltp keygen` for Ed25519 PKCS#8 PEM keys and matching SPKI output
- preflight declared keys during startup and reload using same-descriptor ownership, mode, file-type, and key validation

## Validation

- focused parser, include, runtime preflight, LTP, and keygen tests
- default and Kafka workspace test suites
- workspace and Kafka clippy with warnings denied
- formatting, documentation, snippet inventory, dependency, and supply-chain checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `node_key` configuration for Ed25519 private keys.
  * Added `limpidctl ltp keygen` to securely create keys and output the corresponding public key.
* **Bug Fixes**
  * Configuration includes now correctly preserve keys and reject conflicting declarations.
  * Startup and reload validate key files before services begin.
* **Documentation**
  * Documented key configuration, validation requirements, startup behavior, and key generation usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->