### PR TITLE
feat(metrics): separate processing and delivery latency

### DIFF
--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1104,12 +1104,16 @@ async fn handle_inject(
                 sent
             }
             Target::Output(tx) => {
-                // Inject is a cold path that hands an OwnedEvent
-                // straight to the output's queue. After this change
-                // every queue carries `Event` end-to-end, so there is no
-                // longer a separate `send_owned` codepath — `send`
-                // is the only entry.
-                let sent = tx.send(event).await.is_ok();
+                // A direct output injection has no pipeline Output statement,
+                // so its queue-entry boundary is stamped here, immediately
+                // before the potentially blocking enqueue.
+                let sent = tx
+                    .send(crate::event::QueuedEvent::new(
+                        event,
+                        crate::time::UnixNanos::now(),
+                    ))
+                    .await
+                    .is_ok();
                 if sent && let Some(m) = tx.metrics() {
                     m.events_injected.inc();
                 }

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -200,6 +200,48 @@ pub struct OwnedEvent {
     pub ack: Option<Arc<AckHandle>>,
 }
 
+/// Event snapshot after crossing one concrete pipeline `output` boundary.
+///
+/// The timestamp belongs to the queue item rather than [`OwnedEvent`]: one
+/// input event may fan out through several output statements at different
+/// times, while the event itself remains unchanged.  Keeping the field
+/// required makes every queue producer choose the correct local boundary and
+/// lets disk replay preserve output-delivery latency across daemon restarts.
+#[derive(Debug)]
+pub(crate) struct QueuedEvent {
+    event: OwnedEvent,
+    emitted_ns: crate::time::UnixNanos,
+}
+
+impl QueuedEvent {
+    pub(crate) fn new(event: OwnedEvent, emitted_ns: crate::time::UnixNanos) -> Self {
+        Self { event, emitted_ns }
+    }
+
+    pub(crate) fn emitted_ns(&self) -> crate::time::UnixNanos {
+        self.emitted_ns
+    }
+
+    pub(crate) fn into_parts(self) -> (OwnedEvent, crate::time::UnixNanos) {
+        (self.event, self.emitted_ns)
+    }
+}
+
+impl std::ops::Deref for QueuedEvent {
+    type Target = OwnedEvent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.event
+    }
+}
+
+#[cfg(test)]
+impl std::ops::DerefMut for QueuedEvent {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.event
+    }
+}
+
 impl OwnedEvent {
     pub fn new(ingress: Bytes, source: SocketAddr) -> Self {
         Self {
@@ -399,6 +441,10 @@ impl OwnedEvent {
     /// `OwnedValue::Bytes`.
     pub fn from_json(json_str: &str) -> Option<Self> {
         let v: JsonValue = serde_json::from_str(json_str).ok()?;
+        Self::from_json_value(v)
+    }
+
+    pub(crate) fn from_json_value(v: JsonValue) -> Option<Self> {
         let key = match v.get("key") {
             Some(JsonValue::String(raw)) => {
                 let parsed = uuid::Uuid::parse_str(raw).ok()?;

--- a/crates/limpid/src/main.rs
+++ b/crates/limpid/src/main.rs
@@ -22,6 +22,7 @@ mod queue;
 mod runtime;
 mod signal;
 mod tap;
+mod time;
 mod tls;
 
 use std::net::SocketAddr;

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -36,11 +36,92 @@ pub(crate) fn register_build_info(
 
 pub(crate) const LTP_HOP_LATENCY_BUCKETS: [f64; 8] =
     [0.0001, 0.001, 0.005, 0.025, 0.1, 0.5, 2.5, 10.0];
+pub(crate) const PIPELINE_PROCESSING_BUCKETS: [f64; 8] =
+    [0.0001, 0.001, 0.005, 0.025, 0.1, 0.5, 2.5, 10.0];
+pub(crate) const OUTPUT_DELIVERY_BUCKETS: [f64; 12] = [
+    0.001, 0.005, 0.025, 0.1, 0.5, 2.5, 10.0, 30.0, 60.0, 300.0, 900.0, 3600.0,
+];
+
+#[derive(Clone)]
+pub(crate) struct DurationHistogram {
+    histogram: Arc<registry_core::Histogram>,
+}
+
+impl DurationHistogram {
+    fn new(histogram: Arc<registry_core::Histogram>) -> Self {
+        Self { histogram }
+    }
+
+    pub(crate) fn observe(&self, duration: crate::time::DurationNanos) {
+        self.histogram.observe(duration.as_seconds_f64());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn count(&self) -> u64 {
+        self.histogram.count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sum(&self) -> f64 {
+        self.histogram.sum()
+    }
+
+    #[cfg(test)]
+    fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.histogram, &other.histogram)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PipelineOutputTimer {
+    histogram: DurationHistogram,
+}
+
+impl PipelineOutputTimer {
+    pub(crate) fn register(
+        registry: &Registry,
+        pipeline: &str,
+        output: &str,
+    ) -> Result<Self, MetricsError> {
+        Ok(Self {
+            histogram: DurationHistogram::new(
+                registry
+                    .histogram("limpid_pipeline_processing_seconds")
+                    .label("pipeline", pipeline)
+                    .label("output", output)
+                    .help(
+                        "Time from local input arrival to emission at this pipeline output statement.",
+                    )
+                    .buckets(&PIPELINE_PROCESSING_BUCKETS)
+                    .build()?,
+            ),
+        })
+    }
+
+    pub(crate) fn observe_between(
+        &self,
+        received_at: crate::time::UnixNanos,
+        emitted_at: crate::time::UnixNanos,
+    ) {
+        self.histogram
+            .observe(emitted_at.elapsed_since(received_at).duration);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn count(&self) -> u64 {
+        self.histogram.count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sum(&self) -> f64 {
+        self.histogram.sum()
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct LtpPeerMetrics {
-    pub(crate) network_latency: Arc<registry_core::Histogram>,
-    pub(crate) intra_latency: Arc<registry_core::Histogram>,
+    pub(crate) network_latency: DurationHistogram,
+    pub(crate) intra_latency: DurationHistogram,
     pub(crate) negative_delta: Arc<registry_core::Counter>,
     pub(crate) loop_dropped: Arc<registry_core::Counter>,
 }
@@ -69,6 +150,7 @@ impl LtpMetrics {
                     .help("LTP hop latency between authenticated peers.")
                     .buckets(&LTP_HOP_LATENCY_BUCKETS)
                     .build()
+                    .map(DurationHistogram::new)
             };
             let counter = |name, help| {
                 registry
@@ -344,6 +426,7 @@ pub struct OutputMetrics {
     pub(crate) bytes_written: Arc<registry_core::Counter>,
     pub(crate) queue_depth: Arc<registry_core::Gauge>,
     pub(crate) in_retry: Arc<registry_core::Gauge>,
+    pub(crate) delivery_seconds: DurationHistogram,
 }
 
 impl OutputMetrics {
@@ -404,7 +487,24 @@ impl OutputMetrics {
                 "limpid_output_in_retry",
                 "Whether this output currently has an active retry cycle."
             ),
+            delivery_seconds: DurationHistogram::new(
+                registry
+                    .histogram("limpid_output_delivery_seconds")
+                    .label("output", output)
+                    .help("Time from output-statement emission or direct output injection to confirmed delivery.")
+                    .buckets(&OUTPUT_DELIVERY_BUCKETS)
+                    .build()?,
+            ),
         }))
+    }
+
+    pub(crate) fn observe_delivery(
+        &self,
+        emitted_at: crate::time::UnixNanos,
+        delivered_at: crate::time::UnixNanos,
+    ) {
+        self.delivery_seconds
+            .observe(delivered_at.elapsed_since(emitted_at).duration);
     }
 
     #[cfg(test)]
@@ -1194,7 +1294,8 @@ pub(crate) use registry_core::{MetricsError, Registry};
 mod registry_tests {
     use super::{
         InputMetrics, LTP_HOP_LATENCY_BUCKETS, LtpMetrics, MetricsError, MetricsSnapshot,
-        OutputMetrics, PipelineMetrics, Registry,
+        OUTPUT_DELIVERY_BUCKETS, OutputMetrics, PIPELINE_PROCESSING_BUCKETS, PipelineMetrics,
+        PipelineOutputTimer, Registry,
     };
     use serde_json::Value;
     use std::collections::BTreeSet;
@@ -1204,6 +1305,47 @@ mod registry_tests {
         match result {
             Ok(value) => value,
             Err(error) => panic!("metric registration failed: {error}"),
+        }
+    }
+
+    #[test]
+    fn output_latency_histograms_have_exact_labels_buckets_and_nonnegative_time() {
+        let registry = Registry::new();
+        let pipeline = build_ok(PipelineOutputTimer::register(&registry, "route", "egress"));
+        let output = build_ok(OutputMetrics::register(&registry, "egress"));
+        let start = crate::time::UnixNanos::new(2_000_000_000);
+
+        pipeline.observe_between(start, crate::time::UnixNanos::new(1_000_000_000));
+        pipeline.observe_between(start, crate::time::UnixNanos::new(2_250_000_000));
+        output.observe_delivery(start, crate::time::UnixNanos::new(1_000_000_000));
+        output.observe_delivery(start, crate::time::UnixNanos::new(3_500_000_000));
+
+        let snapshot = snapshot_json(&registry);
+        for (name, labels, bounds, expected_sum) in [
+            (
+                "limpid_pipeline_processing_seconds",
+                serde_json::json!({"pipeline": "route", "output": "egress"}),
+                PIPELINE_PROCESSING_BUCKETS.as_slice(),
+                0.25,
+            ),
+            (
+                "limpid_output_delivery_seconds",
+                serde_json::json!({"output": "egress"}),
+                OUTPUT_DELIVERY_BUCKETS.as_slice(),
+                1.5,
+            ),
+        ] {
+            let family = metric(&snapshot, name);
+            assert_eq!(family["type"], "histogram");
+            let series = &family["series"][0];
+            assert_eq!(series["labels"], labels);
+            assert_eq!(series["count"], 2);
+            assert_eq!(series["sum"].as_f64(), Some(expected_sum));
+            let buckets = series["buckets"].as_array().unwrap();
+            assert_eq!(buckets.len(), bounds.len());
+            for (bucket, bound) in buckets.iter().zip(bounds) {
+                assert_eq!(bucket[0].as_f64(), Some(*bound));
+            }
         }
     }
 
@@ -1367,14 +1509,16 @@ mod registry_tests {
 
         let first_peer_a = metrics.peer("peer-a").unwrap();
         let second_peer_a = metrics.peer("peer-a").unwrap();
-        assert!(Arc::ptr_eq(
-            &first_peer_a.network_latency,
-            &second_peer_a.network_latency
-        ));
-        assert!(Arc::ptr_eq(
-            &first_peer_a.intra_latency,
-            &second_peer_a.intra_latency
-        ));
+        assert!(
+            first_peer_a
+                .network_latency
+                .ptr_eq(&second_peer_a.network_latency)
+        );
+        assert!(
+            first_peer_a
+                .intra_latency
+                .ptr_eq(&second_peer_a.intra_latency)
+        );
         assert!(Arc::ptr_eq(
             &first_peer_a.negative_delta,
             &second_peer_a.negative_delta
@@ -1941,6 +2085,29 @@ mod registry_tests {
             assert_eq!(series[0]["value"], 0, "{name} must start at zero");
         }
 
+        let delivery = metric(&initial, "limpid_output_delivery_seconds");
+        assert_eq!(delivery["type"], "histogram");
+        assert_eq!(
+            delivery["help"],
+            "Time from output-statement emission or direct output injection to confirmed delivery."
+        );
+        let series = delivery["series"]
+            .as_array()
+            .expect("delivery histogram series array");
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0]["labels"], serde_json::json!({"output": "egress"}));
+        assert_eq!(series[0]["count"], 0);
+        assert_eq!(series[0]["sum"], 0.0);
+        assert_eq!(
+            series[0]["buckets"],
+            serde_json::Value::Array(
+                OUTPUT_DELIVERY_BUCKETS
+                    .iter()
+                    .map(|bound| serde_json::json!([bound, 0]))
+                    .collect()
+            )
+        );
+
         macro_rules! inc {
             ($counter:expr, $times:expr) => {
                 for _ in 0..$times {
@@ -1977,7 +2144,7 @@ mod registry_tests {
             .expect("metrics must be an array");
         assert_eq!(
             metrics.len(),
-            21,
+            22,
             "only the documented metric set is registered"
         );
 

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -75,6 +75,7 @@ impl DurationHistogram {
 #[derive(Clone)]
 pub(crate) struct PipelineOutputTimer {
     histogram: DurationHistogram,
+    negative_delta: Arc<registry_core::Counter>,
 }
 
 impl PipelineOutputTimer {
@@ -95,6 +96,12 @@ impl PipelineOutputTimer {
                     .buckets(&PIPELINE_PROCESSING_BUCKETS)
                     .build()?,
             ),
+            negative_delta: registry
+                .counter("limpid_pipeline_processing_negative_delta_total")
+                .label("pipeline", pipeline)
+                .label("output", output)
+                .help("Total pipeline processing durations clamped to zero after a wall-clock reversal.")
+                .build()?,
         })
     }
 
@@ -103,8 +110,11 @@ impl PipelineOutputTimer {
         received_at: crate::time::UnixNanos,
         emitted_at: crate::time::UnixNanos,
     ) {
-        self.histogram
-            .observe(emitted_at.elapsed_since(received_at).duration);
+        let elapsed = emitted_at.elapsed_since(received_at);
+        if elapsed.reversed {
+            self.negative_delta.inc();
+        }
+        self.histogram.observe(elapsed.duration);
     }
 
     #[cfg(test)]
@@ -427,6 +437,7 @@ pub struct OutputMetrics {
     pub(crate) queue_depth: Arc<registry_core::Gauge>,
     pub(crate) in_retry: Arc<registry_core::Gauge>,
     pub(crate) delivery_seconds: DurationHistogram,
+    pub(crate) delivery_negative_delta: Arc<registry_core::Counter>,
 }
 
 impl OutputMetrics {
@@ -495,6 +506,10 @@ impl OutputMetrics {
                     .buckets(&OUTPUT_DELIVERY_BUCKETS)
                     .build()?,
             ),
+            delivery_negative_delta: counter!(
+                "limpid_output_delivery_negative_delta_total",
+                "Total output delivery durations clamped to zero after a wall-clock reversal."
+            ),
         }))
     }
 
@@ -503,8 +518,11 @@ impl OutputMetrics {
         emitted_at: crate::time::UnixNanos,
         delivered_at: crate::time::UnixNanos,
     ) {
-        self.delivery_seconds
-            .observe(delivered_at.elapsed_since(emitted_at).duration);
+        let elapsed = delivered_at.elapsed_since(emitted_at);
+        if elapsed.reversed {
+            self.delivery_negative_delta.inc();
+        }
+        self.delivery_seconds.observe(elapsed.duration);
     }
 
     #[cfg(test)]
@@ -1317,8 +1335,10 @@ mod registry_tests {
 
         pipeline.observe_between(start, crate::time::UnixNanos::new(1_000_000_000));
         pipeline.observe_between(start, crate::time::UnixNanos::new(2_250_000_000));
+        pipeline.observe_between(start, crate::time::UnixNanos::new(2_500_000_000));
         output.observe_delivery(start, crate::time::UnixNanos::new(1_000_000_000));
         output.observe_delivery(start, crate::time::UnixNanos::new(3_500_000_000));
+        output.observe_delivery(start, crate::time::UnixNanos::new(2_500_000_000));
 
         let snapshot = snapshot_json(&registry);
         for (name, labels, bounds, expected_sum) in [
@@ -1326,26 +1346,42 @@ mod registry_tests {
                 "limpid_pipeline_processing_seconds",
                 serde_json::json!({"pipeline": "route", "output": "egress"}),
                 PIPELINE_PROCESSING_BUCKETS.as_slice(),
-                0.25,
+                0.75,
             ),
             (
                 "limpid_output_delivery_seconds",
                 serde_json::json!({"output": "egress"}),
                 OUTPUT_DELIVERY_BUCKETS.as_slice(),
-                1.5,
+                2.0,
             ),
         ] {
             let family = metric(&snapshot, name);
             assert_eq!(family["type"], "histogram");
             let series = &family["series"][0];
             assert_eq!(series["labels"], labels);
-            assert_eq!(series["count"], 2);
+            assert_eq!(series["count"], 3);
             assert_eq!(series["sum"].as_f64(), Some(expected_sum));
             let buckets = series["buckets"].as_array().unwrap();
             assert_eq!(buckets.len(), bounds.len());
             for (bucket, bound) in buckets.iter().zip(bounds) {
                 assert_eq!(bucket[0].as_f64(), Some(*bound));
             }
+        }
+
+        for (name, labels) in [
+            (
+                "limpid_pipeline_processing_negative_delta_total",
+                serde_json::json!({"pipeline": "route", "output": "egress"}),
+            ),
+            (
+                "limpid_output_delivery_negative_delta_total",
+                serde_json::json!({"output": "egress"}),
+            ),
+        ] {
+            let family = metric(&snapshot, name);
+            assert_eq!(family["type"], "counter");
+            assert_eq!(family["series"][0]["labels"], labels);
+            assert_eq!(family["series"][0]["value"], 1);
         }
     }
 
@@ -2134,6 +2170,7 @@ mod registry_tests {
         inc!(output.retries, 14);
         inc!(output.events_wedged, 15);
         inc!(output.events_errored_unwritable, 16);
+        inc!(output.delivery_negative_delta, 17);
         output.bytes_written.inc_by(23);
         output.queue_depth.set(3);
         output.in_retry.set(1);
@@ -2144,7 +2181,7 @@ mod registry_tests {
             .expect("metrics must be an array");
         assert_eq!(
             metrics.len(),
-            22,
+            23,
             "only the documented metric set is registered"
         );
 
@@ -2204,6 +2241,12 @@ mod registry_tests {
                 "output",
                 "egress",
                 16,
+            ),
+            (
+                "limpid_output_delivery_negative_delta_total",
+                "output",
+                "egress",
+                17,
             ),
             ("limpid_output_bytes_written_total", "output", "egress", 23),
         ];

--- a/crates/limpid/src/modules/input/ltp.rs
+++ b/crates/limpid/src/modules/input/ltp.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 use base64::Engine as _;
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
+#[cfg(test)]
+use chrono::Utc;
 use prost::Message as _;
 use rustls::crypto::WebPkiSupportedAlgorithms;
 use rustls::pki_types::{CertificateDer, SubjectPublicKeyInfoDer, UnixTime};
@@ -112,7 +113,7 @@ pub struct LtpInput {
     max_connections: usize,
     metrics: Arc<InputMetrics>,
     ltp_metrics: Arc<LtpMetrics>,
-    now: fn() -> DateTime<Utc>,
+    now: fn() -> crate::time::ClockSample,
     #[cfg(test)]
     hello_started: Option<Arc<tokio::sync::Notify>>,
 }
@@ -123,7 +124,7 @@ struct ConnectionContext {
     peers: PeerRegistry,
     node_id: Arc<str>,
     max_hops: usize,
-    now: fn() -> DateTime<Utc>,
+    now: fn() -> crate::time::ClockSample,
     metrics: Arc<InputMetrics>,
     ltp_metrics: Arc<LtpMetrics>,
     tx: tokio::sync::mpsc::Sender<Event>,
@@ -176,7 +177,7 @@ impl Module for LtpInput {
             max_connections: max_connections as usize,
             metrics: InputMetrics::register(&ctx.metrics, name)?,
             ltp_metrics,
-            now: Utc::now,
+            now: crate::time::ClockSample::now,
             #[cfg(test)]
             hello_started: None,
         })
@@ -587,7 +588,7 @@ fn event_from_frame(
     source: std::net::SocketAddr,
     node_id: &str,
     max_hops: usize,
-    now: fn() -> DateTime<Utc>,
+    now: fn() -> crate::time::ClockSample,
     peer_metrics: &LtpPeerMetrics,
 ) -> Result<FrameDecision> {
     let key: [u8; 16] = meta
@@ -609,24 +610,18 @@ fn event_from_frame(
         warn!("LTP event dropped because its hop history reached max_hops");
         return Ok(FrameDecision::DropMaxHops);
     }
-    let received_at = now();
-    let arrival_unix_nano = received_at
-        .timestamp_nanos_opt()
-        .and_then(|value| u64::try_from(value).ok())
-        .unwrap_or(0);
+    let received = now();
+    let received_at = received.utc;
+    let arrival_unix_nano = received.unix_nanos.to_wire_u64();
     if let Some(previous) = meta.stamps.last()
         && previous.departure_unix_nano != 0
     {
-        let delta = match arrival_unix_nano.checked_sub(previous.departure_unix_nano) {
-            Some(delta) => delta,
-            None => {
-                peer_metrics.negative_delta.inc();
-                0
-            }
-        };
-        peer_metrics
-            .network_latency
-            .observe(delta as f64 / 1_000_000_000.0);
+        let elapsed =
+            crate::time::ElapsedNanos::between_u64(arrival_unix_nano, previous.departure_unix_nano);
+        if elapsed.reversed {
+            peer_metrics.negative_delta.inc();
+        }
+        peer_metrics.network_latency.observe(elapsed.duration);
     }
     meta.stamps.push(HopStamp {
         node_id: node_id.to_owned(),
@@ -775,8 +770,8 @@ mod tests {
         client.shutdown().await.unwrap();
     }
 
-    fn fixed_now() -> DateTime<Utc> {
-        Utc.timestamp_nanos(123)
+    fn fixed_now() -> crate::time::ClockSample {
+        crate::time::ClockSample::from_datetime(Utc.timestamp_nanos(123))
     }
 
     fn v7_key(seed: u8) -> [u8; 16] {
@@ -996,6 +991,7 @@ mod tests {
             panic!("valid frame was dropped");
         };
         assert_eq!(event.key().as_bytes(), &key);
+        assert_eq!(event.received_at, fixed_now().utc);
         assert_eq!(event.ingress, Bytes::from_static(b"payload"));
         assert_eq!(event.egress, Bytes::from_static(b"payload"));
         assert_eq!(event.ltp_stamps()[0], peer_stamp);

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -617,8 +617,9 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
         self.metrics.events_written.inc_by(written);
         let split = (count - rejected) as usize;
         let mut iter = shippable.into_iter();
+        let delivered_at = (split != 0).then(crate::time::UnixNanos::now);
         for (_, ack, _permit) in iter.by_ref().take(split) {
-            ack.resolve_delivered();
+            ack.resolve_delivered_at(delivered_at.expect("non-empty accepted prefix has a time"));
         }
         // Per-event DLQ routing for the trailing `rejected` entries.
         // `events_failed` is bumped by `resolve_ack_from_dlq_outcome`
@@ -912,6 +913,34 @@ impl<P: BatchSinkPolicy> SinkShared<P> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn accepted_batch_samples_delivery_time_once_before_resolving_each_ack() {
+        let src = include_str!("batched.rs");
+        let start = src
+            .find("async fn resolve_send_success(&self, shippable: Vec<ParkedEvent>")
+            .expect("success resolver must exist");
+        let body = &src[start..];
+        let sample = body
+            .find("let delivered_at = (split != 0).then(crate::time::UnixNanos::now);")
+            .expect("accepted prefix must sample one shared delivery time");
+        let loop_start = body
+            .find("for (_, ack, _permit) in iter.by_ref().take(split)")
+            .expect("accepted-prefix loop must exist");
+        assert!(sample < loop_start, "time must be sampled outside the loop");
+        assert_eq!(
+            body[..loop_start]
+                .matches("crate::time::UnixNanos::now")
+                .count(),
+            1,
+            "the accepted batch must take exactly one wall-clock sample"
+        );
+        assert!(
+            body[loop_start..].starts_with("for (_, ack, _permit) in iter.by_ref().take(split)"),
+            "accepted-prefix loop identity changed"
+        );
+        assert!(body[loop_start..].contains("ack.resolve_delivered_at(delivered_at"));
+    }
+
     /// Structural pin: `flush_events`' shutdown-cancel arm and
     /// `flush_events_at_shutdown`'s `Elapsed` arm both route through
     /// `route_shutdown_batch_ambiguous_to_dlq`, not the plain

--- a/crates/limpid/src/modules/output/ltp.rs
+++ b/crates/limpid/src/modules/output/ltp.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 use base64::Engine as _;
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
+#[cfg(test)]
+use chrono::Utc;
 use prost::Message as _;
 use rustls::client::AlwaysResolvesClientRawPublicKeys;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
@@ -93,7 +94,7 @@ pub struct LtpOutput {
     metrics: Arc<OutputMetrics>,
     peer_metrics: LtpPeerMetrics,
     shutdown_signal: tokio::sync::watch::Receiver<bool>,
-    now: fn() -> DateTime<Utc>,
+    now: fn() -> crate::time::UnixNanos,
 }
 
 impl Module for LtpOutput {
@@ -144,7 +145,7 @@ impl Module for LtpOutput {
             metrics: OutputMetrics::register(&ctx.metrics, name)?,
             peer_metrics,
             shutdown_signal: ctx.shutdown_signal.clone(),
-            now: Utc::now,
+            now: crate::time::UnixNanos::now,
         })
     }
 }
@@ -385,11 +386,8 @@ std::thread_local! {
 
 impl LtpOutput {
     fn working_event_meta(&self, event: &Event) -> WorkingEventMeta {
-        let arrival_unix_nano = event
-            .received_at
-            .timestamp_nanos_opt()
-            .and_then(|value| u64::try_from(value).ok())
-            .unwrap_or(0);
+        let arrival_unix_nano =
+            crate::time::UnixNanos::from_datetime(event.received_at).to_wire_u64();
         #[cfg(test)]
         STAMP_CLONE_COUNT.set(STAMP_CLONE_COUNT.get() + 1);
         let mut stamps = event.ltp_stamps().to_vec();
@@ -418,10 +416,7 @@ impl LtpOutput {
     }
 
     fn event_frame(&self, working: &mut WorkingEventMeta, payload: &[u8]) -> Result<Bytes> {
-        let departure_unix_nano = (self.now)()
-            .timestamp_nanos_opt()
-            .and_then(|value| u64::try_from(value).ok())
-            .unwrap_or(0);
+        let departure_unix_nano = (self.now)().to_wire_u64();
         working.meta.stamps[working.local_stamp].departure_unix_nano = departure_unix_nano;
         Ok(Bytes::from(encode_frame(&working.meta, payload)?))
     }
@@ -484,7 +479,7 @@ impl LtpOutput {
             .saturating_sub(stamp.arrival_unix_nano);
         self.peer_metrics
             .intra_latency
-            .observe(delta as f64 / 1_000_000_000.0);
+            .observe(crate::time::DurationNanos::new(delta));
         Ok(())
     }
 
@@ -1130,22 +1125,22 @@ mod tests {
         assert!(format!("{error:#}").contains("LTP event metadata 65537 bytes"));
     }
 
-    fn now_200() -> DateTime<Utc> {
-        Utc.timestamp_nanos(200)
+    fn now_200() -> crate::time::UnixNanos {
+        crate::time::UnixNanos::new(200)
     }
 
-    fn now_negative() -> DateTime<Utc> {
-        Utc.timestamp_nanos(-1)
+    fn now_negative() -> crate::time::UnixNanos {
+        crate::time::UnixNanos::new(-1)
     }
 
     static HELLO_FLUSHED: AtomicBool = AtomicBool::new(false);
 
-    fn now_after_hello_flush() -> DateTime<Utc> {
+    fn now_after_hello_flush() -> crate::time::UnixNanos {
         assert!(
             HELLO_FLUSHED.load(Ordering::SeqCst),
             "departure time must be sampled after the hello has flushed"
         );
-        Utc.timestamp_nanos(200)
+        crate::time::UnixNanos::new(200)
     }
 
     #[test]
@@ -1762,8 +1757,8 @@ mod tests {
 
     static RETRY_NOW: AtomicI64 = AtomicI64::new(300);
 
-    fn retry_now() -> DateTime<Utc> {
-        Utc.timestamp_nanos(RETRY_NOW.fetch_add(1, Ordering::SeqCst))
+    fn retry_now() -> crate::time::UnixNanos {
+        crate::time::UnixNanos::new(RETRY_NOW.fetch_add(1, Ordering::SeqCst))
     }
 
     #[test]

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -28,7 +28,7 @@ use crate::dsl::exec::{
     CompiledProcessRegistry, ExecResult, ProcessError, ProcessMetricStatement, ProcessRegistry,
     exec_process_body, exec_process_body_with_metric_plan,
 };
-use crate::event::{BorrowedEvent, OwnedEvent};
+use crate::event::{BorrowedEvent, OwnedEvent, QueuedEvent};
 use crate::functions::FunctionRegistry;
 use crate::tap::TapRegistry;
 
@@ -458,7 +458,7 @@ impl ErroredEventContext {
 /// passes its own `Vec` and reads it back directly after the call;
 /// the daemon hot path passes `None` and never allocates one.
 pub struct PipelineRunResult {
-    pub outputs: Vec<(String, OwnedEvent)>,
+    pub outputs: Vec<(String, QueuedEvent)>,
     /// True iff at least one `output` statement was reached during
     /// execution (i.e. `outputs` was non-empty *before* the runtime
     /// drained it into the per-output queues). Needed because the
@@ -524,6 +524,7 @@ enum ProcessMetricNodeKind {
 
 enum PipelineMetricStatement {
     None,
+    Output(crate::metrics::PipelineOutputTimer),
     ProcessChain(Vec<usize>),
     If {
         branches: Vec<Vec<PipelineMetricStatement>>,
@@ -554,6 +555,7 @@ impl PipelineProcessMetrics {
             identities: Vec::new(),
             children: Vec::new(),
             next_step: 1,
+            output_timers: HashMap::new(),
         };
         let statements = builder.pipeline_body(&pipeline.body)?;
         Ok(RawPipelineProcessMetrics {
@@ -857,9 +859,9 @@ impl ProcessMetricPlanValidator<'_> {
                     self.pipeline_branch(&arm.body, arm_plan)?;
                 }
             }
+            (PipelineStatement::Output(_), PipelineMetricStatement::Output(_)) => {}
             (
                 PipelineStatement::Input(_)
-                | PipelineStatement::Output(_)
                 | PipelineStatement::Drop
                 | PipelineStatement::Finish
                 | PipelineStatement::Error(_),
@@ -1059,6 +1061,7 @@ struct ProcessMetricsBuilder<'a> {
     identities: Vec<ProcessMetricNodeIdentity>,
     children: Vec<HashMap<String, usize>>,
     next_step: usize,
+    output_timers: HashMap<String, crate::metrics::PipelineOutputTimer>,
 }
 
 impl ProcessMetricsBuilder<'_> {
@@ -1088,6 +1091,21 @@ impl ProcessMetricsBuilder<'_> {
         statement: &PipelineStatement,
     ) -> Result<PipelineMetricStatement, crate::metrics::MetricsError> {
         match statement {
+            PipelineStatement::Output(name) => {
+                let timer = match self.output_timers.get(name) {
+                    Some(timer) => timer.clone(),
+                    None => {
+                        let timer = crate::metrics::PipelineOutputTimer::register(
+                            self.registry,
+                            self.pipeline,
+                            name,
+                        )?;
+                        self.output_timers.insert(name.clone(), timer.clone());
+                        timer
+                    }
+                };
+                Ok(PipelineMetricStatement::Output(timer))
+            }
             PipelineStatement::ProcessChain(chain) => {
                 let mut nodes = Vec::with_capacity(chain.len());
                 for element in chain {
@@ -1648,7 +1666,7 @@ struct PipelineExecOut<'a> {
     /// computing throwaway `String`s on every event just to push them
     /// into a `Vec` nobody drains.
     trace: Option<&'a mut Vec<TraceEntry>>,
-    outputs: &'a mut Vec<(String, OwnedEvent)>,
+    outputs: &'a mut Vec<(String, QueuedEvent)>,
     errored: &'a mut Vec<ErroredEventContext>,
 }
 
@@ -1941,7 +1959,17 @@ fn exec_pipeline_stmt<'bump>(
             } else {
                 event.to_owned_without_workspace()
             };
-            out.outputs.push((name.clone(), snapshot));
+            let emitted_at = crate::time::UnixNanos::now();
+            if let Some(PipelineMetricStatement::Output(timer)) = metric_stmt {
+                timer.observe_between(
+                    crate::time::UnixNanos::from_datetime(event.received_at),
+                    emitted_at,
+                );
+            } else if ctx.registry.process_metrics.is_some() {
+                bail!("compiled pipeline output metric entry is missing");
+            }
+            out.outputs
+                .push((name.clone(), QueuedEvent::new(snapshot, emitted_at)));
             cont(event)
         }
 
@@ -2502,6 +2530,68 @@ def pipeline p {
             result.outputs[1].1.workspace.is_empty(),
             "output 'b' snapshot must have empty workspace under StripAll"
         );
+    }
+
+    #[test]
+    fn output_statements_stamp_each_snapshot_and_fold_same_name_latency_series() {
+        use crate::event::OwnedEvent;
+        use crate::functions::{FunctionRegistry, register_builtins, table::TableStore};
+        use bytes::Bytes;
+
+        let cfg = compile(
+            r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output sink { type stdout }
+def pipeline p {
+    input i
+    output sink
+    output sink
+    finish
+}
+"#,
+        )
+        .unwrap();
+        let pipeline = cfg.pipelines.get("p").unwrap();
+        let registry = crate::metrics::Registry::new();
+        let output_metrics =
+            PipelineProcessMetrics::register(pipeline, &cfg.processes, &registry).unwrap();
+        let mut funcs = FunctionRegistry::new();
+        register_builtins(&mut funcs, TableStore::from_configs(vec![]).unwrap());
+        let mut event = OwnedEvent::new(
+            Bytes::from_static(b"payload"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        event.received_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+
+        let result = run_pipeline_with_process_metrics(
+            pipeline,
+            &event,
+            &cfg,
+            &funcs,
+            None,
+            None,
+            OutputCapturePolicy::StripAll,
+            &mut bumpalo::Bump::new(),
+            &output_metrics,
+        )
+        .unwrap();
+
+        assert_eq!(result.outputs.len(), 2);
+        assert!(result.outputs.iter().all(|(_, queued)| {
+            queued.emitted_ns() >= crate::time::UnixNanos::from_datetime(event.received_at)
+        }));
+        let timers: Vec<&crate::metrics::PipelineOutputTimer> = output_metrics
+            .statements
+            .iter()
+            .filter_map(|stmt| match stmt {
+                PipelineMetricStatement::Output(timer) => Some(timer),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(timers.len(), 2);
+        assert_eq!(timers[0].count(), 2);
+        assert_eq!(timers[1].count(), 2);
+        assert!(timers[0].sum() >= 2.0);
     }
 
     #[test]

--- a/crates/limpid/src/queue/disk.rs
+++ b/crates/limpid/src/queue/disk.rs
@@ -26,11 +26,25 @@ use std::sync::{Arc, Mutex};
 
 use tracing::{debug, error, warn};
 
-use crate::event::Event;
+use crate::event::{Event, QueuedEvent};
 use crate::queue::AckPosition;
 
 const SEGMENT_MAX_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB per segment
 const NEWLINE: u8 = b'\n';
+
+#[cfg(test)]
+std::thread_local! {
+    static CORRUPT_WARNING_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+fn warn_corrupt_line(segment: u64, offset: u64) {
+    #[cfg(test)]
+    CORRUPT_WARNING_COUNT.set(CORRUPT_WARNING_COUNT.get() + 1);
+    warn!(
+        "disk queue: skipping corrupted line in segment {} at byte offset {}",
+        segment, offset
+    );
+}
 
 /// One in-flight (read but not yet acked) event tracked by
 /// [`DiskQueueReceiver`]. `start_*` is the position the
@@ -194,8 +208,17 @@ pub fn create_disk_queue(
 }
 
 impl DiskQueueSender {
-    pub async fn send(&self, event: Event) -> Result<(), super::QueueSendError> {
-        let serialized = match serde_json::to_string(&event.to_json_value()) {
+    pub async fn send(&self, event: QueuedEvent) -> Result<(), super::QueueSendError> {
+        let (event, emitted_ns) = event.into_parts();
+        let mut value = event.to_json_value();
+        let Some(object) = value.as_object_mut() else {
+            unreachable!("event JSON is always an object")
+        };
+        object.insert(
+            "emitted_ns".to_owned(),
+            serde_json::Value::Number(emitted_ns.get().into()),
+        );
+        let serialized = match serde_json::to_string(&value) {
             Ok(s) => s,
             Err(e) => {
                 error!("disk queue: failed to serialize event: {}", e);
@@ -236,7 +259,7 @@ impl DiskQueueReceiver {
         state.write_seq.saturating_sub(state.acked_seq)
     }
 
-    pub async fn recv(&mut self) -> Option<(Event, AckPosition)> {
+    pub async fn recv(&mut self) -> Option<(QueuedEvent, AckPosition)> {
         loop {
             // Register for notification BEFORE checking — prevents missed-wakeup race.
             // Clone the Arc to avoid borrowing self across the await.
@@ -258,7 +281,7 @@ impl DiskQueueReceiver {
     /// on empty (regardless of whether the queue has been closed) —
     /// closure observation is left to a subsequent `recv().await`.
     /// Used as the greedy-drain step inside `QueueReceiver::recv_many`.
-    pub fn try_recv(&mut self) -> Option<(Event, AckPosition)> {
+    pub fn try_recv(&mut self) -> Option<(QueuedEvent, AckPosition)> {
         self.try_read_next()
     }
 
@@ -359,7 +382,7 @@ impl DiskQueueReceiver {
         self.sync_acked_seq();
     }
 
-    fn try_read_next(&mut self) -> Option<(Event, AckPosition)> {
+    fn try_read_next(&mut self) -> Option<(QueuedEvent, AckPosition)> {
         loop {
             let seg_path = segment_path(&self.dir, self.read_seq);
             if !seg_path.exists() {
@@ -432,7 +455,18 @@ impl DiskQueueReceiver {
                 // ack, restart re-reads from `acked_offset` and
                 // replays this event.
 
-                if let Some(event) = Event::from_json(trimmed) {
+                let queued = serde_json::from_str::<serde_json::Value>(trimmed)
+                    .ok()
+                    .and_then(|mut value| {
+                        let emitted_nanos =
+                            value.as_object_mut()?.remove("emitted_ns")?.as_i64()?;
+                        let event = Event::from_json_value(value)?;
+                        Some(QueuedEvent::new(
+                            event,
+                            crate::time::UnixNanos::new(emitted_nanos),
+                        ))
+                    });
+                if let Some(event) = queued {
                     self.in_flight_positions.push_back(InFlight {
                         start_seq,
                         start_offset,
@@ -449,10 +483,7 @@ impl DiskQueueReceiver {
                     ));
                 }
 
-                warn!(
-                    "disk queue: skipping corrupted line in segment {} at byte offset {}",
-                    self.read_seq, self.read_offset
-                );
+                warn_corrupt_line(self.read_seq, self.read_offset);
             }
 
             // Finished this segment — try next
@@ -669,8 +700,11 @@ mod tests {
     use super::*;
     use bytes::Bytes;
 
-    fn make_event(msg: &str) -> Event {
-        Event::new(Bytes::from(msg.to_string()), "127.0.0.1:0".parse().unwrap())
+    fn make_event(msg: &str) -> QueuedEvent {
+        QueuedEvent::new(
+            Event::new(Bytes::from(msg.to_string()), "127.0.0.1:0".parse().unwrap()),
+            crate::time::UnixNanos::now(),
+        )
     }
 
     #[test]
@@ -732,6 +766,7 @@ mod tests {
         let first = make_event("<134>msg1");
         let second = make_event("<134>msg2");
         let first_key = first.key();
+        let first_emitted_at = first.emitted_ns();
         let second_key = second.key();
         tx.send(first).await.unwrap();
         tx.send(second).await.unwrap();
@@ -739,10 +774,56 @@ mod tests {
         let (e1, _p1) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e1.ingress), "<134>msg1");
         assert_eq!(e1.key(), first_key);
+        assert_eq!(e1.emitted_ns(), first_emitted_at);
 
         let (e2, _p2) = rx.recv().await.unwrap();
         assert_eq!(String::from_utf8_lossy(&e2.ingress), "<134>msg2");
         assert_eq!(e2.key(), second_key);
+    }
+
+    #[tokio::test]
+    async fn required_emission_timestamp_adds_one_exact_wal_field_per_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = create_disk_queue(dir.path().to_str().unwrap(), 0).unwrap();
+        let event = Event::new(
+            Bytes::from_static(b"<134>size"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let base_len = serde_json::to_vec(&event.to_json_value()).unwrap().len();
+        let emitted_at = crate::time::UnixNanos::new(1_234_567_890_123_456_789);
+        let emitted_nanos = emitted_at.get();
+        let field_len = format!(",\"emitted_ns\":{emitted_nanos}").len();
+
+        tx.send(QueuedEvent::new(event, emitted_at)).await.unwrap();
+        let wal = std::fs::read(segment_path(dir.path(), 0)).unwrap();
+
+        assert_eq!(wal.last(), Some(&NEWLINE));
+        assert_eq!(wal.len() - 1 - base_len, field_len);
+        assert_eq!(
+            field_len, 33,
+            "WAL overhead must remain one fixed key plus i64"
+        );
+    }
+
+    #[test]
+    fn disk_queue_rejects_records_without_required_output_emission_timestamp() {
+        let warnings_before = CORRUPT_WARNING_COUNT.get();
+        let dir = tempfile::tempdir().unwrap();
+        let legacy = Event::new(
+            Bytes::from_static(b"legacy"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let mut line = serde_json::to_string(&legacy.to_json_value()).unwrap();
+        line.push('\n');
+        fs::write(segment_path(dir.path(), 0), line).unwrap();
+
+        let (_tx, mut rx) = create_disk_queue(dir.path().to_str().unwrap(), 0).unwrap();
+        assert!(rx.try_recv().is_none());
+        assert_eq!(
+            CORRUPT_WARNING_COUNT.get(),
+            warnings_before + 1,
+            "rejecting an incompatible WAL record must remain operator-visible"
+        );
     }
 
     #[tokio::test]
@@ -762,7 +843,9 @@ mod tests {
             stamps.clone(),
         );
 
-        tx.send(event).await.unwrap();
+        tx.send(QueuedEvent::new(event, crate::time::UnixNanos::now()))
+            .await
+            .unwrap();
         let (recovered, _) = rx.recv().await.unwrap();
         assert_eq!(recovered.ltp_stamps(), stamps);
     }

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -13,7 +13,9 @@ use tracing::{info, warn};
 use crate::dsl::ast::Property;
 use crate::dsl::props;
 use crate::dsl::schema::{PropertySpec, PropertyValueKind};
+#[cfg(test)]
 use crate::event::Event;
+use crate::event::QueuedEvent;
 
 // ---------------------------------------------------------------------------
 // Declarative schema for the per-output `queue { ... }` sub-block
@@ -254,7 +256,7 @@ pub struct QueueSender {
 
 #[derive(Clone)]
 enum SenderInner {
-    Memory(tokio::sync::mpsc::Sender<Event>),
+    Memory(tokio::sync::mpsc::Sender<QueuedEvent>),
     Disk(disk::DiskQueueSender),
 }
 
@@ -267,7 +269,7 @@ impl QueueSender {
     /// serialise the same `Event` to JSON for replay. There is no
     /// longer a `Rendered`-vs-`Owned` discriminator at this level
     /// because the queue does not see sink-specific payloads anymore.
-    pub async fn send(&self, event: Event) -> Result<(), QueueSendError> {
+    pub async fn send(&self, event: QueuedEvent) -> Result<(), QueueSendError> {
         let result: Result<(), QueueSendError> = match &self.inner {
             SenderInner::Memory(tx) => tx
                 .send(event)
@@ -521,7 +523,7 @@ pub struct QueueReceiver {
 }
 
 enum ReceiverInner {
-    Memory(tokio::sync::mpsc::Receiver<Event>),
+    Memory(tokio::sync::mpsc::Receiver<QueuedEvent>),
     Disk(disk::DiskQueueReceiver),
 }
 
@@ -570,7 +572,7 @@ impl QueueReceiver {
     /// disposition. The position is captured at the moment of read,
     /// not at ack time — that distinction is what makes the disk
     /// cursor correct under batched, out-of-order acks.
-    pub async fn recv(&mut self) -> Option<(Event, AckPosition)> {
+    pub async fn recv(&mut self) -> Option<(QueuedEvent, AckPosition)> {
         match &mut self.inner {
             ReceiverInner::Memory(rx) => rx.recv().await.map(|e| (e, AckPosition::Memory)),
             ReceiverInner::Disk(rx) => rx.recv().await,
@@ -590,7 +592,7 @@ impl QueueReceiver {
     /// use `close() + recv().await`-until-`None` to avoid dropping
     /// mid-write permit-holder sends. Do not lift `try_recv()` into
     /// any exit path.
-    pub fn try_recv(&mut self) -> Option<(Event, AckPosition)> {
+    pub fn try_recv(&mut self) -> Option<(QueuedEvent, AckPosition)> {
         match &mut self.inner {
             ReceiverInner::Memory(rx) => rx.try_recv().ok().map(|e| (e, AckPosition::Memory)),
             ReceiverInner::Disk(rx) => rx.try_recv(),
@@ -646,7 +648,11 @@ impl QueueReceiver {
     ///    `elapsed()` after — the duration is fed to `record_park`
     ///    so the controller can grow the budget when it sees a park
     ///    that spinning could plausibly have caught.
-    pub async fn recv_many(&mut self, buf: &mut Vec<(Event, AckPosition)>, max: usize) -> usize {
+    pub async fn recv_many(
+        &mut self,
+        buf: &mut Vec<(QueuedEvent, AckPosition)>,
+        max: usize,
+    ) -> usize {
         if max == 0 {
             return 0;
         }
@@ -902,7 +908,6 @@ pub enum AckDisposition {
 /// after `consume` returned `Ok`. The handle's `Drop` impl falls back
 /// to [`AckDisposition::Dropped`] for the unhealthy paths, and
 /// `debug_assert!`s the contract was met.
-#[derive(Debug)]
 pub struct QueueAckHandle {
     tx: Option<tokio::sync::mpsc::UnboundedSender<(AckPosition, AckDisposition)>>,
     /// Position the handle's event occupied in the source queue,
@@ -918,17 +923,23 @@ pub struct QueueAckHandle {
     /// distinguish "resolved cleanly" (silence the debug_assert) from
     /// "dropped without resolve" (fire the assert + send `Dropped`).
     resolved: bool,
+    emitted_ns: crate::time::UnixNanos,
+    metrics: Arc<crate::metrics::OutputMetrics>,
 }
 
 impl QueueAckHandle {
     pub fn new(
         tx: tokio::sync::mpsc::UnboundedSender<(AckPosition, AckDisposition)>,
         position: AckPosition,
+        emitted_ns: crate::time::UnixNanos,
+        metrics: Arc<crate::metrics::OutputMetrics>,
     ) -> Self {
         Self {
             tx: Some(tx),
             position,
             resolved: false,
+            emitted_ns,
+            metrics,
         }
     }
 
@@ -946,7 +957,13 @@ impl QueueAckHandle {
     }
 
     /// Signal that the event was durably delivered. Consumes the handle.
-    pub fn resolve_delivered(mut self) {
+    pub fn resolve_delivered(self) {
+        self.resolve_delivered_at(crate::time::UnixNanos::now());
+    }
+
+    /// Signal delivery using a caller-sampled wall-clock boundary.
+    pub(crate) fn resolve_delivered_at(mut self, delivered_at: crate::time::UnixNanos) {
+        self.metrics.observe_delivery(self.emitted_ns, delivered_at);
         self.resolved = true;
         if let Some(tx) = self.tx.take() {
             let _ = tx.send((self.position, AckDisposition::Delivered));
@@ -1000,7 +1017,15 @@ impl QueueAckHandle {
         tokio::sync::mpsc::UnboundedReceiver<(AckPosition, AckDisposition)>,
     ) {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        (Self::new(tx, AckPosition::Memory), rx)
+        (
+            Self::new(
+                tx,
+                AckPosition::Memory,
+                crate::time::UnixNanos::now(),
+                crate::metrics::OutputMetrics::for_testing(),
+            ),
+            rx,
+        )
     }
 
     /// Test-only constructor that also sets the carried position.
@@ -1012,7 +1037,15 @@ impl QueueAckHandle {
         tokio::sync::mpsc::UnboundedReceiver<(AckPosition, AckDisposition)>,
     ) {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        (Self::new(tx, position), rx)
+        (
+            Self::new(
+                tx,
+                position,
+                crate::time::UnixNanos::now(),
+                crate::metrics::OutputMetrics::for_testing(),
+            ),
+            rx,
+        )
     }
 }
 
@@ -1080,7 +1113,7 @@ pub async fn run_queue_consumer(
     // is cancel-safe up to its first pushed event, and the drain that
     // follows the first push is synchronous, the only state that can
     // survive across select re-entries is an empty buffer.
-    let mut batch: Vec<(Event, AckPosition)> = Vec::with_capacity(RECV_BATCH_MAX);
+    let mut batch: Vec<(QueuedEvent, AckPosition)> = Vec::with_capacity(RECV_BATCH_MAX);
     metrics.queue_depth.set(receiver.depth());
 
     loop {
@@ -1136,7 +1169,12 @@ pub async fn run_queue_consumer(
                                 if let Some(tap) = &tap {
                                     tap.emit(&format!("output {}", name), &event).await;
                                 }
-                                let handle = QueueAckHandle::new(ack_tx.clone(), position);
+                                let handle = QueueAckHandle::new(
+                                    ack_tx.clone(),
+                                    position,
+                                    event.emitted_ns(),
+                                    Arc::clone(&metrics),
+                                );
                                 in_flight += 1;
                                 // `consume_shutdown` (not `consume`) — the
                                 // shutdown contract forbids the steady-state
@@ -1247,7 +1285,12 @@ pub async fn run_queue_consumer(
                         if let Some(tap) = &tap {
                             tap.emit(&format!("output {}", name), &event).await;
                         }
-                        let handle = QueueAckHandle::new(ack_tx.clone(), position);
+                        let handle = QueueAckHandle::new(
+                            ack_tx.clone(),
+                            position,
+                            event.emitted_ns(),
+                            Arc::clone(&metrics),
+                        );
                         in_flight += 1;
                         if let Err(e) = writer.consume(&event, handle).await {
                             // Reaching here means the output returned an
@@ -1459,7 +1502,7 @@ mod wedge_transition_helper_tests {
     #[test]
     fn first_dropped_on_disk_sets_wedge_and_bumps() {
         let mut wedged = false;
-        let metrics = OutputMetrics::for_testing();
+        let metrics = crate::metrics::OutputMetrics::for_testing();
         record_wedge_transition_if_first(
             disk_pos(1),
             AckDisposition::Dropped,
@@ -1541,10 +1584,13 @@ mod consumer_lifecycle_tests {
     use std::sync::Mutex;
     use std::sync::atomic::Ordering;
 
-    fn owned_event() -> Event {
-        Event::new(
-            Bytes::from_static(b"x"),
-            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+    fn owned_event() -> QueuedEvent {
+        QueuedEvent::new(
+            Event::new(
+                Bytes::from_static(b"x"),
+                "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+            ),
+            crate::time::UnixNanos::now(),
         )
     }
 
@@ -1784,6 +1830,75 @@ mod consumer_lifecycle_tests {
             Some((AckPosition::Memory, AckDisposition::Recovered))
         );
         assert_eq!(rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn delivery_latency_is_observed_only_for_delivered_dispositions() {
+        let metrics = crate::metrics::OutputMetrics::for_testing();
+        let emitted_at = crate::time::UnixNanos::new(1_000_000_000);
+
+        let (delivered_tx, mut delivered_rx) = tokio::sync::mpsc::unbounded_channel();
+        QueueAckHandle::new(
+            delivered_tx,
+            AckPosition::Memory,
+            emitted_at,
+            Arc::clone(&metrics),
+        )
+        .resolve_delivered_at(crate::time::UnixNanos::new(3_000_000_000));
+        assert_eq!(
+            delivered_rx.recv().await,
+            Some((AckPosition::Memory, AckDisposition::Delivered))
+        );
+        assert_eq!(metrics.delivery_seconds.count(), 1);
+        assert!(metrics.delivery_seconds.sum() >= 2.0);
+
+        let (recovered_tx, mut recovered_rx) = tokio::sync::mpsc::unbounded_channel();
+        QueueAckHandle::new(
+            recovered_tx,
+            AckPosition::Memory,
+            emitted_at,
+            Arc::clone(&metrics),
+        )
+        .resolve_recovered();
+        assert_eq!(
+            recovered_rx.recv().await,
+            Some((AckPosition::Memory, AckDisposition::Recovered))
+        );
+        assert_eq!(metrics.delivery_seconds.count(), 1);
+
+        let (dropped_tx, mut dropped_rx) = tokio::sync::mpsc::unbounded_channel();
+        QueueAckHandle::new(
+            dropped_tx,
+            AckPosition::Memory,
+            emitted_at,
+            Arc::clone(&metrics),
+        )
+        .resolve_dropped();
+        assert_eq!(
+            dropped_rx.recv().await,
+            Some((AckPosition::Memory, AckDisposition::Dropped))
+        );
+        assert_eq!(metrics.delivery_seconds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn accepted_batch_can_resolve_multiple_acks_at_one_delivery_boundary() {
+        let metrics = crate::metrics::OutputMetrics::for_testing();
+        let delivered_at = crate::time::UnixNanos::new(10_000_000_000);
+        for emitted_at in [
+            crate::time::UnixNanos::new(7_000_000_000),
+            crate::time::UnixNanos::new(8_000_000_000),
+        ] {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            QueueAckHandle::new(tx, AckPosition::Memory, emitted_at, Arc::clone(&metrics))
+                .resolve_delivered_at(delivered_at);
+            assert_eq!(
+                rx.recv().await,
+                Some((AckPosition::Memory, AckDisposition::Delivered))
+            );
+        }
+        assert_eq!(metrics.delivery_seconds.count(), 2);
+        assert_eq!(metrics.delivery_seconds.sum(), 5.0);
     }
 
     #[tokio::test]
@@ -2560,13 +2675,16 @@ mod consumer_lifecycle_tests {
                 Bytes::copy_from_slice(&i.to_le_bytes()),
                 "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
             );
-            sender.send(e).await.unwrap();
+            sender
+                .send(QueuedEvent::new(e, crate::time::UnixNanos::now()))
+                .await
+                .unwrap();
         }
         // Give the sends time to land so recv_many drains the whole
         // backlog in one call (deterministic single-batch scenario).
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        let mut buf: Vec<(Event, AckPosition)> = Vec::with_capacity(16);
+        let mut buf: Vec<(QueuedEvent, AckPosition)> = Vec::with_capacity(16);
         let n = receiver.recv_many(&mut buf, 16).await;
         assert_eq!(n, 8, "single-batch drain must collect all 8 events");
         for (i, (event, _)) in buf.iter().enumerate() {
@@ -2605,7 +2723,7 @@ mod consumer_lifecycle_tests {
         }
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        let mut buf: Vec<(Event, AckPosition)> = Vec::with_capacity(8);
+        let mut buf: Vec<(QueuedEvent, AckPosition)> = Vec::with_capacity(8);
         let n = receiver.recv_many(&mut buf, 8).await;
         assert_eq!(n, 5);
         let mut seen: std::collections::HashSet<AckPosition> = std::collections::HashSet::new();
@@ -2643,7 +2761,7 @@ mod consumer_lifecycle_tests {
         sender.send(owned_event()).await.unwrap();
         drop(sender);
 
-        let mut buf: Vec<(Event, AckPosition)> = Vec::with_capacity(8);
+        let mut buf: Vec<(QueuedEvent, AckPosition)> = Vec::with_capacity(8);
         let n = receiver.recv_many(&mut buf, 8).await;
         assert_eq!(n, 3, "closing after 3 sends must still yield those 3");
         buf.clear();
@@ -2846,7 +2964,7 @@ mod consumer_lifecycle_tests {
 
         // Warm-up round: prove that Some path is exercised.
         sender.send(owned_event()).await.unwrap();
-        let mut buf: Vec<(Event, AckPosition)> = Vec::with_capacity(4);
+        let mut buf: Vec<(QueuedEvent, AckPosition)> = Vec::with_capacity(4);
         assert_eq!(receiver.recv_many(&mut buf, 4).await, 1);
         buf.clear();
 
@@ -2882,7 +3000,7 @@ mod consumer_lifecycle_tests {
         let src = include_str!("mod.rs");
         // Locate the recv_many body between the pub-async signature
         // and the trailing brace at the end of the fn.
-        let sig_marker = "pub async fn recv_many(&mut self, buf: &mut Vec<(Event, AckPosition)>, max: usize) -> usize {";
+        let sig_marker = "pub async fn recv_many(\n        &mut self,\n        buf: &mut Vec<(QueuedEvent, AckPosition)>,\n        max: usize,\n    ) -> usize {";
         let start = src
             .find(sig_marker)
             .expect("recv_many signature marker must exist");

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -2784,10 +2784,14 @@ mod consumer_lifecycle_tests {
         // not span cancellations. We only assert the declaration
         // shape; a rename of `batch` would only fail this pin (not
         // the correctness of the code) and force a deliberate update.
+        // Assemble the declaration so this test cannot satisfy its own
+        // source-text assertion when the production declaration drifts.
+        let batch_declaration = concat!(
+            "let mut batch: Vec<(Queued",
+            "Event, AckPosition)> = Vec::with_capacity(RECV_BATCH_MAX);"
+        );
         assert!(
-            src.contains(
-                "let mut batch: Vec<(Event, AckPosition)> = Vec::with_capacity(RECV_BATCH_MAX);"
-            ),
+            src.contains(batch_declaration),
             "batch buffer must be declared once outside the select loop"
         );
         // The steady-state arm must dispatch through `recv_many` and

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -2648,9 +2648,12 @@ def pipeline p { process a }
         )
         .expect("memory queue");
         queue_sender
-            .send(Event::new(
-                Bytes::from_static(b"filler"),
-                "127.0.0.1:0".parse().unwrap(),
+            .send(crate::event::QueuedEvent::new(
+                Event::new(
+                    Bytes::from_static(b"filler"),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
+                crate::time::UnixNanos::now(),
             ))
             .await
             .expect("prefill queue");

--- a/crates/limpid/src/time.rs
+++ b/crates/limpid/src/time.rs
@@ -1,0 +1,145 @@
+//! Typed wall-clock values used by duration telemetry.
+//!
+//! Queue records persist an absolute wall-clock boundary so delivery latency
+//! can span a restart. Keep that representation separate from elapsed
+//! durations and convert to floating-point seconds only at the metrics facade.
+
+use chrono::{DateTime, Utc};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct UnixNanos(i64);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DurationNanos(u64);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ElapsedNanos {
+    pub(crate) duration: DurationNanos,
+    pub(crate) reversed: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ClockSample {
+    pub(crate) utc: DateTime<Utc>,
+    pub(crate) unix_nanos: UnixNanos,
+}
+
+impl UnixNanos {
+    pub(crate) const fn new(value: i64) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn now() -> Self {
+        Self::from_system_time(SystemTime::now())
+    }
+
+    pub(crate) fn from_system_time(value: SystemTime) -> Self {
+        let nanos = match value.duration_since(UNIX_EPOCH) {
+            Ok(duration) => i128::try_from(duration.as_nanos()).unwrap_or(i128::MAX),
+            Err(error) => -i128::try_from(error.duration().as_nanos()).unwrap_or(i128::MAX),
+        };
+        Self(nanos.clamp(i64::MIN as i128, i64::MAX as i128) as i64)
+    }
+
+    pub(crate) fn from_datetime(value: DateTime<Utc>) -> Self {
+        Self(value.timestamp_nanos_opt().unwrap_or_else(|| {
+            if value.timestamp() < 0 {
+                i64::MIN
+            } else {
+                i64::MAX
+            }
+        }))
+    }
+
+    pub(crate) const fn get(self) -> i64 {
+        self.0
+    }
+
+    pub(crate) const fn to_datetime(self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp_nanos(self.0)
+    }
+
+    pub(crate) fn to_wire_u64(self) -> u64 {
+        u64::try_from(self.0).unwrap_or(0)
+    }
+
+    pub(crate) fn elapsed_since(self, earlier: Self) -> ElapsedNanos {
+        let delta = self.0 as i128 - earlier.0 as i128;
+        if delta < 0 {
+            ElapsedNanos {
+                duration: DurationNanos(0),
+                reversed: true,
+            }
+        } else {
+            ElapsedNanos {
+                duration: DurationNanos(delta as u64),
+                reversed: false,
+            }
+        }
+    }
+}
+
+impl DurationNanos {
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn as_seconds_f64(self) -> f64 {
+        self.0 as f64 / 1_000_000_000.0
+    }
+}
+
+impl ElapsedNanos {
+    pub(crate) fn between_u64(later: u64, earlier: u64) -> Self {
+        match later.checked_sub(earlier) {
+            Some(duration) => Self {
+                duration: DurationNanos(duration),
+                reversed: false,
+            },
+            None => Self {
+                duration: DurationNanos(0),
+                reversed: true,
+            },
+        }
+    }
+}
+
+impl ClockSample {
+    pub(crate) fn now() -> Self {
+        let unix_nanos = UnixNanos::now();
+        Self {
+            utc: unix_nanos.to_datetime(),
+            unix_nanos,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_datetime(utc: DateTime<Utc>) -> Self {
+        Self {
+            unix_nanos: UnixNanos::from_datetime(utc),
+            utc,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_time_is_total_and_elapsed_clamps_reversed_clocks() {
+        let before_epoch = UNIX_EPOCH - std::time::Duration::from_nanos(7);
+        let sample = UnixNanos::from_system_time(before_epoch);
+        assert_eq!(sample.get(), -7);
+        assert_eq!(sample.to_wire_u64(), 0);
+
+        let reversed = UnixNanos::new(4).elapsed_since(UnixNanos::new(9));
+        assert_eq!(reversed.duration, DurationNanos::new(0));
+        assert!(reversed.reversed);
+
+        let wire_reversed = ElapsedNanos::between_u64(i64::MAX as u64, u64::MAX);
+        assert_eq!(wire_reversed.duration, DurationNanos::new(0));
+        assert!(wire_reversed.reversed);
+    }
+}

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -109,6 +109,7 @@ for the same-host multi-instance deployment caveat.
 | `limpid_pipeline_events_errored_total` | `pipeline` | Events that failed at a pipeline-side producer site and were routed to the [error log](./error-log.md). |
 | `limpid_pipeline_events_errored_unwritable_total` | `pipeline` | Pipeline-side error-log writes that failed. |
 | `limpid_pipeline_inflight` | `pipeline` | Pipeline executions currently in progress, including terminal bookkeeping. |
+| `limpid_pipeline_processing_seconds` | `pipeline`, `output` | Local input arrival to the emission of that output statement's event snapshot. |
 
 `events_discarded` is a possible routing-misconfiguration signal: the event
 completed the pipeline but was never sent anywhere.
@@ -119,6 +120,15 @@ completed the pipeline but was never sent anywhere.
 failures are counted under the corresponding output's `events_failed`. The
 original event is preserved when the configured error-log write succeeds; see
 [Error Log → Replay](./error-log.md#replay).
+
+`limpid_pipeline_processing_seconds` is registered once for every configured
+`pipeline`/`output` pair. Each Output statement observes the interval from the
+event's local input `received_at` to that statement's snapshot; repeated calls
+to the same output share one series, while fan-out outputs observe independent
+snapshots. Reaching an Output statement therefore adds one processing
+observation, including each branch of a fan-out. Its finite bucket bounds are
+`0.0001`, `0.001`, `0.005`, `0.025`,
+`0.1`, `0.5`, `2.5`, and `10` seconds.
 
 ### Process invocations
 
@@ -246,6 +256,7 @@ certificates are not classified as unknown peers.
 | `limpid_output_bytes_written_total` | `output` | Logical bytes whose transfer to the destination was confirmed. |
 | `limpid_output_queue_depth` | `output` | Current unread or unacknowledged output queue depth. |
 | `limpid_output_in_retry` | `output` | Whether an output retry cycle is active (`0` or `1`). |
+| `limpid_output_delivery_seconds` | `output` | Output emission or direct injection to confirmed delivery. |
 
 `events_failed` includes retry-budget exhaustion, per-event render failures in
 batched output flushes, shutdown-drain leftovers after a final flush failure,
@@ -260,6 +271,28 @@ and OTLP `partial_success.rejected_log_records`. Evaluate it with the DLQ file,
 
 See the [output disposition contract](../outputs/README.md#disposition-contract)
 and [Error Log → When the DLQ write itself fails](./error-log.md#when-the-dlq-write-itself-fails).
+
+`limpid_output_delivery_seconds` starts at the per-output statement snapshot,
+or immediately before a direct output injection enters the queue. It includes
+remaining pipeline work, enqueue blocking, memory or disk queue residence,
+batching, retries, transport work, and replay after restart. An observation is
+added only when the queue acknowledgement resolves as Delivered; Recovered,
+Dropped, wedge, and enqueue-failure paths do not contribute. This is therefore
+a delivered-event latency distribution, not a success-rate denominator. Its
+finite bucket bounds are `0.001`, `0.005`, `0.025`, `0.1`, `0.5`, `2.5`, `10`,
+`30`, `60`, `300`, `900`, and `3600` seconds.
+
+Each event resolved as Delivered adds one delivery observation. Batched
+outputs share a single delivery-time sample for the accepted prefix, but every
+Delivered event still increments the histogram count. Together with the
+per-Output processing observation above, telemetry work scales proportionally
+with fan-out.
+
+> **Upgrade note:** The disk output-queue record format changed with these
+> latency boundaries. Drain disk-backed output queues before stopping the old
+> daemon and upgrading. Older queued records do not contain the required
+> `emitted_ns` field; the new daemon rejects them and emits the existing
+> corrupted-record warning rather than mixing incompatible latency samples.
 
 Useful relationships are approximate during concurrent updates:
 

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -110,6 +110,7 @@ for the same-host multi-instance deployment caveat.
 | `limpid_pipeline_events_errored_unwritable_total` | `pipeline` | Pipeline-side error-log writes that failed. |
 | `limpid_pipeline_inflight` | `pipeline` | Pipeline executions currently in progress, including terminal bookkeeping. |
 | `limpid_pipeline_processing_seconds` | `pipeline`, `output` | Local input arrival to the emission of that output statement's event snapshot. |
+| `limpid_pipeline_processing_negative_delta_total` | `pipeline`, `output` | Processing durations clamped to zero after a wall-clock reversal. |
 
 `events_discarded` is a possible routing-misconfiguration signal: the event
 completed the pipeline but was never sent anywhere.
@@ -129,6 +130,9 @@ snapshots. Reaching an Output statement therefore adds one processing
 observation, including each branch of a fan-out. Its finite bucket bounds are
 `0.0001`, `0.001`, `0.005`, `0.025`,
 `0.1`, `0.5`, `2.5`, and `10` seconds.
+If the wall clock moves backward between input arrival and output emission, the
+duration is clamped to zero and
+`limpid_pipeline_processing_negative_delta_total` increments.
 
 ### Process invocations
 
@@ -257,6 +261,7 @@ certificates are not classified as unknown peers.
 | `limpid_output_queue_depth` | `output` | Current unread or unacknowledged output queue depth. |
 | `limpid_output_in_retry` | `output` | Whether an output retry cycle is active (`0` or `1`). |
 | `limpid_output_delivery_seconds` | `output` | Output emission or direct injection to confirmed delivery. |
+| `limpid_output_delivery_negative_delta_total` | `output` | Delivery durations clamped to zero after a wall-clock reversal. |
 
 `events_failed` includes retry-budget exhaustion, per-event render failures in
 batched output flushes, shutdown-drain leftovers after a final flush failure,
@@ -281,6 +286,9 @@ Dropped, wedge, and enqueue-failure paths do not contribute. This is therefore
 a delivered-event latency distribution, not a success-rate denominator. Its
 finite bucket bounds are `0.001`, `0.005`, `0.025`, `0.1`, `0.5`, `2.5`, `10`,
 `30`, `60`, `300`, `900`, and `3600` seconds.
+If the wall clock moves backward between emission and delivery, including
+across a daemon restart, the duration is clamped to zero and
+`limpid_output_delivery_negative_delta_total` increments.
 
 Each event resolved as Delivered adds one delivery observation. Batched
 outputs share a single delivery-time sample for the accepted prefix, but every


### PR DESCRIPTION
## Summary

- Record per-Output pipeline processing latency from local input receipt to each reached Output statement.
- Record output delivery latency only for Delivered events, including queueing, batching, retries, transport, and restart recovery.
- Use a common typed duration path while preserving existing histogram storage and LTP wire behavior; batched outputs share one delivery timestamp across the accepted prefix.

## Queue compatibility

Disk queue records now require the breaking `emitted_ns` field. Operators should drain queues before upgrading, as documented.

## Validation

- Workspace tests, formatting, linting, documentation, audit, and dependency-policy gates passed.
- Ubuntu 24.04 aarch64 with Rust 1.95 passed workspace all-features build, test, and clippy.
- Canonical benchmark gates found no catastrophic regression. Measurements ran in a Mac-hosted VM and are not used for single-digit effect-size claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pipeline processing-latency metrics by pipeline and output.
  - Added end-to-end output-delivery latency metrics, including batched delivery tracking.
  - Event timestamps are preserved through in-memory and disk queues.

- **Bug Fixes**
  - Improved latency calculations with consistent timestamp handling and safeguards for reversed clock readings.
  - Disk queues now reject incomplete or invalid timestamp records and report corruption clearly.

- **Documentation**
  - Documented latency metrics, measurement boundaries, batching behavior, and disk-queue upgrade considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->