### PR TITLE
feat(observability): ship Grafana dashboard and alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,128 @@ jobs:
       - name: Clippy (kafka + journal)
         run: cargo clippy --workspace --features kafka,journal -- -D warnings
 
+  observability-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # pin-audit:2026-06-03 de0fac2 | v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # pin-audit:2026-05-21 e18b497 | v2
+        with:
+          key: observability-assets
+          save-if: ${{ github.event_name != 'pull_request' }}
+
+      - name: Validate Grafana dashboard contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          dashboard=packaging/grafana/limpid-dashboard.json
+          jq -e '
+            . as $dashboard |
+            ([.panels[] | select(.type == "row")] | sort_by(.gridPos.y)) as $rows |
+            .uid == "limpid-health-flow" and
+            .title == "Limpid Health & Flow" and
+            .timezone == "browser" and
+            (.tags | index("limpid") != null) and
+            ([.__inputs[] | select(.name == "DS_PROMETHEUS" and .pluginId == "prometheus")] | length == 1) and
+            ([.panels[].id] | length == (unique | length)) and
+            ([.panels[] | [.gridPos.x, .gridPos.y, .gridPos.w, .gridPos.h] | @csv] | length == (unique | length)) and
+            (all(.panels[]; .gridPos.x >= 0 and .gridPos.y >= 0 and .gridPos.w > 0 and .gridPos.h > 0 and (.gridPos.x + .gridPos.w) <= 24)) and
+            ([.panels[] | select(.type != "row")] | length == 22) and
+            ([$rows[].title] == ["Health","Inputs","Pipelines","Processes","Loss & recovery","Outputs","LTP"]) and
+            ([.panels[] | select(.id == 18)] | length == 1 and all(.title == "Input byte rate" and .gridPos.x == 0 and .gridPos.w == 24 and .gridPos.y > $rows[1].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[2].gridPos.y)) and
+            (all(.panels[] | select(.id as $id | [2,3,4,5] | index($id)); .gridPos.y > $rows[0].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[1].gridPos.y)) and
+            (all(.panels[] | select(.id as $id | [7,8,9,28] | index($id)); .gridPos.y > $rows[2].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[3].gridPos.y)) and
+            (all(.panels[] | select(.id as $id | [15,16] | index($id)); .gridPos.y > $rows[3].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[4].gridPos.y)) and
+            (all(.panels[] | select(.id as $id | [11,12,13] | index($id)); .gridPos.y > $rows[4].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[5].gridPos.y)) and
+            (all(.panels[] | select(.id as $id | [19,20,21,29] | index($id)); .gridPos.y > $rows[5].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[6].gridPos.y)) and
+            (all(.panels[] | select(.id as $id | [23,24,25,26] | index($id)); .gridPos.y > $rows[6].gridPos.y)) and
+            (all(.panels[]; .type as $type | (["row", "stat", "timeseries", "heatmap"] | index($type)) != null)) and
+            (all(.panels[] | select(.type != "row"); .datasource.uid == "${DS_PROMETHEUS}")) and
+            (([.templating.list[].name] | sort) == ["input", "instance", "job", "output", "peer", "pipeline"]) and
+            (all(.templating.list[]; .datasource.uid == "${DS_PROMETHEUS}" and .includeAll == true and .multi == true)) and
+            ([.panels[].targets[]?.expr | select(contains("limpid_events_dropped_total"))] | length == 1 and all(contains("process_path=\"/\""))) and
+            ([.panels[].targets[]? | select(.expr | contains("limpid_events_dropped_own_total"))] | length == 1 and all((.expr | contains("process_path!=\"/\"") | not) and (.expr | contains("sum by (instance, pipeline, step, process_name, process_path)")) and (.legendFormat | contains("#{{step}} {{process_path}}")))) and
+            ([.panels[].targets[]?.expr | select(contains("limpid_output_retries_total"))] | length == 1) and
+            ([.panels[].targets[]?.expr] | all(contains("limpid_output_events_retries_total") | not)) and
+            ([.panels[] | select(.id == 4) | .targets[].expr] | length == 1 and all(contains("sum(limpid_output_queue_depth") and contains("} > bool 0)") and (contains("count(limpid_output_queue_depth") | not))) and
+            ([.panels[] | select(.id == 2) | .fieldConfig.defaults] | all(.noValue == "—" and .thresholds.steps == [{"color":"red","value":null},{"color":"green","value":1}])) and
+            ([.panels[] | select(.id == 3) | .fieldConfig.defaults] | all(.noValue == "—" and (has("thresholds") | not))) and
+            ([.panels[] | select(.id == 4 or .id == 5) | .fieldConfig.defaults] | length == 2 and all(.noValue == "—" and .thresholds.steps == [{"color":"green","value":null},{"color":"yellow","value":1}])) and
+            ([.panels[] | select(.id == 19 or .id == 20) | [.gridPos.x, .gridPos.w]] | sort == [[0,12],[12,12]]) and
+            ([.panels[] | select(.id == 19 or .id == 20) | .gridPos.y] | unique | length == 1) and
+            ([.panels[] | select(.id == 20) | [.gridPos.w, .gridPos.h]] | all(.[0] >= 8 and .[1] >= 8)) and
+            ([.panels[] | select(.id == 21)] | all(.gridPos.x == 0 and .gridPos.w == 24 and .gridPos.y == ($dashboard.panels[] | select(.id == 19) | (.gridPos.y + .gridPos.h)))) and
+            ([.panels[] | select(.type != "row") | {id, x:.gridPos.x, y:.gridPos.y, w:.gridPos.w, h:.gridPos.h}] as $panels | [$panels[] as $a | $panels[] as $b | select($a.id < $b.id) | (($a.x + $a.w > $b.x) and ($b.x + $b.w > $a.x) and ($a.y + $a.h > $b.y) and ($b.y + $b.h > $a.y))] | all(. == false)) and
+            ([.panels[].targets[]?.expr] | any(contains("limpid_ltp_hop_latency_seconds_count") and contains("segment=\"network\""))) and
+            ([.panels[].targets[]?.expr | select(contains("limpid_ltp_rejected_unknown_peer_total"))] | length == 1 and all(contains("sum by (instance)") and (contains("peer=~") | not) and (contains("by (instance, peer)") | not))) and
+            ([.panels[].targets[]?.expr | select(contains("limpid_ltp_hop_latency_seconds_bucket"))] | length == 2 and any(contains("segment=\"network\"") and contains("sum by (le)")) and any(contains("segment=\"intra\"") and contains("sum by (le)")) and all(contains("segment)") | not))
+            and ([.panels[] | select(.id == 28) | .targets[]?.expr] | length == 1 and all(contains("limpid_pipeline_processing_seconds_bucket") and contains("pipeline=~\"$pipeline\"") and contains("output=~\"$output\"") and contains("sum by (le)")))
+            and ([.panels[] | select(.id == 29) | .targets[]?.expr] | length == 1 and all(contains("limpid_output_delivery_seconds_bucket") and contains("output=~\"$output\"") and contains("sum by (le)")))
+          ' "$dashboard"
+          jq -e '
+            [.. | strings] |
+            all(
+              (test("dropped_by|dlq_depth|peer_id|canary|dispatcher|site_kind|limpid_output_events_retries_total|Pipeline flow|Process invocation flow|Loss attribution|Outputs and bytes") | not) and
+              (test("(^|[^0-9])([0-9]{1,3}\\.){3}[0-9]{1,3}([^0-9]|$)") | not)
+            )
+          ' "$dashboard"
+
+      - name: Validate PromQL and alert semantics
+        shell: bash
+        env:
+          PROMETHEUS_IMAGE: prom/prometheus@sha256:63805ebb8d2b3920190daf1cb14a60871b16fd38bed42b857a3182bc621f4996
+        run: |
+          set -euo pipefail
+          grafana_dir="$PWD/packaging/grafana"
+          docker run --rm --entrypoint /bin/promtool \
+            -v "$grafana_dir:/work:ro" "$PROMETHEUS_IMAGE" \
+            check rules /work/limpid-alerts.yaml
+          docker run --rm --entrypoint /bin/promtool \
+            -v "$grafana_dir:/work:ro" "$PROMETHEUS_IMAGE" \
+            test rules /work/limpid-alerts.test.yaml
+          mapfile -t expressions < <(
+            jq -r '.panels[].targets[]?.expr // empty' \
+              packaging/grafana/limpid-dashboard.json
+          )
+          for expression in "${expressions[@]}"; do
+            expression="${expression//\$__rate_interval/5m}"
+            docker run --rm --entrypoint /bin/promtool \
+              "$PROMETHEUS_IMAGE" --experimental promql format "$expression" \
+              >/dev/null
+          done
+
+      - name: Verify alert scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          rules=packaging/grafana/limpid-alerts.yaml
+          awk '/^[[:space:]]+- alert:/{print $3}' "$rules" > alert-names.txt
+          test "$(wc -l < alert-names.txt)" -eq 4
+          diff -u \
+            <(printf '%s\n' LimpidOutputQueueBacklog LimpidOutputUnwritable LimpidOutputWedged LimpidPipelineUnwritable) \
+            <(sort alert-names.txt)
+          ! grep -Eq 'rejected_unknown|loop_dropped|events_errored_total|\bup\b' "$rules"
+
+      - name: Verify deb assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo install --locked --version 3.7.0 cargo-deb
+          cargo build --release --locked -p limpid-prometheus
+          cargo deb --no-build --locked -p limpid-prometheus
+          deb="$(find target/debian -maxdepth 1 -type f -name 'limpid-prometheus_*.deb' -print -quit)"
+          test -n "$deb"
+          dpkg-deb --contents "$deb" > deb-contents.txt
+          test "$(grep -c 'usr/share/limpid/grafana/limpid-dashboard.json$' deb-contents.txt)" -eq 1
+          test "$(grep -c 'usr/share/limpid/grafana/limpid-alerts.yaml$' deb-contents.txt)" -eq 1
+          ! grep -q 'limpid-alerts.test.yaml' deb-contents.txt
+
   # Supply-chain audit: `cargo deny check advisories bans sources
   # licenses` gates every dimension `deny.toml` covers — RustSec
   # advisories, banned/duplicate crates, source restrictions, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,13 +173,14 @@ jobs:
             ([.panels[].id] | length == (unique | length)) and
             ([.panels[] | [.gridPos.x, .gridPos.y, .gridPos.w, .gridPos.h] | @csv] | length == (unique | length)) and
             (all(.panels[]; .gridPos.x >= 0 and .gridPos.y >= 0 and .gridPos.w > 0 and .gridPos.h > 0 and (.gridPos.x + .gridPos.w) <= 24)) and
