### PR TITLE
docs(ltp): explain steady-state idle policy

### DIFF
--- a/crates/limpid/src/modules/input/ltp.rs
+++ b/crates/limpid/src/modules/input/ltp.rs
@@ -526,6 +526,14 @@ async fn handle_connection(
         bail!("LTP hello node_id does not match the authenticated peer key");
     }
 
+    // PR #200 decision: https://github.com/naoto256/limpid/pull/200#issuecomment-5355435303
+    // After mutual-RPK authentication and the bound hello, an idle connection is a valid
+    // persistent steady state. LTP has no application-level acknowledgement, so the output
+    // caches this TLS stream and treats local write/flush success as delivery. If the server
+    // closes an idle connection, the next local write can still be reported delivered while
+    // its event is silently lost. HELLO_TIMEOUT therefore bounds only pre-protocol state;
+    // max_connections bounds steady-state resources. An application-level acknowledgement
+    // would invalidate this premise and require revisiting the idle-connection policy.
     loop {
         let frame = match read_frame(&mut stream, &context.metrics).await {
             Ok(Some(frame)) => frame,


### PR DESCRIPTION
Comment-only change with no runtime or schema behavior change. It records the PR #200 owner rationale for allowing authenticated steady-state LTP connections to remain idle, including the no-acknowledgement delivery boundary and the conditions that would require revisiting the policy.\n\nValidation: 17 relevant LTP tests, cargo fmt, targeted Clippy, and diff-check passed. Fable review was CLEAN 3/3. The fresh GEN2 push session completed PASS9/FAIL0 with would_push=true.\n\nMerge is owner-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified connection lifecycle behavior after authentication and protocol establishment.
  * Documented timeout handling, connection capacity limits, and message delivery expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->