### PR TITLE
docs(ltp): add operator guide and e2e test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+### Added — authenticated LTP node transport
+
+Limpid nodes can now exchange events through an unbatched `input ltp` and
+`output ltp` pair authenticated with mutual TLS 1.3 raw public keys. Static peer
+configuration binds each Ed25519 SPKI key to a `node_id`; connections send a
+hello before events, preserve UUIDv7 event keys, reject cycles and bounded hop
+histories, and retain hop stamps across disk queues and dead-letter replay.
+Outputs use the existing queue, retry, shutdown, and dead-letter dispositions.
+
+LTP telemetry pre-registers the configured peer union and reports network and
+intra-node hop-latency histograms, negative-delta clamps, loop or hop-limit
+drops, and undeclared-key or mismatched-identity connection rejections. Peer
+labels are derived only from authenticated or declared configuration.
+
 ### Added — LTP node key provisioning
 
 The optional top-level `node_key` selects an Ed25519 PKCS#8 private-key file.

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -1093,6 +1093,108 @@ mod tests {
             .expect("compile config")
     }
 
+    #[cfg(unix)]
+    fn write_ltp_test_identity(path: &Path) -> String {
+        use base64::Engine as _;
+        use ring::rand::SystemRandom;
+        use ring::signature::{Ed25519KeyPair, KeyPair as _};
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let pkcs8 = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
+        let pair = Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+        std::fs::write(
+            path,
+            pem::encode(&pem::Pem::new("PRIVATE KEY", pkcs8.as_ref())),
+        )
+        .unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let mut spki = crate::ltp::ED25519_SPKI_PREFIX.to_vec();
+        spki.extend_from_slice(pair.public_key().as_ref());
+        base64::engine::general_purpose::STANDARD.encode(spki)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn two_runtimes_deliver_one_event_over_mutual_rpk_ltp() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let node_a_key = dir.path().join("node-a.pem");
+        let node_b_key = dir.path().join("node-b.pem");
+        let node_a_spki = write_ltp_test_identity(&node_a_key);
+        let node_b_spki = write_ltp_test_identity(&node_b_key);
+        let delivered_path = dir.path().join("delivered.log");
+        let node_a_socket = dir.path().join("node-a.sock");
+        let node_b_socket = dir.path().join("node-b.sock");
+
+        let ltp_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let ltp_addr = ltp_listener.local_addr().unwrap();
+        drop(ltp_listener);
+        let node_b_config = compiled_config(&format!(
+            r#"
+node_id "node-b"
+node_key {node_b_key:?}
+control {{ socket {node_b_socket:?} }}
+def input from_a {{
+    type ltp
+    bind "{ltp_addr}"
+    peer {{ node_id "node-a" pubkey {node_a_spki:?} }}
+}}
+def output delivered {{ type file path {delivered_path:?} }}
+def pipeline receive {{ input from_a; output delivered }}
+"#
+        ));
+        let node_b = Runtime::start(node_b_config, dir.path().join("node-b.limpid"))
+            .await
+            .unwrap();
+
+        let udp_listener = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let udp_addr = udp_listener.local_addr().unwrap();
+        drop(udp_listener);
+        let node_a_config = compiled_config(&format!(
+            r#"
+node_id "node-a"
+node_key {node_a_key:?}
+control {{ socket {node_a_socket:?} }}
+def input source {{ type syslog_udp bind "{udp_addr}" }}
+def output to_b {{
+    type ltp
+    peer {{ node_id "node-b" pubkey {node_b_spki:?} endpoint "{ltp_addr}" }}
+}}
+def pipeline relay {{ input source; output to_b }}
+"#
+        ));
+        let node_a = Runtime::start(node_a_config, dir.path().join("node-a.limpid"))
+            .await
+            .unwrap();
+
+        let marker = b"<13>two-runtime-mutual-rpk";
+        let sender = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let delivered = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                sender.send_to(marker, udp_addr).await.unwrap();
+                if let Ok(bytes) = tokio::fs::read(&delivered_path).await
+                    && bytes.windows(marker.len()).any(|window| window == marker)
+                {
+                    break bytes;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await;
+
+        node_a.shutdown().await;
+        node_b.shutdown().await;
+        let delivered = delivered.expect("two-daemon LTP delivery timed out");
+        assert!(
+            delivered
+                .windows(marker.len())
+                .any(|window| window == marker)
+        );
+    }
+
     #[test]
     fn ltp_peer_metric_registration_uses_the_deduplicated_static_config_union() {
         use base64::Engine as _;

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -1118,6 +1118,7 @@ mod tests {
     #[tokio::test]
     async fn two_runtimes_deliver_one_event_over_mutual_rpk_ltp() {
         use std::os::unix::fs::PermissionsExt as _;
+        use tokio::io::AsyncWriteExt as _;
 
         let dir = tempfile::tempdir().unwrap();
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
@@ -1150,15 +1151,15 @@ def pipeline receive {{ input from_a; output delivered }}
             .await
             .unwrap();
 
-        let udp_listener = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
-        let udp_addr = udp_listener.local_addr().unwrap();
-        drop(udp_listener);
+        let tcp_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let tcp_addr = tcp_listener.local_addr().unwrap();
+        drop(tcp_listener);
         let node_a_config = compiled_config(&format!(
             r#"
 node_id "node-a"
 node_key {node_a_key:?}
 control {{ socket {node_a_socket:?} }}
-def input source {{ type syslog_udp bind "{udp_addr}" }}
+def input source {{ type syslog_tcp bind "{tcp_addr}" }}
 def output to_b {{
     type ltp
     peer {{ node_id "node-b" pubkey {node_b_spki:?} endpoint "{ltp_addr}" }}
@@ -1171,14 +1172,26 @@ def pipeline relay {{ input source; output to_b }}
             .unwrap();
 
         let marker = b"<13>two-runtime-mutual-rpk";
-        let sender = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut frame = marker.to_vec();
+        frame.push(b'\n');
+        let mut sender = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match tokio::net::TcpStream::connect(tcp_addr).await {
+                    Ok(stream) => break stream,
+                    Err(_) => tokio::time::sleep(Duration::from_millis(25)).await,
+                }
+            }
+        })
+        .await
+        .expect("syslog TCP input did not become ready");
+        sender.write_all(&frame).await.unwrap();
+        sender.flush().await.unwrap();
         let delivered = tokio::time::timeout(Duration::from_secs(5), async {
             loop {
-                sender.send_to(marker, udp_addr).await.unwrap();
                 if let Ok(bytes) = tokio::fs::read(&delivered_path).await
-                    && bytes.windows(marker.len()).any(|window| window == marker)
+                    && bytes == frame
                 {
-                    break bytes;
+                    break;
                 }
                 tokio::time::sleep(Duration::from_millis(25)).await;
             }
@@ -1187,12 +1200,8 @@ def pipeline relay {{ input source; output to_b }}
 
         node_a.shutdown().await;
         node_b.shutdown().await;
-        let delivered = delivered.expect("two-daemon LTP delivery timed out");
-        assert!(
-            delivered
-                .windows(marker.len())
-                .any(|window| window == marker)
-        );
+        delivered.expect("two-daemon LTP delivery timed out");
+        assert_eq!(tokio::fs::read(&delivered_path).await.unwrap(), frame);
     }
 
     #[test]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -45,6 +45,7 @@
 
 # Protocol Notes
 
+- [LTP — authenticated node transport](./ltp.md)
 - [OTLP — design rationale](./otlp.md)
 
 # Operations

--- a/docs/src/ltp.md
+++ b/docs/src/ltp.md
@@ -17,9 +17,10 @@ does not create another hop.
 
 ## Provision identities
 
-Every participating daemon needs a `node_key`. If `node_id` is omitted, limpid
-uses the hostname resolved once at startup; deployments with multiple instances
-on the same host should set an explicit, deployment-unique `node_id`:
+Every daemon that uses an LTP input or output needs a `node_key`. If `node_id`
+is omitted, limpid uses the hostname resolved once at startup; deployments with
+multiple instances on the same host should set an explicit, deployment-unique
+`node_id`:
 
 ```bash
 limpidctl ltp keygen /etc/limpid/node-key.pem
@@ -97,7 +98,10 @@ outer event frame only; TLS, TCP, and hello overhead are excluded.
 
 The receiver applies normal channel backpressure, and shutdown uses the same
 bounded drain semantics as other outputs. LTP adds no application
-acknowledgement; a successful final write and flush is the delivery boundary.
+acknowledgement; a successful final write and flush is the sender-side handoff
+boundary, not confirmation of peer acceptance or durable storage. An ambiguous
+connection or write failure follows ordinary retry behavior and can therefore
+deliver a duplicate.
 
 ## Hop timing
 

--- a/docs/src/ltp.md
+++ b/docs/src/ltp.md
@@ -1,0 +1,109 @@
+# LTP — Authenticated Node Transport
+
+LTP connects limpid nodes without exposing a plaintext fallback. Each
+connection uses TLS 1.3 mutual raw-public-key authentication. The configured
+RFC 8410 Ed25519 SPKI public key pins the peer, and the first application frame
+binds that authenticated key to its configured `node_id`. X.509 certificates
+and unlisted keys are rejected.
+
+LTP preserves the event's UUIDv7 key and carries its payload plus a bounded hop
+history. The history is runtime metadata: it is visible in JSON tap and is
+preserved by disk queues and the dead-letter log, but it is not exposed to the
+DSL workspace. Each accepting input rejects a cycle or an incoming history at
+its `max_hops` limit before appending its own arrival stamp. An output seals its
+local stamp with the successful attempt's departure time. Retries reuse the
+same bounded history and refresh only that departure time, so a failed attempt
+does not create another hop.
+
+## Provision identities
+
+Every participating daemon needs a `node_key`. If `node_id` is omitted, limpid
+uses the hostname resolved once at startup; deployments with multiple instances
+on the same host should set an explicit, deployment-unique `node_id`:
+
+```bash
+limpidctl ltp keygen /etc/limpid/node-key.pem
+```
+
+The command creates a non-overwriting `0600` PKCS#8 private-key file and prints
+one base64-encoded SPKI public key to stdout. Exchange only that public line.
+Configure the private path and a deployment-unique node identity at top level:
+
+```limpid
+node_id "edge-a"
+node_key "/etc/limpid/node-key.pem"
+```
+
+Startup and reload open the key without following symlinks, validate it through
+the same file descriptor, and require a regular file owned by the daemon's
+effective user with mode exactly `0400` or `0600`. `limpid --check` validates
+the LTP configuration and public keys without reading the private-key file.
+
+## Receive from peers
+
+An input lists every peer permitted to connect. Repeating `peer` is allowed;
+duplicate node identities or public keys are rejected at configuration time.
+
+```limpid
+def input from_edge {
+    type ltp
+    bind "0.0.0.0:7514"
+    peer {
+        node_id "edge-a"
+        pubkey "<edge-a SPKI base64>"
+    }
+    max_hops 16
+    max_connections 1024
+}
+```
+
+| Property | Default | Meaning |
+| --- | --- | --- |
+| `bind` | `0.0.0.0:7514` | TCP listen address. |
+| `peer { node_id pubkey }` | required | An authenticated upstream identity; repeat for each permitted peer. |
+| `max_hops` | `16` | Incoming hop limit, from 1 through 16. An event already at the limit is dropped. |
+| `max_connections` | `1024` | Maximum concurrent accepted connections. |
+
+The wire key must be exactly 16 bytes, use the RFC 4122 variant, and identify a
+UUIDv7. Limpid never replaces an invalid or missing key. After authentication,
+the hello `node_id` must match the identity assigned to the presented public
+key. Protocol errors close that connection; subsequent valid connections are
+independent.
+
+## Send to one peer
+
+An LTP output is unbatched and declares exactly one destination:
+
+```limpid
+def output to_core {
+    type ltp
+    peer {
+        node_id "core-b"
+        pubkey "<core-b SPKI base64>"
+        endpoint "core-b.example:7514"
+    }
+    queue { type disk path "/var/lib/limpid/queues/to-core" }
+    retry { max_attempts 10 initial_wait "1s" }
+}
+```
+
+`endpoint` accepts `host` or `host:port`; the omitted port is `7514`. A new or
+reconnected TLS session always sends the authenticated node hello before its
+first event. Connection, handshake, and write failures use the ordinary output
+retry and dead-letter contract. A payload larger than 16 MiB is a permanent
+per-event failure and goes directly to that contract without connecting or
+consuming retries. A successful event increments output bytes by the complete
+outer event frame only; TLS, TCP, and hello overhead are excluded.
+
+The receiver applies normal channel backpressure, and shutdown uses the same
+bounded drain semantics as other outputs. LTP adds no application
+acknowledgement; a successful final write and flush is the delivery boundary.
+
+## Hop timing
+
+Each hop records `node_id`, `arrival_unix_nano`, and `departure_unix_nano`.
+Input appends arrival with departure zero; the corresponding local output fills
+departure immediately before its final event write. A node that receives and
+then forwards an event therefore contributes one stamp, while the receiving
+node's input contributes the next arrival stamp. See [Metrics](./operations/metrics.md#ltp)
+for the derived network and intra-node latency segments and rejection counters.

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -198,6 +198,38 @@ registry series; `limpid_events_dropped_total` remains authoritative.
 Keeping `received` and `injected` separate makes source traffic distinguishable
 from synthetic and replay traffic.
 
+### LTP
+
+LTP series are registered at startup from the deduplicated union of configured
+input and output peers. The `peer` label therefore comes from authenticated or
+declared configuration, never from untrusted wire metadata, and every series
+exists at zero before traffic arrives.
+
+| Metric | Labels | Meaning |
+| --- | --- | --- |
+| `limpid_ltp_hop_latency_seconds` | `peer`, `segment` | Hop latency histogram. `segment` is `network` or `intra`. |
+| `limpid_ltp_negative_delta_total` | `peer` | Negative cross-host latency deltas clamped to zero. |
+| `limpid_ltp_loop_dropped_total` | `peer` | Events dropped because the incoming history contains this node or has reached `max_hops`. |
+| `limpid_ltp_rejected_unknown_peer_total` | *(none)* | Connection attempts rejected for an undeclared public key or a hello node identity that does not match its authenticated key. |
+
+`network` is observed by the receiving input after cycle and hop-limit checks:
+the previous hop's nonzero departure to the local arrival. Empty history and an
+unsealed departure of zero are skipped. A negative wall-clock delta is observed
+as zero and increments `limpid_ltp_negative_delta_total` for the authenticated
+upstream peer.
+
+`intra` is observed once, only after an output's final event write and flush
+succeeds: the event's persisted local arrival to that successful attempt's
+departure, labeled with the declared destination peer. Failed attempts and
+retries do not add observations. The histogram uses the fixed upper bounds
+`0.0001`, `0.001`, `0.005`, `0.025`, `0.1`, `0.5`, `2.5`, and `10` seconds,
+plus the exported `+Inf` bucket.
+
+An undeclared SPKI is counted at the raw-public-key verifier, and a declared key
+with the wrong hello identity is counted after the handshake. TLS timeouts,
+malformed handshakes, cipher failures, X.509 certificates, and intermediate
+certificates are not classified as unknown peers.
+
 ### Outputs
 
 | Metric | Label | Meaning |

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -222,8 +222,10 @@ upstream peer.
 succeeds: the event's persisted local arrival to that successful attempt's
 departure, labeled with the declared destination peer. Failed attempts and
 retries do not add observations. The histogram uses the fixed upper bounds
-`0.0001`, `0.001`, `0.005`, `0.025`, `0.1`, `0.5`, `2.5`, and `10` seconds,
-plus the exported `+Inf` bucket.
+`0.0001`, `0.001`, `0.005`, `0.025`, `0.1`, `0.5`, `2.5`, and `10` seconds as
+the schema-v1 registry's eight finite bounds. The Prometheus exporter derives
+the `+Inf` bucket from `count`; `limpidctl stats --json` contains no explicit
+`+Inf` bucket.
 
 An undeclared SPKI is counted at the raw-public-key verifier, and a declared key
 with the wrong hello identity is counted after the handshake. TLS timeouts,


### PR DESCRIPTION
## Summary

- Add an LTP operator guide covering authenticated input/output configuration and operating boundaries.
- Document LTP hop telemetry in the metrics guide and record the completed LTP work in the changelog.
- Add a real two-runtime mutual-RPK integration test that exercises configuration, runtime wiring, delivery, and shutdown.

## Validation

- Workspace build, tests, and Clippy passed on Ubuntu with all features enabled.
- A bounded cross-host mutual-RPK dogfood run delivered one event with its UUIDv7 identity and two ordered hop stamps, exposed the expected intra-node and network telemetry, and rejected a plaintext probe without delivery.
- Canonical A–D benchmark repetitions changed sign and moved the greater-than-2% failing workload from A to B. The owner accepted this as infrastructure noise rather than a demonstrated product regression; no additional benchmark run or gate was introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated LTP transport between nodes using mutual TLS 1.3 and Ed25519 identities.
  * Preserved event identifiers and routing history across hops, retries, queues, and dead-letter replay.
  * Added safeguards against routing cycles and excessive hop counts.
  * Added telemetry for peer registration, delivery latency, dropped events, identity mismatches, and peer activity.

* **Documentation**
  * Added setup, configuration, operational, metrics, and troubleshooting guidance for authenticated LTP transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->