-            ([.panels[] | select(.type != "row")] | length == 22) and
+            ([.panels[] | select(.type != "row")] | length == 23) and
+            ([.panels[].targets[]?.expr] | length == 32) and
             ([$rows[].title] == ["Health","Inputs","Pipelines","Processes","Loss & recovery","Outputs","LTP"]) and
             ([.panels[] | select(.id == 18)] | length == 1 and all(.title == "Input byte rate" and .gridPos.x == 0 and .gridPos.w == 24 and .gridPos.y > $rows[1].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[2].gridPos.y)) and
             (all(.panels[] | select(.id as $id | [2,3,4,5] | index($id)); .gridPos.y > $rows[0].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[1].gridPos.y)) and
             (all(.panels[] | select(.id as $id | [7,8,9,28] | index($id)); .gridPos.y > $rows[2].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[3].gridPos.y)) and
             (all(.panels[] | select(.id as $id | [15,16] | index($id)); .gridPos.y > $rows[3].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[4].gridPos.y)) and
-            (all(.panels[] | select(.id as $id | [11,12,13] | index($id)); .gridPos.y > $rows[4].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[5].gridPos.y)) and
+            (all(.panels[] | select(.id as $id | [11,12,13,30] | index($id)); .gridPos.y > $rows[4].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[5].gridPos.y)) and
             (all(.panels[] | select(.id as $id | [19,20,21,29] | index($id)); .gridPos.y > $rows[5].gridPos.y and (.gridPos.y + .gridPos.h) <= $rows[6].gridPos.y)) and
             (all(.panels[] | select(.id as $id | [23,24,25,26] | index($id)); .gridPos.y > $rows[6].gridPos.y)) and
             (all(.panels[]; .type as $type | (["row", "stat", "timeseries", "heatmap"] | index($type)) != null)) and
