### PR TITLE
feat(ltp): add hop telemetry

### DIFF
--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -6,7 +6,7 @@
 //! helper materialises its canonical fully-labelled counter series
 //! in the shared registry.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -32,6 +32,76 @@ pub(crate) fn register_build_info(
         .build()?;
     build_info.set(1);
     Ok(())
+}
+
+pub(crate) const LTP_HOP_LATENCY_BUCKETS: [f64; 8] =
+    [0.0001, 0.001, 0.005, 0.025, 0.1, 0.5, 2.5, 10.0];
+
+#[derive(Clone)]
+pub(crate) struct LtpPeerMetrics {
+    pub(crate) network_latency: Arc<registry_core::Histogram>,
+    pub(crate) intra_latency: Arc<registry_core::Histogram>,
+    pub(crate) negative_delta: Arc<registry_core::Counter>,
+    pub(crate) loop_dropped: Arc<registry_core::Counter>,
+}
+
+pub(crate) struct LtpMetrics {
+    peers: BTreeMap<String, LtpPeerMetrics>,
+    pub(crate) rejected_unknown_peer: Arc<registry_core::Counter>,
+}
+
+impl LtpMetrics {
+    pub(crate) fn register(
+        registry: &Registry,
+        peers: &BTreeSet<String>,
+    ) -> Result<Arc<Self>, MetricsError> {
+        let rejected_unknown_peer = registry
+            .counter("limpid_ltp_rejected_unknown_peer_total")
+            .help("Total LTP peer connection attempts rejected for an undeclared key or mismatched node identity.")
+            .build()?;
+        let mut handles = BTreeMap::new();
+        for peer in peers {
+            let histogram = |segment| {
+                registry
+                    .histogram("limpid_ltp_hop_latency_seconds")
+                    .label("peer", peer)
+                    .label("segment", segment)
+                    .help("LTP hop latency between authenticated peers.")
+                    .buckets(&LTP_HOP_LATENCY_BUCKETS)
+                    .build()
+            };
+            let counter = |name, help| {
+                registry
+                    .counter(name)
+                    .label("peer", peer)
+                    .help(help)
+                    .build()
+            };
+            handles.insert(
+                peer.clone(),
+                LtpPeerMetrics {
+                    network_latency: histogram("network")?,
+                    intra_latency: histogram("intra")?,
+                    negative_delta: counter(
+                        "limpid_ltp_negative_delta_total",
+                        "Total negative cross-host LTP latency deltas clamped to zero.",
+                    )?,
+                    loop_dropped: counter(
+                        "limpid_ltp_loop_dropped_total",
+                        "Total LTP events dropped because of a cycle or hop limit.",
+                    )?,
+                },
+            );
+        }
+        Ok(Arc::new(Self {
+            peers: handles,
+            rejected_unknown_peer,
+        }))
+    }
+
+    pub(crate) fn peer(&self, peer: &str) -> Option<LtpPeerMetrics> {
+        self.peers.get(peer).cloned()
+    }
 }
 
 pub struct InputMetrics {
@@ -545,6 +615,16 @@ mod registry_core {
                     Err(observed) => current = observed,
                 }
             }
+        }
+
+        #[cfg(test)]
+        pub(crate) fn count(&self) -> u64 {
+            self.count.load(Ordering::Relaxed)
+        }
+
+        #[cfg(test)]
+        pub(crate) fn sum(&self) -> f64 {
+            f64::from_bits(self.sum_bits.load(Ordering::Relaxed))
         }
     }
 
