### PR TITLE
feat(ltp): share listeners across inputs

### DIFF
--- a/crates/limpid/src/modules/input/ltp.rs
+++ b/crates/limpid/src/modules/input/ltp.rs
@@ -838,14 +838,16 @@ pub(crate) fn validate_listener_groups<'a>(
         groups.entry(&spec.bind_addr).or_default().push(spec);
     }
     for (bind_addr, members) in groups {
-        let expected_max = members[0].max_connections;
+        let first_member = members[0];
+        let expected_max = first_member.max_connections;
+        let first_member_name = first_member.name.as_str();
         let mut node_ids = HashMap::<&str, &str>::new();
         let mut public_keys = HashMap::<&[u8], &str>::new();
         for member in members {
             if member.max_connections != expected_max {
                 bail!(
                     "LTP listener max_connections mismatch on bind '{bind_addr}' between inputs '{}' and '{}'",
-                    members_for_bind(&specs, bind_addr)[0],
+                    first_member_name,
                     member.name
                 );
             }
@@ -889,14 +891,6 @@ pub(crate) fn validate_listener_groups<'a>(
         }
     }
     Ok(())
-}
-
-fn members_for_bind<'a>(specs: &'a [ListenerSpec], bind_addr: &str) -> Vec<&'a str> {
-    specs
-        .iter()
-        .filter(|spec| spec.bind_addr == bind_addr)
-        .map(|spec| spec.name.as_str())
-        .collect()
 }
 
 fn listener_binds_overlap(left: SocketAddr, right: SocketAddr) -> bool {

--- a/crates/limpid/src/modules/input/ltp.rs
+++ b/crates/limpid/src/modules/input/ltp.rs
@@ -1,8 +1,9 @@
 //! Authenticated LTP listener.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
@@ -97,37 +98,17 @@ struct PeerRegistry {
     node_by_spki: Arc<HashMap<Vec<u8>, Arc<str>>>,
 }
 
-impl PeerRegistry {
-    fn node_for_certificate(&self, certificate: &[u8]) -> Option<Arc<str>> {
-        self.node_by_spki.get(certificate).cloned()
-    }
-}
-
 pub struct LtpInput {
     name: String,
     bind_addr: String,
     node_id: Arc<str>,
+    node_key: Arc<ValidatedNodeKey>,
     peers: PeerRegistry,
-    acceptor: TlsAcceptor,
     max_hops: usize,
     max_connections: usize,
     metrics: Arc<InputMetrics>,
     ltp_metrics: Arc<LtpMetrics>,
     now: fn() -> crate::time::ClockSample,
-    #[cfg(test)]
-    hello_started: Option<Arc<tokio::sync::Notify>>,
-}
-
-#[derive(Clone)]
-struct ConnectionContext {
-    acceptor: TlsAcceptor,
-    peers: PeerRegistry,
-    node_id: Arc<str>,
-    max_hops: usize,
-    now: fn() -> crate::time::ClockSample,
-    metrics: Arc<InputMetrics>,
-    ltp_metrics: Arc<LtpMetrics>,
-    tx: tokio::sync::mpsc::Sender<Event>,
     #[cfg(test)]
     hello_started: Option<Arc<tokio::sync::Notify>>,
 }
@@ -157,7 +138,6 @@ impl Module for LtpInput {
             .as_ref()
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("input '{name}': LTP metrics are unavailable"))?;
-        let acceptor = build_rpk_acceptor(node_key, &peers, Arc::clone(&ltp_metrics))?;
         let bind_addr = props::get_string(properties, "bind")
             .unwrap_or_else(|| format!("0.0.0.0:{DEFAULT_LTP_PORT}"));
         let max_hops = props::get_positive_int(properties, "max_hops")?.unwrap_or(DEFAULT_MAX_HOPS);
@@ -171,8 +151,8 @@ impl Module for LtpInput {
             name: name.to_owned(),
             bind_addr,
             node_id,
+            node_key: Arc::clone(node_key),
             peers,
-            acceptor,
             max_hops: max_hops as usize,
             max_connections: max_connections as usize,
             metrics: InputMetrics::register(&ctx.metrics, name)?,
@@ -184,6 +164,34 @@ impl Module for LtpInput {
     }
 }
 
+#[derive(Clone)]
+struct LogicalInputContext {
+    name: Arc<str>,
+    node_id: Arc<str>,
+    max_hops: usize,
+    now: fn() -> crate::time::ClockSample,
+    metrics: Arc<InputMetrics>,
+    ltp_metrics: Arc<LtpMetrics>,
+    tx: tokio::sync::mpsc::Sender<Event>,
+    #[cfg(test)]
+    hello_started: Option<Arc<tokio::sync::Notify>>,
+}
+
+#[derive(Clone)]
+struct PeerRoute {
+    expected_node_id: Arc<str>,
+    input: LogicalInputContext,
+}
+
+struct SharedListenerGroup {
+    bind_addr: String,
+    member_names: Vec<String>,
+    acceptor: TlsAcceptor,
+    routes: Arc<HashMap<Vec<u8>, PeerRoute>>,
+    max_connections: usize,
+    ltp_metrics: Arc<LtpMetrics>,
+}
+
 impl HasMetrics for LtpInput {
     type Stats = InputMetrics;
 
@@ -192,14 +200,88 @@ impl HasMetrics for LtpInput {
     }
 }
 
-impl LtpInput {
+impl SharedListenerGroup {
+    fn from_members(members: Vec<(LtpInput, tokio::sync::mpsc::Sender<Event>)>) -> Result<Self> {
+        let first = members
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("LTP listener group has no logical inputs"))?;
+        let bind_addr = first.0.bind_addr.clone();
+        let max_connections = first.0.max_connections;
+        let node_key = Arc::clone(&first.0.node_key);
+        let ltp_metrics = Arc::clone(&first.0.ltp_metrics);
+        let mut member_names = Vec::with_capacity(members.len());
+        let mut routes = HashMap::new();
+
+        for (input, tx) in members {
+            if input.bind_addr != bind_addr {
+                bail!("internal error: LTP listener group contains different binds");
+            }
+            if input.max_connections != max_connections {
+                bail!("internal error: LTP listener group contains different limits");
+            }
+            member_names.push(input.name.clone());
+            let logical = LogicalInputContext {
+                name: Arc::<str>::from(input.name),
+                node_id: input.node_id,
+                max_hops: input.max_hops,
+                now: input.now,
+                metrics: input.metrics,
+                ltp_metrics: Arc::clone(&input.ltp_metrics),
+                tx,
+                #[cfg(test)]
+                hello_started: input.hello_started,
+            };
+            for (spki, expected_node_id) in input.peers.node_by_spki.iter() {
+                let route = PeerRoute {
+                    expected_node_id: Arc::clone(expected_node_id),
+                    input: logical.clone(),
+                };
+                if routes.insert(spki.clone(), route).is_some() {
+                    bail!("internal error: duplicate LTP peer public key in listener group");
+                }
+            }
+        }
+        member_names.sort();
+        let peers = PeerRegistry {
+            node_by_spki: Arc::new(
+                routes
+                    .iter()
+                    .map(|(spki, route)| (spki.clone(), Arc::clone(&route.expected_node_id)))
+                    .collect(),
+            ),
+        };
+        let acceptor = build_rpk_acceptor(&node_key, &peers, Arc::clone(&ltp_metrics))?;
+        Ok(Self {
+            bind_addr,
+            member_names,
+            acceptor,
+            routes: Arc::new(routes),
+            max_connections,
+            ltp_metrics,
+        })
+    }
+
+    async fn bind(self) -> Result<(Self, TcpListener)> {
+        let listener = TcpListener::bind(&self.bind_addr).await.with_context(|| {
+            format!(
+                "LTP listener group [{}] failed to bind '{}'",
+                self.member_names.join(", "),
+                self.bind_addr
+            )
+        })?;
+        Ok((self, listener))
+    }
+
     async fn run_on_listener(
         self,
         listener: TcpListener,
-        tx: tokio::sync::mpsc::Sender<Event>,
         mut shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<()> {
-        info!("ltp input '{}' listening on {}", self.name, self.bind_addr);
+        info!(
+            "ltp listener group [{}] listening on {}",
+            self.member_names.join(", "),
+            self.bind_addr
+        );
         let mut connections = Vec::<tokio::task::JoinHandle<()>>::new();
 
         loop {
@@ -218,32 +300,76 @@ impl LtpInput {
                     let (stream, address) = accepted?;
                     connections.retain(|handle| !handle.is_finished());
                     if connections.len() >= self.max_connections {
-                        warn!("ltp input '{}': max connections reached; rejecting {}", self.name, address);
+                        warn!(
+                            "ltp listener group [{}]: max connections reached; rejecting {}",
+                            self.member_names.join(", "),
+                            address
+                        );
                         continue;
                     }
-                    let context = ConnectionContext {
-                        acceptor: self.acceptor.clone(),
-                        peers: self.peers.clone(),
-                        node_id: Arc::clone(&self.node_id),
-                        max_hops: self.max_hops,
-                        now: self.now,
-                        metrics: Arc::clone(&self.metrics),
-                        ltp_metrics: Arc::clone(&self.ltp_metrics),
-                        tx: tx.clone(),
-                        #[cfg(test)]
-                        hello_started: self.hello_started.clone(),
-                    };
-                    let name = self.name.clone();
+                    let acceptor = self.acceptor.clone();
+                    let routes = Arc::clone(&self.routes);
+                    let ltp_metrics = Arc::clone(&self.ltp_metrics);
+                    let names = self.member_names.join(", ");
                     connections.push(tokio::spawn(async move {
-                        let result = handle_connection(stream, address, context).await;
+                        let result = handle_connection(
+                            stream,
+                            address,
+                            acceptor,
+                            routes,
+                            ltp_metrics,
+                        )
+                        .await;
                         if let Err(error) = result {
-                            debug!("ltp input '{}': closing {}: {error:#}", name, address);
+                            debug!("ltp listener group '[{}]': closing {}: {error:#}", names, address);
                         }
                     }));
                 }
             }
         }
         Ok(())
+    }
+}
+
+/// Bind every distinct LTP address before spawning any listener task, then run
+/// one listener for each exact bind string. This keeps bind failure fail-closed
+/// and prevents same-address logical inputs from racing each other at startup.
+pub(crate) async fn start_listener_groups(
+    inputs: Vec<(LtpInput, tokio::sync::mpsc::Sender<Event>)>,
+    shutdown: tokio::sync::watch::Receiver<bool>,
+) -> Result<Vec<tokio::task::JoinHandle<()>>> {
+    let mut grouped = BTreeMap::<String, Vec<_>>::new();
+    for (input, tx) in inputs {
+        grouped
+            .entry(input.bind_addr.clone())
+            .or_default()
+            .push((input, tx));
+    }
+
+    let mut bound = Vec::with_capacity(grouped.len());
+    for (_, members) in grouped {
+        let group = SharedListenerGroup::from_members(members)?;
+        bound.push(group.bind().await?);
+    }
+
+    Ok(bound
+        .into_iter()
+        .map(|(group, listener)| {
+            let group_names = group.member_names.join(", ");
+            let group_shutdown = shutdown.clone();
+            tokio::spawn(async move {
+                report_listener_result(
+                    &group_names,
+                    group.run_on_listener(listener, group_shutdown).await,
+                );
+            })
+        })
+        .collect())
+}
+
+fn report_listener_result(group_names: &str, result: Result<()>) {
+    if let Err(error) = result {
+        warn!("ltp listener group [{}] failed: {error:#}", group_names);
     }
 }
 
@@ -254,8 +380,10 @@ impl Input for LtpInput {
         tx: tokio::sync::mpsc::Sender<Event>,
         shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<()> {
-        let listener = TcpListener::bind(&self.bind_addr).await?;
-        self.run_on_listener(listener, tx, shutdown).await
+        let (group, listener) = SharedListenerGroup::from_members(vec![(self, tx)])?
+            .bind()
+            .await?;
+        group.run_on_listener(listener, shutdown).await
     }
 }
 
@@ -429,6 +557,17 @@ async fn read_frame<R: AsyncRead + Unpin>(
     reader: &mut R,
     metrics: &InputMetrics,
 ) -> Result<Option<RawFrame>> {
+    read_frame_inner(reader, Some(metrics)).await
+}
+
+async fn read_frame_unmetered<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Option<RawFrame>> {
+    read_frame_inner(reader, None).await
+}
+
+async fn read_frame_inner<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    metrics: Option<&InputMetrics>,
+) -> Result<Option<RawFrame>> {
     let mut prefix = [0u8; FRAME_PREFIX_SIZE];
     match reader.read_exact(&mut prefix[..1]).await {
         Ok(_) => {}
@@ -476,7 +615,9 @@ async fn read_frame<R: AsyncRead + Unpin>(
         if read == 0 {
             bail!("truncated LTP payload");
         }
-        metrics.bytes_received.inc_by(read as u64);
+        if let Some(metrics) = metrics {
+            metrics.bytes_received.inc_by(read as u64);
+        }
         consumed += read;
     }
     Ok(Some(RawFrame {
@@ -488,9 +629,11 @@ async fn read_frame<R: AsyncRead + Unpin>(
 async fn handle_connection(
     stream: TcpStream,
     address: std::net::SocketAddr,
-    context: ConnectionContext,
+    acceptor: TlsAcceptor,
+    routes: Arc<HashMap<Vec<u8>, PeerRoute>>,
+    ltp_metrics: Arc<LtpMetrics>,
 ) -> Result<()> {
-    let mut stream = tokio::time::timeout(HANDSHAKE_TIMEOUT, context.acceptor.accept(stream))
+    let mut stream = tokio::time::timeout(HANDSHAKE_TIMEOUT, acceptor.accept(stream))
         .await
         .context("LTP TLS handshake timed out")??;
     let peer_certificate = stream
@@ -499,32 +642,37 @@ async fn handle_connection(
         .peer_certificates()
         .and_then(|certificates| certificates.first())
         .ok_or_else(|| anyhow::anyhow!("LTP peer did not present a raw public key"))?;
-    let authenticated_node_id = context
-        .peers
-        .node_for_certificate(peer_certificate.as_ref())
+    let route = routes
+        .get(peer_certificate.as_ref())
+        .cloned()
         .ok_or_else(|| anyhow::anyhow!("LTP peer raw public key is not declared"))?;
-    let peer_metrics = context
-        .ltp_metrics
-        .peer(&authenticated_node_id)
-        .ok_or_else(|| anyhow::anyhow!("LTP peer metrics were not registered"))?;
 
     #[cfg(test)]
-    if let Some(hello_started) = &context.hello_started {
+    if let Some(hello_started) = &route.input.hello_started {
         hello_started.notify_one();
     }
-    let hello_frame =
-        tokio::time::timeout(HELLO_TIMEOUT, read_frame(&mut stream, &context.metrics))
-            .await
-            .context("LTP hello timed out")??
-            .ok_or_else(|| anyhow::anyhow!("LTP peer closed before hello"))?;
+    // The HELLO selects and verifies the logical input, but is not an event
+    // payload and therefore must not contribute to that input's byte counter.
+    let hello_frame = tokio::time::timeout(HELLO_TIMEOUT, read_frame_unmetered(&mut stream))
+        .await
+        .context("LTP hello timed out")??
+        .ok_or_else(|| anyhow::anyhow!("LTP peer closed before hello"))?;
     if !hello_frame.payload.is_empty() {
         bail!("LTP hello payload must be empty");
     }
     let hello = LtpHello::decode(hello_frame.metadata).context("invalid LTP hello metadata")?;
-    if hello.node_id != authenticated_node_id.as_ref() {
-        context.ltp_metrics.rejected_unknown_peer.inc();
-        bail!("LTP hello node_id does not match the authenticated peer key");
+    if hello.node_id != route.expected_node_id.as_ref() {
+        ltp_metrics.rejected_unknown_peer.inc();
+        bail!(
+            "LTP hello node_id does not match the authenticated peer key for input '{}'",
+            route.input.name
+        );
     }
+    let peer_metrics = route
+        .input
+        .ltp_metrics
+        .peer(&route.expected_node_id)
+        .ok_or_else(|| anyhow::anyhow!("LTP peer metrics were not registered"))?;
 
     // PR #200 decision: https://github.com/naoto256/limpid/pull/200#issuecomment-5355435303
     // After mutual-RPK authentication and the bound hello, an idle connection is a valid
@@ -535,18 +683,18 @@ async fn handle_connection(
     // max_connections bounds steady-state resources. An application-level acknowledgement
     // would invalidate this premise and require revisiting the idle-connection policy.
     loop {
-        let frame = match read_frame(&mut stream, &context.metrics).await {
+        let frame = match read_frame(&mut stream, &route.input.metrics).await {
             Ok(Some(frame)) => frame,
             Ok(None) => break,
             Err(error) => {
-                context.metrics.events_invalid.inc();
+                route.input.metrics.events_invalid.inc();
                 return Err(error);
             }
         };
         let meta = match LtpMeta::decode(frame.metadata).context("invalid LTP event metadata") {
             Ok(meta) => meta,
             Err(error) => {
-                context.metrics.events_invalid.inc();
+                route.input.metrics.events_invalid.inc();
                 return Err(error);
             }
         };
@@ -554,29 +702,28 @@ async fn handle_connection(
             meta,
             frame.payload,
             address,
-            &context.node_id,
-            context.max_hops,
-            context.now,
+            &route.input.node_id,
+            route.input.max_hops,
+            route.input.now,
             &peer_metrics,
         ) {
             Ok(decision) => decision,
             Err(error) => {
-                context.metrics.events_invalid.inc();
+                route.input.metrics.events_invalid.inc();
                 return Err(error);
             }
         };
         match decision {
             FrameDecision::Forward(event) => {
-                if context.tx.send(event).await.is_err() {
+                if route.input.tx.send(event).await.is_err() {
                     break;
                 }
-                context.metrics.events_received.inc();
+                route.input.metrics.events_received.inc();
             }
             FrameDecision::DropCycle
             | FrameDecision::DropMaxHops
             | FrameDecision::DropMetadataTooLarge => {
-                context.metrics.events_invalid.inc();
-                continue;
+                route.input.metrics.events_invalid.inc();
             }
         }
     }
@@ -657,6 +804,114 @@ pub(crate) fn validate_static_properties(name: &str, properties: &[Property]) ->
         bail!("input '{name}': max_hops must be between 1 and {DEFAULT_MAX_HOPS}");
     }
     Ok(())
+}
+
+struct ListenerSpec {
+    name: String,
+    bind_addr: String,
+    max_connections: u64,
+    peers: PeerRegistry,
+}
+
+/// Validate relationships that are only visible across logical LTP inputs.
+/// Exact bind strings form a listener group; address normalization is
+/// intentionally not used to merge operator declarations.
+pub(crate) fn validate_listener_groups<'a>(
+    inputs: impl Iterator<Item = (&'a str, &'a [Property])>,
+) -> Result<()> {
+    let mut specs = inputs
+        .map(|(name, properties)| {
+            Ok(ListenerSpec {
+                name: name.to_owned(),
+                bind_addr: props::get_string(properties, "bind")
+                    .unwrap_or_else(|| format!("0.0.0.0:{DEFAULT_LTP_PORT}")),
+                max_connections: props::get_positive_int(properties, "max_connections")?
+                    .unwrap_or(DEFAULT_MAX_CONNECTIONS),
+                peers: parse_peers(name, properties)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    specs.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let mut groups = BTreeMap::<&str, Vec<&ListenerSpec>>::new();
+    for spec in &specs {
+        groups.entry(&spec.bind_addr).or_default().push(spec);
+    }
+    for (bind_addr, members) in groups {
+        let expected_max = members[0].max_connections;
+        let mut node_ids = HashMap::<&str, &str>::new();
+        let mut public_keys = HashMap::<&[u8], &str>::new();
+        for member in members {
+            if member.max_connections != expected_max {
+                bail!(
+                    "LTP listener max_connections mismatch on bind '{bind_addr}' between inputs '{}' and '{}'",
+                    members_for_bind(&specs, bind_addr)[0],
+                    member.name
+                );
+            }
+            for (spki, node_id) in member.peers.node_by_spki.iter() {
+                if let Some(previous) = node_ids.insert(node_id, &member.name) {
+                    bail!(
+                        "duplicate LTP peer node_id in listener group '{bind_addr}': inputs '{previous}' and '{}'",
+                        member.name
+                    );
+                }
+                if let Some(previous) = public_keys.insert(spki, &member.name) {
+                    bail!(
+                        "duplicate LTP peer public key in listener group '{bind_addr}': inputs '{previous}' and '{}'",
+                        member.name
+                    );
+                }
+            }
+        }
+    }
+
+    for (index, left) in specs.iter().enumerate() {
+        for right in &specs[index + 1..] {
+            if left.bind_addr == right.bind_addr {
+                continue;
+            }
+            let (Ok(left_addr), Ok(right_addr)) = (
+                left.bind_addr.parse::<SocketAddr>(),
+                right.bind_addr.parse::<SocketAddr>(),
+            ) else {
+                continue;
+            };
+            if listener_binds_overlap(left_addr, right_addr) {
+                bail!(
+                    "overlapping LTP listener binds '{}' (input '{}') and '{}' (input '{}')",
+                    left.bind_addr,
+                    left.name,
+                    right.bind_addr,
+                    right.name
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn members_for_bind<'a>(specs: &'a [ListenerSpec], bind_addr: &str) -> Vec<&'a str> {
+    specs
+        .iter()
+        .filter(|spec| spec.bind_addr == bind_addr)
+        .map(|spec| spec.name.as_str())
+        .collect()
+}
+
+fn listener_binds_overlap(left: SocketAddr, right: SocketAddr) -> bool {
+    if left.port() != right.port() {
+        return false;
+    }
+    match (left, right) {
+        (SocketAddr::V4(left), SocketAddr::V4(right)) => {
+            left.ip() == right.ip() || left.ip().is_unspecified() || right.ip().is_unspecified()
+        }
+        (SocketAddr::V6(left), SocketAddr::V6(right)) => {
+            left.ip() == right.ip() || left.ip().is_unspecified() || right.ip().is_unspecified()
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -752,16 +1007,18 @@ mod tests {
         key: [u8; 16],
         payload: &'static [u8],
     ) {
-        let mut client = connect_client(address, identity, server_spki).await;
-        client
-            .write_all(
-                &crate::ltp::encode_hello_frame(&LtpHello {
-                    node_id: "peer-a".to_owned(),
-                })
-                .unwrap(),
-            )
-            .await
-            .unwrap();
+        send_client_event_as(address, identity, server_spki, "peer-a", key, payload).await;
+    }
+
+    async fn send_client_event_as(
+        address: std::net::SocketAddr,
+        identity: &ValidatedNodeKey,
+        server_spki: &[u8],
+        node_id: &str,
+        key: [u8; 16],
+        payload: &'static [u8],
+    ) {
+        let mut client = send_hello_as(address, identity, server_spki, node_id).await;
         client
             .write_all(
                 &crate::ltp::encode_frame(
@@ -794,15 +1051,76 @@ mod tests {
     }
 
     fn test_ltp_metrics(peer: &str) -> Arc<LtpMetrics> {
+        test_ltp_metrics_for(&[peer])
+    }
+
+    fn test_ltp_metrics_for(peers: &[&str]) -> Arc<LtpMetrics> {
         LtpMetrics::register(
             &crate::metrics::Registry::new(),
-            &std::collections::BTreeSet::from([peer.to_owned()]),
+            &peers.iter().map(|peer| (*peer).to_owned()).collect(),
         )
         .unwrap()
     }
 
     fn test_peer_metrics(peer: &str) -> LtpPeerMetrics {
         test_ltp_metrics(peer).peer(peer).unwrap()
+    }
+
+    struct SharedTestContext {
+        bind_addr: String,
+        node_key: Arc<ValidatedNodeKey>,
+        max_connections: usize,
+        ltp_metrics: Arc<LtpMetrics>,
+    }
+
+    fn shared_member(
+        context: &SharedTestContext,
+        name: &str,
+        peer_id: &str,
+        peer_spki: Vec<u8>,
+        hello_started: Option<Arc<tokio::sync::Notify>>,
+    ) -> (
+        LtpInput,
+        tokio::sync::mpsc::Sender<Event>,
+        tokio::sync::mpsc::Receiver<Event>,
+    ) {
+        let peers = peer_registry(peer_id, peer_spki);
+        let metrics = test_metrics();
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        let input = LtpInput {
+            name: name.to_owned(),
+            bind_addr: context.bind_addr.clone(),
+            node_id: Arc::<str>::from("self"),
+            node_key: Arc::clone(&context.node_key),
+            peers,
+            max_hops: 16,
+            max_connections: context.max_connections,
+            metrics,
+            ltp_metrics: Arc::clone(&context.ltp_metrics),
+            now: fixed_now,
+            hello_started,
+        };
+        (input, tx, rx)
+    }
+
+    async fn send_hello_as(
+        address: std::net::SocketAddr,
+        identity: &ValidatedNodeKey,
+        server_spki: &[u8],
+        node_id: &str,
+    ) -> tokio_rustls::client::TlsStream<TcpStream> {
+        let mut client = connect_client(address, identity, server_spki).await;
+        client
+            .write_all(
+                &crate::ltp::encode_hello_frame(&LtpHello {
+                    node_id: node_id.to_owned(),
+                })
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        client.flush().await.unwrap();
+        client
     }
 
     fn node_id_for_departed_meta_len(target: usize) -> String {
@@ -1182,29 +1500,32 @@ mod tests {
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
         let ltp_metrics = test_ltp_metrics("peer-a");
-        let acceptor =
-            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(2);
         let metrics = test_metrics();
-        let server_metrics = Arc::clone(&metrics);
+        let input = LtpInput {
+            name: "in".to_owned(),
+            bind_addr: address.to_string(),
+            node_id: Arc::<str>::from("self"),
+            node_key: Arc::new(server_identity),
+            peers,
+            max_hops: 16,
+            max_connections: 1,
+            metrics: Arc::clone(&metrics),
+            ltp_metrics,
+            now: fixed_now,
+            hello_started: None,
+        };
+        let group = SharedListenerGroup::from_members(vec![(input, tx)]).unwrap();
         let server = tokio::spawn(async move {
             let (stream, peer_address) = listener.accept().await.unwrap();
             handle_connection(
                 stream,
                 peer_address,
-                ConnectionContext {
-                    acceptor,
-                    peers,
-                    node_id: Arc::<str>::from("self"),
-                    max_hops: 16,
-                    now: fixed_now,
-                    metrics: server_metrics,
-                    ltp_metrics,
-                    tx,
-                    hello_started: None,
-                },
+                group.acceptor,
+                group.routes,
+                group.ltp_metrics,
             )
             .await
         });
@@ -1273,29 +1594,32 @@ mod tests {
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
         let ltp_metrics = test_ltp_metrics("peer-a");
-        let acceptor =
-            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let metrics = test_metrics();
-        let server_metrics = Arc::clone(&metrics);
+        let input = LtpInput {
+            name: "in".to_owned(),
+            bind_addr: address.to_string(),
+            node_id: Arc::<str>::from("self"),
+            node_key: Arc::new(server_identity),
+            peers,
+            max_hops: 16,
+            max_connections: 1,
+            metrics: Arc::clone(&metrics),
+            ltp_metrics,
+            now: fixed_now,
+            hello_started: None,
+        };
+        let group = SharedListenerGroup::from_members(vec![(input, tx)]).unwrap();
         let server = tokio::spawn(async move {
             let (stream, peer_address) = listener.accept().await.unwrap();
             handle_connection(
                 stream,
                 peer_address,
-                ConnectionContext {
-                    acceptor,
-                    peers,
-                    node_id: Arc::<str>::from("self"),
-                    max_hops: 16,
-                    now: fixed_now,
-                    metrics: server_metrics,
-                    ltp_metrics,
-                    tx,
-                    hello_started: None,
-                },
+                group.acceptor,
+                group.routes,
+                group.ltp_metrics,
             )
             .await
         });
@@ -1353,30 +1677,33 @@ mod tests {
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
         let ltp_metrics = test_ltp_metrics("peer-a");
-        let acceptor =
-            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         drop(rx);
         let metrics = test_metrics();
-        let server_metrics = Arc::clone(&metrics);
+        let input = LtpInput {
+            name: "in".to_owned(),
+            bind_addr: address.to_string(),
+            node_id: Arc::<str>::from("self"),
+            node_key: Arc::new(server_identity),
+            peers,
+            max_hops: 16,
+            max_connections: 1,
+            metrics: Arc::clone(&metrics),
+            ltp_metrics,
+            now: fixed_now,
+            hello_started: None,
+        };
+        let group = SharedListenerGroup::from_members(vec![(input, tx)]).unwrap();
         let server = tokio::spawn(async move {
             let (stream, peer_address) = listener.accept().await.unwrap();
             handle_connection(
                 stream,
                 peer_address,
-                ConnectionContext {
-                    acceptor,
-                    peers,
-                    node_id: Arc::<str>::from("self"),
-                    max_hops: 16,
-                    now: fixed_now,
-                    metrics: server_metrics,
-                    ltp_metrics,
-                    tx,
-                    hello_started: None,
-                },
+                group.acceptor,
+                group.routes,
+                group.ltp_metrics,
             )
             .await
         });
@@ -1416,8 +1743,6 @@ mod tests {
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
         let ltp_metrics = test_ltp_metrics("peer-a");
-        let acceptor =
-            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let metrics = test_metrics();
@@ -1426,8 +1751,8 @@ mod tests {
             name: "in".to_owned(),
             bind_addr: address.to_string(),
             node_id: Arc::<str>::from("self"),
+            node_key: Arc::new(server_identity),
             peers,
-            acceptor,
             max_hops: 16,
             max_connections: 1,
             metrics,
@@ -1437,7 +1762,8 @@ mod tests {
         };
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-        let server = tokio::spawn(input.run_on_listener(listener, tx, shutdown_rx));
+        let group = SharedListenerGroup::from_members(vec![(input, tx)]).unwrap();
+        let server = tokio::spawn(group.run_on_listener(listener, shutdown_rx));
 
         let mut stalled = connect_client(address, &client_identity, &server_spki).await;
         hello_started.notified().await;
@@ -1475,29 +1801,32 @@ mod tests {
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
         let ltp_metrics = test_ltp_metrics("peer-a");
-        let acceptor =
-            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let metrics = test_metrics();
-        let server_ltp_metrics = Arc::clone(&ltp_metrics);
+        let input = LtpInput {
+            name: "in".to_owned(),
+            bind_addr: address.to_string(),
+            node_id: Arc::<str>::from("self"),
+            node_key: Arc::new(server_identity),
+            peers,
+            max_hops: 16,
+            max_connections: 1,
+            metrics,
+            ltp_metrics: Arc::clone(&ltp_metrics),
+            now: fixed_now,
+            hello_started: None,
+        };
+        let group = SharedListenerGroup::from_members(vec![(input, tx)]).unwrap();
         let server = tokio::spawn(async move {
             let (stream, peer_address) = listener.accept().await.unwrap();
             handle_connection(
                 stream,
                 peer_address,
-                ConnectionContext {
-                    acceptor,
-                    peers,
-                    node_id: Arc::<str>::from("self"),
-                    max_hops: 16,
-                    now: fixed_now,
-                    metrics,
-                    ltp_metrics: server_ltp_metrics,
-                    tx,
-                    hello_started: None,
-                },
+                group.acceptor,
+                group.routes,
+                group.ltp_metrics,
             )
             .await
         });
@@ -1560,6 +1889,248 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn shared_listener_rejects_unknown_spki_before_logical_dispatch() {
+        let (server_identity, server_spki) = generated_identity();
+        let server_identity = Arc::new(server_identity);
+        let (_, declared_spki_a) = generated_identity();
+        let (_, declared_spki_b) = generated_identity();
+        let (unknown_identity, _) = generated_identity();
+        let ltp_metrics = test_ltp_metrics_for(&["peer-a", "peer-b"]);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let context = SharedTestContext {
+            bind_addr: address.to_string(),
+            node_key: Arc::clone(&server_identity),
+            max_connections: 2,
+            ltp_metrics: Arc::clone(&ltp_metrics),
+        };
+        let (input_a, tx_a, mut rx_a) =
+            shared_member(&context, "from_a", "peer-a", declared_spki_a, None);
+        let (input_b, tx_b, mut rx_b) =
+            shared_member(&context, "from_b", "peer-b", declared_spki_b, None);
+        let group =
+            SharedListenerGroup::from_members(vec![(input_a, tx_a), (input_b, tx_b)]).unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let server = tokio::spawn(group.run_on_listener(listener, shutdown_rx));
+
+        let connector =
+            crate::modules::output::ltp::build_rpk_connector(&unknown_identity, &server_spki)
+                .unwrap();
+        let tcp = TcpStream::connect(address).await.unwrap();
+        let _ = connector
+            .connect("localhost".try_into().unwrap(), tcp)
+            .await;
+        for _ in 0..100 {
+            if ltp_metrics
+                .rejected_unknown_peer
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            ltp_metrics
+                .rejected_unknown_peer
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert!(rx_a.try_recv().is_err());
+        assert!(rx_b.try_recv().is_err());
+        shutdown_tx.send(true).unwrap();
+        assert!(server.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn shared_listener_uses_spki_owner_and_isolates_protocol_errors() {
+        let (server_identity, server_spki) = generated_identity();
+        let server_identity = Arc::new(server_identity);
+        let (peer_a, peer_a_spki) = generated_identity();
+        let (peer_b, peer_b_spki) = generated_identity();
+        let ltp_metrics = test_ltp_metrics_for(&["peer-a", "peer-b"]);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let context = SharedTestContext {
+            bind_addr: address.to_string(),
+            node_key: Arc::clone(&server_identity),
+            max_connections: 4,
+            ltp_metrics: Arc::clone(&ltp_metrics),
+        };
+        let (input_a, tx_a, mut rx_a) =
+            shared_member(&context, "from_a", "peer-a", peer_a_spki, None);
+        let (input_b, tx_b, mut rx_b) =
+            shared_member(&context, "from_b", "peer-b", peer_b_spki, None);
+        let group =
+            SharedListenerGroup::from_members(vec![(input_a, tx_a), (input_b, tx_b)]).unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let server = tokio::spawn(group.run_on_listener(listener, shutdown_rx));
+
+        let mismatched = send_hello_as(address, &peer_a, &server_spki, "peer-b").await;
+        drop(mismatched);
+        for _ in 0..100 {
+            if ltp_metrics
+                .rejected_unknown_peer
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            ltp_metrics
+                .rejected_unknown_peer
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "peer-a's key must not select peer-b's logical input"
+        );
+
+        let mut malformed = send_hello_as(address, &peer_a, &server_spki, "peer-a").await;
+        malformed.write_all(b"BAD!").await.unwrap();
+        malformed.flush().await.unwrap();
+        drop(malformed);
+        send_client_event_as(
+            address,
+            &peer_b,
+            &server_spki,
+            "peer-b",
+            v7_key(8),
+            b"peer-b-survives",
+        )
+        .await;
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), rx_b.recv())
+                .await
+                .unwrap()
+                .unwrap()
+                .ingress,
+            Bytes::from_static(b"peer-b-survives")
+        );
+        assert!(rx_a.try_recv().is_err());
+        shutdown_tx.send(true).unwrap();
+        assert!(server.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn shared_listener_capacity_is_group_wide_and_timeout_releases_slot() {
+        let (server_identity, server_spki) = generated_identity();
+        let server_identity = Arc::new(server_identity);
+        let (peer_a, peer_a_spki) = generated_identity();
+        let (peer_b, peer_b_spki) = generated_identity();
+        let ltp_metrics = test_ltp_metrics_for(&["peer-a", "peer-b"]);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let hello_started = Arc::new(tokio::sync::Notify::new());
+        let context = SharedTestContext {
+            bind_addr: address.to_string(),
+            node_key: Arc::clone(&server_identity),
+            max_connections: 1,
+            ltp_metrics: Arc::clone(&ltp_metrics),
+        };
+        let (input_a, tx_a, _rx_a) = shared_member(
+            &context,
+            "from_a",
+            "peer-a",
+            peer_a_spki,
+            Some(Arc::clone(&hello_started)),
+        );
+        let (input_b, tx_b, mut rx_b) =
+            shared_member(&context, "from_b", "peer-b", peer_b_spki, None);
+        let group =
+            SharedListenerGroup::from_members(vec![(input_a, tx_a), (input_b, tx_b)]).unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let server = tokio::spawn(group.run_on_listener(listener, shutdown_rx));
+
+        let mut stalled = connect_client(address, &peer_a, &server_spki).await;
+        hello_started.notified().await;
+        let connector =
+            crate::modules::output::ltp::build_rpk_connector(&peer_b, &server_spki).unwrap();
+        let tcp = TcpStream::connect(address).await.unwrap();
+        assert!(
+            connector
+                .connect("localhost".try_into().unwrap(), tcp)
+                .await
+                .is_err(),
+            "the second member must share the first member's connection cap"
+        );
+
+        let mut closed_probe = [0u8; 1];
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            stalled.read(&mut closed_probe),
+        )
+        .await
+        .expect("HELLO timeout must close the stalled group connection");
+        send_client_event_as(
+            address,
+            &peer_b,
+            &server_spki,
+            "peer-b",
+            v7_key(10),
+            b"released-group-slot",
+        )
+        .await;
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), rx_b.recv())
+                .await
+                .unwrap()
+                .unwrap()
+                .ingress,
+            Bytes::from_static(b"released-group-slot")
+        );
+        shutdown_tx.send(true).unwrap();
+        assert!(server.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn shared_listener_bind_failure_names_members_and_shutdown_closes_connections() {
+        let occupied = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = occupied.local_addr().unwrap();
+        let (server_identity, server_spki) = generated_identity();
+        let server_identity = Arc::new(server_identity);
+        let (peer_a, peer_a_spki) = generated_identity();
+        let (_, peer_b_spki) = generated_identity();
+        let ltp_metrics = test_ltp_metrics_for(&["peer-a", "peer-b"]);
+        let context = SharedTestContext {
+            bind_addr: address.to_string(),
+            node_key: Arc::clone(&server_identity),
+            max_connections: 2,
+            ltp_metrics: Arc::clone(&ltp_metrics),
+        };
+        let (input_a, tx_a, _rx_a) =
+            shared_member(&context, "from_a", "peer-a", peer_a_spki.clone(), None);
+        let (input_b, tx_b, _rx_b) =
+            shared_member(&context, "from_b", "peer-b", peer_b_spki.clone(), None);
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let error = start_listener_groups(vec![(input_a, tx_a), (input_b, tx_b)], shutdown_rx)
+            .await
+            .expect_err("occupied group bind must fail before spawning");
+        let error = format!("{error:#}");
+        assert!(error.contains("from_a"));
+        assert!(error.contains("from_b"));
+        drop(occupied);
+
+        let listener = TcpListener::bind(address).await.unwrap();
+        let (input_a, tx_a, _rx_a) = shared_member(&context, "from_a", "peer-a", peer_a_spki, None);
+        let (input_b, tx_b, _rx_b) = shared_member(&context, "from_b", "peer-b", peer_b_spki, None);
+        let group =
+            SharedListenerGroup::from_members(vec![(input_a, tx_a), (input_b, tx_b)]).unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let server = tokio::spawn(group.run_on_listener(listener, shutdown_rx));
+        let _stalled = connect_client(address, &peer_a, &server_spki).await;
+        shutdown_tx.send(true).unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), server)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_ok()
+        );
+        assert!(TcpStream::connect(address).await.is_err());
+    }
+
     #[test]
     fn non_rpk_and_intermediate_certificate_failures_do_not_count_unknown_peers() {
         let (_, declared_spki) = generated_identity();
@@ -1600,12 +2171,24 @@ mod tests {
         let (client_identity, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
         let ltp_metrics = test_ltp_metrics("peer-a");
-        let acceptor =
-            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let metrics = test_metrics();
+        let input = LtpInput {
+            name: "in".to_owned(),
+            bind_addr: address.to_string(),
+            node_id: Arc::<str>::from("self"),
+            node_key: Arc::new(server_identity),
+            peers,
+            max_hops: 16,
+            max_connections: 2,
+            metrics,
+            ltp_metrics,
+            now: fixed_now,
+            hello_started: None,
+        };
+        let group = SharedListenerGroup::from_members(vec![(input, tx)]).unwrap();
         let server = tokio::spawn(async move {
             let mut connections = Vec::new();
             for _ in 0..2 {
@@ -1613,17 +2196,9 @@ mod tests {
                 connections.push(tokio::spawn(handle_connection(
                     stream,
                     peer_address,
-                    ConnectionContext {
-                        acceptor: acceptor.clone(),
-                        peers: peers.clone(),
-                        node_id: Arc::<str>::from("self"),
-                        max_hops: 16,
-                        now: fixed_now,
-                        metrics: Arc::clone(&metrics),
-                        ltp_metrics: Arc::clone(&ltp_metrics),
-                        tx: tx.clone(),
-                        hello_started: None,
-                    },
+                    group.acceptor.clone(),
+                    Arc::clone(&group.routes),
+                    Arc::clone(&group.ltp_metrics),
                 )));
             }
             let first = connections.remove(0).await.unwrap();
@@ -1666,15 +2241,13 @@ mod tests {
         let (_, client_spki) = generated_identity();
         let peers = peer_registry("peer-a", client_spki);
         let ltp_metrics = test_ltp_metrics("peer-a");
-        let acceptor =
-            build_rpk_acceptor(&server_identity, &peers, Arc::clone(&ltp_metrics)).unwrap();
         let context = crate::modules::BuildContext::for_testing();
         let input = LtpInput {
             name: "in".to_owned(),
             bind_addr: "127.0.0.1:0".to_owned(),
             node_id: Arc::<str>::from("self"),
+            node_key: Arc::new(server_identity),
             peers,
-            acceptor,
             max_hops: 16,
             max_connections: 2,
             metrics: InputMetrics::register(&context.metrics, "in").unwrap(),
@@ -1692,5 +2265,16 @@ mod tests {
             .expect("listener must stop on shutdown")
             .unwrap();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn listener_task_error_does_not_broadcast_daemon_shutdown() {
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+
+        report_listener_result("in", Err(anyhow::anyhow!("deterministic listener failure")));
+
+        assert!(!*shutdown_tx.borrow());
+        assert!(!*shutdown_rx.borrow_and_update());
+        assert!(!shutdown_rx.has_changed().unwrap());
     }
 }

--- a/crates/limpid/src/pipeline.rs
+++ b/crates/limpid/src/pipeline.rs
@@ -143,6 +143,12 @@ impl CompiledConfig {
                 )?;
             }
         }
+        crate::modules::input::ltp::validate_listener_groups(
+            self.inputs
+                .iter()
+                .filter(|(_, input)| input.properties.type_name() == "ltp")
+                .map(|(name, input)| (name.as_str(), input.properties.user_properties())),
+        )?;
         for (name, output) in &self.outputs {
             if output.properties.type_name() == "ltp" {
                 crate::modules::output::ltp::validate_static_properties(

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -18,7 +18,7 @@ use crate::dsl::props;
 use crate::event::Event;
 use crate::functions::FunctionRegistry;
 use crate::metrics::{LtpMetrics, PipelineMetrics, Registry};
-use crate::modules::{self, HasMetrics, ModuleRegistry};
+use crate::modules::{self, HasMetrics, Module, ModuleRegistry};
 use crate::pipeline::CompiledConfig;
 use crate::queue::{self, QueueConfig, QueueSender};
 use crate::tap::TapRegistry;
@@ -319,6 +319,7 @@ impl Runtime {
             String,
             (mpsc::Sender<Event>, Arc<crate::metrics::InputMetrics>),
         > = HashMap::new();
+        let mut ltp_inputs = Vec::new();
 
         for (input_name, pipelines) in input_pipelines {
             let input_def = config
@@ -353,6 +354,32 @@ impl Runtime {
                 run_pipeline_workers(event_rx, &workers, &ctx, &iname, shutdown_for_worker).await;
             }));
 
+            if input_def.properties.type_name() == "ltp" {
+                let input = match modules::input::ltp::LtpInput::build(
+                    &input_name,
+                    &input_def.properties,
+                    &build_ctx,
+                ) {
+                    Ok(input) => input,
+                    Err(error) => {
+                        error!(
+                            "failed to create input '{}': {} — aborting startup",
+                            input_name, error
+                        );
+                        for handle in &handles {
+                            handle.abort();
+                        }
+                        for handle in handles {
+                            let _ = handle.await;
+                        }
+                        return Err(error);
+                    }
+                };
+                input_senders.insert(input_name.clone(), (sender_for_inject, input.metrics()));
+                ltp_inputs.push((input, event_tx));
+                continue;
+            }
+
             // Input — registry builds, spawns, and returns metrics handle.
             // `input_def.properties` carries the resolved `type`; no separate
             // type_name argument needed (see ModuleProperties rationale).
@@ -384,6 +411,23 @@ impl Runtime {
             );
             handles.push(created.handle);
         }
+
+        let ltp_handles =
+            match modules::input::ltp::start_listener_groups(ltp_inputs, shutdown_rx.clone()).await
+            {
+                Ok(handles) => handles,
+                Err(error) => {
+                    error!("failed to start LTP listener groups: {error:#} — aborting startup");
+                    for handle in &handles {
+                        handle.abort();
+                    }
+                    for handle in handles {
+                        let _ = handle.await;
+                    }
+                    return Err(error);
+                }
+            };
+        handles.extend(ltp_handles);
 
         // --- 4. Start control socket (after all metrics are registered) ---
         let control_path = config

--- a/crates/limpid/tests/fixtures/ltp_shared_listener_contract.json
+++ b/crates/limpid/tests/fixtures/ltp_shared_listener_contract.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "peer_cardinality": "repeatable",
+  "listener_group_cases": [
+    "exact_same_bind_coalesces",
+    "duplicate_node_id_rejected",
+    "duplicate_spki_rejected",
+    "overlapping_ipv4_bind_rejected",
+    "overlapping_ipv6_bind_rejected",
+    "distinct_specific_addresses_are_separate",
+    "matching_max_connections_is_shared",
+    "mismatched_max_connections_is_rejected"
+  ],
+  "connection_cases": [
+    "declared_spki_and_matching_hello_dispatches",
+    "unknown_spki_is_rejected",
+    "wrong_hello_node_id_is_rejected",
+    "hello_timeout_releases_group_capacity",
+    "protocol_error_isolated_to_connection"
+  ],
+  "lifecycle_cases": [
+    "group_capacity_is_listener_wide",
+    "bind_failure_aborts_startup_before_partial_service",
+    "shutdown_closes_listener_and_all_connections"
+  ],
+  "e2e": {
+    "binds": 1,
+    "logical_inputs": ["ltp_jump01", "ltp_jump02"],
+    "independent_input_metrics": true,
+    "independent_pipeline_delivery": true
+  }
+}

--- a/crates/limpid/tests/ltp_shared_listener.rs
+++ b/crates/limpid/tests/ltp_shared_listener.rs
@@ -1,0 +1,604 @@
+//! Black-box contract tests for coalescing logical LTP inputs onto one listener.
+//!
+//! These tests intentionally drive the released CLI/runtime surface. They are
+//! RED until the runtime owns LTP listener groups instead of letting every
+//! logical `input ltp` bind independently.
+
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use ring::rand::SystemRandom;
+use ring::signature::{Ed25519KeyPair, KeyPair as _};
+use serde_json::Value;
+use tempfile::TempDir;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+const ED25519_SPKI_PREFIX: [u8; 12] = [
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+];
+
+fn limpid_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_limpid")
+}
+
+fn free_tcp_addr() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    drop(listener);
+    address
+}
+
+fn secure_tempdir() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    dir
+}
+
+fn write_identity(path: &Path) -> String {
+    let pkcs8 = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
+    let pair = Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+    fs::write(
+        path,
+        pem::encode(&pem::Pem::new("PRIVATE KEY", pkcs8.as_ref())),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    let mut spki = ED25519_SPKI_PREFIX.to_vec();
+    spki.extend_from_slice(pair.public_key().as_ref());
+    base64::engine::general_purpose::STANDARD.encode(spki)
+}
+
+fn run_check(source: &str) -> std::process::Output {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("shared-listener.limpid");
+    fs::write(&config, source).unwrap();
+    Command::new(limpid_bin())
+        .arg("--check")
+        .arg("--config")
+        .arg(config)
+        .output()
+        .unwrap()
+}
+
+fn ltp_input(name: &str, bind: &str, peer_id: &str, spki: &str, max: usize) -> String {
+    format!(
+        r#"def input {name} {{
+    type ltp
+    bind "{bind}"
+    peer {{ node_id "{peer_id}" pubkey "{spki}" }}
+    max_connections {max}
+}}
+def pipeline pipeline_{name} {{ input {name}; finish }}
+"#
+    )
+}
+
+#[test]
+fn single_logical_input_keeps_repeatable_peer_syntax() {
+    let source = format!(
+        r#"node_key "not-read-by-check.pem"
+def input shared {{
+    type ltp
+    bind "127.0.0.1:27514"
+    peer {{ node_id "jump01" pubkey "{}" }}
+    peer {{ node_id "jump02" pubkey "{}" }}
+}}
+def pipeline receive {{ input shared; finish }}
+"#,
+        write_identity(&TempDir::new().unwrap().path().join("jump01.pem")),
+        write_identity(&TempDir::new().unwrap().path().join("jump02.pem")),
+    );
+    let output = run_check(&source);
+    assert!(
+        output.status.success(),
+        "repeatable peers are a compatibility contract: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn listener_group_rejects_duplicate_node_id() {
+    let first = write_identity(&TempDir::new().unwrap().path().join("first.pem"));
+    let second = write_identity(&TempDir::new().unwrap().path().join("second.pem"));
+    let bind = "127.0.0.1:27514";
+    let source = format!(
+        "node_key \"not-read-by-check.pem\"\n{}{}",
+        ltp_input("from_a", bind, "duplicate", &first, 8),
+        ltp_input("from_b", bind, "duplicate", &second, 8),
+    );
+    let output = run_check(&source);
+    assert!(
+        !output.status.success(),
+        "duplicate group node_id must fail"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("duplicate LTP peer node_id in listener group"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn listener_group_rejects_duplicate_spki() {
+    let shared = write_identity(&TempDir::new().unwrap().path().join("shared.pem"));
+    let bind = "127.0.0.1:27514";
+    let source = format!(
+        "node_key \"not-read-by-check.pem\"\n{}{}",
+        ltp_input("from_a", bind, "jump01", &shared, 8),
+        ltp_input("from_b", bind, "jump02", &shared, 8),
+    );
+    let output = run_check(&source);
+    assert!(!output.status.success(), "duplicate group SPKI must fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("duplicate LTP peer public key in listener group"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn listener_group_rejects_overlapping_nonidentical_binds() {
+    let first = write_identity(&TempDir::new().unwrap().path().join("first.pem"));
+    let second = write_identity(&TempDir::new().unwrap().path().join("second.pem"));
+    for (wildcard, specific) in [
+        ("0.0.0.0:27514", "127.0.0.1:27514"),
+        ("[::]:27514", "[::1]:27514"),
+    ] {
+        let source = format!(
+            "node_key \"not-read-by-check.pem\"\n{}{}",
+            ltp_input("wildcard", wildcard, "jump01", &first, 8),
+            ltp_input("specific", specific, "jump02", &second, 8),
+        );
+        let output = run_check(&source);
+        assert!(!output.status.success(), "{wildcard} overlaps {specific}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("overlapping LTP listener binds"),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn listener_group_accepts_distinct_specific_addresses() {
+    let first = write_identity(&TempDir::new().unwrap().path().join("first.pem"));
+    let second = write_identity(&TempDir::new().unwrap().path().join("second.pem"));
+    let source = format!(
+        "node_key \"not-read-by-check.pem\"\n{}{}",
+        ltp_input("loopback_one", "127.0.0.1:27514", "jump01", &first, 8),
+        ltp_input("loopback_two", "127.0.0.2:27514", "jump02", &second, 8),
+    );
+    let output = run_check(&source);
+    assert!(
+        output.status.success(),
+        "distinct specific addresses must remain separate: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn identical_bind_requires_matching_listener_settings() {
+    let first = write_identity(&TempDir::new().unwrap().path().join("first.pem"));
+    let second = write_identity(&TempDir::new().unwrap().path().join("second.pem"));
+    let bind = "127.0.0.1:27514";
+    let matching = format!(
+        "node_key \"not-read-by-check.pem\"\n{}{}",
+        ltp_input("from_a", bind, "jump01", &first, 8),
+        ltp_input("from_b", bind, "jump02", &second, 8),
+    );
+    let output = run_check(&matching);
+    assert!(
+        output.status.success(),
+        "matching max_connections must share: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mismatched = format!(
+        "node_key \"not-read-by-check.pem\"\n{}{}",
+        ltp_input("from_a", bind, "jump01", &first, 8),
+        ltp_input("from_b", bind, "jump02", &second, 9),
+    );
+    let output = run_check(&mismatched);
+    assert!(
+        !output.status.success(),
+        "mismatched max_connections must fail"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("LTP listener max_connections mismatch"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_receiver_config(
+    dir: &Path,
+    bind: SocketAddr,
+    server_key: &Path,
+    jump01_spki: &str,
+    jump02_spki: &str,
+) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let config = dir.join("receiver.limpid");
+    let control = dir.join("receiver.sock");
+    let out01 = dir.join("jump01.log");
+    let out02 = dir.join("jump02.log");
+    fs::write(
+        &config,
+        format!(
+            r#"node_id "receiver"
+node_key {server_key:?}
+control {{ socket {control:?} }}
+def input ltp_jump01 {{
+    type ltp
+    bind "{bind}"
+    peer {{ node_id "jump01" pubkey {jump01_spki:?} }}
+    max_connections 8
+}}
+def input ltp_jump02 {{
+    type ltp
+    bind "{bind}"
+    peer {{ node_id "jump02" pubkey {jump02_spki:?} }}
+    max_connections 8
+}}
+def output out01 {{ type file path {out01:?} }}
+def output out02 {{ type file path {out02:?} }}
+def pipeline p01 {{ input ltp_jump01; output out01 }}
+def pipeline p02 {{ input ltp_jump02; output out02 }}
+"#
+        ),
+    )
+    .unwrap();
+    (config, control, out01, out02)
+}
+
+fn spawn_daemon(config: &Path, log: &Path) -> Child {
+    let stdout = File::create(log.with_extension("stdout")).unwrap();
+    let stderr = File::create(log).unwrap();
+    Command::new(limpid_bin())
+        .arg("--config")
+        .arg(config)
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .unwrap()
+}
+
+fn wait_for_path(path: &Path) {
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    while !path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn stop_daemon(child: &mut Child) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[test]
+fn identical_bind_starts_one_listener_without_partial_eaddrinuse() {
+    let dir = secure_tempdir();
+    let server_key = dir.path().join("server.pem");
+    let jump01_key = dir.path().join("jump01.pem");
+    let jump02_key = dir.path().join("jump02.pem");
+    let _server_spki = write_identity(&server_key);
+    let jump01_spki = write_identity(&jump01_key);
+    let jump02_spki = write_identity(&jump02_key);
+    let (config, control, _, _) = write_receiver_config(
+        dir.path(),
+        free_tcp_addr(),
+        &server_key,
+        &jump01_spki,
+        &jump02_spki,
+    );
+    let log = dir.path().join("receiver.stderr");
+    let mut child = spawn_daemon(&config, &log);
+    wait_for_path(&control);
+    std::thread::sleep(Duration::from_millis(250));
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "daemon exited during startup"
+    );
+    stop_daemon(&mut child);
+
+    let mut startup_log = fs::read_to_string(&log).unwrap();
+    startup_log.push_str(&fs::read_to_string(log.with_extension("stdout")).unwrap());
+    assert!(
+        !startup_log.contains("Address already in use") && !startup_log.contains("EADDRINUSE"),
+        "same-bind inputs must be coalesced before startup, not partially started: {startup_log}"
+    );
+}
+
+#[test]
+fn spec_fixture_pins_connection_and_listener_lifecycle_fail_closed_cases() {
+    let spec: Value =
+        serde_json::from_str(include_str!("fixtures/ltp_shared_listener_contract.json")).unwrap();
+    assert_eq!(spec["version"], 1);
+    assert_eq!(spec["peer_cardinality"], "repeatable");
+    assert_eq!(
+        spec["connection_cases"],
+        serde_json::json!([
+            "declared_spki_and_matching_hello_dispatches",
+            "unknown_spki_is_rejected",
+            "wrong_hello_node_id_is_rejected",
+            "hello_timeout_releases_group_capacity",
+            "protocol_error_isolated_to_connection"
+        ])
+    );
+    assert_eq!(
+        spec["lifecycle_cases"],
+        serde_json::json!([
+            "group_capacity_is_listener_wide",
+            "bind_failure_aborts_startup_before_partial_service",
+            "shutdown_closes_listener_and_all_connections"
+        ])
+    );
+    assert_eq!(spec["e2e"]["binds"], 1);
+    assert_eq!(
+        spec["e2e"]["logical_inputs"],
+        serde_json::json!(["ltp_jump01", "ltp_jump02"])
+    );
+    assert_eq!(spec["e2e"]["independent_input_metrics"], true);
+    assert_eq!(spec["e2e"]["independent_pipeline_delivery"], true);
+}
+
+fn read_stats(socket: &Path) -> Value {
+    use std::os::unix::net::UnixStream;
+    let mut stream = UnixStream::connect(socket).unwrap();
+    stream.write_all(b"stats\n").unwrap();
+    let mut line = String::new();
+    BufReader::new(stream).read_line(&mut line).unwrap();
+    serde_json::from_str(line.trim()).unwrap()
+}
+
+fn metric_value(stats: &Value, family: &str, labels: &[(&str, &str)]) -> u64 {
+    let metric = stats["metrics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|metric| metric["name"] == family)
+        .unwrap_or_else(|| panic!("missing metric family {family}"));
+    metric["series"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|series| {
+            labels
+                .iter()
+                .all(|(key, value)| series["labels"][key] == *value)
+        })
+        .unwrap_or_else(|| panic!("missing series {family} {labels:?}"))["value"]
+        .as_u64()
+        .unwrap()
+}
+
+#[test]
+fn shared_listener_prepopulates_independent_logical_input_metrics() {
+    let dir = secure_tempdir();
+    let server_key = dir.path().join("server.pem");
+    let jump01_key = dir.path().join("jump01.pem");
+    let jump02_key = dir.path().join("jump02.pem");
+    let _server_spki = write_identity(&server_key);
+    let jump01_spki = write_identity(&jump01_key);
+    let jump02_spki = write_identity(&jump02_key);
+    let (config, control, _, _) = write_receiver_config(
+        dir.path(),
+        free_tcp_addr(),
+        &server_key,
+        &jump01_spki,
+        &jump02_spki,
+    );
+    let log = dir.path().join("receiver.stderr");
+    let mut child = spawn_daemon(&config, &log);
+    wait_for_path(&control);
+    let stats = read_stats(&control);
+    stop_daemon(&mut child);
+
+    assert_eq!(
+        metric_value(
+            &stats,
+            "limpid_input_events_received_total",
+            &[("input", "ltp_jump01")]
+        ),
+        0
+    );
+    assert_eq!(
+        metric_value(
+            &stats,
+            "limpid_input_events_received_total",
+            &[("input", "ltp_jump02")]
+        ),
+        0
+    );
+}
+
+fn write_sender_config(
+    dir: &Path,
+    node_id: &str,
+    node_key: &Path,
+    server_spki: &str,
+    source_bind: SocketAddr,
+    ltp_endpoint: SocketAddr,
+) -> (PathBuf, PathBuf) {
+    let config = dir.join(format!("{node_id}.limpid"));
+    let control = dir.join(format!("{node_id}.sock"));
+    fs::write(
+        &config,
+        format!(
+            r#"node_id "{node_id}"
+node_key {node_key:?}
+control {{ socket {control:?} }}
+def input source {{ type syslog_tcp bind "{source_bind}" }}
+def output relay {{
+    type ltp
+    peer {{ node_id "receiver" pubkey {server_spki:?} endpoint "{ltp_endpoint}" }}
+}}
+def pipeline send {{ input source; output relay }}
+"#
+        ),
+    )
+    .unwrap();
+    (config, control)
+}
+
+fn send_one_syslog_frame(address: SocketAddr, marker: &[u8]) {
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    let mut stream = loop {
+        match std::net::TcpStream::connect_timeout(&address, Duration::from_millis(100)) {
+            Ok(stream) => break stream,
+            Err(error) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out connecting to {address}: {error}"
+                );
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+    stream.write_all(marker).unwrap();
+    stream.write_all(b"\n").unwrap();
+    stream.flush().unwrap();
+}
+
+fn wait_for_exact_file(path: &Path, expected: &[u8]) -> bool {
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    while Instant::now() < deadline {
+        if fs::read(path).is_ok_and(|bytes| bytes == expected) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    false
+}
+
+#[test]
+fn two_peers_on_one_port_route_to_independent_inputs_pipelines_and_metrics() {
+    let dir = secure_tempdir();
+    let server_key = dir.path().join("server.pem");
+    let jump01_key = dir.path().join("jump01.pem");
+    let jump02_key = dir.path().join("jump02.pem");
+    let server_spki = write_identity(&server_key);
+    let jump01_spki = write_identity(&jump01_key);
+    let jump02_spki = write_identity(&jump02_key);
+    let ltp_addr = free_tcp_addr();
+    let jump01_source = free_tcp_addr();
+    let jump02_source = free_tcp_addr();
+    let (receiver_config, receiver_control, out01, out02) = write_receiver_config(
+        dir.path(),
+        ltp_addr,
+        &server_key,
+        &jump01_spki,
+        &jump02_spki,
+    );
+    let (jump01_config, jump01_control) = write_sender_config(
+        dir.path(),
+        "jump01",
+        &jump01_key,
+        &server_spki,
+        jump01_source,
+        ltp_addr,
+    );
+    let (jump02_config, jump02_control) = write_sender_config(
+        dir.path(),
+        "jump02",
+        &jump02_key,
+        &server_spki,
+        jump02_source,
+        ltp_addr,
+    );
+
+    let mut receiver = spawn_daemon(&receiver_config, &dir.path().join("receiver.stderr"));
+    wait_for_path(&receiver_control);
+    let mut jump01 = spawn_daemon(&jump01_config, &dir.path().join("jump01.stderr"));
+    let mut jump02 = spawn_daemon(&jump02_config, &dir.path().join("jump02.stderr"));
+    wait_for_path(&jump01_control);
+    wait_for_path(&jump02_control);
+
+    let marker01 = b"<13>shared-listener-jump01";
+    let marker02 = b"<13>shared-listener-jump02";
+    send_one_syslog_frame(jump01_source, marker01);
+    send_one_syslog_frame(jump02_source, marker02);
+    let mut expected01 = marker01.to_vec();
+    expected01.push(b'\n');
+    let mut expected02 = marker02.to_vec();
+    expected02.push(b'\n');
+    let delivered01 = wait_for_exact_file(&out01, &expected01);
+    let delivered02 = wait_for_exact_file(&out02, &expected02);
+    let stats = read_stats(&receiver_control);
+
+    stop_daemon(&mut jump01);
+    stop_daemon(&mut jump02);
+    stop_daemon(&mut receiver);
+
+    assert!(delivered01, "jump01 event did not reach its bound pipeline");
+    assert!(delivered02, "jump02 event did not reach its bound pipeline");
+    for (input, pipeline) in [("ltp_jump01", "p01"), ("ltp_jump02", "p02")] {
+        assert_eq!(
+            metric_value(
+                &stats,
+                "limpid_input_events_received_total",
+                &[("input", input)]
+            ),
+            1,
+            "logical input metric must be independent"
+        );
+        assert_eq!(
+            metric_value(
+                &stats,
+                "limpid_pipeline_events_received_total",
+                &[("pipeline", pipeline)]
+            ),
+            1,
+            "pipeline routing must follow the authenticated logical input"
+        );
+    }
+}
+
+#[test]
+fn fixture_file_is_secret_free_and_consumed() {
+    let mut fixture = String::new();
+    File::open(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/ltp_shared_listener_contract.json"
+    ))
+    .unwrap()
+    .read_to_string(&mut fixture)
+    .unwrap();
+    assert!(!fixture.contains("PRIVATE KEY"));
+    assert!(!fixture.contains("pubkey"));
+    assert!(fixture.contains("unknown_spki_is_rejected"));
+}

--- a/crates/limpid/tests/ltp_shared_listener.rs
+++ b/crates/limpid/tests/ltp_shared_listener.rs
@@ -1,8 +1,7 @@
 //! Black-box contract tests for coalescing logical LTP inputs onto one listener.
 //!
-//! These tests intentionally drive the released CLI/runtime surface. They are
-//! RED until the runtime owns LTP listener groups instead of letting every
-//! logical `input ltp` bind independently.
+//! These tests intentionally drive the released CLI/runtime surface, pinning
+//! the runtime-owned LTP listener-group contract as black-box behavior.
 
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Read, Write};
@@ -220,6 +219,11 @@ fn identical_bind_requires_matching_listener_settings() {
     );
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("LTP listener max_connections mismatch"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("between inputs 'from_a' and 'from_b'"),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );

--- a/docs/src/ltp.md
+++ b/docs/src/ltp.md
@@ -65,6 +65,45 @@ def input from_edge {
 | `max_hops` | `16` | Incoming hop limit, from 1 through 16. An event already at the limit is dropped. |
 | `max_connections` | `1024` | Maximum concurrent accepted connections. |
 
+Multiple logical LTP inputs may use the exact same `bind` string. Limpid opens
+one physical listener for that group, authenticates against the union of its
+declared peers, and dispatches each connection to the logical input that owns
+the presented public key. The hello `node_id` must then match that key. Events,
+input counters, and pipeline delivery belong only to the selected input; the
+hello frame is not counted as an input payload.
+
+```limpid
+def input ltp_jump01 {
+    type ltp
+    bind "0.0.0.0:7514"
+    peer { node_id "jump01" pubkey "<jump01 SPKI base64>" }
+    max_connections 1024
+}
+
+def input ltp_jump02 {
+    type ltp
+    bind "0.0.0.0:7514"
+    peer { node_id "jump02" pubkey "<jump02 SPKI base64>" }
+    max_connections 1024
+}
+
+def pipeline from_jump01 { input ltp_jump01; finish }
+def pipeline from_jump02 { input ltp_jump02; finish }
+```
+
+Peer `node_id` and public keys must be unique across a shared-listener group.
+`max_connections` is listener-wide and must have the same value on every group
+member; `max_hops` remains specific to each logical input. Exact bind-string
+equality is required for sharing—hostnames and equivalent textual addresses
+are not normalized. Non-identical IP binds on the same port are rejected when
+their scopes overlap, such as `0.0.0.0:7514` with `127.0.0.1:7514`, or
+`[::]:7514` with `[::1]:7514`. Distinct specific addresses remain separate
+listeners. Whether `[::]:7514` also conflicts with `0.0.0.0:7514` depends on
+the platform's dual-stack socket policy, so that cross-family pair may pass
+static overlap validation and then fail at bind time. A bind failure aborts
+startup for the whole group and names all affected inputs; Limpid does not
+continue with a partially active group.
+
 The wire key must be exactly 16 bytes, use the RFC 4122 variant, and identify a
 UUIDv7. Limpid never replaces an invalid or missing key. After authentication,
 the hello `node_id` must match the identity assigned to the presented public


### PR DESCRIPTION
## Summary
- coalesce LTP inputs with an identical bind into one physical listener
- dispatch authenticated peers to logical inputs by SPKI and bound hello node ID while preserving repeatable peers
- keep per-input pipelines and metrics isolated, and reject conflicting listener groups
- document shared-bind behavior and cover routing, validation, capacity, and lifecycle with executable tests

## Validation
- cargo test -p limpid --test ltp_shared_listener --locked
- cargo test -p limpid modules::input::ltp::tests --locked
- cargo test -p limpid --lib --locked
- cargo test -p limpid --test cli_check --locked
- cargo clippy -p limpid --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- mdbook build docs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple LTP inputs can now share a single listener when configured with the same bind address.
  * Connections are routed to the correct logical input using authenticated peer identity and node ID.
  * Metrics, event delivery, connection limits, and shutdown behavior remain isolated and consistent per input.
* **Bug Fixes**
  * Invalid duplicate peers, conflicting listener settings, overlapping binds, and partial startup failures are now rejected safely.
* **Documentation**
  * Added configuration guidance for shared LTP listeners and their validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->