@@ -204,6 +205,10 @@ jobs:
             ([.panels[].targets[]?.expr | select(contains("limpid_ltp_hop_latency_seconds_bucket"))] | length == 2 and any(contains("segment=\"network\"") and contains("sum by (le)")) and any(contains("segment=\"intra\"") and contains("sum by (le)")) and all(contains("segment)") | not))
             and ([.panels[] | select(.id == 28) | .targets[]?.expr] | length == 1 and all(contains("limpid_pipeline_processing_seconds_bucket") and contains("pipeline=~\"$pipeline\"") and contains("output=~\"$output\"") and contains("sum by (le)")))
             and ([.panels[] | select(.id == 29) | .targets[]?.expr] | length == 1 and all(contains("limpid_output_delivery_seconds_bucket") and contains("output=~\"$output\"") and contains("sum by (le)")))
+            and ([.panels[] | select(.id == 30 and .title == "Clock-reversed latency observations")] | length == 1)
+            and ([.panels[] | select(.id == 30) | .targets[]] | length == 2)
+            and ([.panels[] | select(.id == 30) | .targets[] | select(.refId == "A")] | length == 1 and all((.expr | contains("limpid_pipeline_processing_negative_delta_total") and contains("job=~\"$job\"") and contains("instance=~\"$instance\"") and contains("pipeline=~\"$pipeline\"") and contains("output=~\"$output\"") and contains("sum by (instance, pipeline, output)")) and (.legendFormat | startswith("pipeline clamp "))))
+            and ([.panels[] | select(.id == 30) | .targets[] | select(.refId == "B")] | length == 1 and all((.expr | contains("limpid_output_delivery_negative_delta_total") and contains("job=~\"$job\"") and contains("instance=~\"$instance\"") and contains("output=~\"$output\"") and contains("sum by (instance, output)")) and (.legendFormat | startswith("output clamp "))))
           ' "$dashboard"
           jq -e '
             [.. | strings] |

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -44,6 +44,8 @@ depends = "limpid"
 assets = [
     ["target/release/limpid-prometheus", "usr/bin/", "755"],
     ["../../packaging/limpid-prometheus.default", "etc/default/limpid-prometheus", "644"],
+    ["../../packaging/grafana/limpid-dashboard.json", "usr/share/limpid/grafana/", "644"],
+    ["../../packaging/grafana/limpid-alerts.yaml", "usr/share/limpid/grafana/", "644"],
 ]
 # start = false mirrors limpid.service. Without it, cargo-deb's
 # dh_installsystemd port defaults `start` to true and would start the

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -431,6 +431,77 @@ complete schema-v1 snapshot and emits Prometheus text exposition format 0.0.4:
 This ordering is a reproducible exposition surface only; it has no PromQL or
 Grafana ordering meaning.
 