@@ -1113,9 +1193,11 @@ pub(crate) use registry_core::{MetricsError, Registry};
 #[cfg(test)]
 mod registry_tests {
     use super::{
-        InputMetrics, MetricsError, MetricsSnapshot, OutputMetrics, PipelineMetrics, Registry,
+        InputMetrics, LTP_HOP_LATENCY_BUCKETS, LtpMetrics, MetricsError, MetricsSnapshot,
+        OutputMetrics, PipelineMetrics, Registry,
     };
     use serde_json::Value;
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     fn build_ok<T>(result: Result<T, MetricsError>) -> T {
@@ -1271,6 +1353,95 @@ mod registry_tests {
             }])
         );
         assert_eq!(snapshot["metrics"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn ltp_metrics_prepopulate_the_static_peer_union_with_exact_metadata() {
+        let registry = Registry::new();
+        let peers = BTreeSet::from([
+            "peer-b".to_owned(),
+            "peer-a".to_owned(),
+            "peer-a".to_owned(),
+        ]);
+        let metrics = LtpMetrics::register(&registry, &peers).unwrap();
+
+        let first_peer_a = metrics.peer("peer-a").unwrap();
+        let second_peer_a = metrics.peer("peer-a").unwrap();
+        assert!(Arc::ptr_eq(
+            &first_peer_a.network_latency,
+            &second_peer_a.network_latency
+        ));
+        assert!(Arc::ptr_eq(
+            &first_peer_a.intra_latency,
+            &second_peer_a.intra_latency
+        ));
+        assert!(Arc::ptr_eq(
+            &first_peer_a.negative_delta,
+            &second_peer_a.negative_delta
+        ));
+        assert!(Arc::ptr_eq(
+            &first_peer_a.loop_dropped,
+            &second_peer_a.loop_dropped
+        ));
+        assert!(metrics.peer("peer-b").is_some());
+        assert!(metrics.peer("unknown").is_none());
+
+        let snapshot = snapshot_json(&registry);
+        let latency = metric(&snapshot, "limpid_ltp_hop_latency_seconds");
+        assert_eq!(latency["type"], "histogram");
+        assert_eq!(
+            latency["help"],
+            "LTP hop latency between authenticated peers."
+        );
+        let series = latency["series"].as_array().unwrap();
+        assert_eq!(series.len(), 4);
+        assert_eq!(
+            series
+                .iter()
+                .map(|series| (
+                    series["labels"]["peer"].as_str().unwrap(),
+                    series["labels"]["segment"].as_str().unwrap(),
+                    series["count"].as_u64().unwrap(),
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("peer-a", "network", 0),
+                ("peer-a", "intra", 0),
+                ("peer-b", "network", 0),
+                ("peer-b", "intra", 0),
+            ]
+        );
+        for series in series {
+            let buckets = series["buckets"].as_array().unwrap();
+            assert_eq!(buckets.len(), LTP_HOP_LATENCY_BUCKETS.len());
+            for (actual, expected) in buckets.iter().zip(LTP_HOP_LATENCY_BUCKETS) {
+                assert_eq!(actual[0].as_f64().unwrap(), expected);
+                assert_eq!(actual[1], 0);
+            }
+        }
+
+        for (name, labels) in [
+            ("limpid_ltp_negative_delta_total", 2),
+            ("limpid_ltp_loop_dropped_total", 2),
+            ("limpid_ltp_rejected_unknown_peer_total", 1),
+        ] {
+            let family = metric(&snapshot, name);
+            assert_eq!(family["type"], "counter");
+            assert_eq!(family["series"].as_array().unwrap().len(), labels);
+            assert!(
+                family["series"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|s| s["value"] == 0)
+            );
+        }
+        assert!(
+            metric(&snapshot, "limpid_ltp_rejected_unknown_peer_total")["series"][0]["labels"]
+                .as_object()
+                .unwrap()
+                .is_empty()
+        );
     }
 
     fn metric<'a>(snapshot: &'a Value, name: &str) -> &'a Value {

--- a/crates/limpid/src/modules/input/ltp.rs
+++ b/crates/limpid/src/modules/input/ltp.rs
@@ -1,6 +1,7 @@
 //! Authenticated LTP listener.
 
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::io;
 use std::sync::Arc;
 
@@ -30,7 +31,7 @@ use crate::ltp::{
     ED25519_SPKI_PREFIX, FRAME_MAGIC, FRAME_PREFIX_SIZE, FRAME_VERSION, HopStamp, LtpHello,
     LtpMeta, MAX_META_LEN, MAX_PAYLOAD_LEN, PAYLOAD_LEN_SIZE, ValidatedNodeKey,
 };
-use crate::metrics::InputMetrics;
+use crate::metrics::{InputMetrics, LtpMetrics, LtpPeerMetrics};
 use crate::modules::{HasMetrics, Input, Module};
 
 const DEFAULT_LTP_PORT: u16 = 7514;
@@ -110,6 +111,7 @@ pub struct LtpInput {
     max_hops: usize,
     max_connections: usize,
     metrics: Arc<InputMetrics>,
+    ltp_metrics: Arc<LtpMetrics>,
     now: fn() -> DateTime<Utc>,
     #[cfg(test)]
     hello_started: Option<Arc<tokio::sync::Notify>>,
@@ -123,6 +125,7 @@ struct ConnectionContext {
     max_hops: usize,
     now: fn() -> DateTime<Utc>,
     metrics: Arc<InputMetrics>,
+    ltp_metrics: Arc<LtpMetrics>,
     tx: tokio::sync::mpsc::Sender<Event>,
     #[cfg(test)]
     hello_started: Option<Arc<tokio::sync::Notify>>,
@@ -148,7 +151,12 @@ impl Module for LtpInput {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("input '{name}': LTP node key is unavailable"))?;
         let peers = parse_peers(name, properties)?;
-        let acceptor = build_rpk_acceptor(node_key, &peers)?;
+        let ltp_metrics = ctx
+            .ltp_metrics
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("input '{name}': LTP metrics are unavailable"))?;
+        let acceptor = build_rpk_acceptor(node_key, &peers, Arc::clone(&ltp_metrics))?;
         let bind_addr = props::get_string(properties, "bind")
             .unwrap_or_else(|| format!("0.0.0.0:{DEFAULT_LTP_PORT}"));
         let max_hops = props::get_positive_int(properties, "max_hops")?.unwrap_or(DEFAULT_MAX_HOPS);
@@ -167,6 +175,7 @@ impl Module for LtpInput {
             max_hops: max_hops as usize,
             max_connections: max_connections as usize,
             metrics: InputMetrics::register(&ctx.metrics, name)?,
+            ltp_metrics,
             now: Utc::now,
             #[cfg(test)]
             hello_started: None,
@@ -218,6 +227,7 @@ impl LtpInput {
                         max_hops: self.max_hops,
                         now: self.now,
                         metrics: Arc::clone(&self.metrics),
+                        ltp_metrics: Arc::clone(&self.ltp_metrics),
                         tx: tx.clone(),
                         #[cfg(test)]
                         hello_started: self.hello_started.clone(),
@@ -248,10 +258,20 @@ impl Input for LtpInput {
     }
 }
 
-#[derive(Debug)]
 struct DeclaredClientVerifier {
     allowed_spki: Arc<HashSet<Vec<u8>>>,
     algorithms: WebPkiSupportedAlgorithms,
+    ltp_metrics: Arc<LtpMetrics>,
+}
+
+impl fmt::Debug for DeclaredClientVerifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DeclaredClientVerifier")
+            .field("allowed_spki", &self.allowed_spki)
+            .field("algorithms", &self.algorithms)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ClientCertVerifier for DeclaredClientVerifier {
@@ -265,7 +285,18 @@ impl ClientCertVerifier for DeclaredClientVerifier {
         intermediates: &[CertificateDer<'_>],
         _now: UnixTime,
     ) -> std::result::Result<ClientCertVerified, TlsError> {
-        if !intermediates.is_empty() || !self.allowed_spki.contains(end_entity.as_ref()) {
+        if !intermediates.is_empty() {
+            return Err(TlsError::InvalidCertificate(
+                CertificateError::UnknownIssuer,
+            ));
+        }
+        if !self.allowed_spki.contains(end_entity.as_ref()) {
+            let candidate = end_entity.as_ref();
+            if candidate.len() == ED25519_SPKI_PREFIX.len() + 32
+                && candidate.starts_with(&ED25519_SPKI_PREFIX)
+            {
+                self.ltp_metrics.rejected_unknown_peer.inc();
+            }
             return Err(TlsError::InvalidCertificate(
                 CertificateError::UnknownIssuer,
             ));
@@ -305,12 +336,17 @@ impl ClientCertVerifier for DeclaredClientVerifier {
     }
 }
 
-fn build_rpk_acceptor(node_key: &ValidatedNodeKey, peers: &PeerRegistry) -> Result<TlsAcceptor> {
+fn build_rpk_acceptor(
+    node_key: &ValidatedNodeKey,
+    peers: &PeerRegistry,
+    ltp_metrics: Arc<LtpMetrics>,
+) -> Result<TlsAcceptor> {
     crate::tls::install_default_crypto_provider();
     let provider = rustls::crypto::aws_lc_rs::default_provider();
     let verifier = DeclaredClientVerifier {
         allowed_spki: Arc::new(peers.node_by_spki.keys().cloned().collect()),
         algorithms: provider.signature_verification_algorithms,
+        ltp_metrics,
     };
     let config = rustls::ServerConfig::builder_with_provider(Arc::new(provider))
         .with_protocol_versions(&[&rustls::version::TLS13])
@@ -466,6 +502,10 @@ async fn handle_connection(
         .peers
         .node_for_certificate(peer_certificate.as_ref())
         .ok_or_else(|| anyhow::anyhow!("LTP peer raw public key is not declared"))?;
+    let peer_metrics = context
+        .ltp_metrics
+        .peer(&authenticated_node_id)
+        .ok_or_else(|| anyhow::anyhow!("LTP peer metrics were not registered"))?;
 
     #[cfg(test)]
     if let Some(hello_started) = &context.hello_started {
@@ -481,6 +521,7 @@ async fn handle_connection(
     }
     let hello = LtpHello::decode(hello_frame.metadata).context("invalid LTP hello metadata")?;
     if hello.node_id != authenticated_node_id.as_ref() {
+        context.ltp_metrics.rejected_unknown_peer.inc();
         bail!("LTP hello node_id does not match the authenticated peer key");
     }
 
@@ -507,6 +548,7 @@ async fn handle_connection(
             &context.node_id,
             context.max_hops,
             context.now,
+            &peer_metrics,
         ) {
             Ok(decision) => decision,
             Err(error) => {
@@ -546,6 +588,7 @@ fn event_from_frame(
     node_id: &str,
     max_hops: usize,
     now: fn() -> DateTime<Utc>,
+    peer_metrics: &LtpPeerMetrics,
 ) -> Result<FrameDecision> {
     let key: [u8; 16] = meta
         .key
@@ -557,10 +600,12 @@ fn event_from_frame(
         bail!("LTP event key must be an RFC 4122 UUIDv7");
     }
     if meta.stamps.iter().any(|stamp| stamp.node_id == node_id) {
+        peer_metrics.loop_dropped.inc();
         warn!("LTP event dropped because its hop history already contains this node");
         return Ok(FrameDecision::DropCycle);
     }
     if meta.stamps.len() >= max_hops {
+        peer_metrics.loop_dropped.inc();
         warn!("LTP event dropped because its hop history reached max_hops");
         return Ok(FrameDecision::DropMaxHops);
     }
@@ -569,6 +614,20 @@ fn event_from_frame(
         .timestamp_nanos_opt()
         .and_then(|value| u64::try_from(value).ok())
         .unwrap_or(0);
+    if let Some(previous) = meta.stamps.last()
+        && previous.departure_unix_nano != 0
+    {
+        let delta = match arrival_unix_nano.checked_sub(previous.departure_unix_nano) {
+            Some(delta) => delta,
+            None => {
+                peer_metrics.negative_delta.inc();
+                0
+            }
+        };
+        peer_metrics
+            .network_latency
+            .observe(delta as f64 / 1_000_000_000.0);
+    }
     meta.stamps.push(HopStamp {
         node_id: node_id.to_owned(),
         arrival_unix_nano,
@@ -731,6 +790,18 @@ mod tests {
         InputMetrics::for_testing()
     }
 
+    fn test_ltp_metrics(peer: &str) -> Arc<LtpMetrics> {
+        LtpMetrics::register(
+            &crate::metrics::Registry::new(),
+            &std::collections::BTreeSet::from([peer.to_owned()]),
+        )
+        .unwrap()
+    }
+
+    fn test_peer_metrics(peer: &str) -> LtpPeerMetrics {
+        test_ltp_metrics(peer).peer(peer).unwrap()
+    }
+
     fn node_id_for_departed_meta_len(target: usize) -> String {
         ((target - 128)..=target)
             .find_map(|len| {
@@ -790,12 +861,24 @@ mod tests {
     #[test]
     fn event_validation_requires_uuid_v7_key_and_orders_cycle_before_hop_limit() {
         let source = "127.0.0.1:7514".parse().unwrap();
+        let peer_metrics = test_peer_metrics("peer");
         for key_len in [0, 15, 17] {
             let meta = LtpMeta {
                 key: vec![7; key_len],
                 stamps: Vec::new(),
             };
-            assert!(event_from_frame(meta, Bytes::new(), source, "self", 16, fixed_now).is_err());
+            assert!(
+                event_from_frame(
+                    meta,
+                    Bytes::new(),
+                    source,
+                    "self",
+                    16,
+                    fixed_now,
+                    &peer_metrics,
+                )
+                .is_err()
+            );
         }
 
         for invalid_key in [
@@ -822,6 +905,7 @@ mod tests {
                     "self",
                     16,
                     fixed_now,
+                    &peer_metrics,
                 )
                 .is_err()
             );
@@ -836,7 +920,16 @@ mod tests {
             }],
         };
         assert!(matches!(
-            event_from_frame(cycle, Bytes::new(), source, "self", 1, fixed_now).unwrap(),
+            event_from_frame(
+                cycle,
+                Bytes::new(),
+                source,
+                "self",
+                1,
+                fixed_now,
+                &peer_metrics,
+            )
+            .unwrap(),
             FrameDecision::DropCycle
         ));
 
@@ -849,9 +942,31 @@ mod tests {
             }],
         };
         assert!(matches!(
-            event_from_frame(full, Bytes::new(), source, "self", 1, fixed_now).unwrap(),
+            event_from_frame(
+                full,
+                Bytes::new(),
+                source,
+                "self",
+                1,
+                fixed_now,
+                &peer_metrics,
+            )
+            .unwrap(),
             FrameDecision::DropMaxHops
         ));
+        assert_eq!(
+            peer_metrics
+                .loop_dropped
+                .load(std::sync::atomic::Ordering::Relaxed),
+            2
+        );
+        assert_eq!(peer_metrics.network_latency.count(), 0);
+        assert_eq!(
+            peer_metrics
+                .negative_delta
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
     }
 
     #[test]
@@ -863,6 +978,7 @@ mod tests {
             departure_unix_nano: 11,
         };
         let source = "127.0.0.1:7514".parse().unwrap();
+        let peer_metrics = test_peer_metrics("peer");
         let decision = event_from_frame(
             LtpMeta {
                 key: key.to_vec(),
@@ -873,6 +989,7 @@ mod tests {
             "self",
             16,
             fixed_now,
+            &peer_metrics,
         )
         .unwrap();
         let FrameDecision::Forward(event) = decision else {
@@ -882,6 +999,8 @@ mod tests {
         assert_eq!(event.ingress, Bytes::from_static(b"payload"));
         assert_eq!(event.egress, Bytes::from_static(b"payload"));
         assert_eq!(event.ltp_stamps()[0], peer_stamp);
+        assert_eq!(peer_metrics.network_latency.count(), 1);
+        assert_eq!(peer_metrics.network_latency.sum(), 112.0 / 1_000_000_000.0);
         assert_eq!(
             event.ltp_stamps()[1],
             HopStamp {
@@ -889,6 +1008,42 @@ mod tests {
                 arrival_unix_nano: 123,
                 departure_unix_nano: 0,
             }
+        );
+    }
+
+    #[test]
+    fn network_latency_skips_unsealed_history_and_clamps_negative_deltas() {
+        let source = "127.0.0.1:7514".parse().unwrap();
+        let peer_metrics = test_peer_metrics("peer");
+        for departure_unix_nano in [0, 124] {
+            assert!(matches!(
+                event_from_frame(
+                    LtpMeta {
+                        key: v7_key(departure_unix_nano as u8).to_vec(),
+                        stamps: vec![HopStamp {
+                            node_id: "upstream".to_owned(),
+                            arrival_unix_nano: 1,
+                            departure_unix_nano,
+                        }],
+                    },
+                    Bytes::new(),
+                    source,
+                    "self",
+                    16,
+                    fixed_now,
+                    &peer_metrics,
+                )
+                .unwrap(),
+                FrameDecision::Forward(_)
+            ));
+        }
+        assert_eq!(peer_metrics.network_latency.count(), 1);
+        assert_eq!(peer_metrics.network_latency.sum(), 0.0);
+        assert_eq!(
+            peer_metrics
+                .negative_delta
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
         );
     }
 
@@ -906,6 +1061,7 @@ mod tests {
             &exact_node,
             16,
             fixed_now,
+            &test_peer_metrics("peer"),
         )
         .unwrap() else {
             panic!("metadata at the exact output boundary must be accepted");
@@ -932,6 +1088,7 @@ mod tests {
                 &oversized_node,
                 16,
                 fixed_now,
+                &test_peer_metrics("peer"),
             )
             .unwrap(),
             FrameDecision::DropMetadataTooLarge
@@ -1020,7 +1177,9 @@ mod tests {
         let (server_identity, server_spki) = generated_identity();
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(2);
@@ -1038,6 +1197,7 @@ mod tests {
                     max_hops: 16,
                     now: fixed_now,
                     metrics: server_metrics,
+                    ltp_metrics,
                     tx,
                     hello_started: None,
                 },
@@ -1108,7 +1268,9 @@ mod tests {
         let (server_identity, server_spki) = generated_identity();
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
@@ -1126,6 +1288,7 @@ mod tests {
                     max_hops: 16,
                     now: fixed_now,
                     metrics: server_metrics,
+                    ltp_metrics,
                     tx,
                     hello_started: None,
                 },
@@ -1185,7 +1348,9 @@ mod tests {
         let (server_identity, server_spki) = generated_identity();
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, rx) = tokio::sync::mpsc::channel(1);
@@ -1204,6 +1369,7 @@ mod tests {
                     max_hops: 16,
                     now: fixed_now,
                     metrics: server_metrics,
+                    ltp_metrics,
                     tx,
                     hello_started: None,
                 },
@@ -1245,7 +1411,9 @@ mod tests {
         let (server_identity, server_spki) = generated_identity();
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let metrics = test_metrics();
@@ -1259,6 +1427,7 @@ mod tests {
             max_hops: 16,
             max_connections: 1,
             metrics,
+            ltp_metrics,
             now: fixed_now,
             hello_started: Some(Arc::clone(&hello_started)),
         };
@@ -1301,11 +1470,14 @@ mod tests {
         let (server_identity, server_spki) = generated_identity();
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let metrics = test_metrics();
+        let server_ltp_metrics = Arc::clone(&ltp_metrics);
         let server = tokio::spawn(async move {
             let (stream, peer_address) = listener.accept().await.unwrap();
             handle_connection(
@@ -1318,6 +1490,7 @@ mod tests {
                     max_hops: 16,
                     now: fixed_now,
                     metrics,
+                    ltp_metrics: server_ltp_metrics,
                     tx,
                     hello_started: None,
                 },
@@ -1341,6 +1514,12 @@ mod tests {
         let error = server.await.unwrap().unwrap_err().to_string();
         assert!(error.contains("hello node_id"));
         assert!(rx.try_recv().is_err());
+        assert_eq!(
+            ltp_metrics
+                .rejected_unknown_peer
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
     }
 
     #[tokio::test]
@@ -1349,7 +1528,9 @@ mod tests {
         let (_, declared_spki) = generated_identity();
         let (unknown_identity, _) = generated_identity();
         let peers = peer_registry("peer-a", declared_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
@@ -1367,6 +1548,46 @@ mod tests {
         let server_result = server.await.unwrap();
         assert!(client_result.is_err() || server_result.is_err());
         assert!(server_result.is_err());
+        assert_eq!(
+            ltp_metrics
+                .rejected_unknown_peer
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn non_rpk_and_intermediate_certificate_failures_do_not_count_unknown_peers() {
+        let (_, declared_spki) = generated_identity();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let verifier = DeclaredClientVerifier {
+            allowed_spki: Arc::new(HashSet::from([declared_spki.clone()])),
+            algorithms: rustls::crypto::aws_lc_rs::default_provider()
+                .signature_verification_algorithms,
+            ltp_metrics: Arc::clone(&ltp_metrics),
+        };
+        let now = UnixTime::since_unix_epoch(std::time::Duration::ZERO);
+
+        assert!(
+            verifier
+                .verify_client_cert(&CertificateDer::from(vec![1, 2, 3]), &[], now)
+                .is_err()
+        );
+        assert!(
+            verifier
+                .verify_client_cert(
+                    &CertificateDer::from(declared_spki),
+                    &[CertificateDer::from(vec![4, 5, 6])],
+                    now,
+                )
+                .is_err()
+        );
+        assert_eq!(
+            ltp_metrics
+                .rejected_unknown_peer
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
     }
 
     #[tokio::test]
@@ -1374,7 +1595,9 @@ mod tests {
         let (server_identity, server_spki) = generated_identity();
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
@@ -1393,6 +1616,7 @@ mod tests {
                         max_hops: 16,
                         now: fixed_now,
                         metrics: Arc::clone(&metrics),
+                        ltp_metrics: Arc::clone(&ltp_metrics),
                         tx: tx.clone(),
                         hello_started: None,
                     },
@@ -1437,7 +1661,9 @@ mod tests {
         let (server_identity, _) = generated_identity();
         let (_, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
-        let acceptor = build_rpk_acceptor(&server_identity, &peers).unwrap();
+        let ltp_metrics = test_ltp_metrics("peer-a");
+        let acceptor =
+            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let context = crate::modules::BuildContext::for_testing();
         let input = LtpInput {
             name: "in".to_owned(),
@@ -1448,6 +1674,7 @@ mod tests {
             max_hops: 16,
             max_connections: 2,
             metrics: InputMetrics::register(&context.metrics, "in").unwrap(),
+            ltp_metrics,
             now: fixed_now,
             hello_started: None,
         };

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -70,6 +70,7 @@ pub struct BuildContext {
     /// receive the in-memory material and never reopen `node_key`.
     pub(crate) ltp_node_id: Option<Arc<str>>,
     pub(crate) ltp_node_key: Option<Arc<crate::ltp::ValidatedNodeKey>>,
+    pub(crate) ltp_metrics: Option<Arc<crate::metrics::LtpMetrics>>,
 }
 
 /// Shared retry-backoff helper for unbatched sinks: sleep `wait`, but
@@ -170,6 +171,7 @@ impl BuildContext {
             shutdown_signal: rx,
             ltp_node_id: None,
             ltp_node_key: None,
+            ltp_metrics: None,
         }
     }
 }

--- a/crates/limpid/src/modules/output/ltp.rs
+++ b/crates/limpid/src/modules/output/ltp.rs
@@ -27,7 +27,7 @@ use crate::ltp::{
     ED25519_SPKI_PREFIX, HopStamp, LtpHello, LtpMeta, MAX_META_LEN, MAX_PAYLOAD_LEN,
     ValidatedNodeKey, encode_frame, encode_hello_frame,
 };
-use crate::metrics::OutputMetrics;
+use crate::metrics::{LtpPeerMetrics, OutputMetrics};
 use crate::modules::output::syslog_peers::{
     PEER_CONNECT_TIMEOUT, PEER_HANDSHAKE_TIMEOUT, PEER_WRITE_TIMEOUT,
 };
@@ -91,6 +91,7 @@ pub struct LtpOutput {
     error_log: Option<Arc<crate::error_log::ErrorLogWriter>>,
     error_log_fallback: crate::error_log::ErrorLogFallback,
     metrics: Arc<OutputMetrics>,
+    peer_metrics: LtpPeerMetrics,
     shutdown_signal: tokio::sync::watch::Receiver<bool>,
     now: fn() -> DateTime<Utc>,
 }
@@ -106,6 +107,11 @@ impl Module for LtpOutput {
         ctx: &crate::modules::BuildContext,
     ) -> Result<Self> {
         let peer = parse_peer(name, properties.user_properties())?;
+        let peer_metrics = ctx
+            .ltp_metrics
+            .as_ref()
+            .and_then(|metrics| metrics.peer(&peer.node_id))
+            .ok_or_else(|| anyhow::anyhow!("output '{name}': LTP peer metrics are unavailable"))?;
         let node_id =
             ctx.ltp_node_id.as_ref().cloned().ok_or_else(|| {
                 anyhow::anyhow!("output '{name}': LTP node identity is unavailable")
@@ -136,6 +142,7 @@ impl Module for LtpOutput {
             error_log: ctx.error_log.as_ref().map(Arc::clone),
             error_log_fallback: ctx.error_log_fallback,
             metrics: OutputMetrics::register(&ctx.metrics, name)?,
+            peer_metrics,
             shutdown_signal: ctx.shutdown_signal.clone(),
             now: Utc::now,
         })
@@ -471,6 +478,13 @@ impl LtpOutput {
         let frame = self.event_frame(working, payload)?;
         Self::write_bytes(stream, &frame).await?;
         self.metrics.bytes_written.inc_by(frame.len() as u64);
+        let stamp = &working.meta.stamps[working.local_stamp];
+        let delta = stamp
+            .departure_unix_nano
+            .saturating_sub(stamp.arrival_unix_nano);
+        self.peer_metrics
+            .intra_latency
+            .observe(delta as f64 / 1_000_000_000.0);
         Ok(())
     }
 
@@ -771,14 +785,19 @@ mod tests {
         )
         .unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        (
-            crate::modules::BuildContext {
-                ltp_node_id: Some(Arc::<str>::from(node_id)),
-                ltp_node_key: Some(Arc::new(crate::ltp::load_node_key(&path).unwrap())),
-                ..crate::modules::BuildContext::for_testing()
-            },
-            spki,
-        )
+        let mut context = crate::modules::BuildContext {
+            ltp_node_id: Some(Arc::<str>::from(node_id)),
+            ltp_node_key: Some(Arc::new(crate::ltp::load_node_key(&path).unwrap())),
+            ..crate::modules::BuildContext::for_testing()
+        };
+        context.ltp_metrics = Some(
+            crate::metrics::LtpMetrics::register(
+                &context.metrics,
+                &std::collections::BTreeSet::from(["peer-a".to_owned()]),
+            )
+            .unwrap(),
+        );
+        (context, spki)
     }
 
     fn build_context(node_id: &str) -> crate::modules::BuildContext {
@@ -1282,6 +1301,7 @@ mod tests {
         let mut output = output_for("127.0.0.1:1");
         output.now = now_200;
         let mut event = Event::new(Bytes::new(), "127.0.0.1:1".parse().unwrap());
+        event.received_at = Utc.timestamp_nanos(100);
         event.egress = Bytes::from_static(b"payload");
         let mut working = output.working_event_meta(&event);
         let expected_len = output
@@ -1299,6 +1319,7 @@ mod tests {
         assert_eq!(flush_failure.bytes.len(), expected_len as usize);
         assert_eq!(flush_failure.flushes, 1);
         assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.peer_metrics.intra_latency.count(), 0);
 
         let mut success = ScriptedWriter::new(3, FlushAction::Ok);
         output
@@ -1311,6 +1332,11 @@ mod tests {
             output.metrics.bytes_written.load(Ordering::Relaxed),
             expected_len,
             "a retry success owns exactly one event-frame byte increment"
+        );
+        assert_eq!(output.peer_metrics.intra_latency.count(), 1);
+        assert_eq!(
+            output.peer_metrics.intra_latency.sum(),
+            100.0 / 1_000_000_000.0
         );
     }
 
@@ -1551,6 +1577,7 @@ mod tests {
             event_frame.len() as u64,
             "shutdown success owns exactly one event-frame byte increment"
         );
+        assert_eq!(output.peer_metrics.intra_latency.count(), 1);
     }
 
     #[tokio::test]
@@ -1774,6 +1801,7 @@ mod tests {
         output.consume(&event, ack).await.unwrap();
         assert_eq!(output.metrics.retries.load(Ordering::Relaxed), 1);
         assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert_eq!(output.peer_metrics.intra_latency.count(), 0);
         assert!(matches!(
             ack_rx.recv().await,
             Some((_, AckDisposition::Recovered))

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -4,7 +4,7 @@
 //! Runtime does NOT count metrics — each component counts its own.
 //! Runtime distributes one shared metrics registry to every component.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -17,7 +17,7 @@ use crate::dsl::ast::*;
 use crate::dsl::props;
 use crate::event::Event;
 use crate::functions::FunctionRegistry;
-use crate::metrics::{PipelineMetrics, Registry};
+use crate::metrics::{LtpMetrics, PipelineMetrics, Registry};
 use crate::modules::{self, HasMetrics, ModuleRegistry};
 use crate::pipeline::CompiledConfig;
 use crate::queue::{self, QueueConfig, QueueSender};
@@ -28,6 +28,39 @@ pub struct Runtime {
     handles: Vec<tokio::task::JoinHandle<()>>,
     config_file: PathBuf,
     compiled_config: CompiledConfig,
+}
+
+fn configured_ltp_peer_ids(config: &CompiledConfig) -> Result<BTreeSet<String>> {
+    let mut peers = BTreeSet::new();
+    for (kind, name, properties) in config
+        .inputs
+        .iter()
+        .map(|(name, def)| ("input", name, &def.properties))
+        .chain(
+            config
+                .outputs
+                .iter()
+                .map(|(name, def)| ("output", name, &def.properties)),
+        )
+        .filter(|(_, _, properties)| properties.type_name() == "ltp")
+    {
+        for peer in properties
+            .user_properties()
+            .iter()
+            .filter_map(|property| match property {
+                Property::Block {
+                    key, properties, ..
+                } if key == "peer" => Some(properties.as_slice()),
+                _ => None,
+            })
+        {
+            let node_id = props::get_string(peer, "node_id").ok_or_else(|| {
+                anyhow::anyhow!("{kind} '{name}': peer node_id requires a string value")
+            })?;
+            peers.insert(node_id);
+        }
+    }
+    Ok(peers)
 }
 
 impl Runtime {
@@ -74,6 +107,12 @@ impl Runtime {
         let func_registry = Arc::new(func_registry);
 
         config.validate()?;
+        let ltp_peer_ids = configured_ltp_peer_ids(&config)?;
+        let ltp_metrics = if ltp_peer_ids.is_empty() {
+            None
+        } else {
+            Some(LtpMetrics::register(&metrics_registry, &ltp_peer_ids)?)
+        };
         let ltp_node_key = config
             .node_key
             .as_deref()
@@ -163,6 +202,7 @@ impl Runtime {
             shutdown_signal: shutdown_rx.clone(),
             ltp_node_id: Some(Arc::<str>::from(node_id.clone())),
             ltp_node_key,
+            ltp_metrics,
         };
 
         // --- 1. Create outputs (each output owns its own OutputMetrics) ---
@@ -1051,6 +1091,29 @@ mod tests {
     fn compiled_config(src: &str) -> CompiledConfig {
         CompiledConfig::from_config(parse_config(src).expect("parse config"))
             .expect("compile config")
+    }
+
+    #[test]
+    fn ltp_peer_metric_registration_uses_the_deduplicated_static_config_union() {
+        use base64::Engine as _;
+
+        let mut spki = crate::ltp::ED25519_SPKI_PREFIX.to_vec();
+        spki.extend_from_slice(&[7; 32]);
+        let pubkey = base64::engine::general_purpose::STANDARD.encode(spki);
+        let config = compiled_config(&format!(
+            "def input ltp_in {{ type ltp peer {{ node_id \"peer-input\" pubkey {pubkey:?} }} }}\n\
+             def output ltp_out_a {{ type ltp peer {{ node_id \"peer-a\" pubkey {pubkey:?} endpoint \"127.0.0.1:7514\" }} }}\n\
+             def output ltp_out_b {{ type ltp peer {{ node_id \"peer-b\" pubkey {pubkey:?} endpoint \"127.0.0.1:7515\" }} }}"
+        ));
+
+        assert_eq!(
+            configured_ltp_peer_ids(&config).unwrap(),
+            BTreeSet::from([
+                "peer-a".to_owned(),
+                "peer-b".to_owned(),
+                "peer-input".to_owned(),
+            ])
+        );
     }
 
     fn metric_series(registry: &Registry, name: &str) -> Vec<serde_json::Value> {


### PR DESCRIPTION
## Summary

- Pre-register LTP telemetry for the deduplicated union of configured input and output peers.
- Expose hop latency, negative-delta, loop-drop, and unknown-peer metrics without creating dynamic series at runtime.

## Semantics

- Record the `network` latency segment from the authenticated upstream peer's sealed departure to local arrival after cycle and hop-limit validation.
- Record the `intra` latency segment for the declared destination peer exactly once after a successful final output write and flush.
- Clamp negative cross-host deltas to zero and count them per authenticated peer.
- Count cycle and max-hop drops in the same peer-labelled loop family. Count undeclared client keys and authenticated-key/hello identity mismatches in the global unknown-peer family; other TLS handshake failures do not affect it.
- Peer labels come only from static authenticated or declared configuration identities.

## Validation

- Added focused coverage for metric metadata and zero-value prepopulation, peer-union deduplication, authenticated input accounting, output success/failure accounting, and negative/loop/unknown-peer boundaries.
- Verified the workspace test suite, Kafka feature tests, all-target Clippy with warnings denied, formatting and diff checks, dependency audit, and dependency-policy checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-peer LTP network and intra-peer latency metrics.
  - Added counters for loop-dropped events, negative timestamp deltas, and rejected unknown peers.
  - Automatically discovers configured peers and registers their metric series, including zero-value data.

- **Bug Fixes**
  - Improved handling and visibility of TLS peer validation failures.
  - Prevented invalid latency calculations from producing negative measurements.
  - Ensured failed event writes do not report successful latency observations.

- **Tests**
  - Added coverage for peer discovery, metric registration, latency buckets, and event-processing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->