### PR TITLE
fix(metrics): clarify process order and stats views

### DIFF
--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -938,14 +938,13 @@ impl ProcessMetricPlanValidator<'_> {
                 let expected = if let Some(existing) = self.edges.get(&(parent, name.clone())) {
                     *existing
                 } else {
+                    let step = self.next_step;
+                    self.next_step += 1;
                     let identity = self.raw.identities.get(*token).ok_or_else(|| {
                         anyhow::anyhow!("compiled nested process token is out of range")
                     })?;
-                    let parent_identity = self.raw.identities.get(parent).ok_or_else(|| {
-                        anyhow::anyhow!("compiled parent process token is out of range")
-                    })?;
                     if identity.parent != Some(parent)
-                        || identity.step != parent_identity.step
+                        || identity.step != step
                         || identity.kind != ProcessMetricNodeKind::Named(name.clone())
                     {
                         anyhow::bail!("compiled nested process token identity mismatch");
@@ -1092,8 +1091,6 @@ impl ProcessMetricsBuilder<'_> {
             PipelineStatement::ProcessChain(chain) => {
                 let mut nodes = Vec::with_capacity(chain.len());
                 for element in chain {
-                    let step = self.next_step;
-                    self.next_step += 1;
                     let (name, kind, body) = match element {
                         ProcessChainElement::Named(name) => (
                             name.as_str(),
@@ -1109,11 +1106,8 @@ impl ProcessMetricsBuilder<'_> {
                         ),
                     };
                     nodes.push(self.add_node(
-                        ProcessMetricNodeIdentity {
-                            parent: None,
-                            step,
-                            kind,
-                        },
+                        None,
+                        kind,
                         name,
                         format!("/{name}"),
                         body,
@@ -1149,14 +1143,16 @@ impl ProcessMetricsBuilder<'_> {
 
     fn add_node(
         &mut self,
-        identity: ProcessMetricNodeIdentity,
+        parent: Option<usize>,
+        kind: ProcessMetricNodeKind,
         name: &str,
         path: String,
         body: Option<&[ProcessStatement]>,
         ancestors: &mut Vec<(String, usize)>,
     ) -> Result<usize, crate::metrics::MetricsError> {
+        let step = self.next_step;
+        self.next_step += 1;
         let id = self.nodes.len();
-        let step = identity.step;
         self.nodes.push(ProcessMetricNode {
             counters: crate::metrics::ProcessCounters::register(
                 self.registry,
@@ -1169,11 +1165,12 @@ impl ProcessMetricsBuilder<'_> {
             #[cfg(test)]
             call_sites: Vec::new(),
         });
-        self.identities.push(identity);
+        self.identities
+            .push(ProcessMetricNodeIdentity { parent, step, kind });
         self.children.push(HashMap::new());
         ancestors.push((name.to_owned(), id));
         if let Some(body) = body {
-            self.nodes[id].body_plan = self.process_body(id, &path, step, body, ancestors)?;
+            self.nodes[id].body_plan = self.process_body(id, &path, body, ancestors)?;
         }
         ancestors.pop();
         Ok(id)
@@ -1183,14 +1180,11 @@ impl ProcessMetricsBuilder<'_> {
         &mut self,
         parent: usize,
         parent_path: &str,
-        step: usize,
         body: &[ProcessStatement],
         ancestors: &mut Vec<(String, usize)>,
     ) -> Result<Vec<ProcessMetricStatement>, crate::metrics::MetricsError> {
         body.iter()
-            .map(|statement| {
-                self.process_statement(parent, parent_path, step, statement, ancestors)
-            })
+            .map(|statement| self.process_statement(parent, parent_path, statement, ancestors))
             .collect()
     }
 
@@ -1198,7 +1192,6 @@ impl ProcessMetricsBuilder<'_> {
         &mut self,
         parent: usize,
         parent_path: &str,
-        step: usize,
         statement: &ProcessStatement,
         ancestors: &mut Vec<(String, usize)>,
     ) -> Result<ProcessMetricStatement, crate::metrics::MetricsError> {
@@ -1223,11 +1216,8 @@ impl ProcessMetricsBuilder<'_> {
                         .get(name)
                         .map(|process| process.body.as_slice());
                     let child = self.add_node(
-                        ProcessMetricNodeIdentity {
-                            parent: Some(parent),
-                            step,
-                            kind: ProcessMetricNodeKind::Named(name.clone()),
-                        },
+                        Some(parent),
+                        ProcessMetricNodeKind::Named(name.clone()),
                         name,
                         format!("{parent_path}/{name}"),
                         body,
@@ -1244,14 +1234,12 @@ impl ProcessMetricsBuilder<'_> {
                 let branches = chain
                     .branches
                     .iter()
-                    .map(|(_, body)| {
-                        self.process_branch(parent, parent_path, step, body, ancestors)
-                    })
+                    .map(|(_, body)| self.process_branch(parent, parent_path, body, ancestors))
                     .collect::<Result<Vec<_>, _>>()?;
                 let else_body = chain
                     .else_body
                     .as_deref()
-                    .map(|body| self.process_branch(parent, parent_path, step, body, ancestors))
+                    .map(|body| self.process_branch(parent, parent_path, body, ancestors))
                     .transpose()?;
                 Ok(ProcessMetricStatement::If {
                     branches,
@@ -1260,19 +1248,13 @@ impl ProcessMetricsBuilder<'_> {
             }
             ProcessStatement::Switch(_, arms) => Ok(ProcessMetricStatement::Switch(
                 arms.iter()
-                    .map(|arm| self.process_branch(parent, parent_path, step, &arm.body, ancestors))
+                    .map(|arm| self.process_branch(parent, parent_path, &arm.body, ancestors))
                     .collect::<Result<Vec<_>, _>>()?,
             )),
             ProcessStatement::TryCatch(try_body, catch_body) => {
                 Ok(ProcessMetricStatement::TryCatch {
-                    try_body: self.process_body(parent, parent_path, step, try_body, ancestors)?,
-                    catch_body: self.process_body(
-                        parent,
-                        parent_path,
-                        step,
-                        catch_body,
-                        ancestors,
-                    )?,
+                    try_body: self.process_body(parent, parent_path, try_body, ancestors)?,
+                    catch_body: self.process_body(parent, parent_path, catch_body, ancestors)?,
                 })
             }
             _ => Ok(ProcessMetricStatement::None),
@@ -1283,14 +1265,13 @@ impl ProcessMetricsBuilder<'_> {
         &mut self,
         parent: usize,
         parent_path: &str,
-        step: usize,
         body: &[BranchBody],
         ancestors: &mut Vec<(String, usize)>,
     ) -> Result<Vec<ProcessMetricStatement>, crate::metrics::MetricsError> {
         body.iter()
             .map(|item| match item {
                 BranchBody::Process(statement) => {
-                    self.process_statement(parent, parent_path, step, statement, ancestors)
+                    self.process_statement(parent, parent_path, statement, ancestors)
                 }
                 BranchBody::Pipeline(_) => Ok(ProcessMetricStatement::None),
             })

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -1293,18 +1293,18 @@ def pipeline topology {
         ];
         let expected = [
             ("1", "/parent_one", "parent_one"),
-            ("1", "/parent_one/leaf", "leaf"),
-            ("2", "/parent_two", "parent_two"),
-            ("2", "/parent_two/leaf", "leaf"),
-            ("3", "/repeated", "repeated"),
-            ("4", "/repeated", "repeated"),
-            ("5", "/dispatch", "dispatch"),
-            ("5", "/dispatch/leaf", "leaf"),
-            ("6", "/branch_then", "branch_then"),
-            ("7", "/branch_else", "branch_else"),
-            ("8", "/arm_first", "arm_first"),
-            ("9", "/arm_default", "arm_default"),
-            ("10", "/(inline)", "(inline)"),
+            ("2", "/parent_one/leaf", "leaf"),
+            ("3", "/parent_two", "parent_two"),
+            ("4", "/parent_two/leaf", "leaf"),
+            ("5", "/repeated", "repeated"),
+            ("6", "/repeated", "repeated"),
+            ("7", "/dispatch", "dispatch"),
+            ("8", "/dispatch/leaf", "leaf"),
+            ("9", "/branch_then", "branch_then"),
+            ("10", "/branch_else", "branch_else"),
+            ("11", "/arm_first", "arm_first"),
+            ("12", "/arm_default", "arm_default"),
+            ("13", "/(inline)", "(inline)"),
         ];
         for family in process_families {
             let series = metric_series(&registry, family);
@@ -1413,8 +1413,8 @@ def pipeline p {
         .expect("compile process metric plan");
 
         let parent_one = plan.root_token_for_testing(1).expect("parent_one token");
-        let parent_two = plan.root_token_for_testing(2).expect("parent_two token");
-        let dispatch = plan.root_token_for_testing(3).expect("dispatch token");
+        let parent_two = plan.root_token_for_testing(3).expect("parent_two token");
+        let dispatch = plan.root_token_for_testing(5).expect("dispatch token");
         let parent_one_leaf = plan
             .child_token_for_testing(parent_one, 0)
             .expect("parent_one leaf token");
@@ -1503,7 +1503,7 @@ def pipeline execute { process dispatch; finish }
             &execution_registry,
             &[
                 ("pipeline", "execute"),
-                ("step", "1"),
+                ("step", "2"),
                 ("process_path", "/dispatch/leaf"),
                 ("process_name", "leaf"),
             ],
@@ -1771,9 +1771,9 @@ def pipeline p_fallback { process defaults; finish }
             "p_nonfirst",
             &[
                 ("1", "/nonfirst", "nonfirst", [1, 1, 0, 0]),
-                ("1", "/nonfirst/first", "first", [0, 0, 0, 0]),
-                ("1", "/nonfirst/selected", "selected", [2, 2, 0, 0]),
-                ("1", "/nonfirst/fallback", "fallback", [0, 0, 0, 0]),
+                ("2", "/nonfirst/first", "first", [0, 0, 0, 0]),
+                ("3", "/nonfirst/selected", "selected", [2, 2, 0, 0]),
+                ("4", "/nonfirst/fallback", "fallback", [0, 0, 0, 0]),
             ],
         )
         .await;
@@ -1782,9 +1782,9 @@ def pipeline p_fallback { process defaults; finish }
             "p_fallback",
             &[
                 ("1", "/defaults", "defaults", [1, 1, 0, 0]),
-                ("1", "/defaults/first", "first", [0, 0, 0, 0]),
-                ("1", "/defaults/selected", "selected", [0, 0, 0, 0]),
-                ("1", "/defaults/fallback", "fallback", [2, 2, 0, 0]),
+                ("2", "/defaults/first", "first", [0, 0, 0, 0]),
+                ("3", "/defaults/selected", "selected", [0, 0, 0, 0]),
+                ("4", "/defaults/fallback", "fallback", [2, 2, 0, 0]),
             ],
         )
         .await;
@@ -1818,10 +1818,10 @@ def pipeline p_fallback {
             SOURCE,
             "p_nonfirst",
             &[
-                ("2", "/parent", "parent", [1, 1, 0, 0]),
-                ("2", "/parent/leaf", "leaf", [1, 1, 0, 0]),
-                ("5", "/parent", "parent", [1, 1, 0, 0]),
-                ("5", "/parent/leaf", "leaf", [1, 1, 0, 0]),
+                ("3", "/parent", "parent", [1, 1, 0, 0]),
+                ("4", "/parent/leaf", "leaf", [1, 1, 0, 0]),
+                ("9", "/parent", "parent", [1, 1, 0, 0]),
+                ("10", "/parent/leaf", "leaf", [1, 1, 0, 0]),
             ],
         )
         .await;
@@ -1829,10 +1829,10 @@ def pipeline p_fallback {
             SOURCE,
             "p_fallback",
             &[
-                ("3", "/parent", "parent", [1, 1, 0, 0]),
-                ("3", "/parent/leaf", "leaf", [1, 1, 0, 0]),
-                ("6", "/parent", "parent", [1, 1, 0, 0]),
+                ("5", "/parent", "parent", [1, 1, 0, 0]),
                 ("6", "/parent/leaf", "leaf", [1, 1, 0, 0]),
+                ("11", "/parent", "parent", [1, 1, 0, 0]),
+                ("12", "/parent/leaf", "leaf", [1, 1, 0, 0]),
             ],
         )
         .await;
@@ -1995,10 +1995,10 @@ def pipeline p { process dispatch; finish }
             fixture_event(),
         )
         .await;
-        for path in ["/dispatch", "/dispatch/leaf"] {
+        for (step, path) in [("1", "/dispatch"), ("2", "/dispatch/leaf")] {
             let labels = [
                 ("pipeline", "p"),
-                ("step", "1"),
+                ("step", step),
                 ("process_path", path),
                 ("process_name", path.rsplit('/').next().unwrap()),
             ];
@@ -2016,10 +2016,13 @@ def pipeline p { process dispatch; finish }
             fixture_event(),
         )
         .await;
-        for (path, name) in [("/dispatch", "dispatch"), ("/dispatch/leaf", "leaf")] {
+        for (step, path, name) in [
+            ("1", "/dispatch", "dispatch"),
+            ("2", "/dispatch/leaf", "leaf"),
+        ] {
             let labels = [
                 ("pipeline", "p"),
-                ("step", "1"),
+                ("step", step),
                 ("process_path", path),
                 ("process_name", name),
             ];
@@ -2064,7 +2067,7 @@ def pipeline p { process catcher; finish }
             &caught,
             &[
                 ("pipeline", "p"),
-                ("step", "1"),
+                ("step", "2"),
                 ("process_path", "/catcher/fail"),
                 ("process_name", "fail"),
             ],
@@ -2091,10 +2094,10 @@ def pipeline p { process outer; finish }
             fixture_event(),
         )
         .await;
-        for (path, name) in [("/outer", "outer"), ("/outer/fail", "fail")] {
+        for (step, path, name) in [("1", "/outer", "outer"), ("2", "/outer/fail", "fail")] {
             let labels = [
                 ("pipeline", "p"),
-                ("step", "1"),
+                ("step", step),
                 ("process_path", path),
                 ("process_name", name),
             ];
@@ -2164,12 +2167,12 @@ def pipeline nested { process outer; finish }
             ),
             1
         );
-        for (path, name) in [("/outer", "outer"), ("/outer/leaf", "leaf")] {
+        for (step, path, name) in [("1", "/outer", "outer"), ("2", "/outer/leaf", "leaf")] {
             assert_process_vector(
                 &nested,
                 &[
                     ("pipeline", "nested"),
-                    ("step", "1"),
+                    ("step", step),
                     ("process_path", path),
                     ("process_name", name),
                 ],

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -622,7 +622,24 @@ impl ProcessIdentity {
 
 type ProcessMetricValues = BTreeMap<ProcessIdentity, u64>;
 
-fn process_tree_names(identities: &[&ProcessIdentity]) -> Vec<(String, String)> {
+fn process_tree_names(identities: &[&ProcessIdentity]) -> Option<Vec<(String, String)>> {
+    let mut active_ancestors: Vec<&ProcessIdentity> = Vec::new();
+    for identity in identities {
+        let depth = identity.depth();
+        if depth == 0 {
+            return None;
+        }
+        active_ancestors.truncate(depth - 1);
+        if depth > 1 {
+            let parent = active_ancestors.get(depth - 2)?;
+            let (parent_path, _) = identity.process_path.rsplit_once('/')?;
+            if parent.process_path != parent_path {
+                return None;
+            }
+        }
+        active_ancestors.push(*identity);
+    }
+
     let depths = identities
         .iter()
         .map(|identity| identity.depth())
@@ -639,7 +656,7 @@ fn process_tree_names(identities: &[&ProcessIdentity]) -> Vec<(String, String)> 
         .collect::<Vec<_>>();
 
     let mut ancestor_is_last = Vec::new();
-    identities
+    let names = identities
         .iter()
         .enumerate()
         .map(|(index, identity)| {
@@ -663,7 +680,8 @@ fn process_tree_names(identities: &[&ProcessIdentity]) -> Vec<(String, String)> 
             ancestor_is_last.push(is_last_sibling[index]);
             (rendered, detail_prefix)
         })
-        .collect()
+        .collect();
+    Some(names)
 }
 
 fn format_stats(json: &str) {
@@ -902,7 +920,7 @@ fn render_default_stats_inner(
                 identities[start..end]
                     .iter()
                     .copied()
-                    .zip(process_tree_names(&identities[start..end])),
+                    .zip(process_tree_names(&identities[start..end])?),
             );
             start = end;
         }
@@ -1772,15 +1790,61 @@ mod tests {
         });
         assert_eq!(
             process_tree_names(&identities.iter().collect::<Vec<_>>()),
-            [
+            Some(vec![
                 ("├─ first".to_owned(), "│  ".to_owned()),
                 ("├─ second".to_owned(), "│  ".to_owned()),
                 ("│  ├─ child_a".to_owned(), "│  │  ".to_owned()),
                 ("│  │  └─ leaf".to_owned(), "│  │     ".to_owned()),
                 ("│  └─ child_b".to_owned(), "│     ".to_owned()),
                 ("└─ third".to_owned(), "   ".to_owned()),
-            ]
+            ])
         );
+    }
+
+    #[test]
+    fn process_tree_names_reject_false_parent_topologies() {
+        let identities = |paths: &[&str]| {
+            paths
+                .iter()
+                .enumerate()
+                .map(|(index, path)| ProcessIdentity {
+                    pipeline: "pipeline".to_owned(),
+                    step: index + 1,
+                    process_path: (*path).to_owned(),
+                    process_name: path.rsplit('/').next().unwrap().to_owned(),
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for paths in [
+            &["/a", "/b/c"][..],
+            &["/a", "/a/b/c"][..],
+            &["/a", "/a/b", "/a/c/d"][..],
+        ] {
+            let identities = identities(paths);
+            assert!(process_tree_names(&identities.iter().collect::<Vec<_>>()).is_none());
+        }
+    }
+
+    #[test]
+    fn false_process_topology_preserves_mode_specific_fallbacks() {
+        let mut fixture = serde_json::to_value(process_tree_snapshot()).unwrap();
+        for family in fixture["metrics"].as_array_mut().unwrap() {
+            let Some(series) = family["series"].as_array_mut() else {
+                continue;
+            };
+            for item in series {
+                if item["labels"]["process_path"] == "/root_two/child_a" {
+                    item["labels"]["process_path"] = "/missing/child_a".into();
+                }
+            }
+        }
+        let snapshot = serde_json::from_value(fixture).unwrap();
+
+        assert!(render_default_stats(&snapshot).is_none());
+        let details = render_stats_details(&snapshot).unwrap();
+        assert!(!details.contains("\nProcesses:\n"));
+        assert!(details.contains("series: unavailable as a process summary; use --raw"));
     }
 
     #[test]

--- a/crates/limpidctl/src/main.rs
+++ b/crates/limpidctl/src/main.rs
@@ -7,7 +7,7 @@
 //!   limpidctl inject input <name> [--json]  Inject stdin lines into a named input
 //!   limpidctl inject output <name> [--json] Inject stdin lines into a named output queue
 //!   limpidctl list [--json]                 List pipelines and tap points
-//!   limpidctl stats [--json]                Show pipeline/output metrics
+//!   limpidctl stats [--details|--raw|--json] Show pipeline/output metrics
 //!   limpidctl health [--json]               Check daemon health
 //!
 //! Connects to limpid's control socket (default: /var/run/limpid/control.sock).
@@ -55,12 +55,15 @@ enum Command {
     },
     /// Show pipeline/input/output metrics
     Stats {
-        /// Output raw JSON instead of formatted text
-        #[arg(long, conflicts_with = "details")]
+        /// Output schema-v1 JSON instead of formatted text
+        #[arg(long, conflicts_with_all = ["details", "raw"])]
         json: bool,
-        /// Show every metric family and series with complete labels
-        #[arg(long, conflicts_with = "json")]
+        /// Show expanded human-readable metrics
+        #[arg(long, conflicts_with_all = ["json", "raw"])]
         details: bool,
+        /// Show every metric family and series in the legacy text format
+        #[arg(long, conflicts_with_all = ["json", "details"])]
+        raw: bool,
     },
     /// Check daemon health
     Health {
@@ -237,11 +240,13 @@ fn main() {
                 format_list(&response);
             }
         }
-        Command::Stats { json, details } => {
+        Command::Stats { json, details, raw } => {
             let response = query_command(&cli.socket, "stats");
             exit_on_daemon_error(&response);
             if json {
                 print!("{}", response);
+            } else if raw {
+                format_stats_raw(&response);
             } else if details {
                 format_stats_details(&response);
             } else {
@@ -606,7 +611,60 @@ struct ProcessIdentity {
     process_name: String,
 }
 
+impl ProcessIdentity {
+    fn depth(&self) -> usize {
+        self.process_path
+            .bytes()
+            .filter(|byte| *byte == b'/')
+            .count()
+    }
+}
+
 type ProcessMetricValues = BTreeMap<ProcessIdentity, u64>;
+
+fn process_tree_names(identities: &[&ProcessIdentity]) -> Vec<(String, String)> {
+    let depths = identities
+        .iter()
+        .map(|identity| identity.depth())
+        .collect::<Vec<_>>();
+    let is_last_sibling = depths
+        .iter()
+        .enumerate()
+        .map(|(index, depth)| {
+            depths[index + 1..]
+                .iter()
+                .find(|next_depth| **next_depth <= *depth)
+                .is_none_or(|next_depth| *next_depth < *depth)
+        })
+        .collect::<Vec<_>>();
+
+    let mut ancestor_is_last = Vec::new();
+    identities
+        .iter()
+        .enumerate()
+        .map(|(index, identity)| {
+            ancestor_is_last.truncate(identity.depth().saturating_sub(1));
+            let mut rendered = String::new();
+            for is_last in &ancestor_is_last {
+                rendered.push_str(if *is_last { "   " } else { "│  " });
+            }
+            let mut detail_prefix = rendered.clone();
+            rendered.push_str(if is_last_sibling[index] {
+                "└─ "
+            } else {
+                "├─ "
+            });
+            detail_prefix.push_str(if is_last_sibling[index] {
+                "   "
+            } else {
+                "│  "
+            });
+            rendered.push_str(&identity.process_name);
+            ancestor_is_last.push(is_last_sibling[index]);
+            (rendered, detail_prefix)
+        })
+        .collect()
+}
 
 fn format_stats(json: &str) {
     let rendered = serde_json::from_str::<MetricsSnapshot>(json)
@@ -621,18 +679,19 @@ fn format_stats(json: &str) {
 /// Renders the operator table (Pipelines, Inputs, Outputs) from a
 /// schema v1 snapshot. Families outside the canonical 16 are
 /// skipped here so the layout stays operator-runbook-shaped —
-/// well-formed non-canonical families render under `--details`,
-/// malformed ones trigger the raw fallback there too. A canonical
+/// `--details` adds them in a separate human-readable section, while
+/// `--raw` preserves the complete legacy family exposition. A canonical
 /// family that fails validation returns `None`, so the caller falls
 /// back to the raw response rather than emit a partial table that
 /// omits or lies about a counter.
 fn render_default_stats(snapshot: &MetricsSnapshot) -> Option<String> {
-    render_default_stats_inner(snapshot, true)
+    render_default_stats_inner(snapshot, true, false)
 }
 
 fn render_default_stats_inner(
     snapshot: &MetricsSnapshot,
     validate_process_families: bool,
+    show_process_identity: bool,
 ) -> Option<String> {
     if snapshot.schema != 1 {
         return None;
@@ -830,20 +889,52 @@ fn render_default_stats_inner(
     }
     if let Some(identities) = process_identities {
         writeln!(rendered, "\nProcesses:").ok()?;
-        for identity in identities.keys() {
+        let identities = identities.keys().collect::<Vec<_>>();
+        let mut process_rows = Vec::with_capacity(identities.len());
+        let mut start = 0;
+        while start < identities.len() {
+            let pipeline = &identities[start].pipeline;
+            let end = identities[start..]
+                .iter()
+                .position(|identity| identity.pipeline != *pipeline)
+                .map_or(identities.len(), |offset| start + offset);
+            process_rows.extend(
+                identities[start..end]
+                    .iter()
+                    .copied()
+                    .zip(process_tree_names(&identities[start..end])),
+            );
+            start = end;
+        }
+        let name_width = process_rows
+            .iter()
+            .map(|(_, (name, _))| name.chars().count())
+            .max()
+            .unwrap_or(0);
+        let mut current_pipeline = None;
+        for (identity, (process_name, detail_prefix)) in process_rows {
+            if current_pipeline != Some(identity.pipeline.as_str()) {
+                writeln!(rendered, "  {}", identity.pipeline).ok()?;
+                current_pipeline = Some(identity.pipeline.as_str());
+            }
             writeln!(
                 rendered,
-                "  {:<16} {:>4}  {:<32} {:<16} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
-                identity.pipeline,
-                identity.step,
-                identity.process_path,
-                identity.process_name,
+                "  {:<name_width$} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
+                process_name,
                 process_metric_value(&process_families, PROCESS_METRICS[0], identity)?,
                 process_metric_value(&process_families, PROCESS_METRICS[1], identity)?,
                 process_metric_value(&process_families, PROCESS_METRICS[2], identity)?,
                 process_metric_value(&process_families, PROCESS_METRICS[3], identity)?,
             )
             .ok()?;
+            if show_process_identity {
+                writeln!(
+                    rendered,
+                    "  {detail_prefix}step: {}  path: {}",
+                    identity.step, identity.process_path
+                )
+                .ok()?;
+            }
         }
     }
     Some(rendered)
@@ -938,6 +1029,16 @@ fn format_stats_details(json: &str) {
     }
 }
 
+fn format_stats_raw(json: &str) {
+    let rendered = serde_json::from_str::<MetricsSnapshot>(json)
+        .ok()
+        .and_then(|snapshot| render_stats_raw(&snapshot));
+    match rendered {
+        Some(rendered) => print!("{}", rendered),
+        None => print!("{}", json),
+    }
+}
+
 fn render_stats_details(snapshot: &MetricsSnapshot) -> Option<String> {
     if snapshot.schema != 1 {
         return None;
@@ -953,10 +1054,104 @@ fn render_stats_details(snapshot: &MetricsSnapshot) -> Option<String> {
     // subset leaks. Well-formed non-canonical families are
     // intentionally unaffected — the fallback scopes to the
     // canonical subset only.
+    let has_canonical_metrics = metrics.iter().any(|metric| is_default_metric(&metric.name));
+    let (summary, has_process_summary) = if has_canonical_metrics {
+        let base = render_default_stats_inner(snapshot, false, false)?;
+        match render_default_stats_inner(snapshot, true, true) {
+            Some(summary) => {
+                let has_process_summary = summary.contains("\nProcesses:\n");
+                (summary, has_process_summary)
+            }
+            None => (base, false),
+        }
+    } else {
+        (String::new(), false)
+    };
+    metrics.sort_by(|left, right| left.name.cmp(&right.name));
+    if metrics.windows(2).any(|pair| pair[0].name == pair[1].name) {
+        return None;
+    }
+
+    let metrics = metrics;
+    let mut rendered = summary;
+    if !metrics.is_empty() {
+        if !rendered.is_empty() {
+            rendered.push('\n');
+        }
+        writeln!(rendered, "Metrics:").ok()?;
+    }
+    for metric in metrics {
+        writeln!(rendered, "  {}", metric.name).ok()?;
+        writeln!(rendered, "    type: {}", metric.kind.name()).ok()?;
+        writeln!(rendered, "    help: {}", metric.help).ok()?;
+        if PROCESS_METRICS.contains(&metric.name.as_str()) {
+            let summary = if has_process_summary {
+                if metric.name == DROPPED_EVENTS_METRIC {
+                    "summarized in Pipelines and Processes above"
+                } else {
+                    "summarized in Processes above"
+                }
+            } else {
+                "unavailable as a process summary; use --raw"
+            };
+            writeln!(rendered, "    series: {summary}").ok()?;
+            continue;
+        }
+        writeln!(rendered, "    series:").ok()?;
+        match metric.kind {
+            DetailKind::Counter(series) | DetailKind::Gauge(series) => {
+                for item in series {
+                    render_detail_labels(&mut rendered, &item.labels)?;
+                    writeln!(rendered, "        value: {}", item.value).ok()?;
+                }
+            }
+            DetailKind::Histogram(series) => {
+                for item in series {
+                    render_detail_labels(&mut rendered, &item.labels)?;
+                    writeln!(rendered, "        buckets:").ok()?;
+                    for (bound, count) in item.buckets {
+                        writeln!(rendered, "          <= {bound}: {count}").ok()?;
+                    }
+                    writeln!(rendered, "        sum: {}", item.sum).ok()?;
+                    writeln!(rendered, "        count: {}", item.count).ok()?;
+                }
+            }
+        }
+    }
+    Some(rendered)
+}
+
+fn is_default_metric(name: &str) -> bool {
+    known_metric_label(name).is_some()
+        || PROCESS_METRICS.contains(&name)
+        || name == DROPPED_EVENTS_METRIC
+}
+
+fn render_detail_labels(rendered: &mut String, labels: &[(String, String)]) -> Option<()> {
+    if labels.is_empty() {
+        writeln!(rendered, "      - labels: none").ok()?;
+        return Some(());
+    }
+    writeln!(rendered, "      - labels:").ok()?;
+    for (key, value) in labels {
+        writeln!(rendered, "          {key}: \"{}\"", value.escape_default()).ok()?;
+    }
+    Some(())
+}
+
+fn render_stats_raw(snapshot: &MetricsSnapshot) -> Option<String> {
+    if snapshot.schema != 1 {
+        return None;
+    }
+    let mut metrics: Vec<DetailMetric> = snapshot
+        .metrics
+        .iter()
+        .map(parse_detail_metric)
+        .collect::<Option<_>>()?;
     if metrics
         .iter()
         .any(|metric| known_metric_label(&metric.name).is_some())
-        && render_default_stats_inner(snapshot, false).is_none()
+        && render_default_stats_inner(snapshot, false, false).is_none()
     {
         return None;
     }
@@ -1496,6 +1691,167 @@ mod tests {
             }));
         }
         serde_json::from_value(serde_json::json!({"schema": 1, "metrics": metrics})).unwrap()
+    }
+
+    fn process_tree_snapshot() -> limpid_metrics_schema::MetricsSnapshot {
+        let mut payload = serde_json::to_value(canonical_shared_snapshot(false)).unwrap();
+        let identities = [
+            ("compact", 2, "/root_one", "root_one"),
+            ("compact", 3, "/root_two", "root_two"),
+            ("compact", 4, "/root_two/child_a", "child_a"),
+            (
+                "compact",
+                5,
+                "/root_two/child_a/parse_paloalto_cef_normalize_severity",
+                "parse_paloalto_cef_normalize_severity",
+            ),
+            ("compact", 6, "/root_two/child_b", "child_b"),
+            ("compact", 7, "/root_two/child_b/leaf", "leaf"),
+            ("compact", 8, "/duplicate_root", "duplicate_root"),
+            ("compact", 9, "/duplicate_root", "duplicate_root"),
+            ("full", 1, "/only_root", "only_root"),
+        ];
+        let process_series = || {
+            identities
+                .iter()
+                .map(|(pipeline, step, process_path, process_name)| {
+                    serde_json::json!({
+                        "labels": {
+                            "pipeline": pipeline,
+                            "step": step.to_string(),
+                            "process_path": process_path,
+                            "process_name": process_name,
+                        },
+                        "value": step,
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
+        for name in [
+            "limpid_process_events_in_total",
+            "limpid_process_events_out_total",
+            "limpid_process_events_errored_total",
+        ] {
+            payload["metrics"]
+                .as_array_mut()
+                .unwrap()
+                .push(serde_json::json!({
+                    "name": name,
+                    "type": "counter",
+                    "help": "Process invocation fixture.",
+                    "series": process_series(),
+                }));
+        }
+        payload["metrics"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|family| family["name"] == DROPPED_EVENTS_METRIC)
+            .unwrap()["series"]
+            .as_array_mut()
+            .unwrap()
+            .extend(process_series());
+        serde_json::from_value(payload).unwrap()
+    }
+
+    #[test]
+    fn process_tree_names_render_siblings_and_ancestor_continuations() {
+        let identities = [
+            (1, "/first", "first"),
+            (2, "/second", "second"),
+            (3, "/second/child_a", "child_a"),
+            (4, "/second/child_a/leaf", "leaf"),
+            (5, "/second/child_b", "child_b"),
+            (6, "/third", "third"),
+        ]
+        .map(|(step, process_path, process_name)| ProcessIdentity {
+            pipeline: "pipeline".to_owned(),
+            step,
+            process_path: process_path.to_owned(),
+            process_name: process_name.to_owned(),
+        });
+        assert_eq!(
+            process_tree_names(&identities.iter().collect::<Vec<_>>()),
+            [
+                ("├─ first".to_owned(), "│  ".to_owned()),
+                ("├─ second".to_owned(), "│  ".to_owned()),
+                ("│  ├─ child_a".to_owned(), "│  │  ".to_owned()),
+                ("│  │  └─ leaf".to_owned(), "│  │     ".to_owned()),
+                ("│  └─ child_b".to_owned(), "│     ".to_owned()),
+                ("└─ third".to_owned(), "   ".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn process_tree_is_byte_exact_grouped_and_dynamically_aligned() {
+        let rendered = render_default_stats(&process_tree_snapshot()).unwrap();
+        let processes = rendered
+            .split_once("Processes:\n")
+            .map(|(_, processes)| processes)
+            .expect("process section");
+        let expected = format!(
+            concat!(
+                "  compact\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+                "  full\n",
+                "  {:<46} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+            ),
+            "├─ root_one",
+            2,
+            2,
+            2,
+            2,
+            "├─ root_two",
+            3,
+            3,
+            3,
+            3,
+            "│  ├─ child_a",
+            4,
+            4,
+            4,
+            4,
+            "│  │  └─ parse_paloalto_cef_normalize_severity",
+            5,
+            5,
+            5,
+            5,
+            "│  └─ child_b",
+            6,
+            6,
+            6,
+            6,
+            "│     └─ leaf",
+            7,
+            7,
+            7,
+            7,
+            "├─ duplicate_root",
+            8,
+            8,
+            8,
+            8,
+            "└─ duplicate_root",
+            9,
+            9,
+            9,
+            9,
+            "└─ only_root",
+            1,
+            1,
+            1,
+            1,
+        );
+        assert_eq!(processes, expected);
+        assert!(!processes.contains('\t'));
     }
 
     #[test]

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -513,7 +513,7 @@ fn line_tokens(text: &str, token: &str) -> Vec<String> {
 }
 
 #[test]
-fn process_counters_render_a_numerically_sorted_default_invocation_table() {
+fn process_counters_render_a_source_ordered_tree_and_preserve_raw_modes() {
     let payload = process_snapshot();
     let response = format!("{payload}\n");
 
@@ -528,78 +528,101 @@ fn process_counters_render_a_numerically_sorted_default_invocation_table() {
         .split_whitespace()
         .collect::<Vec<_>>();
     assert_eq!(process_header, ["Processes:"]);
+    let pipeline_row = default
+        .lines()
+        .find(|line| line.trim() == "compact")
+        .expect("pipeline heading");
+    assert_eq!(pipeline_row, "  compact");
     let root_row = default
         .lines()
-        .find(|line| line.contains("/dispatch "))
+        .find(|line| line.split_whitespace().nth(1) == Some("dispatch"))
         .expect("root process row");
     assert_eq!(
         root_row,
         format!(
-            "  {:<16} {:>4}  {:<32} {:<16} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
-            "compact", 2, "/dispatch", "dispatch", 4, 4, 0, 0
+            "  {:<11} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
+            "└─ dispatch", 4, 4, 0, 0
         )
     );
     let leaf_row = default
         .lines()
-        .find(|line| line.contains("/dispatch/leaf "))
+        .find(|line| line.split_whitespace().nth(1) == Some("leaf"))
         .expect("leaf process row");
     assert_eq!(
         leaf_row,
         format!(
-            "  {:<16} {:>4}  {:<32} {:<16} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
-            "compact", 10, "/dispatch/leaf", "leaf", 3, 1, 1, 1
+            "  {:<11} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored",
+            "   └─ leaf", 3, 1, 1, 1
         )
     );
     assert_eq!(
-        line_tokens(&default, "/dispatch"),
+        line_tokens(&default, "dispatch"),
         [
-            "compact",
-            "2",
-            "/dispatch",
-            "dispatch",
-            "4",
-            "in",
-            "4",
-            "out",
-            "0",
-            "dropped",
-            "0",
-            "errored",
+            "└─", "dispatch", "4", "in", "4", "out", "0", "dropped", "0", "errored",
         ]
     );
     assert_eq!(
-        line_tokens(&default, "/dispatch/leaf"),
+        line_tokens(&default, "leaf"),
         [
-            "compact",
-            "10",
-            "/dispatch/leaf",
-            "leaf",
-            "3",
-            "in",
-            "1",
-            "out",
-            "1",
-            "dropped",
-            "1",
-            "errored",
+            "└─", "leaf", "3", "in", "1", "out", "1", "dropped", "1", "errored",
         ]
     );
-    let root = default.find("/dispatch ").expect("root row");
-    let leaf = default.find("/dispatch/leaf ").expect("leaf row");
-    assert!(root < leaf, "step 2 must sort before step 10 numerically");
+    assert!(!default.contains("/dispatch"));
+    let root = default.find(root_row).expect("root row");
+    let leaf = default.find(leaf_row).expect("leaf row");
+    assert!(root < leaf, "source-order step 2 must sort before step 10");
 
     let details = run_stats(&response, &["--details"]);
     assert!(details.status.success(), "{details:?}");
     let details = stdout(&details);
+    assert!(details.contains("  └─ dispatch"));
+    assert!(details.contains("     step: 2  path: /dispatch"));
+    assert!(details.contains("     └─ leaf"));
+    assert!(details.contains("        step: 10  path: /dispatch/leaf"));
+    assert_eq!(details.matches("limpid_process_events_in_total").count(), 1);
+    assert!(details.contains("series: summarized in Processes above"));
+    assert!(!details.contains("process_path: \"/dispatch"));
+    let process_summary = details
+        .split_once("\nMetrics:\n")
+        .map(|(summary, _)| summary)
+        .expect("expanded metrics section");
+    let expected_process_summary = format!(
+        concat!(
+            "{}",
+            "\nProcesses:\n",
+            "  compact\n",
+            "  {:<11} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+            "     step: 2  path: /dispatch\n",
+            "  {:<11} {:>8} in  {:>8} out  {:>8} dropped  {:>8} errored\n",
+            "        step: 10  path: /dispatch/leaf\n",
+        ),
+        expected_default_table(),
+        "└─ dispatch",
+        4,
+        4,
+        0,
+        0,
+        "   └─ leaf",
+        3,
+        1,
+        1,
+        1,
+    );
+    assert_eq!(process_summary, expected_process_summary);
+    assert!(!process_summary.contains('\t'));
+
+    let raw = run_stats(&response, &["--raw"]);
+    assert!(raw.status.success(), "{raw:?}");
+    let raw = stdout(&raw);
     for name in [
         "limpid_process_events_in_total",
         "limpid_process_events_out_total",
         "limpid_events_dropped_total",
         "limpid_process_events_errored_total",
     ] {
-        assert!(details.contains(name), "missing {name}");
+        assert!(raw.contains(name), "missing {name}");
     }
-    assert!(details.contains(
+    assert!(raw.contains(
         r#"pipeline="compact", process_name="leaf", process_path="/dispatch/leaf", step="10""#
     ));
 
@@ -686,7 +709,7 @@ fn malformed_dropped_hierarchy_roots_fall_back_to_the_raw_response() {
         ("missing root", missing_root),
     ] {
         let response = format!("{payload}\n");
-        for args in [&[][..], &["--details"][..]] {
+        for args in [&[][..], &["--details"][..], &["--raw"][..]] {
             let output = run_stats(&response, args);
             assert!(output.status.success(), "{name}: {output:?}");
             assert_eq!(output.stdout, response.as_bytes(), "{name}: {args:?}");
@@ -695,7 +718,7 @@ fn malformed_dropped_hierarchy_roots_fall_back_to_the_raw_response() {
 }
 
 #[test]
-fn details_remains_generic_for_process_default_validator_only_defects() {
+fn details_omit_the_process_summary_when_process_validation_fails() {
     for (name, payload) in process_default_validator_only_defects() {
         let response = format!("{payload}\n");
         let output = run_stats(&response, &["--details"]);
@@ -703,14 +726,22 @@ fn details_remains_generic_for_process_default_validator_only_defects() {
         assert_ne!(
             output.stdout,
             response.as_bytes(),
-            "{name} is DTO-valid and must remain generic in details mode"
+            "{name} is DTO-valid and must remain human-readable in details mode"
         );
-        assert!(stdout(&output).contains("limpid_process_events_in_total"));
+        let text = stdout(&output);
+        assert!(text.contains("Pipelines:"));
+        assert!(!text.contains("Processes:"));
+        assert!(text.contains("limpid_process_events_in_total"));
+        assert!(text.contains("series: unavailable as a process summary; use --raw"));
+
+        let raw = run_stats(&response, &["--raw"]);
+        assert!(raw.status.success(), "{name}: {raw:?}");
+        assert!(stdout(&raw).contains("limpid_process_events_in_total"));
     }
 }
 
 #[test]
-fn details_remains_generic_when_process_families_are_incomplete() {
+fn details_omit_the_process_summary_when_process_families_are_incomplete() {
     let mut payload = process_snapshot();
     payload["metrics"]
         .as_array_mut()
@@ -721,7 +752,15 @@ fn details_remains_generic_when_process_families_are_incomplete() {
     let output = run_stats(&response, &["--details"]);
     assert!(output.status.success(), "{output:?}");
     assert_ne!(output.stdout, response.as_bytes());
-    assert!(stdout(&output).contains("limpid_process_events_in_total"));
+    let text = stdout(&output);
+    assert!(text.contains("Pipelines:"));
+    assert!(!text.contains("Processes:"));
+    assert!(text.contains("limpid_process_events_in_total"));
+    assert!(text.contains("series: unavailable as a process summary; use --raw"));
+
+    let raw = run_stats(&response, &["--raw"]);
+    assert!(raw.status.success(), "{raw:?}");
+    assert!(stdout(&raw).contains("limpid_process_events_in_total"));
 }
 
 #[test]
@@ -742,7 +781,7 @@ fn json_mode_preserves_the_complete_control_response() {
 }
 
 #[test]
-fn details_renders_all_types_with_deterministic_order_and_complete_fields() {
+fn details_and_raw_render_all_types_with_deterministic_complete_fields() {
     let payload = json!({
         "schema": 1,
         "metrics": [
@@ -784,42 +823,65 @@ fn details_renders_all_types_with_deterministic_order_and_complete_fields() {
         "stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let text = stdout(&output);
+    let expected_details = concat!(
+        "Metrics:\n",
+        "  metric_alpha\n",
+        "    type: counter\n",
+        "    help: Accepted events.\n",
+        "    series:\n",
+        "      - labels:\n",
+        "          a: \"one\"\n",
+        "          z: \"last\"\n",
+        "        value: 1\n",
+        "      - labels:\n",
+        "          a: \"two\"\n",
+        "          z: \"first\"\n",
+        "        value: 2\n",
+        "  metric_middle\n",
+        "    type: gauge\n",
+        "    help: Current depth.\n",
+        "    series:\n",
+        "      - labels:\n",
+        "          env: \"prod\\\"east\\\\one\\nline\"\n",
+        "        value: 9\n",
+        "  metric_zeta\n",
+        "    type: histogram\n",
+        "    help: Latency distribution.\n",
+        "    series:\n",
+        "      - labels:\n",
+        "          route: \"west\"\n",
+        "        buckets:\n",
+        "          <= 0.125: 17\n",
+        "          <= 0.875: 29\n",
+        "        sum: 13.75\n",
+        "        count: 31\n",
+    );
+    assert_eq!(stdout(&output), expected_details);
 
-    let counter = text.find("metric_alpha").unwrap();
-    let gauge = text.find("metric_middle").unwrap();
-    let histogram = text.find("metric_zeta").unwrap();
-    assert!(counter < gauge && gauge < histogram);
-    let counter_block = &text[counter..gauge];
-    let gauge_block = &text[gauge..histogram];
-    let histogram_block = &text[histogram..];
-    assert!(counter_block.contains("counter"));
-    assert!(counter_block.contains("Accepted events."));
-    assert!(text.find("a=\"one\"").unwrap() < text.find("a=\"two\"").unwrap());
-    assert!(counter_block.contains(
-        r#"  labels: a="one", z="last"
-    value: 1
-"#
-    ));
-    assert!(counter_block.contains(
-        r#"  labels: a="two", z="first"
-    value: 2
-"#
-    ));
-    assert!(gauge_block.contains("gauge"));
-    assert!(gauge_block.contains("Current depth."));
-    assert!(gauge_block.contains(
-        r#"  labels: env="prod\"east\\one\nline"
-    value: 9
-"#
-    ));
-    assert!(histogram_block.contains("histogram"));
-    assert!(histogram_block.contains("Latency distribution."));
-    assert!(histogram_block.contains("route=\"west\""));
-    assert!(histogram_block.contains("    buckets: 0.125 => 17 0.875 => 29\n"));
-    assert!(histogram_block.contains("    sum: 13.75\n"));
-    assert!(histogram_block.contains("    count: 31\n"));
-    assert!(!histogram_block.contains("+Inf"));
+    let raw = run_stats(&response, &["--raw"]);
+    assert!(raw.status.success(), "{raw:?}");
+    let expected_raw = concat!(
+        "metric_alpha:\n",
+        "  type: counter\n",
+        "  help: Accepted events.\n",
+        "  labels: a=\"one\", z=\"last\"\n",
+        "    value: 1\n",
+        "  labels: a=\"two\", z=\"first\"\n",
+        "    value: 2\n",
+        "metric_middle:\n",
+        "  type: gauge\n",
+        "  help: Current depth.\n",
+        "  labels: env=\"prod\\\"east\\\\one\\nline\"\n",
+        "    value: 9\n",
+        "metric_zeta:\n",
+        "  type: histogram\n",
+        "  help: Latency distribution.\n",
+        "  labels: route=\"west\"\n",
+        "    buckets: 0.125 => 17 0.875 => 29\n",
+        "    sum: 13.75\n",
+        "    count: 31\n",
+    );
+    assert_eq!(stdout(&raw), expected_raw);
 }
 
 #[test]
@@ -870,7 +932,7 @@ fn default_ignores_unknown_families_but_details_includes_them() {
     let details_output = run_stats(&response, &["--details"]);
     assert!(details_output.status.success(), "{:?}", details_output);
     assert!(stdout(&details_output).contains("future_metric"));
-    assert!(stdout(&details_output).contains("scope=\"future\""));
+    assert!(stdout(&details_output).contains("scope: \"future\""));
     assert!(stdout(&details_output).contains("42"));
 }
 
@@ -899,9 +961,15 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
     assert!(details.contains("limpid_build_info"));
     assert!(details.contains("gauge"));
     assert!(details.contains("Build information for the running limpid node."));
-    assert!(details.contains("node_id=\"edge-a\""));
-    assert!(details.contains("version=\"0.7.15\""));
+    assert!(details.contains("node_id: \"edge-a\""));
+    assert!(details.contains("version: \"0.7.15\""));
     assert!(details.contains("value: 1"));
+
+    let raw_output = run_stats(&response, &["--raw"]);
+    assert!(raw_output.status.success(), "{raw_output:?}");
+    let raw = stdout(&raw_output);
+    assert!(raw.contains("node_id=\"edge-a\""));
+    assert!(raw.contains("version=\"0.7.15\""));
 
     let json_output = run_stats(&response, &["--json"]);
     assert!(json_output.status.success(), "{json_output:?}");
@@ -976,7 +1044,7 @@ fn invalid_and_unsupported_responses_preserve_raw_fallback() {
         "{\"schema\":2,\"metrics\":[]}\n",
         "{\"schema\":1,\"metrics\":\"wrong\"}\n",
     ] {
-        for args in [&[][..], &["--details"][..]] {
+        for args in [&[][..], &["--details"][..], &["--raw"][..]] {
             let output = run_stats(response, args);
             assert!(
                 output.status.success(),
@@ -992,15 +1060,34 @@ fn invalid_and_unsupported_responses_preserve_raw_fallback() {
 }
 
 #[test]
-fn json_and_details_are_mutually_exclusive() {
+fn stats_output_modes_are_mutually_exclusive_and_documented() {
     let _process_guard = process_lock();
-    let output = Command::new(env!("CARGO_BIN_EXE_limpidctl"))
-        .args(["stats", "--json", "--details"])
+    for (left, right) in [
+        ("--json", "--details"),
+        ("--json", "--raw"),
+        ("--details", "--raw"),
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_limpidctl"))
+            .args(["stats", left, right])
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(2));
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains(left));
+        assert!(stderr.contains(right));
+        assert!(stderr.contains("cannot be used with"));
+    }
+
+    let help = Command::new(env!("CARGO_BIN_EXE_limpidctl"))
+        .args(["stats", "--help"])
         .output()
         .unwrap();
-    assert_eq!(output.status.code(), Some(2));
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("--json"));
-    assert!(stderr.contains("--details"));
-    assert!(stderr.contains("cannot be used with"));
+    assert!(help.status.success());
+    let help = String::from_utf8(help.stdout).unwrap();
+    assert!(help.contains("--details"));
+    assert!(help.contains("Show expanded human-readable metrics"));
+    assert!(help.contains("--raw"));
+    assert!(help.contains("legacy text format"));
+    assert!(help.contains("--json"));
+    assert!(help.contains("schema-v1 JSON"));
 }

--- a/docs/src/operations/cli.md
+++ b/docs/src/operations/cli.md
@@ -105,6 +105,7 @@ limpidctl list --json
 # Show metrics
 limpidctl stats
 limpidctl stats --details
+limpidctl stats --raw
 limpidctl stats --json
 
 # Health check
@@ -115,12 +116,14 @@ limpidctl health --json
 limpidctl ltp keygen /etc/limpid/node-key.pem
 ```
 
-`limpidctl stats` renders the established operator table from the schema-v1
-snapshot. `stats --details` instead renders every counter, gauge, and histogram
-family and series in deterministic human-readable order. `stats --json` prints
-the complete control-socket response unchanged. `--details` and `--json` are
-mutually exclusive. See [Metrics](./metrics.md#viewing-metrics-with-limpidctl)
-for the formatting, validation, and raw-fallback contracts.
+`limpidctl stats` renders the human operator summary from the schema-v1
+snapshot. `stats --details` expands that view with each process's step and path
+and a structured human-readable view of every metric family. `stats --raw`
+prints the complete legacy generic family-and-series text. `stats --json`
+prints the complete schema-v1 control-socket response unchanged. `--details`,
+`--raw`, and `--json` are mutually exclusive. See
+[Metrics](./metrics.md#viewing-metrics-with-limpidctl) for the formatting,
+validation, and raw-fallback contracts.
 
 `limpidctl ltp keygen` never overwrites an existing path and does not create a
 missing parent directory. Stdout contains only the base64 SPKI public key line,

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -322,31 +322,45 @@ confirmed by `send`.
 # Operator-focused table: Pipelines, Inputs, Outputs, then Processes when present
 sudo limpidctl stats
 
-# Generic human view of every schema-v1 family and series
+# Expanded human view with process identity and structured metric families
 sudo limpidctl stats --details
 
-# Complete raw control-socket response, byte-for-byte
+# Complete legacy generic family-and-series text
+sudo limpidctl stats --raw
+
+# Complete schema-v1 control-socket response, byte-for-byte
 sudo limpidctl stats --json
 ```
 
 The default table preserves the established component-counter view and appends
-a `Processes` invocation table when all four process families are present and
-valid. Process rows sort by pipeline, numeric step, path, and name. Component
-names are sorted and alarm fields such as `wedged` and `errored_unwritable` are
-shown under their existing conditional rules. Unknown future families are
-ignored in this mode. If a known family is missing, duplicated, has the wrong
-type or value, or does not have exactly its fixed labels, limpidctl prints the
-raw response rather than inventing a zero or a partial table.
+a `Processes` invocation table only when all four process families pass their
+strict validation. Process rows sort by pipeline, numeric step, path, and name.
+Component names are sorted and alarm fields such as `wedged` and
+`errored_unwritable` are shown under their existing conditional rules. Unknown
+future families are ignored in this mode. If the response fails wire, schema,
+or base canonical-family validation, the human modes print the raw response
+rather than inventing a zero or a partial table.
 
-`--details` replaces the default table with a generic view. Families are sorted
-by metric name, series by their canonical label key/value tuples, and labels by
-key. Every family shows its name, type, help, complete labels, and values.
-Histograms show the finite cumulative buckets stored in schema v1 plus `sum`
-and `count`; they do not synthesize `+Inf` in this human view.
+`--details` expands the human view. When strict process validation succeeds, it
+keeps the default component tables and process tree, adds each process's
+numeric `step` and `process_path` beneath its row, and presents every metric
+family in a structured `Metrics` section. Families are sorted by metric name,
+series by their canonical label key/value tuples, and labels by key. Counters
+and gauges show their labels and values; histograms show the finite cumulative
+buckets stored in schema v1 plus `sum` and `count`. This view does not
+synthesize `+Inf`. A DTO-valid process-only semantic defect or incomplete
+process-family set instead preserves the base component summary, omits
+`Processes`, and retains each process family in `Metrics` with
+`series: unavailable as a process summary; use --raw`.
+
+`--raw` prints the complete legacy generic family-and-series text. It retains
+each family's name, type, help, complete labels, and value or histogram data,
+including process labels that the human views organize into the process tree.
 
 `--json` bypasses parsing and formatting. It cannot be combined with
-`--details`. Invalid JSON, unsupported schemas, and malformed schema-v1 data
-retain the existing successful raw-response fallback for the human modes.
+`--details` or `--raw`; the three options are mutually exclusive. Wire,
+schema, and base canonical-family validation failures retain the existing
+successful raw-response fallback for the human modes.
 
 The deterministic human ordering is for reproducibility and testing only. It
 does not assign display or query semantics to a metric, series, or dashboard.


### PR DESCRIPTION
## Summary

- assign process metric steps as a pipeline-wide, source-order DFS sequence while preserving same-parent fold behavior
- render the default process view as a pipeline-grouped hierarchy with aligned counters and no raw path or step columns
- make `stats --details` a structured human view with process identity metadata, retain the legacy complete family dump under `--raw`, and keep schema-v1 JSON unchanged
- document all four stats modes, their validation behavior, and mutual exclusion

## Validation

- workspace tests and Clippy with warnings denied
- focused CLI byte-exact, hierarchy, schema, and option-conflict tests
- formatting, diff checks, and mdBook build
- candidate amd64 package exercised across three deployed nodes, including LTP marker delivery, drained queues, and preserved service configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `limpidctl stats --raw` for complete legacy metric output.
  * Reformatted default statistics as hierarchical process trees with clearer alignment and optional identity details.
  * Improved detailed statistics with summaries and fallback guidance for unavailable process metrics.
  * Ensured JSON, detailed, and raw output modes are mutually exclusive.

* **Bug Fixes**
  * Corrected process step numbering so nested processes follow sequential ordering while preserving paths and metric data.

* **Documentation**
  * Updated CLI and metrics documentation for all statistics output formats and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->