+### Scrape every limpid node
+
+Bind each exporter to a management address reachable by Prometheus, and apply
+the same network-access policy used for the node's other management services.
+Do not expose the exporter to an untrusted network. A three-node forwarding
+topology can use one job:
+
+```yaml
+scrape_configs:
+  - job_name: limpid
+    static_configs:
+      - targets:
+          - sender-a.example.com:9100
+          - sender-b.example.com:9100
+          - receiver.example.com:9100
+```
+
+Scraping only a receiver gives an incomplete view. In an LTP topology the
+receiver observes the network hop, while each sender observes its local
+intra-daemon hop and output-delivery latency. Pipeline processing latency is
+also local to the daemon that runs the pipeline. The dashboard remains
+portable across one or several jobs; its `job` and `instance` variables are
+derived from `limpid_build_info` rather than fixed deployment names.
+
+After Prometheus reloads the checked configuration, verify all expected nodes
+and both latency boundaries:
+
+```promql
+count(up{job="limpid"} == 1)
+count(limpid_build_info{job="limpid"})
+sum by (instance) (limpid_pipeline_processing_seconds_count{job="limpid"})
+sum by (instance) (limpid_output_delivery_seconds_count{job="limpid"})
+sum by (instance, segment) (limpid_ltp_hop_latency_seconds_count{job="limpid"})
+```
+
+The expected node count is deployment-specific. A zero histogram count is a
+valid pre-registered series before traffic; a missing node or missing family is
+not equivalent to zero.
+
+### Import the dashboard and alert rules
+
+The `limpid-prometheus` package installs these operator assets:
+
+- `/usr/share/limpid/grafana/limpid-dashboard.json`
+- `/usr/share/limpid/grafana/limpid-alerts.yaml`
+
+For an interactive Grafana import, open **Dashboards → New → Import**, upload
+`limpid-dashboard.json`, and map its Prometheus input to the deployment's
+Prometheus datasource. The stable dashboard UID is `limpid-health-flow`, so an
+update replaces that dashboard instead of creating another copy.
+
+For file provisioning, render `${DS_PROMETHEUS}` in the JSON to the provisioned
+Prometheus datasource UID, remove the top-level `__inputs` import metadata, and
+place the rendered JSON under a Grafana dashboard provider's configured path.
+Validate the resulting dashboard has the intended datasource before restarting
+or reloading Grafana.
+
+Before deploying the alert rules, validate them with the same Prometheus
+version that will load them:
+
+```bash
+promtool check rules limpid-alerts.yaml
+```
+
+Copy the checked file into the Prometheus server's configuration-managed rules
+directory, add that path to `rule_files`, validate the complete Prometheus
+configuration, and use the deployment's supported reload mechanism. The rules
+cover output wedges, unwritable pipeline/output recovery records, and a
+persistent non-zero output backlog. They intentionally do not define alert
+routing or receivers.
+
 The translator validates the entire snapshot before exposing any samples. It
 rejects malformed or unsupported families, duplicate family names, inconsistent
 label-name sets within a family, duplicate source or mapped labelsets, invalid

--- a/packaging/grafana/limpid-alerts.test.yaml
+++ b/packaging/grafana/limpid-alerts.test.yaml
@@ -1,0 +1,98 @@
+rule_files:
+  - limpid-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - name: critical counters fire on a new event
+    interval: 1m
+    input_series:
+      - series: 'limpid_output_events_wedged_total{instance="node-a",output="sink-a"}'
+        values: '0 0 0 1 1 1'
+      - series: 'limpid_pipeline_events_errored_unwritable_total{instance="node-a",pipeline="main"}'
+        values: '0 0 0 1 1 1'
+      - series: 'limpid_output_events_errored_unwritable_total{instance="node-a",output="sink-a"}'
+        values: '0 0 0 1 1 1'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: LimpidOutputWedged
+        exp_alerts:
+          - exp_labels:
+              instance: node-a
+              output: sink-a
+              severity: critical
+            exp_annotations:
+              summary: Output queue entered a fail-stop wedge
+              description: An output could not safely advance its durable queue cursor.
+      - eval_time: 4m
+        alertname: LimpidPipelineUnwritable
+        exp_alerts:
+          - exp_labels:
+              instance: node-a
+              pipeline: main
+              severity: critical
+            exp_annotations:
+              summary: Pipeline failure record could not be written
+              description: A pipeline error could not be persisted to the configured recovery log.
+      - eval_time: 4m
+        alertname: LimpidOutputUnwritable
+        exp_alerts:
+          - exp_labels:
+              instance: node-a
+              output: sink-a
+              severity: critical
+            exp_annotations:
+              summary: Output failure record could not be written
+              description: An output error could not be persisted to the configured recovery log.
+
+  - name: a pure counter reset and absent series do not fire
+    interval: 1m
+    input_series:
+      - series: 'limpid_output_events_wedged_total{instance="node-a",output="sink-a"}'
+        values: '5 5 5 0 0 0'
+      - series: 'limpid_pipeline_events_errored_unwritable_total{instance="node-a",pipeline="main"}'
+        values: '8 8 8 0 0 0'
+      - series: 'limpid_output_events_errored_unwritable_total{instance="node-a",output="sink-a"}'
+        values: '7 7 7 0 0 0'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LimpidOutputWedged
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: LimpidPipelineUnwritable
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: LimpidOutputUnwritable
+        exp_alerts: []
+
+  - name: queue backlog waits for the full hold duration
+    interval: 1m
+    input_series:
+      - series: 'limpid_output_queue_depth{instance="node-a",output="sink-a"}'
+        values: '1+0x20'
+      - series: 'limpid_output_queue_depth{instance="node-a",output="sink-zero"}'
+        values: '0+0x20'
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: LimpidOutputQueueBacklog
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: LimpidOutputQueueBacklog
+        exp_alerts:
+          - exp_labels:
+              instance: node-a
+              output: sink-a
+              severity: warning
+            exp_annotations:
+              summary: Output queue has a persistent backlog
+              description: The output queue depth has remained non-zero for 15 minutes.
+
+  - name: queue recovery before the hold duration does not fire
+    interval: 1m
+    input_series:
+      - series: 'limpid_output_queue_depth{instance="node-a",output="sink-a"}'
+        values: '1+0x10 0+0x10'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: LimpidOutputQueueBacklog
+        exp_alerts: []

--- a/packaging/grafana/limpid-alerts.yaml
+++ b/packaging/grafana/limpid-alerts.yaml
@@ -1,0 +1,42 @@
+groups:
+  - name: limpid
+    rules:
+      - alert: LimpidOutputWedged
+        expr: increase(limpid_output_events_wedged_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: Output queue entered a fail-stop wedge
+          description: An output could not safely advance its durable queue cursor.
+
+      - alert: LimpidPipelineUnwritable
+        expr: increase(limpid_pipeline_events_errored_unwritable_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: Pipeline failure record could not be written
+          description: A pipeline error could not be persisted to the configured recovery log.
+
+      - alert: LimpidOutputUnwritable
+        expr: increase(limpid_output_events_errored_unwritable_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: Output failure record could not be written
+          description: An output error could not be persisted to the configured recovery log.
+
+      # queue_depth is an event count for memory queues and a segment-distance
+      # gauge for disk queues. A backend-neutral numeric capacity threshold
+      # would therefore be misleading; a non-zero value sustained for 15
+      # minutes detects persistent backlog without pretending the units match.
+      - alert: LimpidOutputQueueBacklog
+        expr: limpid_output_queue_depth > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Output queue has a persistent backlog
+          description: The output queue depth has remained non-zero for 15 minutes.

--- a/packaging/grafana/limpid-dashboard.json
+++ b/packaging/grafana/limpid-dashboard.json
@@ -1,0 +1,468 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource containing limpid exporter metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Health",
+      "description": "Is limpid serving traffic without blocked or retrying outputs? Drill down with `limpidctl stats --details`.",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Reporting exporters",
+      "description": "Number of selected limpid exporters currently reporting build information.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "count(limpid_build_info{job=~\"$job\",instance=~\"$instance\"})", "legendFormat": "exporters" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "noValue": "—", "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Pipeline executions in flight",
+      "description": "Current selected pipeline executions, including work waiting on terminal accounting and recovery logging.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum(limpid_pipeline_inflight{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"})", "legendFormat": "in flight" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "noValue": "—" }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Outputs with queued work",
+      "description": "Number of selected outputs with a non-zero queue depth. Each series is converted to 0 or 1 before summing, so memory-queue event counts are never added to disk-queue segment distances.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum(limpid_output_queue_depth{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"} > bool 0)", "legendFormat": "outputs with backlog" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "noValue": "—", "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 1 }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Outputs retrying",
+      "description": "Selected outputs currently inside a retry cycle.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum(limpid_output_in_retry{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"})", "legendFormat": "retrying" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "noValue": "—", "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 }
+    },
+    {
+      "id": 27,
+      "type": "row",
+      "title": "Inputs",
+      "description": "Are selected inputs consuming payload bytes?",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "Pipelines",
+      "description": "How quickly are events entering, finishing, and dropping at pipeline roots?",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Pipeline received rate",
+      "description": "Events accepted by each selected pipeline per second.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline) (rate(limpid_pipeline_events_received_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval]))", "legendFormat": "{{instance}} / {{pipeline}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Pipeline finished rate",
+      "description": "Events reaching each selected pipeline terminal per second.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline) (rate(limpid_pipeline_events_finished_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval]))", "legendFormat": "{{instance}} / {{pipeline}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Pipeline root drop rate",
+      "description": "Unified event drops attributed once at process_path=/; nested process invocation counters are deliberately excluded.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline) (rate(limpid_events_dropped_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\",process_path=\"/\"}[$__rate_interval]))", "legendFormat": "{{instance}} / {{pipeline}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 }
+    },
+    {
+      "id": 28,
+      "type": "heatmap",
+      "title": "Pipeline processing latency distribution",
+      "description": "Rate of local processing-latency histogram buckets in seconds, from this daemon's input receipt to each reached Output statement. Fan-out contributes one observation per reached output.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (le) (rate(limpid_pipeline_processing_seconds_bucket{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\",output=~\"$output\"}[$__rate_interval]))", "format": "heatmap", "legendFormat": "processing" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "showColorScale": false, "yHistogram": false } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 }
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Loss & recovery",
+      "description": "Where are drops and recovery failures occurring? Inspect affected identities with `limpidctl stats --details`.",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 42 },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Top lexical drop sites",
+      "description": "Top process sites by their own drop rate. This is lexical attribution, not a second event total.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "topk(10, sum by (instance, pipeline, step, process_name, process_path) (rate(limpid_events_dropped_own_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval])))", "legendFormat": "{{instance}} / {{pipeline}} / #{{step}} {{process_path}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 43 }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Pipeline discarded rate",
+      "description": "Events intentionally discarded by selected pipelines per second.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline) (rate(limpid_pipeline_events_discarded_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval]))", "legendFormat": "{{instance}} / {{pipeline}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 43 }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Unwritable recovery records",
+      "description": "Pipeline and output failures whose recovery record could not be written. Any increase needs immediate investigation.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline) (rate(limpid_pipeline_events_errored_unwritable_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval]))", "legendFormat": "pipeline {{instance}} / {{pipeline}}" },
+        { "refId": "B", "expr": "sum by (instance, output) (rate(limpid_output_events_errored_unwritable_total{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "output {{instance}} / {{output}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 43 }
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Processes",
+      "description": "Which process invocations are active? These counters count invocation frames and must not be summed as event totals.",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Process invocation in/out rate",
+      "description": "Source-order process identities and their invocation flow. Use `limpidctl stats --details` for the complete tree and step/path metadata.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline, step, process_name, process_path) (rate(limpid_process_events_in_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval]))", "legendFormat": "in {{pipeline}} #{{step}} {{process_path}}" },
+        { "refId": "B", "expr": "sum by (instance, pipeline, step, process_name, process_path) (rate(limpid_process_events_out_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval]))", "legendFormat": "out {{pipeline}} #{{step}} {{process_path}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 33 }
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Process invocation errors",
+      "description": "Errored invocation frames by exact process identity; not an event-total panel.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline, step, process_name, process_path) (rate(limpid_process_events_errored_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\"}[$__rate_interval]))", "legendFormat": "{{pipeline}} #{{step}} {{process_path}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 33 }
+    },
+    {
+      "id": 17,
+      "type": "row",
+      "title": "Outputs",
+      "description": "Are selected outputs draining without retry, failure, or wedge?",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
+      "panels": []
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Input byte rate",
+      "description": "Logical payload bytes consumed by selected inputs per second.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, input) (rate(limpid_input_bytes_received_total{job=~\"$job\",instance=~\"$instance\",input=~\"$input\"}[$__rate_interval]))", "legendFormat": "{{instance}} / {{input}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 7 }
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Output byte rate",
+      "description": "Event outer-frame or payload bytes successfully written by selected outputs per second.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, output) (rate(limpid_output_bytes_written_total{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "{{instance}} / {{output}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Output delivery outcomes",
+      "description": "Successful writes, terminal failures, retries, and fail-stop wedges. Inspect an event path with `limpidctl tap --help` before sampling.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, output) (rate(limpid_output_events_written_total{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "written {{instance}} / {{output}}" },
+        { "refId": "B", "expr": "sum by (instance, output) (rate(limpid_output_retries_total{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "retries {{instance}} / {{output}}" },
+        { "refId": "C", "expr": "sum by (instance, output) (rate(limpid_output_events_failed_total{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "failed {{instance}} / {{output}}" },
+        { "refId": "D", "expr": "sum by (instance, output) (rate(limpid_output_events_wedged_total{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "wedged {{instance}} / {{output}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Queue depth and retry state",
+      "description": "Per-output backlog and retry state. Queue depth units differ by backend; persistent non-zero depth is the portable signal.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "max by (instance, output) (limpid_output_queue_depth{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"})", "legendFormat": "depth {{instance}} / {{output}}" },
+        { "refId": "B", "expr": "max by (instance, output) (limpid_output_in_retry{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"})", "legendFormat": "retry {{instance}} / {{output}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 60 }
+    },
+    {
+      "id": 29,
+      "type": "heatmap",
+      "title": "Output delivery latency distribution",
+      "description": "Rate of delivered-event latency histogram buckets in seconds, from per-output emission to Delivered acknowledgement. This includes enqueue blocking, queue residence, batching, retry, transport, and restart; failed, dropped, or wedged events are not observed.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (le) (rate(limpid_output_delivery_seconds_bucket{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "format": "heatmap", "legendFormat": "delivery" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "showColorScale": false, "yHistogram": false } },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 68 }
+    },
+    {
+      "id": 22,
+      "type": "row",
+      "title": "LTP",
+      "description": "Are authenticated peers forwarding promptly without loop, identity, or clock anomalies?",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 77 },
+      "panels": []
+    },
+    {
+      "id": 23,
+      "type": "heatmap",
+      "title": "LTP network hop latency distribution",
+      "description": "Rate of network hop-latency histogram buckets in seconds. A hop is one peer-to-peer forwarding step. A heatmap remains informative when sparse traffic makes point quantiles NaN.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (le) (rate(limpid_ltp_hop_latency_seconds_bucket{job=~\"$job\",instance=~\"$instance\",peer=~\"$peer\",segment=\"network\"}[$__rate_interval]))", "format": "heatmap", "legendFormat": "network" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "showColorScale": false, "yHistogram": false } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 78 }
+    },
+    {
+      "id": 26,
+      "type": "heatmap",
+      "title": "LTP intra-daemon latency distribution",
+      "description": "Rate of intra-daemon hop-latency histogram buckets in seconds, from persisted arrival through successful final departure. A hop is one peer-to-peer forwarding step.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (le) (rate(limpid_ltp_hop_latency_seconds_bucket{job=~\"$job\",instance=~\"$instance\",peer=~\"$peer\",segment=\"intra\"}[$__rate_interval]))", "format": "heatmap", "legendFormat": "intra" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "showColorScale": false, "yHistogram": false } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 78 }
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Authenticated peer throughput",
+      "description": "Network hop observations per second by authenticated peer; a hop is one peer-to-peer forwarding step. This is derived from the network histogram count rather than an invented throughput counter.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, peer) (rate(limpid_ltp_hop_latency_seconds_count{job=~\"$job\",instance=~\"$instance\",peer=~\"$peer\",segment=\"network\"}[$__rate_interval]))", "legendFormat": "{{instance}} / {{peer}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 87 }
+    },
+    {
+      "id": 25,
+      "type": "timeseries",
+      "title": "LTP rejection and anomaly rates",
+      "description": "Unknown-peer rejection, loop drops, and negative timestamp clamps. These are diagnostic signals, not bundled alerts.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (rate(limpid_ltp_rejected_unknown_peer_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))", "legendFormat": "unknown {{instance}}" },
+        { "refId": "B", "expr": "sum by (instance, peer) (rate(limpid_ltp_loop_dropped_total{job=~\"$job\",instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))", "legendFormat": "loop {{instance}} / {{peer}}" },
+        { "refId": "C", "expr": "sum by (instance, peer) (rate(limpid_ltp_negative_delta_total{job=~\"$job\",instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))", "legendFormat": "negative {{instance}} / {{peer}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 87 }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": ["limpid"],
+  "templating": {
+    "list": [
+      {
+        "name": "job",
+        "label": "Job",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(limpid_build_info, job)",
+        "query": { "query": "label_values(limpid_build_info, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(limpid_build_info{job=~\"$job\"}, instance)",
+        "query": { "query": "label_values(limpid_build_info{job=~\"$job\"}, instance)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "pipeline",
+        "label": "Pipeline",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(limpid_pipeline_events_received_total{job=~\"$job\",instance=~\"$instance\"}, pipeline)",
+        "query": { "query": "label_values(limpid_pipeline_events_received_total{job=~\"$job\",instance=~\"$instance\"}, pipeline)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "input",
+        "label": "Input",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(limpid_input_events_received_total{job=~\"$job\",instance=~\"$instance\"}, input)",
+        "query": { "query": "label_values(limpid_input_events_received_total{job=~\"$job\",instance=~\"$instance\"}, input)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "output",
+        "label": "Output",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(limpid_output_events_received_total{job=~\"$job\",instance=~\"$instance\"}, output)",
+        "query": { "query": "label_values(limpid_output_events_received_total{job=~\"$job\",instance=~\"$instance\"}, output)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "peer",
+        "label": "LTP peer",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(limpid_ltp_hop_latency_seconds_count{job=~\"$job\",instance=~\"$instance\"}, peer)",
+        "query": { "query": "label_values(limpid_ltp_hop_latency_seconds_count{job=~\"$job\",instance=~\"$instance\"}, peer)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Limpid Health & Flow",
+  "uid": "limpid-health-flow",
+  "version": 1,
+  "weekStart": ""
+}

--- a/packaging/grafana/limpid-dashboard.json
+++ b/packaging/grafana/limpid-dashboard.json
@@ -196,6 +196,20 @@
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 43 }
     },
     {
+      "id": 30,
+      "type": "timeseries",
+      "title": "Clock-reversed latency observations",
+      "description": "Rates of latency observations clamped to zero after wall-clock reversal. These counters count affected observations, not clock-reversal incidents; zero is normal.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance, pipeline, output) (rate(limpid_pipeline_processing_negative_delta_total{job=~\"$job\",instance=~\"$instance\",pipeline=~\"$pipeline\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "pipeline clamp {{instance}} / {{pipeline}} / {{output}}" },
+        { "refId": "B", "expr": "sum by (instance, output) (rate(limpid_output_delivery_negative_delta_total{job=~\"$job\",instance=~\"$instance\",output=~\"$output\"}[$__rate_interval]))", "legendFormat": "output clamp {{instance}} / {{output}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 }
+    },
+    {
       "id": 14,
       "type": "row",
       "title": "Processes",
@@ -237,7 +251,7 @@
       "title": "Outputs",
       "description": "Are selected outputs draining without retry, failure, or wedge?",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 59 },
       "panels": []
     },
     {
@@ -264,7 +278,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 }
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 60 }
     },
     {
       "id": 20,
@@ -280,7 +294,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 }
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 60 }
     },
     {
       "id": 21,
@@ -294,7 +308,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 60 }
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 68 }
     },
     {
       "id": 29,
@@ -307,7 +321,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
       "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "showColorScale": false, "yHistogram": false } },
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 68 }
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 76 }
     },
     {
       "id": 22,
@@ -315,7 +329,7 @@
       "title": "LTP",
       "description": "Are authenticated peers forwarding promptly without loop, identity, or clock anomalies?",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 77 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 85 },
       "panels": []
     },
     {
@@ -329,7 +343,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
       "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "showColorScale": false, "yHistogram": false } },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 78 }
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 86 }
     },
     {
       "id": 26,
@@ -342,7 +356,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
       "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "showColorScale": false, "yHistogram": false } },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 78 }
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 86 }
     },
     {
       "id": 24,
@@ -355,7 +369,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 87 }
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 95 }
     },
     {
       "id": 25,
@@ -370,7 +384,7 @@
       ],
       "fieldConfig": { "defaults": { "unit": "eps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": false } }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 87 }
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 95 }
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## Summary

- ship a portable `Limpid Health & Flow` Grafana dashboard with health, input, pipeline, process, loss, output, and LTP views
- add processing and delivered-only output latency heatmaps plus wall-clock reversal diagnostics
- package four Prometheus alert rules with deterministic rule tests and CI validation
- document all-node scraping, dashboard provisioning, and alert-rule deployment

## Validation

- Prometheus 3.5 rule checks, rule tests, and dashboard PromQL parsing
- dashboard JSON, layout, datasource portability, and packaged asset checks
- workspace tests, all-target Clippy with warnings denied, formatting, and mdBook
- multi-node scrape and dashboard query validation with all expected targets healthy

The dashboard and rules contain no deployment-specific addresses or private labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Grafana dashboard for monitoring pipeline health, event flow, delivery performance, recovery, processes, and network activity.
  * Added Prometheus alerts for stalled queues, unwritable recovery records, and sustained queue backlogs.
  * Included monitoring assets in Debian packages for deployment.

* **Documentation**
  * Added guidance for Prometheus scraping, Grafana setup, alert validation, dashboard provisioning, and interpreting missing metrics.

* **Tests**
  * Added validation for alert behavior, counter resets, absent metrics, queue recovery, dashboard structure, and packaged assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->