### PR TITLE
fix(runtime): make startup transactional

### DIFF
--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -57,6 +57,13 @@ const MAX_CONTROL_CONNECTIONS: usize = 8;
 /// pressure.
 const MAX_INJECT_BYTES: u64 = 16 * 1024 * 1024;
 
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 /// Per-input inject target: event channel + metrics handle (for events_injected).
 pub type InputInjectTarget = (mpsc::Sender<Event>, Arc<crate::metrics::InputMetrics>);
 
@@ -443,7 +450,11 @@ impl ControlServer {
         }
     }
 
-    pub async fn run(self, mut shutdown: tokio::sync::watch::Receiver<bool>) {
+    pub async fn run(
+        self,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+        mut startup: Option<tokio::sync::oneshot::Sender<std::result::Result<(), String>>>,
+    ) {
         // Parent directory has already been validated and (when absent)
         // created at 0o750 under a trusted ancestor by
         // `validate_control_socket_parent`, called from `Runtime::start`
@@ -467,10 +478,15 @@ impl ControlServer {
                 Ok(meta) => {
                     let ft = meta.file_type();
                     if ft.is_symlink() {
+                        let diagnostic = format!(
+                            "control socket: {:?} is a symlink — refusing to remove",
+                            self.socket_path
+                        );
                         error!(
                             "control socket: {:?} is a symlink — refusing to remove",
                             self.socket_path
                         );
+                        send_control_startup(&mut startup, Err(diagnostic));
                         return;
                     }
                     if !ft.is_socket() {
@@ -494,17 +510,68 @@ impl ControlServer {
                              is correct.",
                             self.socket_path, shape
                         );
+                        send_control_startup(
+                            &mut startup,
+                            Err(format!(
+                                "control socket: {:?} is a {shape}; refusing to remove",
+                                self.socket_path
+                            )),
+                        );
                         return;
                     }
-                    // Actual stale socket — safe to unlink.
-                    let _ = std::fs::remove_file(&self.socket_path);
+                    // Do not steal a live daemon's control path. A successful
+                    // stream connection proves an active owner; only the
+                    // connection-refused/not-found stale shapes may be
+                    // unlinked under the already-validated parent boundary.
+                    match std::os::unix::net::UnixStream::connect(&self.socket_path) {
+                        Ok(stream) => {
+                            drop(stream);
+                            let diagnostic = format!(
+                                "control socket: {:?} is already owned by an active listener",
+                                self.socket_path
+                            );
+                            error!("{diagnostic}");
+                            send_control_startup(&mut startup, Err(diagnostic));
+                            return;
+                        }
+                        Err(error)
+                            if matches!(
+                                error.kind(),
+                                std::io::ErrorKind::ConnectionRefused
+                                    | std::io::ErrorKind::NotFound
+                            ) =>
+                        {
+                            if let Err(error) = std::fs::remove_file(&self.socket_path) {
+                                let diagnostic = format!(
+                                    "control socket: failed to remove stale socket {:?}: {error}",
+                                    self.socket_path
+                                );
+                                error!("{diagnostic}");
+                                send_control_startup(&mut startup, Err(diagnostic));
+                                return;
+                            }
+                        }
+                        Err(error) => {
+                            let diagnostic = format!(
+                                "control socket: cannot prove existing socket {:?} is stale: {error}",
+                                self.socket_path
+                            );
+                            error!("{diagnostic}");
+                            send_control_startup(&mut startup, Err(diagnostic));
+                            return;
+                        }
+                    }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     // No node at the path — `bind(2)` will create it
                     // fresh.
                 }
                 Err(e) => {
-                    warn!("control socket: cannot stat {:?}: {}", self.socket_path, e);
+                    let diagnostic =
+                        format!("control socket: cannot stat {:?}: {e}", self.socket_path);
+                    error!("{diagnostic}");
+                    send_control_startup(&mut startup, Err(diagnostic));
+                    return;
                 }
             }
         }
@@ -512,10 +579,13 @@ impl ControlServer {
         let listener = match UnixListener::bind(&self.socket_path) {
             Ok(l) => l,
             Err(e) => {
+                let diagnostic =
+                    format!("control socket: failed to bind {:?}: {e}", self.socket_path);
                 error!(
                     "control socket: failed to bind {:?}: {}",
                     self.socket_path, e
                 );
+                send_control_startup(&mut startup, Err(diagnostic));
                 return;
             }
         };
@@ -584,13 +654,9 @@ impl ControlServer {
         //   3. return without entering the accept loop so no client
         //      connects to a mis-moded socket.
         //
-        // The daemon as a whole remains up (control is a fire-and-
-        // forget task and cannot abort daemon startup from here);
-        // operator response is `journalctl -u limpid | grep chmod`
-        // + reconfigure and restart. That is a narrowing over the
-        // previous warn-and-continue shape, which let the daemon
-        // appear healthy while the control socket carried the
-        // wrong mode.
+        // The startup readiness channel makes this fatal to the daemon
+        // transaction as well as to the control task: Runtime::start rolls
+        // back every earlier owner and returns the chmod error.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -628,9 +694,18 @@ impl ControlServer {
                         ),
                     }
                 }
+                send_control_startup(
+                    &mut startup,
+                    Err(format!(
+                        "control socket: chmod 0o660 failed on {:?}: {e}",
+                        self.socket_path
+                    )),
+                );
                 return;
             }
         }
+
+        send_control_startup(&mut startup, Ok(()));
 
         info!("control socket listening on {:?}", self.socket_path);
 
@@ -650,8 +725,8 @@ impl ControlServer {
             tokio::select! {
                 biased;
 
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() {
+                terminal = shutdown_change_is_terminal(&mut shutdown) => {
+                    if terminal {
                         info!("control socket: shutting down");
                         for h in &conn_handles {
                             h.abort();
@@ -745,6 +820,15 @@ impl ControlServer {
         {
             let _ = std::fs::remove_file(&self.socket_path);
         }
+    }
+}
+
+fn send_control_startup(
+    startup: &mut Option<tokio::sync::oneshot::Sender<std::result::Result<(), String>>>,
+    result: std::result::Result<(), String>,
+) {
+    if let Some(sender) = startup.take() {
+        let _ = sender.send(result);
     }
 }
 
@@ -1280,7 +1364,7 @@ def pipeline p { input i; output o }
         );
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-        tokio::spawn(server.run(shutdown_rx));
+        tokio::spawn(server.run(shutdown_rx, None));
 
         // Poll for the socket file to appear instead of a fixed sleep —
         // bind happens early in `run` but is still async relative to
@@ -1734,7 +1818,7 @@ mod tests {
         // fn signature and stop at the module-scope closer that
         // follows the `impl ControlServer` block.
         let run_start = src
-            .find("pub async fn run(self")
+            .find("pub async fn run(\n        self,")
             .expect("ControlServer::run must exist");
         // The body is not enormous; take a generous slice.
         let slice_end = (run_start + 20_000).min(src.len());
@@ -1755,6 +1839,50 @@ mod tests {
             body.contains("(bound_dev, bound_ino)"),
             "chmod-failure cleanup must be gated by a bound (dev, ino) match so a swapped \
              entry is not blindly unlinked"
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_control_accept_loop() {
+        let (sender, mut receiver) = tokio::sync::watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("control.rs").contains(&marker));
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("closed-watch.sock");
+        let config = CompiledConfig::from_config(
+            crate::dsl::parser::parse_config("").expect("empty config parses"),
+        )
+        .expect("empty config compiles");
+        let server = ControlServer::new(
+            Some(socket.to_string_lossy().into_owned()),
+            TapRegistry::new(),
+            Arc::new(crate::metrics::Registry::new()),
+            Arc::new(config),
+            HashMap::new(),
+            Arc::new(HashMap::new()),
+            Instant::now(),
+        );
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        drop(shutdown_tx);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            server.run(shutdown_rx, None),
+        )
+        .await
+        .expect("actual control accept loop must terminate on a closed watch");
+        assert!(
+            !socket.exists(),
+            "control cleanup must unlink the owned socket"
         );
     }
 }

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -541,11 +541,10 @@ impl ControlServer {
                                     | std::io::ErrorKind::NotFound
                             ) =>
                         {
-                            if let Err(error) = std::fs::remove_file(&self.socket_path) {
-                                let diagnostic = format!(
-                                    "control socket: failed to remove stale socket {:?}: {error}",
-                                    self.socket_path
-                                );
+                            if let Err(diagnostic) = classify_stale_socket_removal(
+                                &self.socket_path,
+                                std::fs::remove_file(&self.socket_path),
+                            ) {
                                 error!("{diagnostic}");
                                 send_control_startup(&mut startup, Err(diagnostic));
                                 return;
@@ -1512,9 +1511,44 @@ def pipeline p { input i; output o }
     }
 }
 
+#[cfg(unix)]
+fn classify_stale_socket_removal(
+    socket_path: &std::path::Path,
+    removal: std::io::Result<()>,
+) -> Result<(), String> {
+    match removal {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "control socket: failed to remove stale socket {socket_path:?}: {error}"
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn stale_socket_removal_accepts_not_found_race_but_preserves_other_errors() {
+        let socket = std::path::Path::new("/run/limpid/control.sock");
+        assert!(
+            classify_stale_socket_removal(
+                socket,
+                Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
+            )
+            .is_ok()
+        );
+
+        let error = classify_stale_socket_removal(
+            socket,
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+        )
+        .expect_err("non-NotFound removal failures must remain fatal");
+        assert!(error.contains("failed to remove stale socket"));
+        assert!(error.to_lowercase().contains("permission denied"));
+    }
 
     #[test]
     #[cfg(unix)]

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -38,6 +38,13 @@ use std::time::Duration;
 
 use super::journal_sys::Journal;
 use anyhow::Result;
+
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
 use bytes::Bytes;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use tracing::{error, info, warn};
@@ -186,6 +193,7 @@ impl Input for JournalInput {
         // which may never arrive on a quiet system.
         let reader_shutdown = Arc::new(AtomicBool::new(false));
         let reader_shutdown_for_thread = Arc::clone(&reader_shutdown);
+        let (reader_startup_tx, reader_startup_rx) = tokio::sync::oneshot::channel();
 
         let journal_handle = tokio::task::spawn_blocking(move || {
             run_journal_reader(
@@ -194,8 +202,23 @@ impl Input for JournalInput {
                 poll_interval,
                 entry_tx,
                 reader_shutdown_for_thread,
+                reader_startup_tx,
             )
         });
+
+        match reader_startup_rx.await {
+            Ok(Ok(())) => crate::modules::input_startup_ready(),
+            Ok(Err(error)) => {
+                reader_shutdown.store(true, Ordering::Relaxed);
+                let _ = journal_handle.await;
+                anyhow::bail!(error);
+            }
+            Err(_) => {
+                reader_shutdown.store(true, Ordering::Relaxed);
+                let _ = journal_handle.await;
+                anyhow::bail!("journal reader exited before startup readiness");
+            }
+        }
 
         // Ack channel: pipeline workers drop the per-event AckHandle on
         // completion, which sends the carried journald cursor back here.
@@ -211,21 +234,14 @@ impl Input for JournalInput {
             tokio::select! {
                 biased;
 
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() {
+                terminal = shutdown_change_is_terminal(&mut shutdown) => {
+                    if terminal {
                         info!("journal: shutting down");
-                        // Tell the blocking reader to exit; `abort()`
-                        // alone would not (the reader is already
-                        // running on a blocking thread).
+                        // Tell the blocking reader to exit. Its handle
+                        // is awaited below before this input actor can
+                        // finish, so the runtime's MustJoin ownership
+                        // includes the actual reader thread.
                         reader_shutdown.store(true, Ordering::Relaxed);
-                        journal_handle.abort();
-                        // Drain in-flight acks one last time so the
-                        // most-recent processed cursor lands on disk.
-                        if let Some(last) = drain_cursor_acks(&mut ack_rx)
-                            && let Some(ref sf) = self.state_file
-                        {
-                            save_cursor(sf, &last);
-                        }
                         break;
                     }
                 }
@@ -276,6 +292,25 @@ impl Input for JournalInput {
                     }
                 }
             }
+        }
+
+        // Every exit path (watch closure, downstream closure, reader
+        // completion, or explicit shutdown) cooperatively stops and
+        // joins the blocking reader. Dropping a spawn_blocking handle
+        // would detach it, and aborting a running blocking task is a
+        // no-op, so neither is an acceptable resource disposition.
+        reader_shutdown.store(true, Ordering::Relaxed);
+        match journal_handle.await {
+            Ok(()) => {}
+            Err(error) => error!("journal reader task failed: {error}"),
+        }
+
+        // Drain in-flight acks after the reader is fully stopped so the
+        // most-recent processed cursor lands on disk exactly once.
+        if let Some(last) = drain_cursor_acks(&mut ack_rx)
+            && let Some(ref sf) = self.state_file
+        {
+            save_cursor(sf, &last);
         }
 
         Ok(())
@@ -402,11 +437,17 @@ fn run_journal_reader(
     poll_interval: Duration,
     tx: tokio::sync::mpsc::Sender<(Vec<u8>, String)>,
     shutdown: Arc<AtomicBool>,
+    startup: tokio::sync::oneshot::Sender<std::result::Result<(), String>>,
 ) {
+    let mut startup = Some(startup);
     let mut journal = match Journal::open() {
         Ok(j) => j,
         Err(e) => {
             error!("journal: failed to open: {}", e);
+            let _ = startup
+                .take()
+                .expect("journal startup sender")
+                .send(Err(format!("journal: failed to open: {e}")));
             return;
         }
     };
@@ -431,6 +472,12 @@ fn run_journal_reader(
                  load time; reader terminating",
                 m
             );
+            let _ = startup
+                .take()
+                .expect("journal startup sender")
+                .send(Err(format!(
+                    "journal input: match '{m}' has no '=' separator"
+                )));
             return;
         };
         if let Err(e) = journal.match_add(key, val) {
@@ -448,6 +495,9 @@ fn run_journal_reader(
              terminating (semantics: no journal entry can satisfy the specified configuration, \
              so zero events is the correct output — fix the offending filter(s) and restart)"
         );
+        let _ = startup.take().expect("journal startup sender").send(Err(
+            "journal input: one or more match filters were rejected by libsystemd".to_string(),
+        ));
         return;
     }
 
@@ -479,6 +529,8 @@ fn run_journal_reader(
     } else {
         anchor_at_tail_or_head(&mut journal);
     }
+
+    let _ = startup.take().expect("journal startup sender").send(Ok(()));
 
     loop {
         if shutdown.load(Ordering::Relaxed) {
@@ -898,5 +950,44 @@ def pipeline p { input j; output o }
             "should not over-sleep wildly; took {:?}",
             elapsed
         );
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_journal_loop() {
+        let (sender, mut receiver) = tokio::sync::watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("journal.rs").contains(&marker));
+    }
+
+    #[tokio::test]
+    async fn closed_watch_stops_and_joins_actual_journal_reader() {
+        let registry = crate::metrics::Registry::new();
+        let input = JournalInput {
+            matches: Vec::new(),
+            state_file: None,
+            poll_interval: Duration::from_secs(30),
+            metrics: InputMetrics::register(&registry, "journal-closed-watch").unwrap(),
+        };
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(1);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        drop(shutdown_tx);
+
+        tokio::time::timeout(Duration::from_secs(2), input.run(event_tx, shutdown_rx))
+            .await
+            .expect("closed watch must stop and join the blocking journal reader")
+            .expect("journal input shutdown must be clean");
+
+        let source = include_str!("journal.rs");
+        assert!(source.contains("journal_handle.await"));
+        assert!(!source.contains(&["journal_handle", ".abort()"].concat()));
     }
 }

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -58,6 +58,19 @@ use crate::modules::{HasMetrics, Input, Module};
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const JOURNAL_SOURCE: &str = "127.0.0.1:0";
 
+#[cfg(test)]
+#[derive(Default)]
+struct ControlledJournalReader {
+    started: AtomicBool,
+    stopped: AtomicBool,
+    join_observed: AtomicBool,
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_JOURNAL_READER: Arc<ControlledJournalReader>;
+}
+
 const JOURNAL_INPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
         name: "match",
@@ -195,7 +208,23 @@ impl Input for JournalInput {
         let reader_shutdown_for_thread = Arc::clone(&reader_shutdown);
         let (reader_startup_tx, reader_startup_rx) = tokio::sync::oneshot::channel();
 
+        #[cfg(test)]
+        let controlled_reader = TEST_JOURNAL_READER.try_with(Arc::clone).ok();
+        #[cfg(test)]
+        let controlled_reader_for_thread = controlled_reader.clone();
+
         let journal_handle = tokio::task::spawn_blocking(move || {
+            #[cfg(test)]
+            if let Some(control) = controlled_reader_for_thread {
+                control.started.store(true, Ordering::SeqCst);
+                let _ = reader_startup_tx.send(Ok(()));
+                while !reader_shutdown_for_thread.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                control.stopped.store(true, Ordering::SeqCst);
+                return;
+            }
+
             run_journal_reader(
                 matches,
                 state_file,
@@ -300,7 +329,12 @@ impl Input for JournalInput {
         // would detach it, and aborting a running blocking task is a
         // no-op, so neither is an acceptable resource disposition.
         reader_shutdown.store(true, Ordering::Relaxed);
-        match journal_handle.await {
+        let join_result = journal_handle.await;
+        #[cfg(test)]
+        if let Some(control) = controlled_reader {
+            control.join_observed.store(true, Ordering::SeqCst);
+        }
+        match join_result {
             Ok(()) => {}
             Err(error) => error!("journal reader task failed: {error}"),
         }
@@ -969,7 +1003,8 @@ def pipeline p { input j; output o }
     }
 
     #[tokio::test]
-    async fn closed_watch_stops_and_joins_actual_journal_reader() {
+    async fn closed_watch_stops_and_joins_controlled_blocking_reader() {
+        let control = Arc::new(ControlledJournalReader::default());
         let registry = crate::metrics::Registry::new();
         let input = JournalInput {
             matches: Vec::new(),
@@ -981,13 +1016,16 @@ def pipeline p { input j; output o }
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         drop(shutdown_tx);
 
-        tokio::time::timeout(Duration::from_secs(2), input.run(event_tx, shutdown_rx))
-            .await
-            .expect("closed watch must stop and join the blocking journal reader")
-            .expect("journal input shutdown must be clean");
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            TEST_JOURNAL_READER.scope(Arc::clone(&control), input.run(event_tx, shutdown_rx)),
+        )
+        .await
+        .expect("closed watch must stop and join the controlled blocking reader")
+        .expect("journal input shutdown must be clean");
 
-        let source = include_str!("journal.rs");
-        assert!(source.contains("journal_handle.await"));
-        assert!(!source.contains(&["journal_handle", ".abort()"].concat()));
+        assert!(control.started.load(Ordering::SeqCst));
+        assert!(control.stopped.load(Ordering::SeqCst));
+        assert!(control.join_observed.load(Ordering::SeqCst));
     }
 }

--- a/crates/limpid/src/modules/input/otlp/grpc.rs
+++ b/crates/limpid/src/modules/input/otlp/grpc.rs
@@ -44,7 +44,7 @@ use prost::Message;
 use tokio::sync::mpsc;
 use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 use tonic::{Request, Response, Status};
-use tracing::{info, warn};
+use tracing::info;
 
 use super::split_request;
 use crate::dsl::props;
@@ -159,15 +159,16 @@ impl Input for OtlpGrpcInput {
                 .tls_config(tls)
                 .context("otlp_grpc: failed to install server TLS config")?;
         }
+        let incoming = tonic::transport::server::TcpIncoming::bind(addr)
+            .with_context(|| format!("otlp_grpc: failed to bind {addr}"))?;
+        crate::modules::input_startup_ready();
         let server = builder
             .add_service(LogsServiceServer::new(svc))
-            .serve_with_shutdown(addr, async move {
+            .serve_with_incoming_shutdown(incoming, async move {
                 let _ = shutdown.changed().await;
             });
 
-        if let Err(e) = server.await {
-            warn!("otlp_grpc server error: {}", e);
-        }
+        server.await.context("otlp_grpc server failed")?;
         info!("otlp_grpc: shutting down");
         Ok(())
     }

--- a/crates/limpid/src/modules/input/otlp/grpc.rs
+++ b/crates/limpid/src/modules/input/otlp/grpc.rs
@@ -160,7 +160,8 @@ impl Input for OtlpGrpcInput {
                 .context("otlp_grpc: failed to install server TLS config")?;
         }
         let incoming = tonic::transport::server::TcpIncoming::bind(addr)
-            .with_context(|| format!("otlp_grpc: failed to bind {addr}"))?;
+            .with_context(|| format!("otlp_grpc: failed to bind {addr}"))?
+            .with_nodelay(Some(true));
         crate::modules::input_startup_ready();
         let server = builder
             .add_service(LogsServiceServer::new(svc))
@@ -268,6 +269,56 @@ fn empty_response() -> ExportLogsServiceResponse {
 mod tests {
     use super::*;
     use crate::dsl::ast::Property;
+
+    #[test]
+    fn manual_tcp_incoming_preserves_tonic_nodelay_default() {
+        let source = include_str!("grpc.rs");
+        let test_module = ["#[cfg(", "test)]\nmod tests"].concat();
+        let production = source
+            .split_once(&test_module)
+            .expect("test module boundary must remain explicit")
+            .0;
+        let bind = ["TcpIncoming::", "bind(addr)"].concat();
+        let nodelay = [".with_", "nodelay(Some(true))"].concat();
+        let bind_at = production
+            .find(&bind)
+            .expect("manual TcpIncoming bind must remain in production");
+        let configured = &production[bind_at..];
+        let nodelay_at = configured
+            .find(&nodelay)
+            .expect("the configured incoming must enable TCP_NODELAY");
+        let serve = ["serve_with_", "incoming_shutdown(incoming"].concat();
+        let serve_at = configured
+            .find(&serve)
+            .expect("the configured incoming must be served");
+        assert!(
+            nodelay_at < serve_at,
+            "TCP_NODELAY must be set before serving"
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_tcp_incoming_sets_nodelay_on_accepted_socket() {
+        use tokio_stream::StreamExt as _;
+
+        let mut incoming = tonic::transport::server::TcpIncoming::bind(
+            "127.0.0.1:0".parse().expect("loopback address"),
+        )
+        .expect("bind test incoming")
+        .with_nodelay(Some(true));
+        let address = incoming.local_addr().expect("bound address");
+        let client = tokio::net::TcpStream::connect(address)
+            .await
+            .expect("connect to test incoming");
+        let accepted = incoming
+            .next()
+            .await
+            .expect("incoming stream must yield")
+            .expect("accept must succeed");
+
+        assert!(accepted.nodelay().expect("read accepted TCP_NODELAY"));
+        drop(client);
+    }
 
     /// Wrap a property list in a `ModuleProperties` shaped for this test module.
     /// Mirrors what the parser produces for `def input/output ... { type otlp_grpc; ... }`

--- a/crates/limpid/src/modules/input/otlp/http.rs
+++ b/crates/limpid/src/modules/input/otlp/http.rs
@@ -313,25 +313,42 @@ impl Input for OtlpHttpInput {
         let make_service = app.into_make_service_with_connect_info::<SocketAddr>();
         let result = match rustls {
             Some(config) => {
-                axum_server::bind_rustls(addr, config)
-                    .handle(handle)
-                    .serve(make_service)
-                    .await
+                let server = axum_server::bind_rustls(addr, config)
+                    .handle(handle.clone())
+                    .serve(make_service);
+                serve_after_listening(handle, server).await
             }
             None => {
-                axum_server::bind(addr)
-                    .handle(handle)
-                    .serve(make_service)
-                    .await
+                let server = axum_server::bind(addr)
+                    .handle(handle.clone())
+                    .serve(make_service);
+                serve_after_listening(handle, server).await
             }
         };
         shutdown_task.abort();
 
-        if let Err(e) = result {
-            warn!("otlp_http server error: {}", e);
-        }
+        result.context("otlp_http server failed")?;
         info!("otlp_http: shutting down");
         Ok(())
+    }
+}
+
+async fn serve_after_listening<F>(handle: Handle, server: F) -> std::io::Result<()>
+where
+    F: std::future::Future<Output = std::io::Result<()>>,
+{
+    tokio::pin!(server);
+    tokio::select! {
+        result = &mut server => result,
+        listening = handle.listening() => {
+            if listening.is_none() {
+                return Err(std::io::Error::other(
+                    "otlp_http server stopped before acquiring its listener",
+                ));
+            }
+            crate::modules::input_startup_ready();
+            server.await
+        }
     }
 }
 

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -30,6 +30,13 @@ use crate::metrics::InputMetrics;
 use crate::modules::{HasMetrics, Input, Module};
 use crate::tls::TlsConfig;
 
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 const SYSLOG_TCP_INPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
         name: "bind",
@@ -229,6 +236,7 @@ impl Input for SyslogTcpInput {
         };
 
         let listener = TcpListener::bind(&self.bind_addr).await?;
+        crate::modules::input_startup_ready();
         info!(
             "syslog_tcp listening on {} ({})",
             self.bind_addr,
@@ -253,8 +261,8 @@ impl Input for SyslogTcpInput {
             tokio::select! {
                 biased;
 
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() {
+                terminal = shutdown_change_is_terminal(&mut shutdown) => {
+                    if terminal {
                         info!("syslog_tcp: shutting down ({} active connections)", conn_handles.len());
                         for h in &conn_handles {
                             h.abort();
@@ -1531,5 +1539,30 @@ mod tests {
         let _ = held;
         let _ = sd_tx.send(true);
         let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_syslog_tcp_loop() {
+        let (sender, mut receiver) = tokio::sync::watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("syslog_tcp.rs").contains(&marker));
+
+        let (handle, shutdown, _events, _metrics) =
+            spawn_plain_input(format!("127.0.0.1:{}", pick_port()), 1);
+        drop(shutdown);
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("actual TCP loop must terminate on a closed watch")
+            .expect("TCP task must join")
+            .expect("TCP loop must exit cleanly");
     }
 }

--- a/crates/limpid/src/modules/input/syslog_udp.rs
+++ b/crates/limpid/src/modules/input/syslog_udp.rs
@@ -18,6 +18,13 @@ use crate::event::Event;
 use crate::metrics::InputMetrics;
 use crate::modules::{HasMetrics, Input, Module};
 
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 const SYSLOG_UDP_INPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
         name: "bind",
@@ -78,6 +85,7 @@ impl Input for SyslogUdpInput {
         mut shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<()> {
         let socket = UdpSocket::bind(&self.bind_addr).await?;
+        crate::modules::input_startup_ready();
         info!("syslog_udp listening on {}", self.bind_addr);
 
         let limiter = self.rate_limit.map(RateLimiter::new);
@@ -91,8 +99,8 @@ impl Input for SyslogUdpInput {
             tokio::select! {
                 biased;
 
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() {
+                terminal = shutdown_change_is_terminal(&mut shutdown) => {
+                    if terminal {
                         info!("syslog_udp: shutting down");
                         break;
                     }
@@ -279,5 +287,30 @@ mod tests {
             result.is_ok(),
             "run loop did not terminate after receiver drop"
         );
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_syslog_udp_loop() {
+        let (sender, mut receiver) = tokio::sync::watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("syslog_udp.rs").contains(&marker));
+
+        let (handle, shutdown, _events, _metrics) =
+            spawn_input(format!("127.0.0.1:{}", pick_port()));
+        drop(shutdown);
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("actual UDP loop must terminate on a closed watch")
+            .expect("UDP task must join")
+            .expect("UDP loop must exit cleanly");
     }
 }

--- a/crates/limpid/src/modules/input/tail.rs
+++ b/crates/limpid/src/modules/input/tail.rs
@@ -27,6 +27,13 @@ use crate::event::{AckHandle, AckPosition, Event};
 use crate::metrics::InputMetrics;
 use crate::modules::{HasMetrics, Input, Module};
 
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 const TAIL_INPUT_SCHEMA: &[PropertySpec] = &[
     PropertySpec {
         name: "path",
@@ -128,6 +135,7 @@ impl Input for TailInput {
         let mut read_offset = self.initial_offset().await;
         let mut acked_offset = read_offset;
         let mut last_inode = get_inode(&self.path);
+        crate::modules::input_startup_ready();
 
         // Generation namespace for `AckPosition::Offset`. Bumps on every
         // rotation / truncation so that late acks still travelling inside
@@ -150,8 +158,8 @@ impl Input for TailInput {
             // Check for shutdown
             tokio::select! {
                 biased;
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() {
+                terminal = shutdown_change_is_terminal(&mut shutdown) => {
+                    if terminal {
                         info!("tail {}: shutting down", self.path.display());
                         // Drain any in-flight acks before the final save so
                         // events that finished between the last periodic
@@ -1044,5 +1052,33 @@ mod tests {
         // would be flaky. Accept either outcome as "valid system
         // behaviour" but pin that get_inode returns Some on both.
         let _ = (ino1, ino2);
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_tail_loop() {
+        let (sender, mut receiver) = tokio::sync::watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("tail.rs").contains(&marker));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("closed-watch.log");
+        std::fs::write(&path, b"queued-before-close\n").unwrap();
+        let input = make_input(&path, None);
+        let (event_tx, _events) = tokio::sync::mpsc::channel(4);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        drop(shutdown_tx);
+        tokio::time::timeout(Duration::from_secs(2), input.run(event_tx, shutdown_rx))
+            .await
+            .expect("actual tail loop must terminate on a closed watch")
+            .expect("tail loop must exit cleanly");
     }
 }

--- a/crates/limpid/src/modules/input/unix_socket.rs
+++ b/crates/limpid/src/modules/input/unix_socket.rs
@@ -20,6 +20,13 @@ use crate::event::Event;
 use crate::metrics::InputMetrics;
 use crate::modules::{HasMetrics, Input, Module};
 
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 const UNIX_SOURCE: &str = "127.0.0.1:0";
 
 /// True when the parent dir's mode lets an outside-the-owner
@@ -353,6 +360,8 @@ impl Input for UnixSocketInput {
             }
         }
 
+        crate::modules::input_startup_ready();
+
         let source_addr = UNIX_SOURCE.parse().unwrap();
         let mut buf = vec![0u8; 65536];
 
@@ -360,8 +369,8 @@ impl Input for UnixSocketInput {
             tokio::select! {
                 biased;
 
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() {
+                terminal = shutdown_change_is_terminal(&mut shutdown) => {
+                    if terminal {
                         info!("unix_socket {}: shutting down", self.path);
                         #[cfg(unix)]
                         {
@@ -873,6 +882,36 @@ mod tests {
             post_meta.ino(),
             swapped_meta.ino(),
             "swapped inode must not have been unlinked by shutdown",
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_unix_socket_loop() {
+        let (sender, mut receiver) = tokio::sync::watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("unix_socket.rs").contains(&marker));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("closed-watch.sock");
+        let (handle, shutdown, _events) = spawn_with_path(&path);
+        drop(shutdown);
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("actual Unix socket loop must terminate on a closed watch")
+            .expect("Unix socket task must join")
+            .expect("Unix socket loop must exit cleanly");
+        assert!(
+            !path.exists(),
+            "closed-watch cleanup must unlink owned socket"
         );
     }
 }

--- a/crates/limpid/src/modules/mod.rs
+++ b/crates/limpid/src/modules/mod.rs
@@ -1210,6 +1210,30 @@ pub async fn route_event_to_dlq(
 pub struct CreatedInput {
     pub handle: tokio::task::JoinHandle<()>,
     pub metrics: Arc<InputMetrics>,
+    pub(crate) startup: tokio::sync::oneshot::Receiver<Result<()>>,
+}
+
+tokio::task_local! {
+    static INPUT_STARTUP_SIGNAL: std::cell::RefCell<Option<tokio::sync::oneshot::Sender<Result<()>>>>;
+}
+
+/// Complete the private startup handshake after an input has acquired the
+/// resource its run loop owns. This deliberately stays below the public
+/// `Input` trait: it is only the built-in registry/runtime transaction seam.
+pub(crate) fn input_startup_ready() {
+    let _ = INPUT_STARTUP_SIGNAL.try_with(|slot| {
+        if let Some(sender) = slot.borrow_mut().take() {
+            let _ = sender.send(Ok(()));
+        }
+    });
+}
+
+fn input_startup_failed(error: anyhow::Error) {
+    let _ = INPUT_STARTUP_SIGNAL.try_with(|slot| {
+        if let Some(sender) = slot.borrow_mut().take() {
+            let _ = sender.send(Err(error));
+        }
+    });
 }
 
 /// Returned by output factory: the constructed sink + metrics handle.
@@ -1458,12 +1482,29 @@ where
             let input = T::from_properties(name, properties, ctx)?;
             let metrics = HasMetrics::metrics(&input);
             let input_name = name.to_string();
+            let (startup_tx, startup) = tokio::sync::oneshot::channel();
             let handle = tokio::spawn(async move {
-                if let Err(e) = Input::run(input, tx, shutdown).await {
-                    tracing::error!("input '{}' failed: {}", input_name, e);
-                }
+                INPUT_STARTUP_SIGNAL
+                    .scope(std::cell::RefCell::new(Some(startup_tx)), async move {
+                        match Input::run(input, tx, shutdown).await {
+                            Ok(()) => input_startup_failed(anyhow::anyhow!(
+                                "input '{}' exited before reporting startup readiness",
+                                input_name
+                            )),
+                            Err(error) => {
+                                let diagnostic = format!("{error:#}");
+                                input_startup_failed(error);
+                                tracing::error!("input '{}' failed: {}", input_name, diagnostic);
+                            }
+                        }
+                    })
+                    .await;
             });
-            Ok(CreatedInput { handle, metrics })
+            Ok(CreatedInput {
+                handle,
+                metrics,
+                startup,
+            })
         },
     );
 }

--- a/crates/limpid/src/modules/output/batched.rs
+++ b/crates/limpid/src/modules/output/batched.rs
@@ -54,6 +54,67 @@ use crate::event::Event;
 use crate::metrics::OutputMetrics;
 use crate::queue::{QueueAckHandle, RetryConfig};
 
+#[cfg(test)]
+pub(crate) struct ShutdownTestObserver {
+    calls: std::sync::atomic::AtomicUsize,
+    completions: std::sync::atomic::AtomicUsize,
+    resolved_dispositions: std::sync::atomic::AtomicU64,
+    completed: Notify,
+}
+
+#[cfg(test)]
+impl ShutdownTestObserver {
+    pub(crate) fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn completions(&self) -> usize {
+        self.completions.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn resolved_dispositions(&self) -> u64 {
+        self.resolved_dispositions.load(Ordering::SeqCst)
+    }
+
+    pub(crate) async fn wait_for_completion(&self) {
+        while self.completions() == 0 {
+            self.completed.notified().await;
+        }
+    }
+}
+
+#[cfg(test)]
+fn shutdown_test_observers()
+-> &'static std::sync::Mutex<std::collections::HashMap<String, Arc<ShutdownTestObserver>>> {
+    static OBSERVERS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<String, Arc<ShutdownTestObserver>>>,
+    > = std::sync::OnceLock::new();
+    OBSERVERS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+pub(crate) fn observe_shutdown_for_testing(name: &str) -> Arc<ShutdownTestObserver> {
+    let observer = Arc::new(ShutdownTestObserver {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        completions: std::sync::atomic::AtomicUsize::new(0),
+        resolved_dispositions: std::sync::atomic::AtomicU64::new(0),
+        completed: Notify::new(),
+    });
+    shutdown_test_observers()
+        .lock()
+        .expect("batched shutdown observer registry")
+        .insert(name.to_owned(), Arc::clone(&observer));
+    observer
+}
+
+#[cfg(test)]
+fn take_shutdown_test_observer(name: &str) -> Option<Arc<ShutdownTestObserver>> {
+    shutdown_test_observers()
+        .lock()
+        .expect("batched shutdown observer registry")
+        .remove(name)
+}
+
 /// One parked event in the batched sink's buffer: the event, the ack
 /// handle whose disposition it drives, and an optional bounded-ownership
 /// permit.
@@ -364,6 +425,13 @@ impl<P: BatchSinkPolicy> BatchedSink<P> {
     }
 
     pub(crate) async fn shutdown(&self) -> Result<()> {
+        #[cfg(test)]
+        let shutdown_observer = take_shutdown_test_observer(&self.inner.name);
+        #[cfg(test)]
+        if let Some(observer) = &shutdown_observer {
+            observer.calls.fetch_add(1, Ordering::SeqCst);
+        }
+
         // 1. Signal cooperative shutdown. `is_shutting_down`
         //    propagates to the actor's outer `select!`, to the
         //    retry sleep race, and (via the transport-cancel race
@@ -406,6 +474,16 @@ impl<P: BatchSinkPolicy> BatchedSink<P> {
         //    DLQ + Recovered.
         let leftover = std::mem::take(&mut *self.inner.batch.lock().await);
         self.inner.flush_events_at_shutdown(leftover).await;
+        #[cfg(test)]
+        if let Some(observer) = shutdown_observer {
+            observer.resolved_dispositions.store(
+                self.inner.metrics.events_written.load(Ordering::SeqCst)
+                    + self.inner.metrics.events_failed.load(Ordering::SeqCst),
+                Ordering::SeqCst,
+            );
+            observer.completions.fetch_add(1, Ordering::SeqCst);
+            observer.completed.notify_one();
+        }
         Ok(())
     }
 

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -1,8 +1,14 @@
-//! Stdout output: prints event messages to standard output (debugging/testing).
+//! Stdout output: writes event messages to standard output (debugging/testing).
 
+use std::fmt;
+use std::io;
+#[cfg(test)]
+use std::os::fd::FromRawFd;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::sync::Arc;
+use std::sync::OnceLock;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use crate::dsl::schema::PropertySpec;
 use crate::event::Event;
@@ -10,12 +16,406 @@ use crate::metrics::OutputMetrics;
 use crate::modules::{HasMetrics, Module, Output};
 use crate::queue::{QueueAckHandle, RetryConfig};
 
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 /// `output stdout` has no module-specific properties; only the
 /// common `retry { ... } / queue { ... }` sub-blocks apply.
 const STDOUT_OUTPUT_SCHEMA: &[PropertySpec] = &[
     crate::queue::RETRY_PROPERTY_SPEC,
     crate::queue::QUEUE_PROPERTY_SPEC,
 ];
+
+/// Process-wide stdout readiness registration and serialization. Every stdout
+/// output shares this one Unix transport so frames from distinct output actors
+/// cannot interleave. It is deliberately module-local: this is not a generic
+/// writer abstraction and does not change the output trait.
+struct StdoutTransport {
+    backend: StdoutBackend,
+    serial: tokio::sync::Mutex<()>,
+    #[cfg(test)]
+    observer: Option<Arc<WriteObserver>>,
+}
+
+enum StdoutBackend {
+    Async(tokio::io::unix::AsyncFd<StdoutFd>),
+    Regular(StdoutFd),
+}
+
+struct StdoutFd {
+    fd: RawFd,
+    // Production borrows fd 1. Tests can give the transport an owned pipe or
+    // PTY descriptor whose lifetime must cover readiness registration.
+    _owned: Option<OwnedFd>,
+}
+
+impl AsRawFd for StdoutFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+#[derive(Debug)]
+struct StdoutWriteError {
+    source: io::Error,
+    written: usize,
+}
+
+impl fmt::Display for StdoutWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.written == 0 {
+            write!(formatter, "stdout write failed: {}", self.source)
+        } else {
+            write!(
+                formatter,
+                "stdout write failed after {} confirmed byte(s): {}",
+                self.written, self.source
+            )
+        }
+    }
+}
+
+impl std::error::Error for StdoutWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+static STDOUT_TRANSPORT: OnceLock<Arc<StdoutTransport>> = OnceLock::new();
+static STDOUT_TRANSPORT_INIT: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_STDOUT_TRANSPORT: Arc<StdoutTransport>;
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct WriteObserver {
+    written: std::sync::atomic::AtomicUsize,
+    waiting_count: std::sync::atomic::AtomicUsize,
+    waiting: tokio::sync::Notify,
+    progressed: tokio::sync::Notify,
+}
+
+impl StdoutTransport {
+    fn stdout() -> Result<Arc<Self>> {
+        #[cfg(test)]
+        if let Ok(transport) = TEST_STDOUT_TRANSPORT.try_with(Arc::clone) {
+            return Ok(transport);
+        }
+
+        Self::shared_for_cell(&STDOUT_TRANSPORT, &STDOUT_TRANSPORT_INIT, || {
+            Self::from_fd(1, None)
+        })
+    }
+
+    /// Returns the one process-wide transport without memoizing constructor
+    /// failures. Initialization is serialized before the constructor touches
+    /// fd 1, so a successful transport has no racing AsyncFd owner or flag
+    /// restoration from a losing candidate.
+    fn shared_for_cell(
+        cell: &OnceLock<Arc<Self>>,
+        init_lock: &std::sync::Mutex<()>,
+        initialize: impl FnOnce() -> io::Result<Self>,
+    ) -> Result<Arc<Self>> {
+        Self::shared_for_cell_inner(cell, init_lock, || {}, initialize)
+    }
+
+    fn shared_for_cell_inner(
+        cell: &OnceLock<Arc<Self>>,
+        init_lock: &std::sync::Mutex<()>,
+        before_lock: impl FnOnce(),
+        initialize: impl FnOnce() -> io::Result<Self>,
+    ) -> Result<Arc<Self>> {
+        if let Some(transport) = cell.get() {
+            return Ok(Arc::clone(transport));
+        }
+
+        before_lock();
+        let _init_guard = init_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(transport) = cell.get() {
+            return Ok(Arc::clone(transport));
+        }
+
+        let transport = Arc::new(initialize()?);
+        if cell.set(Arc::clone(&transport)).is_ok() {
+            return Ok(transport);
+        }
+        Ok(Arc::clone(cell.get().expect(
+            "successful stdout transport initialization must populate OnceLock",
+        )))
+    }
+
+    #[cfg(test)]
+    fn shared_for_cell_observed(
+        cell: &OnceLock<Arc<Self>>,
+        init_lock: &std::sync::Mutex<()>,
+        before_lock: impl FnOnce(),
+        initialize: impl FnOnce() -> io::Result<Self>,
+    ) -> Result<Arc<Self>> {
+        Self::shared_for_cell_inner(cell, init_lock, before_lock, initialize)
+    }
+
+    fn from_fd(fd: RawFd, owned: Option<OwnedFd>) -> io::Result<Self> {
+        let backend = if fd_is_regular_file(fd)? {
+            StdoutBackend::Regular(StdoutFd { fd, _owned: owned })
+        } else {
+            let original_flags = get_fd_flags(fd)?;
+            let changed = original_flags & libc::O_NONBLOCK == 0;
+            if changed {
+                set_fd_flags(fd, original_flags | libc::O_NONBLOCK)?;
+            }
+            match tokio::io::unix::AsyncFd::new(StdoutFd { fd, _owned: owned }) {
+                Ok(async_fd) => StdoutBackend::Async(async_fd),
+                Err(error) => {
+                    if changed {
+                        let _ = set_fd_flags(fd, original_flags);
+                    }
+                    return Err(error);
+                }
+            }
+        };
+        Ok(Self {
+            backend,
+            serial: tokio::sync::Mutex::new(()),
+            #[cfg(test)]
+            observer: None,
+        })
+    }
+
+    #[cfg(test)]
+    fn from_owned(fd: OwnedFd, observer: Option<Arc<WriteObserver>>) -> io::Result<Arc<Self>> {
+        let raw = fd.as_raw_fd();
+        let mut transport = Self::from_fd(raw, Some(fd))?;
+        transport.observer = observer;
+        Ok(Arc::new(transport))
+    }
+
+    async fn write_frame(
+        &self,
+        frame: &[u8],
+        shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    ) -> std::result::Result<(), StdoutWriteError> {
+        self.write_frame_mode(frame, shutdown, false).await
+    }
+
+    async fn write_frame_drain(
+        &self,
+        frame: &[u8],
+        shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    ) -> std::result::Result<(), StdoutWriteError> {
+        self.write_frame_mode(frame, shutdown, true).await
+    }
+
+    async fn write_frame_mode(
+        &self,
+        frame: &[u8],
+        shutdown: &mut tokio::sync::watch::Receiver<bool>,
+        drain: bool,
+    ) -> std::result::Result<(), StdoutWriteError> {
+        if !drain && *shutdown.borrow() {
+            return Err(StdoutWriteError {
+                source: io::Error::new(io::ErrorKind::Interrupted, "stdout shutdown requested"),
+                written: 0,
+            });
+        }
+
+        let _serial = if drain {
+            self.serial.lock().await
+        } else {
+            tokio::select! {
+                guard = self.serial.lock() => guard,
+                terminal = shutdown_change_is_terminal(shutdown) => {
+                    let message = if terminal {
+                        "stdout shutdown requested"
+                    } else {
+                        "stdout shutdown signal changed"
+                    };
+                    return Err(StdoutWriteError {
+                        source: io::Error::new(io::ErrorKind::Interrupted, message),
+                        written: 0,
+                    });
+                }
+            }
+        };
+
+        if let StdoutBackend::Regular(fd) = &self.backend {
+            let raw_fd = fd.as_raw_fd();
+            let bytes = frame.to_vec();
+            return tokio::task::spawn_blocking(move || raw_write_all(raw_fd, &bytes))
+                .await
+                .map_err(|error| StdoutWriteError {
+                    source: io::Error::other(format!(
+                        "stdout regular-file writer task failed: {error}"
+                    )),
+                    written: 0,
+                })?;
+        }
+
+        let StdoutBackend::Async(fd) = &self.backend else {
+            unreachable!("regular stdout handled above")
+        };
+
+        let mut offset = 0usize;
+        while offset < frame.len() {
+            if !drain && *shutdown.borrow() {
+                return Err(StdoutWriteError {
+                    source: io::Error::new(io::ErrorKind::Interrupted, "stdout shutdown requested"),
+                    written: offset,
+                });
+            }
+            #[cfg(test)]
+            if let Some(observer) = &self.observer {
+                observer
+                    .waiting_count
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                observer.waiting.notify_waiters();
+            }
+            let mut readiness = if drain {
+                fd.writable().await.map_err(|source| StdoutWriteError {
+                    source,
+                    written: offset,
+                })?
+            } else {
+                tokio::select! {
+                    result = fd.writable() => result.map_err(|source| StdoutWriteError { source, written: offset })?,
+                    terminal = shutdown_change_is_terminal(shutdown) => {
+                        let message = if terminal {
+                            "stdout shutdown requested"
+                        } else {
+                            "stdout shutdown signal changed"
+                        };
+                        return Err(StdoutWriteError {
+                            source: io::Error::new(io::ErrorKind::Interrupted, message),
+                            written: offset,
+                        });
+                    }
+                }
+            };
+            match readiness.try_io(|inner| raw_write(inner.get_ref().as_raw_fd(), &frame[offset..]))
+            {
+                Ok(Ok(0)) => {
+                    return Err(StdoutWriteError {
+                        source: io::Error::new(
+                            io::ErrorKind::WriteZero,
+                            "stdout write returned zero",
+                        ),
+                        written: offset,
+                    });
+                }
+                Ok(Ok(written)) => {
+                    offset += written;
+                    #[cfg(test)]
+                    if let Some(observer) = &self.observer {
+                        observer
+                            .written
+                            .store(offset, std::sync::atomic::Ordering::SeqCst);
+                        observer.progressed.notify_waiters();
+                    }
+                }
+                Ok(Err(source)) => {
+                    return Err(StdoutWriteError {
+                        source,
+                        written: offset,
+                    });
+                }
+                Err(_would_block) => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+fn set_nonblocking(fd: RawFd) -> io::Result<()> {
+    // SAFETY: `fd` is a live descriptor supplied by the process or owned by
+    // the transport. fcntl does not access Rust memory.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    if flags & libc::O_NONBLOCK == 0 {
+        // SAFETY: same descriptor validity argument as above.
+        if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+fn get_fd_flags(fd: RawFd) -> io::Result<i32> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(flags)
+    }
+}
+
+fn set_fd_flags(fd: RawFd, flags: i32) -> io::Result<()> {
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags) } == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn fd_is_regular_file(fd: RawFd) -> io::Result<bool> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    let stat = unsafe { stat.assume_init() };
+    Ok(stat.st_mode & libc::S_IFMT == libc::S_IFREG)
+}
+
+pub(crate) fn stdout_is_regular_file() -> io::Result<bool> {
+    fd_is_regular_file(1)
+}
+
+fn raw_write_all(fd: RawFd, bytes: &[u8]) -> std::result::Result<(), StdoutWriteError> {
+    let mut written = 0;
+    while written < bytes.len() {
+        match raw_write(fd, &bytes[written..]) {
+            Ok(0) => {
+                return Err(StdoutWriteError {
+                    source: io::Error::new(io::ErrorKind::WriteZero, "stdout write returned zero"),
+                    written,
+                });
+            }
+            Ok(count) => written += count,
+            Err(source) => return Err(StdoutWriteError { source, written }),
+        }
+    }
+    Ok(())
+}
+
+fn raw_write(fd: RawFd, bytes: &[u8]) -> io::Result<usize> {
+    // SAFETY: `bytes` is valid for the duration of write(2); the descriptor is
+    // held alive by `StdoutFd` (or is process fd 1).
+    let written = unsafe { libc::write(fd, bytes.as_ptr().cast(), bytes.len()) };
+    if written == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(written as usize)
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn with_test_stdout_fd<T>(
+    fd: OwnedFd,
+    future: impl std::future::Future<Output = T>,
+) -> io::Result<T> {
+    let transport = StdoutTransport::from_owned(fd, None)?;
+    Ok(TEST_STDOUT_TRANSPORT.scope(transport, future).await)
+}
 
 pub struct StdoutOutput {
     name: String,
@@ -56,51 +456,115 @@ impl HasMetrics for StdoutOutput {
 }
 
 impl StdoutOutput {
-    /// Pure write step — extracted so `consume` can drive the retry
-    /// loop without duplicating the print. Goes through
-    /// `io::stdout().lock()` + `write_all` rather than the
-    /// `println!` macro: `println!` panics on a broken pipe (the
-    /// canonical case is `limpid | head` where `head` exits before
-    /// draining stdout), which would tear down the daemon mid-run.
-    /// The locked-write path surfaces the I/O error here instead so
-    /// the retry / DLQ path in `consume` decides the disposition.
-    ///
-    /// The bytes are written verbatim; using `writeln!` on a lossy
-    /// `String::from_utf8_lossy` view would silently replace
-    /// non-UTF-8 payload bytes with U+FFFD (`\xEF\xBF\xBD`) — a
-    /// silent corruption on a security telemetry pipeline that can
-    /// carry binary payloads.
-    ///
-    /// Payload bytes and the trailing `\n` are concatenated into a
-    /// single buffer and written with one `write_all` call. This
-    /// does NOT make the frame atomic — `write_all` internally loops
-    /// over `write(2)` and can still leave partial bytes if the
-    /// underlying writer errors mid-frame — but it removes the
-    /// second `write_all` boundary that could silently succeed
-    /// on the payload and then fail on the delimiter, leaving an
-    /// unterminated line that a retry would double.
-    fn write_event(&self, event: &Event) -> Result<()> {
-        let mut out = std::io::stdout().lock();
-        self.write_event_to(&mut out, event)
+    async fn write_event_async(
+        &self,
+        event: &Event,
+        shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    ) -> std::result::Result<(), StdoutWriteError> {
+        let frame = super::frame_with_newline(&event.egress);
+        let transport = StdoutTransport::stdout().map_err(|error| StdoutWriteError {
+            source: io::Error::other(error.to_string()),
+            written: 0,
+        })?;
+        transport.write_frame(&frame, shutdown).await?;
+        self.metrics.bytes_written.inc_by(frame.len() as u64);
+        Ok(())
     }
 
-    /// Private writer seam: `write_event` locks stdout and delegates
-    /// here so the confirmed-bytes contract stays testable against
-    /// an arbitrary `impl Write`. The counter bump follows the
-    /// `write_all` `?`, so a partial or failing write leaves the
-    /// counter untouched.
+    async fn write_event_drain(&self, event: &Event) -> std::result::Result<(), StdoutWriteError> {
+        let frame = super::frame_with_newline(&event.egress);
+        let transport = StdoutTransport::stdout().map_err(|error| StdoutWriteError {
+            source: io::Error::other(error.to_string()),
+            written: 0,
+        })?;
+        let mut shutdown = self.shutdown_signal.clone();
+        transport.write_frame_drain(&frame, &mut shutdown).await?;
+        self.metrics.bytes_written.inc_by(frame.len() as u64);
+        Ok(())
+    }
+
+    #[cfg(test)]
     fn write_event_to(&self, out: &mut impl std::io::Write, event: &Event) -> Result<()> {
         let buf = super::frame_with_newline(&event.egress);
-        out.write_all(&buf).context("stdout write failed")?;
+        out.write_all(&buf)
+            .map_err(|error| anyhow::anyhow!("stdout write failed: {error}"))?;
         self.metrics.bytes_written.inc_by(buf.len() as u64);
         Ok(())
     }
 
-    /// Retry-loop seam shared by `consume` and its test scaffolding.
-    /// Production callers pass a closure that delegates to
-    /// `write_event`; test callers pass a scripted closure so
-    /// retry / shutdown / gauge state can be exercised without an
-    /// actual stdout write.
+    async fn route_failed_event(&self, event: &Event, ack: QueueAckHandle, reason: &str) {
+        let outcome = crate::modules::route_event_to_dlq(
+            self.error_log.as_ref(),
+            self.error_log_fallback,
+            &self.metrics,
+            &self.name,
+            event,
+            ack.position(),
+            reason,
+        )
+        .await;
+        crate::modules::resolve_ack_from_dlq_outcome(ack, outcome, &self.metrics);
+    }
+
+    async fn consume_nonblocking(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
+        let mut attempt = 0u32;
+        let mut wait = self.retry.initial_wait;
+        let mut shutdown = self.shutdown_signal.clone();
+        loop {
+            match self.write_event_async(event, &mut shutdown).await {
+                Ok(()) => {
+                    self.metrics.in_retry.set(0);
+                    self.metrics.events_written.inc();
+                    ack.resolve_delivered();
+                    return Ok(());
+                }
+                Err(error) => {
+                    attempt += 1;
+                    self.metrics.retries.inc();
+
+                    // A retry after a partial frame would duplicate the
+                    // confirmed prefix. Resolve it through the existing DLQ
+                    // policy immediately instead. Shutdown interruption is
+                    // likewise terminal for the current queue acknowledgement.
+                    if error.written != 0 || *shutdown.borrow() {
+                        self.metrics.in_retry.set(0);
+                        let reason =
+                            format!("output write stopped after {attempt} attempt(s): {error}");
+                        self.route_failed_event(event, ack, &reason).await;
+                        return Ok(());
+                    }
+
+                    if attempt >= self.retry.max_attempts {
+                        self.metrics.in_retry.set(0);
+                        let reason =
+                            format!("output write failed after {attempt} attempts: {error}");
+                        self.route_failed_event(event, ack, &reason).await;
+                        return Ok(());
+                    }
+                    self.metrics.in_retry.set(1);
+                    tracing::warn!(
+                        "output '{}': write failed (attempt {}/{}): {} — retrying in {:?}",
+                        self.name,
+                        attempt,
+                        self.retry.max_attempts,
+                        error,
+                        wait
+                    );
+                    if crate::modules::sleep_or_shutdown(&mut shutdown, wait).await {
+                        self.metrics.in_retry.set(0);
+                        let reason = format!(
+                            "output write failed and shutdown observed mid-retry after {attempt} attempts: {error}"
+                        );
+                        self.route_failed_event(event, ack, &reason).await;
+                        return Ok(());
+                    }
+                    wait = self.retry.next_wait(wait);
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
     async fn consume_with_write<F>(
         &self,
         event: &Event,
@@ -195,29 +659,22 @@ impl StdoutOutput {
 #[async_trait::async_trait]
 impl Output for StdoutOutput {
     async fn consume(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        self.consume_with_write(event, ack, |event| self.write_event(event))
-            .await
+        self.consume_nonblocking(event, ack).await
     }
 
     async fn consume_shutdown(&self, event: &Event, ack: QueueAckHandle) -> Result<()> {
-        // `write_event` is a synchronous write with no metric side
-        // effects, so the success + failure paths reduce to the
-        // canonical shape `finalize_shutdown_singleton_disposition`
-        // handles: bump events_written on Ok, route to DLQ on Err.
-        // Delegating removes the inline `route_event_to_dlq` +
-        // `resolve_ack_from_dlq_outcome` pair and lines up with the
-        // sibling sinks (syslog_tcp, syslog_udp, unix_socket, kafka)
-        // that already use the helper.
-        crate::modules::finalize_shutdown_singleton_disposition(
-            self.write_event(event),
-            self.error_log.as_ref(),
-            self.error_log_fallback,
-            &self.metrics,
-            &self.name,
-            event,
-            ack,
-        )
-        .await;
+        let mut ack = ack;
+        ack.allow_abort_drop();
+        match self.write_event_drain(event).await {
+            Ok(()) => {
+                self.metrics.events_written.inc();
+                ack.resolve_delivered();
+            }
+            Err(error) => {
+                let reason = format!("output shutdown write failed: {error}");
+                self.route_failed_event(event, ack, &reason).await;
+            }
+        }
         Ok(())
     }
 }
@@ -227,6 +684,214 @@ mod metrics_registration_tests {
     use super::*;
     use crate::dsl::module_props::ModuleProperties;
     use crate::metrics::{MetricsError, OutputMetrics, Registry};
+
+    fn unix_pipe() -> (OwnedFd, OwnedFd) {
+        let mut fds = [-1; 2];
+        // SAFETY: `fds` points to two writable integers and successful pipe(2)
+        // initializes both descriptors, which are immediately owned below.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        // SAFETY: successful pipe(2) returned new uniquely-owned descriptors.
+        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    }
+
+    fn test_output(
+        name: &str,
+        shutdown_signal: tokio::sync::watch::Receiver<bool>,
+        retry: RetryConfig,
+    ) -> Arc<StdoutOutput> {
+        Arc::new(StdoutOutput {
+            name: name.to_owned(),
+            retry,
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+            metrics: OutputMetrics::for_testing(),
+            shutdown_signal,
+        })
+    }
+
+    fn one_attempt_retry() -> RetryConfig {
+        RetryConfig {
+            max_attempts: 1,
+            initial_wait: std::time::Duration::from_millis(1),
+            max_wait: std::time::Duration::from_millis(1),
+            backoff: crate::queue::BackoffStrategy::Fixed,
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_stdout_transport_initialization_is_retried_and_usable() {
+        let cell = OnceLock::new();
+        let init_lock = std::sync::Mutex::new(());
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+
+        let error = match StdoutTransport::shared_for_cell(&cell, &init_lock, || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(io::Error::other("forced first initialization failure"))
+        }) {
+            Ok(_) => panic!("forced initialization failure unexpectedly succeeded"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("forced first initialization failure")
+        );
+        assert!(
+            cell.get().is_none(),
+            "a failed constructor must not populate the cell"
+        );
+
+        let (read_fd, write_fd) = unix_pipe();
+        let transport = StdoutTransport::shared_for_cell(&cell, &init_lock, || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let raw = write_fd.as_raw_fd();
+            StdoutTransport::from_fd(raw, Some(write_fd))
+        })
+        .unwrap();
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert!(Arc::ptr_eq(&transport, cell.get().unwrap()));
+
+        let read_fd = async_owned_fd(read_fd);
+        let (_shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+        transport
+            .write_frame(b"retry-success\n", &mut shutdown_rx)
+            .await
+            .unwrap();
+        assert_eq!(read_exact_fd(&read_fd, 14).await, b"retry-success\n");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn concurrent_stdout_first_use_constructs_one_shared_async_fd_transport() {
+        const CALLERS: usize = 4;
+        let cell = Arc::new(OnceLock::new());
+        let init_lock = Arc::new(std::sync::Mutex::new(()));
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        match StdoutTransport::shared_for_cell(&cell, &init_lock, || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(io::Error::other("forced pre-race failure"))
+        }) {
+            Ok(_) => panic!("forced pre-race failure unexpectedly succeeded"),
+            Err(error) => assert!(error.to_string().contains("forced pre-race failure")),
+        }
+        assert!(cell.get().is_none());
+
+        let (read_fd, write_fd) = unix_pipe();
+        let shared_raw_fd = write_fd.as_raw_fd();
+        assert_eq!(get_fd_flags(shared_raw_fd).unwrap() & libc::O_NONBLOCK, 0);
+        let barrier = Arc::new(std::sync::Barrier::new(CALLERS));
+        let tasks: Vec<_> = (0..CALLERS)
+            .map(|_| {
+                let cell = Arc::clone(&cell);
+                let init_lock = Arc::clone(&init_lock);
+                let attempts = Arc::clone(&attempts);
+                let barrier = Arc::clone(&barrier);
+                tokio::spawn(async move {
+                    StdoutTransport::shared_for_cell_observed(
+                        &cell,
+                        &init_lock,
+                        || {
+                            barrier.wait();
+                        },
+                        || {
+                            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            StdoutTransport::from_fd(shared_raw_fd, None)
+                        },
+                    )
+                    .unwrap()
+                })
+            })
+            .collect();
+        let mut transports = Vec::with_capacity(CALLERS);
+        for task in tasks {
+            transports.push(task.await.unwrap());
+        }
+
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "one failed call and exactly one racing successful constructor must run"
+        );
+        let canonical = Arc::clone(cell.get().unwrap());
+        assert!(
+            transports
+                .iter()
+                .all(|transport| Arc::ptr_eq(transport, &canonical)),
+            "all callers must receive the one canonical successful transport"
+        );
+        assert_ne!(
+            get_fd_flags(shared_raw_fd).unwrap() & libc::O_NONBLOCK,
+            0,
+            "no losing constructor may restore blocking flags behind the winner"
+        );
+
+        let read_fd = async_owned_fd(read_fd);
+        let (_shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+        canonical
+            .write_frame(b"shared-first-use\n", &mut shutdown_rx)
+            .await
+            .unwrap();
+        assert_eq!(read_exact_fd(&read_fd, 17).await, b"shared-first-use\n");
+
+        drop(transports);
+        drop(canonical);
+        drop(cell);
+        drop(write_fd);
+    }
+
+    fn fill_pipe(fd: RawFd) -> usize {
+        set_nonblocking(fd).unwrap();
+        let chunk = [b'x'; 8192];
+        let mut total = 0;
+        loop {
+            match raw_write(fd, &chunk) {
+                Ok(written) => total += written,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return total,
+                Err(error) => panic!("fill pipe: {error}"),
+            }
+        }
+    }
+
+    async fn read_exact_fd(fd: &tokio::io::unix::AsyncFd<StdoutFd>, size: usize) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(size);
+        while bytes.len() < size {
+            let mut ready = fd.readable().await.unwrap();
+            match ready.try_io(|inner| {
+                let mut chunk = [0u8; 8192];
+                let remaining = (size - bytes.len()).min(chunk.len());
+                // SAFETY: chunk is valid writable memory and the descriptor is
+                // held by AsyncFd for the entire read.
+                let count = unsafe {
+                    libc::read(
+                        inner.get_ref().as_raw_fd(),
+                        chunk.as_mut_ptr().cast(),
+                        remaining,
+                    )
+                };
+                if count == -1 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(chunk[..count as usize].to_vec())
+                }
+            }) {
+                Ok(Ok(chunk)) if chunk.is_empty() => panic!("unexpected EOF"),
+                Ok(Ok(chunk)) => bytes.extend_from_slice(&chunk),
+                Ok(Err(error)) => panic!("read failed: {error}"),
+                Err(_would_block) => {}
+            }
+        }
+        bytes
+    }
+
+    fn async_owned_fd(fd: OwnedFd) -> tokio::io::unix::AsyncFd<StdoutFd> {
+        let raw = fd.as_raw_fd();
+        set_nonblocking(raw).unwrap();
+        tokio::io::unix::AsyncFd::new(StdoutFd {
+            fd: raw,
+            _owned: Some(fd),
+        })
+        .unwrap()
+    }
 
     fn assert_output_duplicate(error: &MetricsError, label_value: &str, diagnostic: &str) {
         let (name, labelset) = match error {
@@ -249,6 +914,399 @@ mod metrics_registration_tests {
         assert_eq!(labelset, &[("output".to_owned(), label_value.to_owned())]);
         assert!(diagnostic.contains(&format!("name={name:?}")));
         assert!(diagnostic.contains(&format!("labelset={labelset:?}")));
+    }
+
+    #[tokio::test]
+    async fn full_stdout_pipe_is_shutdown_interruptible_and_resolves_current_ack() {
+        let (read_fd, write_fd) = unix_pipe();
+        let capacity = fill_pipe(write_fd.as_raw_fd());
+        assert!(capacity > 0);
+        let observer = Arc::new(WriteObserver::default());
+        let transport = StdoutTransport::from_owned(write_fd, Some(Arc::clone(&observer))).unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let output = test_output("stdout-full-pipe", shutdown_rx, one_attempt_retry());
+        let event = Event::new(
+            bytes::Bytes::from_static(b"blocked"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, mut ack_rx) = QueueAckHandle::for_test();
+        let task_output = Arc::clone(&output);
+        let task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
+            task_output.consume(&event, ack).await
+        }));
+
+        while observer
+            .waiting_count
+            .load(std::sync::atomic::Ordering::SeqCst)
+            == 0
+        {
+            observer.waiting.notified().await;
+        }
+        let readiness_waits = observer
+            .waiting_count
+            .load(std::sync::atomic::Ordering::SeqCst);
+        for _ in 0..32 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            observer
+                .waiting_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            readiness_waits,
+            "a full pipe must stay parked on readiness rather than busy-spin"
+        );
+        assert!(ack_rx.try_recv().is_err());
+        shutdown_tx.send(true).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("shutdown must interrupt stdout readiness wait")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            ack_rx.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        assert_eq!(
+            output
+                .metrics
+                .events_written
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        drop(read_fd);
+    }
+
+    #[tokio::test]
+    async fn partial_stdout_write_then_shutdown_never_retries_confirmed_prefix() {
+        let (read_fd, write_fd) = unix_pipe();
+        let observer = Arc::new(WriteObserver::default());
+        let transport = StdoutTransport::from_owned(write_fd, Some(Arc::clone(&observer))).unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let output = test_output("stdout-partial", shutdown_rx, one_attempt_retry());
+        let payload = vec![b'p'; 2 * 1024 * 1024];
+        let frame_len = payload.len() + 1;
+        let event = Event::new(bytes::Bytes::from(payload), "127.0.0.1:0".parse().unwrap());
+        let (ack, mut ack_rx) = QueueAckHandle::for_test();
+        let task_output = Arc::clone(&output);
+        let task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
+            task_output.consume(&event, ack).await
+        }));
+
+        while observer.written.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+            observer.progressed.notified().await;
+        }
+        let confirmed = observer.written.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            confirmed < frame_len,
+            "fixture must stop at a partial frame"
+        );
+        assert!(!task.is_finished());
+        shutdown_tx.send(true).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("partial write must be interruptible")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            ack_rx.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        assert_eq!(
+            observer.written.load(std::sync::atomic::Ordering::SeqCst),
+            confirmed,
+            "shutdown must not restart a partially written frame"
+        );
+        assert_eq!(
+            output
+                .metrics
+                .retries
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the partial attempt is terminal and is never retried"
+        );
+        drop(read_fd);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn broken_pipe_uses_retry_then_existing_dlq_ack_semantics() {
+        let (read_fd, write_fd) = unix_pipe();
+        drop(read_fd);
+        let transport = StdoutTransport::from_owned(write_fd, None).unwrap();
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let output = test_output(
+            "stdout-epipe",
+            shutdown_rx,
+            RetryConfig {
+                max_attempts: 2,
+                initial_wait: std::time::Duration::from_millis(25),
+                max_wait: std::time::Duration::from_millis(25),
+                backoff: crate::queue::BackoffStrategy::Fixed,
+            },
+        );
+        let event = Event::new(
+            bytes::Bytes::from_static(b"epipe"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, mut ack_rx) = QueueAckHandle::for_test();
+        let task_output = Arc::clone(&output);
+        let task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
+            task_output.consume(&event, ack).await
+        }));
+
+        while output
+            .metrics
+            .in_retry
+            .load(std::sync::atomic::Ordering::SeqCst)
+            == 0
+        {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(std::time::Duration::from_millis(25)).await;
+        task.await.unwrap().unwrap();
+        assert_eq!(
+            output
+                .metrics
+                .retries
+                .load(std::sync::atomic::Ordering::SeqCst),
+            2
+        );
+        assert!(matches!(
+            ack_rx.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        assert_eq!(
+            output
+                .metrics
+                .events_failed
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn pty_transport_preserves_payload_bytes_verbatim() {
+        let mut master = -1;
+        let mut slave = -1;
+        // SAFETY: pointers are valid; null termios/winsize requests defaults.
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut slave,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )
+            },
+            0
+        );
+        // SAFETY: successful openpty returned uniquely-owned descriptors.
+        let (master, slave) =
+            unsafe { (OwnedFd::from_raw_fd(master), OwnedFd::from_raw_fd(slave)) };
+        let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+        // SAFETY: slave is live and tcgetattr initializes termios on success.
+        assert_eq!(
+            unsafe { libc::tcgetattr(slave.as_raw_fd(), termios.as_mut_ptr()) },
+            0
+        );
+        // SAFETY: tcgetattr succeeded, so the value is initialized.
+        let mut termios = unsafe { termios.assume_init() };
+        // SAFETY: cfmakeraw mutates only the initialized termios value.
+        unsafe { libc::cfmakeraw(&mut termios) };
+        // SAFETY: slave is live and termios remains initialized.
+        assert_eq!(
+            unsafe { libc::tcsetattr(slave.as_raw_fd(), libc::TCSANOW, &termios) },
+            0
+        );
+
+        let transport = StdoutTransport::from_owned(slave, None).unwrap();
+        let transport_keepalive = Arc::clone(&transport);
+        let master = async_owned_fd(master);
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let output = test_output("stdout-pty", shutdown_rx, one_attempt_retry());
+        let payload = bytes::Bytes::from_static(b"\x00\xffA\nB");
+        let event = Event::new(payload.clone(), "127.0.0.1:0".parse().unwrap());
+        let (ack, _ack_rx) = QueueAckHandle::for_test();
+        TEST_STDOUT_TRANSPORT
+            .scope(transport, output.consume(&event, ack))
+            .await
+            .unwrap();
+        let observed = read_exact_fd(&master, payload.len() + 1).await;
+        drop(transport_keepalive);
+        let mut expected = payload.to_vec();
+        expected.push(b'\n');
+        assert_eq!(observed, expected);
+    }
+
+    #[tokio::test]
+    async fn queue_consumer_shutdown_drains_writable_stdout_exactly() {
+        let (read_fd, write_fd) = unix_pipe();
+        let transport = StdoutTransport::from_owned(write_fd, None).unwrap();
+        let read_fd = async_owned_fd(read_fd);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let output = test_output(
+            "stdout-shutdown-drain",
+            shutdown_rx.clone(),
+            one_attempt_retry(),
+        );
+        let payload = bytes::Bytes::from_static(b"drain-me");
+        let event = Event::new(payload.clone(), "127.0.0.1:0".parse().unwrap());
+        let (sender, receiver) = crate::queue::create_queue(
+            "stdout-shutdown-drain".to_string(),
+            crate::queue::QueueConfig {
+                queue_type: crate::queue::QueueType::Memory,
+                capacity: 4,
+            },
+        )
+        .unwrap();
+        sender
+            .send(crate::event::QueuedEvent::new(
+                event,
+                crate::time::UnixNanos::now(),
+            ))
+            .await
+            .unwrap();
+        drop(sender);
+        shutdown_tx.send(true).unwrap();
+
+        let writer: Arc<dyn crate::modules::Output> = output.clone();
+        let metrics = Arc::clone(&output.metrics);
+        let reader = tokio::spawn(async move { read_exact_fd(&read_fd, payload.len() + 1).await });
+        TEST_STDOUT_TRANSPORT
+            .scope(transport, async move {
+                crate::queue::run_queue_consumer(
+                    receiver,
+                    writer,
+                    None,
+                    metrics,
+                    None,
+                    shutdown_rx,
+                )
+                .await;
+            })
+            .await;
+
+        let observed = reader.await.unwrap();
+        assert_eq!(observed, b"drain-me\n");
+        assert_eq!(
+            output
+                .metrics
+                .events_written
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        assert_eq!(
+            output
+                .metrics
+                .events_failed
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn subprocess_fd1_regular_file_preserves_bytes_and_flags() {
+        const CHILD: &str = "LIMPID_STDOUT_REGULAR_FILE_CHILD";
+        if let Some(path) = std::env::var_os(CHILD) {
+            use std::os::fd::IntoRawFd as _;
+            let saved = unsafe { libc::dup(1) };
+            assert_ne!(saved, -1);
+            let file = std::fs::File::create(path).unwrap();
+            let file_fd = file.into_raw_fd();
+            assert_ne!(unsafe { libc::dup2(file_fd, 1) }, -1);
+            unsafe { libc::close(file_fd) };
+
+            let flags_before = get_fd_flags(1).unwrap();
+            assert_eq!(flags_before & libc::O_NONBLOCK, 0);
+            assert!(stdout_is_regular_file().unwrap());
+            let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            let output = test_output("stdout-regular-child", shutdown_rx, one_attempt_retry());
+            let event = Event::new(
+                bytes::Bytes::from_static(b"regular-file-exact"),
+                "127.0.0.1:0".parse().unwrap(),
+            );
+            let (ack, mut ack_rx) = QueueAckHandle::for_test();
+            output.consume(&event, ack).await.unwrap();
+            assert!(matches!(
+                ack_rx.recv().await,
+                Some((_, crate::queue::AckDisposition::Delivered))
+            ));
+            assert_eq!(get_fd_flags(1).unwrap(), flags_before);
+            assert_ne!(unsafe { libc::dup2(saved, 1) }, -1);
+            unsafe { libc::close(saved) };
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("stdout.log");
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("modules::output::stdout::metrics_registration_tests::subprocess_fd1_regular_file_preserves_bytes_and_flags")
+            .arg("--nocapture")
+            .env(CHILD, &output_path)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        assert_eq!(std::fs::read(output_path).unwrap(), b"regular-file-exact\n");
+    }
+
+    #[tokio::test]
+    async fn multiple_stdout_outputs_share_one_frame_serialization_lock() {
+        let (read_fd, write_fd) = unix_pipe();
+        let transport = StdoutTransport::from_owned(write_fd, None).unwrap();
+        let read_fd = async_owned_fd(read_fd);
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let first = test_output("stdout-a", shutdown_rx.clone(), one_attempt_retry());
+        let second = test_output("stdout-b", shutdown_rx, one_attempt_retry());
+        let a = vec![b'a'; 256 * 1024];
+        let b = vec![b'b'; 256 * 1024];
+        let total = a.len() + b.len() + 2;
+        let reader = tokio::spawn(async move { read_exact_fd(&read_fd, total).await });
+
+        let first_transport = Arc::clone(&transport);
+        let first_task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(first_transport, async move {
+            let event = Event::new(bytes::Bytes::from(a), "127.0.0.1:0".parse().unwrap());
+            let (ack, _ack_rx) = QueueAckHandle::for_test();
+            first.consume(&event, ack).await
+        }));
+        let second_task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
+            let event = Event::new(bytes::Bytes::from(b), "127.0.0.1:0".parse().unwrap());
+            let (ack, _ack_rx) = QueueAckHandle::for_test();
+            second.consume(&event, ack).await
+        }));
+        first_task.await.unwrap().unwrap();
+        second_task.await.unwrap().unwrap();
+        let observed = reader.await.unwrap();
+        let split = observed.iter().position(|byte| *byte == b'\n').unwrap();
+        assert!(
+            split == 256 * 1024
+                && (observed[..split].iter().all(|byte| *byte == b'a')
+                    || observed[..split].iter().all(|byte| *byte == b'b'))
+        );
+        let second_frame = &observed[split + 1..];
+        assert_eq!(second_frame.len(), 256 * 1024 + 1);
+        assert_eq!(second_frame.last(), Some(&b'\n'));
+        let expected = if observed[0] == b'a' { b'b' } else { b'a' };
+        assert!(
+            second_frame[..second_frame.len() - 1]
+                .iter()
+                .all(|byte| *byte == expected)
+        );
+    }
+
+    #[test]
+    fn stdout_transport_mutant_sensitivity_pins_nonblocking_worker_path() {
+        let source = include_str!("stdout.rs");
+        assert!(!source.contains(&["std::io::", "stdout"].concat()));
+        assert_eq!(source.matches(&["spawn_", "blocking"].concat()).count(), 1);
+        assert!(source.contains("StdoutBackend::Regular"));
+        assert!(source.contains("StdoutBackend::Async"));
+        assert!(source.contains("fd.writable()"));
+        assert!(source.contains("readiness.try_io"));
+        assert!(source.contains("let mut offset = 0usize"));
+        assert!(source.contains("let _serial = tokio::select!"));
+        assert!(source.contains("error.written != 0"));
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -1298,15 +1298,23 @@ mod metrics_registration_tests {
     #[test]
     fn stdout_transport_mutant_sensitivity_pins_nonblocking_worker_path() {
         let source = include_str!("stdout.rs");
-        assert!(!source.contains(&["std::io::", "stdout"].concat()));
-        assert_eq!(source.matches(&["spawn_", "blocking"].concat()).count(), 1);
-        assert!(source.contains("StdoutBackend::Regular"));
-        assert!(source.contains("StdoutBackend::Async"));
-        assert!(source.contains("fd.writable()"));
-        assert!(source.contains("readiness.try_io"));
-        assert!(source.contains("let mut offset = 0usize"));
-        assert!(source.contains("let _serial = tokio::select!"));
-        assert!(source.contains("error.written != 0"));
+        let test_module = ["#[cfg(", "test)]\nmod metrics_registration_tests"].concat();
+        let production = source
+            .split_once(&test_module)
+            .expect("test module boundary must remain explicit")
+            .0;
+        assert!(!production.contains(&["std::io::", "stdout"].concat()));
+        assert_eq!(
+            production.matches(&["spawn_", "blocking"].concat()).count(),
+            1
+        );
+        assert!(production.contains(&["StdoutBackend::", "Regular"].concat()));
+        assert!(production.contains(&["StdoutBackend::", "Async"].concat()));
+        assert!(production.contains(&["fd.", "writable()"].concat()));
+        assert!(production.contains(&["readiness.", "try_io"].concat()));
+        assert!(production.contains(&["let mut ", "offset = 0usize"].concat()));
+        assert!(production.contains(&["let _serial = if ", "drain {"].concat()));
+        assert!(production.contains(&["error.", "written != 0"].concat()));
     }
 
     #[test]

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -275,7 +275,11 @@ impl QueueSender {
                 .send(event)
                 .await
                 .map_err(|_| QueueSendError::ChannelClosed),
-            SenderInner::Disk(tx) => tx.send(event).await,
+            SenderInner::Disk(tx) => {
+                #[cfg(test)]
+                wait_on_test_wal_barrier().await;
+                tx.send(event).await
+            }
         };
         if let Some(m) = &self.metrics {
             if result.is_ok() {
@@ -305,6 +309,70 @@ impl QueueSender {
     /// Access the attached metrics (e.g. to increment `events_injected` on inject).
     pub fn metrics(&self) -> Option<&Arc<crate::metrics::OutputMetrics>> {
         self.metrics.as_ref()
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct TestWalBarrier {
+    reached: tokio::sync::Notify,
+    was_reached: std::sync::atomic::AtomicBool,
+    release: tokio::sync::Notify,
+    released: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(test)]
+impl TestWalBarrier {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            reached: tokio::sync::Notify::new(),
+            was_reached: std::sync::atomic::AtomicBool::new(false),
+            release: tokio::sync::Notify::new(),
+            released: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+
+    pub(crate) async fn wait_reached(&self) {
+        while !self.was_reached.load(std::sync::atomic::Ordering::SeqCst) {
+            self.reached.notified().await;
+        }
+    }
+
+    pub(crate) fn release(&self) {
+        self.released
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.release.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_WAL_BARRIER: Arc<TestWalBarrier>;
+}
+
+#[cfg(test)]
+pub(crate) fn current_test_wal_barrier() -> Option<Arc<TestWalBarrier>> {
+    TEST_WAL_BARRIER.try_with(Arc::clone).ok()
+}
+
+#[cfg(test)]
+pub(crate) async fn with_test_wal_barrier<T>(
+    barrier: Arc<TestWalBarrier>,
+    future: impl std::future::Future<Output = T>,
+) -> T {
+    TEST_WAL_BARRIER.scope(barrier, future).await
+}
+
+#[cfg(test)]
+async fn wait_on_test_wal_barrier() {
+    let barrier = current_test_wal_barrier();
+    if let Some(barrier) = barrier {
+        barrier
+            .was_reached
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        barrier.reached.notify_waiters();
+        while !barrier.released.load(std::sync::atomic::Ordering::SeqCst) {
+            barrier.release.notified().await;
+        }
     }
 }
 
@@ -927,6 +995,11 @@ pub struct QueueAckHandle {
     metrics: Arc<crate::metrics::OutputMetrics>,
 }
 
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_IMPLICIT_DROP_COUNT: Arc<std::sync::atomic::AtomicUsize>;
+}
+
 impl QueueAckHandle {
     pub fn new(
         tx: tokio::sync::mpsc::UnboundedSender<(AckPosition, AckDisposition)>,
@@ -1009,6 +1082,13 @@ impl QueueAckHandle {
         }
     }
 
+    /// Mark cancellation of the owning AbortSafe future as an intentional
+    /// `Dropped` disposition. The transmitter remains armed, so `Drop` emits
+    /// exactly one disposition unless a normal resolve method consumes it.
+    pub(crate) fn allow_abort_drop(&mut self) {
+        self.resolved = true;
+    }
+
     /// Test-only constructor returning the handle and the receiving
     /// half of its ack channel, so tests can assert on the disposition.
     #[cfg(test)]
@@ -1057,9 +1137,21 @@ impl Drop for QueueAckHandle {
              — bug: outputs MUST explicitly resolve their disposition"
         );
         if let Some(tx) = self.tx.take() {
+            #[cfg(test)]
+            let _ = TEST_IMPLICIT_DROP_COUNT.try_with(|count| {
+                count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            });
             let _ = tx.send((self.position, AckDisposition::Dropped));
         }
     }
+}
+
+#[cfg(test)]
+pub(crate) async fn with_test_implicit_drop_count<T>(
+    count: Arc<std::sync::atomic::AtomicUsize>,
+    future: impl std::future::Future<Output = T>,
+) -> T {
+    TEST_IMPLICIT_DROP_COUNT.scope(count, future).await
 }
 
 /// Maximum number of events drained per [`QueueReceiver::recv_many`]
@@ -1082,6 +1174,13 @@ const RECV_BATCH_MAX: usize = 64;
 /// the queue cursor when its disposition comes back". The cursor
 /// only advances after the output's handle resolves, which for
 /// batched outputs happens at flush time, not at buffer-accept time.
+async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_queue_consumer(
     mut receiver: QueueReceiver,
@@ -1120,8 +1219,8 @@ pub async fn run_queue_consumer(
         tokio::select! {
             biased;
 
-            _ = shutdown.changed(), if accepting || wedged => {
-                if *shutdown.borrow() {
+            terminal = shutdown_change_is_terminal(&mut shutdown), if accepting || wedged => {
+                if terminal {
                     // Wedged path: skip the drain and break immediately.
                     // The consumer is not accepting new events (that is
                     // the wedge contract), and any handles still parked
@@ -1705,6 +1804,33 @@ mod consumer_lifecycle_tests {
     }
 
     // ---- queue boundary error tests ----
+
+    #[tokio::test]
+    async fn closed_watch_drains_memory_queue_and_terminates_consumer() {
+        let (sender, receiver) = create_queue(
+            "closed-watch".into(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 4,
+            },
+        )
+        .unwrap();
+        sender.send(owned_event()).await.unwrap();
+        let writer = Arc::new(ScriptedWriter::new(vec![Outcome::Delivered]));
+        let metrics = writer.metrics();
+        let writer_for_task: Arc<dyn Output> = writer.clone();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        drop(shutdown_tx);
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            run_queue_consumer(receiver, writer_for_task, None, metrics, None, shutdown_rx),
+        )
+        .await
+        .expect("closed watch must drain and terminate the queue consumer");
+        assert_eq!(writer.calls(), 1);
+        drop(sender);
+    }
 
     #[tokio::test]
     async fn queue_sender_send_returns_channel_closed_when_receiver_dropped() {
@@ -3311,7 +3437,9 @@ mod consumer_lifecycle_tests {
     fn shutdown_drain_arm_is_backend_aware_and_uses_close_recv_pattern() {
         let src = include_str!("mod.rs");
         let arm_start = src
-            .find("_ = shutdown.changed(), if accepting || wedged =>")
+            .find(
+                "terminal = shutdown_change_is_terminal(&mut shutdown), if accepting || wedged =>",
+            )
             .expect("shutdown arm marker must exist");
         // Isolate the arm body from the wedge-shutdown early-break
         // to the next `break;` — the exit of the memory drain — and
@@ -3507,5 +3635,21 @@ mod schema_splice_tests {
         assert_eq!(cfg.initial_wait, std::time::Duration::from_millis(100));
         assert_eq!(cfg.max_wait, std::time::Duration::from_secs(5));
         assert!(matches!(cfg.backoff, BackoffStrategy::Exponential));
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_queue_consumer() {
+        let (sender, mut receiver) = tokio::sync::watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                super::shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("mod.rs").contains(&marker));
     }
 }

--- a/crates/limpid/src/runtime.rs
+++ b/crates/limpid/src/runtime.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::sync::{mpsc, watch};
 use tracing::{error, info, warn};
 
@@ -23,11 +23,384 @@ use crate::pipeline::CompiledConfig;
 use crate::queue::{self, QueueConfig, QueueSender};
 use crate::tap::TapRegistry;
 
+async fn shutdown_change_is_terminal(shutdown: &mut watch::Receiver<bool>) -> bool {
+    match shutdown.changed().await {
+        Ok(()) => *shutdown.borrow(),
+        Err(_) => true,
+    }
+}
+
 pub struct Runtime {
     shutdown_tx: watch::Sender<bool>,
-    handles: Vec<tokio::task::JoinHandle<()>>,
+    handles: Vec<TrackedTask>,
     config_file: PathBuf,
     compiled_config: CompiledConfig,
+}
+
+const SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const ABORT_JOIN_RESERVE: std::time::Duration = std::time::Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CleanupOutcome {
+    forced_abort: bool,
+    abort_safe_incomplete: usize,
+    must_join_exceeded_threshold: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TaskKind {
+    AbortSafe,
+    MustJoin,
+}
+
+fn output_task_kind(
+    output_type: &str,
+    queue_type: &queue::QueueType,
+    has_error_log: bool,
+    stdout_regular_file: bool,
+) -> TaskKind {
+    if output_type == "file"
+        || (output_type == "stdout" && stdout_regular_file)
+        || matches!(queue_type, queue::QueueType::Disk { .. })
+        || has_error_log
+    {
+        TaskKind::MustJoin
+    } else {
+        TaskKind::AbortSafe
+    }
+}
+
+fn pipeline_task_kind(has_error_log: bool, has_disk_output: bool) -> TaskKind {
+    if has_error_log || has_disk_output {
+        TaskKind::MustJoin
+    } else {
+        TaskKind::AbortSafe
+    }
+}
+
+fn input_task_kind(input_type: &str) -> TaskKind {
+    if input_type == "journal" {
+        TaskKind::MustJoin
+    } else {
+        TaskKind::AbortSafe
+    }
+}
+
+struct TrackedTask {
+    kind: TaskKind,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// Owns every task created during startup until the runtime is fully committed.
+/// Any explicit startup error uses [`Self::rollback`]; cancellation or panic is
+/// covered by `Drop`, which transfers cleanup to the current Tokio runtime.
+struct StartupGuard {
+    shutdown_tx: Option<watch::Sender<bool>>,
+    handles: Vec<TrackedTask>,
+    cleanup_executor: tokio::runtime::Handle,
+    #[cfg(test)]
+    drop_cleanup_observer: Option<Arc<DropCleanupObserver>>,
+}
+
+impl StartupGuard {
+    fn new(shutdown_tx: watch::Sender<bool>) -> Self {
+        Self {
+            shutdown_tx: Some(shutdown_tx),
+            handles: Vec::new(),
+            cleanup_executor: tokio::runtime::Handle::current(),
+            #[cfg(test)]
+            drop_cleanup_observer: DROP_CLEANUP_RESULT.try_with(Arc::clone).ok(),
+        }
+    }
+
+    fn track(&mut self, kind: TaskKind, handle: tokio::task::JoinHandle<()>) {
+        self.handles.push(TrackedTask {
+            kind,
+            handle: Some(handle),
+        });
+    }
+
+    fn extend(
+        &mut self,
+        kind: TaskKind,
+        handles: impl IntoIterator<Item = tokio::task::JoinHandle<()>>,
+    ) {
+        self.handles
+            .extend(handles.into_iter().map(|handle| TrackedTask {
+                kind,
+                handle: Some(handle),
+            }));
+    }
+
+    async fn rollback(self, original: anyhow::Error) -> anyhow::Error {
+        self.rollback_with_timeout(original, SHUTDOWN_TIMEOUT).await
+    }
+
+    async fn rollback_with_timeout(
+        mut self,
+        original: anyhow::Error,
+        timeout: std::time::Duration,
+    ) -> anyhow::Error {
+        let shutdown_tx = self.shutdown_tx.take().expect("startup guard sender");
+        let mut handles = std::mem::take(&mut self.handles);
+        let cleanup = shutdown_tasks_with_timeout(&shutdown_tx, &mut handles, timeout).await;
+        drop(shutdown_tx);
+        if cleanup.abort_safe_incomplete != 0 {
+            original.context(format!(
+                "runtime startup rollback reached the hard cleanup deadline; {} abort-safe task(s) remain incomplete after abort",
+                cleanup.abort_safe_incomplete
+            ))
+        } else if cleanup.must_join_exceeded_threshold {
+            original.context(
+                "runtime startup rollback exceeded the 10s health threshold; must-join resource owners completed before return",
+            )
+        } else if cleanup.forced_abort {
+            original.context(
+                "runtime startup rollback exceeded the graceful phase; pending tasks were aborted and joined within the global cleanup deadline",
+            )
+        } else {
+            original.context("runtime startup rolled back all started tasks")
+        }
+    }
+
+    fn commit(mut self) -> (watch::Sender<bool>, Vec<TrackedTask>) {
+        let shutdown_tx = self.shutdown_tx.take().expect("startup guard sender");
+        let handles = std::mem::take(&mut self.handles);
+        (shutdown_tx, handles)
+    }
+}
+
+impl Drop for StartupGuard {
+    fn drop(&mut self) {
+        let Some(shutdown_tx) = self.shutdown_tx.take() else {
+            return;
+        };
+        let mut handles = std::mem::take(&mut self.handles);
+        let _ = shutdown_tx.send(true);
+        if handles.is_empty() {
+            #[cfg(test)]
+            if let Some(observer) = self.drop_cleanup_observer.take() {
+                observer.complete(CleanupOutcome::default());
+            }
+            return;
+        }
+        #[cfg(test)]
+        let observer = self.drop_cleanup_observer.take();
+        // The originating runtime must remain alive until this cleanup task
+        // completes. Dropping the runtime itself cancels all tasks by Tokio's
+        // contract; no handle can extend an executor beyond that boundary.
+        self.cleanup_executor.spawn(async move {
+            let outcome = shutdown_tasks(&shutdown_tx, &mut handles).await;
+            #[cfg(test)]
+            if let Some(observer) = observer {
+                observer.complete(outcome);
+            }
+            #[cfg(not(test))]
+            let _ = outcome;
+        });
+    }
+}
+
+fn record_join_result(result: std::result::Result<(), tokio::task::JoinError>) {
+    if let Err(error) = result
+        && error.is_panic()
+    {
+        error!("task panicked during shutdown: {error}");
+    }
+}
+
+async fn shutdown_tasks(
+    shutdown_tx: &watch::Sender<bool>,
+    handles: &mut [TrackedTask],
+) -> CleanupOutcome {
+    shutdown_tasks_with_timeout(shutdown_tx, handles, SHUTDOWN_TIMEOUT).await
+}
+
+async fn shutdown_tasks_with_timeout(
+    shutdown_tx: &watch::Sender<bool>,
+    handles: &mut [TrackedTask],
+    total_timeout: std::time::Duration,
+) -> CleanupOutcome {
+    let _ = shutdown_tx.send(true);
+    let started = tokio::time::Instant::now();
+    let overall_deadline = started + total_timeout;
+    let abort_reserve = ABORT_JOIN_RESERVE.min(total_timeout / 2);
+    let graceful_deadline = overall_deadline - abort_reserve;
+
+    for task in handles.iter_mut() {
+        let Some(handle) = task.handle.as_mut() else {
+            continue;
+        };
+        match tokio::time::timeout_at(graceful_deadline, handle).await {
+            Ok(result) => {
+                record_join_result(result);
+                task.handle = None;
+            }
+            Err(_) => break,
+        }
+    }
+
+    let forced_abort = handles
+        .iter()
+        .any(|task| task.kind == TaskKind::AbortSafe && task.handle.is_some());
+    for task in handles.iter() {
+        if task.kind == TaskKind::AbortSafe
+            && let Some(handle) = &task.handle
+        {
+            handle.abort();
+        }
+    }
+
+    for task in handles.iter_mut() {
+        if task.kind != TaskKind::AbortSafe {
+            continue;
+        }
+        let Some(handle) = task.handle.as_mut() else {
+            continue;
+        };
+        match tokio::time::timeout_at(overall_deadline, handle).await {
+            Ok(result) => {
+                record_join_result(result);
+                task.handle = None;
+            }
+            Err(_) => break,
+        }
+    }
+
+    // Consume MustJoin handles that completed by the health threshold before
+    // deciding whether the threshold was exceeded. This also preserves the
+    // one-poll ownership invariant for every completed handle.
+    for task in handles.iter_mut() {
+        if task.kind == TaskKind::MustJoin
+            && task
+                .handle
+                .as_ref()
+                .is_some_and(|handle| handle.is_finished())
+            && let Some(handle) = task.handle.take()
+        {
+            record_join_result(handle.await);
+        }
+    }
+
+    let abort_safe_incomplete = handles
+        .iter()
+        .filter(|task| task.kind == TaskKind::AbortSafe && task.handle.is_some())
+        .count();
+    let must_join_exceeded_threshold = handles
+        .iter()
+        .any(|task| task.kind == TaskKind::MustJoin && task.handle.is_some());
+
+    // Must-join tasks own durability or disposition state. The 10-second
+    // deadline is a health threshold for them, never permission to abort or
+    // detach. Await every remaining owner before returning.
+    for task in handles.iter_mut() {
+        if task.kind != TaskKind::MustJoin {
+            continue;
+        }
+        if let Some(handle) = task.handle.as_mut() {
+            record_join_result(handle.await);
+            task.handle = None;
+        }
+    }
+
+    CleanupOutcome {
+        forced_abort,
+        abort_safe_incomplete,
+        must_join_exceeded_threshold,
+    }
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    static LATE_POST_LISTENER_FAILURE: std::cell::Cell<bool>;
+    static DROP_CLEANUP_RESULT: Arc<DropCleanupObserver>;
+    static POST_OUTPUT_PREACTIVATION_FAILURE: std::cell::RefCell<Option<PostOutputFailure>>;
+    static STARTUP_TASK_COMPLETIONS: Arc<StartupTaskCompletionObserver>;
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct DropCleanupObserver {
+    outcome: std::sync::Mutex<Option<CleanupOutcome>>,
+    completed: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+impl DropCleanupObserver {
+    fn complete(&self, outcome: CleanupOutcome) {
+        *self.outcome.lock().expect("drop cleanup observer") = Some(outcome);
+        self.completed.notify_one();
+    }
+
+    async fn wait(&self) -> CleanupOutcome {
+        loop {
+            if let Some(outcome) = *self.outcome.lock().expect("drop cleanup observer") {
+                return outcome;
+            }
+            self.completed.notified().await;
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct StartupTaskCompletionObserver {
+    output_queues: std::sync::atomic::AtomicUsize,
+    pipelines: std::sync::atomic::AtomicUsize,
+}
+
+#[cfg(test)]
+enum PostOutputFailureMode {
+    Error,
+    Park,
+}
+
+#[cfg(test)]
+struct PostOutputFailure {
+    mode: PostOutputFailureMode,
+    reached: Arc<tokio::sync::Notify>,
+    enqueue_probe: bool,
+}
+
+async fn post_output_preactivation_failure(_sender: &mut QueueSender) -> Result<()> {
+    #[cfg(test)]
+    if let Some(failure) = POST_OUTPUT_PREACTIVATION_FAILURE
+        .try_with(|slot| slot.borrow_mut().take())
+        .ok()
+        .flatten()
+    {
+        if failure.enqueue_probe {
+            _sender
+                .send(crate::event::QueuedEvent::new(
+                    Event::new(
+                        bytes::Bytes::from_static(b"startup-rollback-probe"),
+                        "127.0.0.1:1".parse().expect("static probe address"),
+                    ),
+                    crate::time::UnixNanos::now(),
+                ))
+                .await
+                .context("failed to enqueue startup rollback probe")?;
+        }
+        failure.reached.notify_one();
+        match failure.mode {
+            PostOutputFailureMode::Error => {
+                anyhow::bail!("test failpoint: post-output preactivation failure");
+            }
+            PostOutputFailureMode::Park => std::future::pending::<()>().await,
+        }
+    }
+    Ok(())
+}
+
+fn late_post_listener_failure() -> Result<()> {
+    #[cfg(test)]
+    if LATE_POST_LISTENER_FAILURE
+        .try_with(|armed| armed.replace(false))
+        .unwrap_or(false)
+    {
+        anyhow::bail!("test failpoint: late post-listener startup failure");
+    }
+    Ok(())
 }
 
 fn configured_ltp_peer_ids(config: &CompiledConfig) -> Result<BTreeSet<String>> {
@@ -92,7 +465,6 @@ impl Runtime {
         F: FnOnce() -> Result<String>,
     {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
         let mut registry = ModuleRegistry::new();
         modules::register_builtins(&mut registry);
@@ -205,97 +577,34 @@ impl Runtime {
             ltp_metrics,
         };
 
-        // --- 1. Create outputs (each output owns its own OutputMetrics) ---
-        let mut output_senders: HashMap<String, QueueSender> = HashMap::new();
-        let mut output_receivers = Vec::new();
-        // Populated in the loop below alongside the queue creation so
-        // the same `QueueConfig` decides which set of outputs need a
-        // workspace-carrying snapshot at `output` statement time. See
-        // `PipelineContext::disk_outputs` for the runtime contract.
-        let mut disk_outputs: HashSet<String> = HashSet::new();
+        // Complete every deterministic plan named by the startup contract
+        // before an output factory can acquire a resource.
+        let compiled_config = config.clone();
+        let control_path = config
+            .global_blocks
+            .get("control")
+            .and_then(|p| props::get_string(p, "socket"));
+        crate::control::validate_control_socket_parent(control_path.as_deref())?;
+        let stdout_regular_file = if config
+            .outputs
+            .values()
+            .any(|output| output.properties.type_name() == "stdout")
+        {
+            crate::modules::output::stdout::stdout_is_regular_file()
+                .context("failed to classify stdout backend")?
+        } else {
+            false
+        };
 
-        for (name, output_def) in &config.outputs {
-            let queue_config =
-                QueueConfig::from_output_properties(name, output_def.properties.user_properties())?;
-            if matches!(queue_config.queue_type, queue::QueueType::Disk { .. }) {
-                disk_outputs.insert(name.clone());
-            }
-            // Retry config is parsed by each output's `from_properties`
-            // (outputs own retry + DLQ). The runtime no longer needs a
-            // copy here.
-            let (mut sender, receiver) = queue::create_queue(name.clone(), queue_config)?;
-
-            // `output_def.properties` is a `ModuleProperties`: it carries the
-            // resolved `type` already, so `create_output` doesn't take a
-            // separate type_name argument (and can't be passed one — the
-            // strip is the whole point). `BuildContext` carries `funcs` and
-            // the optional `error_log` so outputs can stash them at
-            // construction time.
-            let created = match registry.create_output(name, &output_def.properties, &build_ctx) {
-                Ok(c) => c,
-                Err(e) => {
-                    error!(
-                        "failed to create output '{}': {} — aborting startup",
-                        name, e
-                    );
-                    for h in &handles {
-                        h.abort();
-                    }
-                    for h in handles {
-                        let _ = h.await;
-                    }
-                    return Err(e);
-                }
-            };
-
-            // Attach metrics so QueueSender::send counts events_received.
-            sender.attach_metrics(Arc::clone(&created.metrics));
-            output_senders.insert(name.clone(), sender);
-
-            let output_metrics = Arc::clone(&created.metrics);
-            tap.register(&format!("output {}", name)).await;
-
-            output_receivers.push((name.clone(), receiver, created.output, output_metrics));
-        }
-
-        // Start queue consumers (no metrics counting here — output does it)
-        for (_name, receiver, writer, output_metrics) in output_receivers {
-            let shutdown = shutdown_rx.clone();
-            let tap_clone = tap.clone();
-            let error_log_for_consumer = error_log.as_ref().map(Arc::clone);
-            handles.push(tokio::spawn(async move {
-                queue::run_queue_consumer(
-                    receiver,
-                    writer,
-                    Some(tap_clone),
-                    output_metrics,
-                    error_log_for_consumer,
-                    shutdown,
-                )
-                .await;
-            }));
-        }
-
-        let output_senders = Arc::new(output_senders);
-        let disk_outputs = Arc::new(disk_outputs);
-
-        // --- 2. Group pipelines by input ---
-        //
-        // A pipeline with `input a, b;` (fan-in) is registered under every listed
-        // input. Events from each input are still fed into the pipeline's
-        // per-input worker dispatcher; since a single `PipelineWorker` instance
-        // is shared across inputs (wrapped in Arc at spawn time), its metrics
-        // aggregate across inputs without per-input attribution — by design.
+        // Group pipelines by input and compile every process-metric plan.
         let mut input_pipelines: HashMap<String, Vec<Arc<PipelineWorker>>> = HashMap::new();
-
         for pipeline_def in config.pipelines.values() {
             let worker = Arc::new(PipelineWorker::new_with_process_metrics(
                 pipeline_def.clone(),
                 &config.processes,
                 &metrics_registry,
             )?);
-            let input_names = get_pipeline_inputs(pipeline_def);
-            for input_name in input_names {
+            for input_name in get_pipeline_inputs(pipeline_def) {
                 input_pipelines
                     .entry(input_name.clone())
                     .or_default()
@@ -303,7 +612,29 @@ impl Runtime {
             }
         }
 
-        // --- 2b. Register tap points for inputs and processes ---
+        let mut input_queue_sizes = HashMap::new();
+        let mut prepared_ltp_inputs = HashMap::new();
+        for input_name in input_pipelines.keys() {
+            let input_def = config
+                .inputs
+                .get(input_name)
+                .ok_or_else(|| anyhow::anyhow!("input '{}' not found", input_name))?;
+            let queue_size =
+                props::get_positive_int(input_def.properties.user_properties(), "queue_size")?
+                    .unwrap_or(4096) as usize;
+            input_queue_sizes.insert(input_name.clone(), queue_size);
+            if input_def.properties.type_name() == "ltp" {
+                let input = modules::input::ltp::LtpInput::build(
+                    input_name,
+                    &input_def.properties,
+                    &build_ctx,
+                )
+                .with_context(|| format!("failed to create input '{input_name}'"))?;
+                prepared_ltp_inputs.insert(input_name.clone(), input);
+            }
+        }
+
+        // Tap registration does not create runtime actors or output resources.
         for input_name in input_pipelines.keys() {
             tap.register(&format!("input {}", input_name)).await;
         }
@@ -311,9 +642,101 @@ impl Runtime {
             tap.register(&format!("process {}", proc_name)).await;
         }
 
-        // --- 3. Start inputs (each input owns its own InputMetrics) ---
-        let compiled_config = config.clone();
+        // From this point on, every acquired output resource is transactionally
+        // owned. Each real queue consumer is spawned and registered immediately
+        // after its output factory succeeds, before the next await or fallible
+        // edge.
+        let mut startup_guard = StartupGuard::new(shutdown_tx);
+
+        // --- 1. Create outputs (each output owns its own OutputMetrics) ---
+        let mut output_senders: HashMap<String, QueueSender> = HashMap::new();
+        // Populated in the loop below alongside the queue creation so
+        // the same `QueueConfig` decides which set of outputs need a
+        // workspace-carrying snapshot at `output` statement time. See
+        // `PipelineContext::disk_outputs` for the runtime contract.
+        let mut disk_outputs: HashSet<String> = HashSet::new();
+
+        for (name, output_def) in &config.outputs {
+            let queue_config = match QueueConfig::from_output_properties(
+                name,
+                output_def.properties.user_properties(),
+            ) {
+                Ok(config) => config,
+                Err(error) => return Err(startup_guard.rollback(error).await),
+            };
+            let output_task_kind = output_task_kind(
+                output_def.properties.type_name(),
+                &queue_config.queue_type,
+                error_log.is_some(),
+                stdout_regular_file,
+            );
+            if matches!(queue_config.queue_type, queue::QueueType::Disk { .. }) {
+                disk_outputs.insert(name.clone());
+            }
+            // Retry config is parsed by each output's `from_properties`
+            // (outputs own retry + DLQ). The runtime no longer needs a
+            // copy here.
+            let (mut sender, receiver) = match queue::create_queue(name.clone(), queue_config) {
+                Ok(queue) => queue,
+                Err(error) => return Err(startup_guard.rollback(error).await),
+            };
+
+            // `output_def.properties` is a `ModuleProperties`: it carries the
+            // resolved `type` already, so `create_output` doesn't take a
+            // separate type_name argument (and can't be passed one — the
+            // strip is the whole point). `BuildContext` carries `funcs` and
+            // the optional `error_log` so outputs can stash them at
+            // construction time.
+            let created = match registry
+                .create_output(name, &output_def.properties, &build_ctx)
+                .with_context(|| format!("failed to create output '{name}'"))
+            {
+                Ok(created) => created,
+                Err(error) => return Err(startup_guard.rollback(error).await),
+            };
+
+            // Attach metrics so QueueSender::send counts events_received.
+            sender.attach_metrics(Arc::clone(&created.metrics));
+            let output_metrics = Arc::clone(&created.metrics);
+            let shutdown = shutdown_rx.clone();
+            let tap_clone = tap.clone();
+            let error_log_for_consumer = error_log.as_ref().map(Arc::clone);
+            #[cfg(test)]
+            let completion_observer = STARTUP_TASK_COMPLETIONS.try_with(Arc::clone).ok();
+            startup_guard.track(
+                output_task_kind,
+                tokio::spawn(async move {
+                    queue::run_queue_consumer(
+                        receiver,
+                        created.output,
+                        Some(tap_clone),
+                        output_metrics,
+                        error_log_for_consumer,
+                        shutdown,
+                    )
+                    .await;
+                    #[cfg(test)]
+                    if let Some(observer) = completion_observer {
+                        observer
+                            .output_queues
+                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                }),
+            );
+            if let Err(error) = post_output_preactivation_failure(&mut sender).await {
+                return Err(startup_guard.rollback(error).await);
+            }
+            output_senders.insert(name.clone(), sender);
+            tap.register(&format!("output {}", name)).await;
+        }
+
+        let output_senders = Arc::new(output_senders);
+        let has_disk_output = !disk_outputs.is_empty();
+        let disk_outputs = Arc::new(disk_outputs);
+
         let config = Arc::new(config);
+
+        // --- 3. Start inputs (each input owns its own InputMetrics) ---
 
         let mut input_senders: HashMap<
             String,
@@ -322,14 +745,10 @@ impl Runtime {
         let mut ltp_inputs = Vec::new();
 
         for (input_name, pipelines) in input_pipelines {
-            let input_def = config
-                .inputs
-                .get(&input_name)
-                .ok_or_else(|| anyhow::anyhow!("input '{}' not found", input_name))?;
-
-            let queue_size =
-                props::get_positive_int(input_def.properties.user_properties(), "queue_size")?
-                    .unwrap_or(4096) as usize;
+            let input_def = config.inputs.get(&input_name).expect("input preflight");
+            let queue_size = input_queue_sizes
+                .remove(&input_name)
+                .expect("input queue-size preflight");
             let (event_tx, event_rx) = mpsc::channel::<Event>(queue_size);
 
             // Pipeline workers subscribed to this input. A pipeline with fan-in
@@ -350,31 +769,47 @@ impl Runtime {
             let iname = input_name.clone();
             let shutdown_for_worker = shutdown_rx.clone();
             let sender_for_inject = event_tx.clone();
-            handles.push(tokio::spawn(async move {
-                run_pipeline_workers(event_rx, &workers, &ctx, &iname, shutdown_for_worker).await;
-            }));
+            #[cfg(test)]
+            let completion_observer = STARTUP_TASK_COMPLETIONS.try_with(Arc::clone).ok();
+            #[cfg(test)]
+            let wal_barrier = queue::current_test_wal_barrier();
+            let pipeline_task_kind = pipeline_task_kind(error_log.is_some(), has_disk_output);
+            startup_guard.track(
+                pipeline_task_kind,
+                tokio::spawn(async move {
+                    #[cfg(test)]
+                    if let Some(barrier) = wal_barrier {
+                        queue::with_test_wal_barrier(
+                            barrier,
+                            run_pipeline_workers(
+                                event_rx,
+                                &workers,
+                                &ctx,
+                                &iname,
+                                shutdown_for_worker,
+                            ),
+                        )
+                        .await;
+                    } else {
+                        run_pipeline_workers(event_rx, &workers, &ctx, &iname, shutdown_for_worker)
+                            .await;
+                    }
+                    #[cfg(not(test))]
+                    run_pipeline_workers(event_rx, &workers, &ctx, &iname, shutdown_for_worker)
+                        .await;
+                    #[cfg(test)]
+                    if let Some(observer) = completion_observer {
+                        observer
+                            .pipelines
+                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                }),
+            );
 
             if input_def.properties.type_name() == "ltp" {
-                let input = match modules::input::ltp::LtpInput::build(
-                    &input_name,
-                    &input_def.properties,
-                    &build_ctx,
-                ) {
-                    Ok(input) => input,
-                    Err(error) => {
-                        error!(
-                            "failed to create input '{}': {} — aborting startup",
-                            input_name, error
-                        );
-                        for handle in &handles {
-                            handle.abort();
-                        }
-                        for handle in handles {
-                            let _ = handle.await;
-                        }
-                        return Err(error);
-                    }
-                };
+                let input = prepared_ltp_inputs
+                    .remove(&input_name)
+                    .expect("LTP input preflight");
                 input_senders.insert(input_name.clone(), (sender_for_inject, input.metrics()));
                 ltp_inputs.push((input, event_tx));
                 continue;
@@ -392,24 +827,29 @@ impl Runtime {
             ) {
                 Ok(c) => c,
                 Err(e) => {
-                    error!(
-                        "failed to start input '{}': {} — aborting startup",
-                        input_name, e
-                    );
-                    for h in &handles {
-                        h.abort();
-                    }
-                    for h in handles {
-                        let _ = h.await;
-                    }
-                    return Err(e);
+                    let error = e.context(format!("failed to start input '{input_name}'"));
+                    return Err(startup_guard.rollback(error).await);
                 }
             };
             input_senders.insert(
                 input_name.clone(),
                 (sender_for_inject, Arc::clone(&created.metrics)),
             );
-            handles.push(created.handle);
+            let input_task_kind = input_task_kind(input_def.properties.type_name());
+            startup_guard.track(input_task_kind, created.handle);
+            match created.startup.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    let error = error.context(format!("failed to start input '{input_name}'"));
+                    return Err(startup_guard.rollback(error).await);
+                }
+                Err(_) => {
+                    let error = anyhow::anyhow!(
+                        "input '{input_name}' task exited before startup readiness"
+                    );
+                    return Err(startup_guard.rollback(error).await);
+                }
+            }
         }
 
         let ltp_handles =
@@ -417,31 +857,18 @@ impl Runtime {
             {
                 Ok(handles) => handles,
                 Err(error) => {
-                    error!("failed to start LTP listener groups: {error:#} — aborting startup");
-                    for handle in &handles {
-                        handle.abort();
-                    }
-                    for handle in handles {
-                        let _ = handle.await;
-                    }
-                    return Err(error);
+                    return Err(startup_guard
+                        .rollback(error.context("failed to start LTP listener groups"))
+                        .await);
                 }
             };
-        handles.extend(ltp_handles);
+        startup_guard.extend(TaskKind::AbortSafe, ltp_handles);
+
+        if let Err(error) = late_post_listener_failure() {
+            return Err(startup_guard.rollback(error).await);
+        }
 
         // --- 4. Start control socket (after all metrics are registered) ---
-        let control_path = config
-            .global_blocks
-            .get("control")
-            .and_then(|p| props::get_string(p, "socket"));
-        // Validate the control socket's parent BEFORE the control
-        // task is spawned. `ControlServer::run` returns `()` and is
-        // fire-and-forget from the runtime's perspective, so a
-        // fail-closed check inside the task would just make the
-        // control socket die silently while the daemon runs on.
-        // Bailing here stops the whole startup — the same shape as
-        // `ErrorLogWriter::validate_at_startup`.
-        crate::control::validate_control_socket_parent(control_path.as_deref())?;
         let started_at = std::time::Instant::now();
         let control = ControlServer::new(
             control_path,
@@ -453,10 +880,28 @@ impl Runtime {
             started_at,
         );
         let s = shutdown_rx.clone();
-        handles.push(tokio::spawn(async move {
-            control.run(s).await;
-        }));
+        let (control_startup_tx, control_startup_rx) = tokio::sync::oneshot::channel();
+        startup_guard.track(
+            TaskKind::AbortSafe,
+            tokio::spawn(async move {
+                control.run(s, Some(control_startup_tx)).await;
+            }),
+        );
+        match control_startup_rx.await {
+            Ok(Ok(())) => {}
+            Ok(Err(diagnostic)) => {
+                return Err(startup_guard.rollback(anyhow::anyhow!(diagnostic)).await);
+            }
+            Err(_) => {
+                return Err(startup_guard
+                    .rollback(anyhow::anyhow!(
+                        "control task exited before startup readiness"
+                    ))
+                    .await);
+            }
+        }
 
+        let (shutdown_tx, handles) = startup_guard.commit();
         info!("limpid daemon started");
         Ok(Self {
             shutdown_tx,
@@ -475,43 +920,27 @@ impl Runtime {
     }
 
     pub async fn shutdown(self) {
-        use std::time::Duration;
-        use tokio::time::timeout;
-
-        const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
-
         info!(
             "initiating graceful shutdown (timeout: {}s)",
             SHUTDOWN_TIMEOUT.as_secs()
         );
-        let _ = self.shutdown_tx.send(true);
-
-        // Collect abort handles before moving JoinHandles into join_all
-        let abort_handles: Vec<_> = self.handles.iter().map(|h| h.abort_handle()).collect();
-
-        match timeout(SHUTDOWN_TIMEOUT, Self::join_all(self.handles)).await {
-            Ok(()) => {
-                info!("shutdown complete");
-            }
-            Err(_) => {
-                error!(
-                    "shutdown timed out after {}s — aborting remaining tasks",
-                    SHUTDOWN_TIMEOUT.as_secs()
-                );
-                for ah in &abort_handles {
-                    ah.abort();
-                }
-            }
-        }
-    }
-
-    async fn join_all(handles: Vec<tokio::task::JoinHandle<()>>) {
-        for handle in handles {
-            if let Err(e) = handle.await
-                && e.is_panic()
-            {
-                error!("task panicked during shutdown: {}", e);
-            }
+        let mut handles = self.handles;
+        let cleanup = shutdown_tasks(&self.shutdown_tx, &mut handles).await;
+        if cleanup.abort_safe_incomplete != 0 {
+            error!(
+                "shutdown reached the {}s hard deadline — {} abort-safe task(s) remain incomplete after abort",
+                SHUTDOWN_TIMEOUT.as_secs(),
+                cleanup.abort_safe_incomplete,
+            );
+        } else if cleanup.must_join_exceeded_threshold {
+            warn!(
+                "shutdown exceeded the {}s health threshold; must-join resource owners completed before return",
+                SHUTDOWN_TIMEOUT.as_secs(),
+            );
+        } else if cleanup.forced_abort {
+            warn!("shutdown exceeded the graceful phase; pending tasks were aborted and joined");
+        } else {
+            info!("shutdown complete");
         }
     }
 }
@@ -733,8 +1162,8 @@ async fn run_pipeline_workers(
         let event = tokio::select! {
             biased;
 
-            _ = shutdown.changed() => {
-                if *shutdown.borrow() {
+            terminal = shutdown_change_is_terminal(&mut shutdown) => {
+                if terminal {
                     // Close the receiver first, then drain with
                     // `recv().await` until `None`. The previous
                     // `try_recv()` snapshot loop raced with input
@@ -1094,11 +1523,47 @@ mod tests {
     use crate::dsl::parser::parse_config;
     use crate::event::Event;
     use crate::metrics::{MetricsError, OutputMetrics, Registry};
+    use crate::modules::Output;
+    use crate::queue::{QueueAckHandle, QueueType};
     use bytes::Bytes;
     use std::net::SocketAddr;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     use std::str::FromStr;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
+
+    fn full_stdout_pipe() -> (OwnedFd, OwnedFd) {
+        let mut fds = [-1; 2];
+        // SAFETY: pipe initializes both integers on success.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        // SAFETY: successful pipe returned two uniquely-owned descriptors.
+        let (read_fd, write_fd) =
+            unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) };
+        let flags = unsafe { libc::fcntl(write_fd.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(flags, -1);
+        assert_ne!(
+            unsafe {
+                libc::fcntl(
+                    write_fd.as_raw_fd(),
+                    libc::F_SETFL,
+                    flags | libc::O_NONBLOCK,
+                )
+            },
+            -1
+        );
+        let chunk = [b'x'; 8192];
+        loop {
+            // SAFETY: descriptor and chunk are live for write(2).
+            let written =
+                unsafe { libc::write(write_fd.as_raw_fd(), chunk.as_ptr().cast(), chunk.len()) };
+            if written == -1 {
+                let error = std::io::Error::last_os_error();
+                assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+                break;
+            }
+        }
+        (read_fd, write_fd)
+    }
 
     fn assert_output_duplicate(error: &MetricsError, label_value: &str, diagnostic: &str) {
         let (name, labelset) = match error {
@@ -1137,6 +1602,706 @@ mod tests {
             .expect("compile config")
     }
 
+    struct ShutdownCountingOutput {
+        metrics: Arc<crate::metrics::OutputMetrics>,
+        shutdown_calls: std::sync::atomic::AtomicUsize,
+        resolved: std::sync::atomic::AtomicUsize,
+        parked: std::sync::Mutex<Vec<QueueAckHandle>>,
+        consumed: tokio::sync::Notify,
+    }
+
+    impl ShutdownCountingOutput {
+        fn new() -> Self {
+            Self {
+                metrics: crate::metrics::OutputMetrics::for_testing(),
+                shutdown_calls: std::sync::atomic::AtomicUsize::new(0),
+                resolved: std::sync::atomic::AtomicUsize::new(0),
+                parked: std::sync::Mutex::new(Vec::new()),
+                consumed: tokio::sync::Notify::new(),
+            }
+        }
+    }
+
+    impl HasMetrics for ShutdownCountingOutput {
+        type Stats = crate::metrics::OutputMetrics;
+
+        fn metrics(&self) -> Arc<Self::Stats> {
+            Arc::clone(&self.metrics)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Output for ShutdownCountingOutput {
+        async fn consume(&self, _event: &Event, ack: QueueAckHandle) -> Result<()> {
+            self.parked.lock().unwrap().push(ack);
+            self.consumed.notify_one();
+            Ok(())
+        }
+
+        async fn consume_shutdown(&self, _event: &Event, ack: QueueAckHandle) -> Result<()> {
+            self.parked.lock().unwrap().push(ack);
+            self.consumed.notify_one();
+            Ok(())
+        }
+
+        async fn shutdown(
+            &self,
+            _error_log: Option<&Arc<crate::error_log::ErrorLogWriter>>,
+        ) -> Result<()> {
+            self.shutdown_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            for ack in self.parked.lock().unwrap().drain(..) {
+                ack.resolve_delivered();
+                self.resolved
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn startup_rollback_calls_output_shutdown_once_and_resolves_parked_ack() {
+        let (mut sender, receiver) = queue::create_queue(
+            "rollback-output".to_owned(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 4,
+            },
+        )
+        .unwrap();
+        let writer = Arc::new(ShutdownCountingOutput::new());
+        sender.attach_metrics(writer.metrics());
+        sender
+            .send(crate::event::QueuedEvent::new(
+                Event::new(
+                    bytes::Bytes::from_static(b"parked"),
+                    "127.0.0.1:1".parse().unwrap(),
+                ),
+                crate::time::UnixNanos::now(),
+            ))
+            .await
+            .unwrap();
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let mut guard = StartupGuard::new(shutdown_tx);
+        let metrics = writer.metrics();
+        let writer_for_task: Arc<dyn Output> = writer.clone();
+        guard.track(
+            TaskKind::MustJoin,
+            tokio::spawn(async move {
+                queue::run_queue_consumer(
+                    receiver,
+                    writer_for_task,
+                    None,
+                    metrics,
+                    None,
+                    shutdown_rx,
+                )
+                .await;
+            }),
+        );
+        writer.consumed.notified().await;
+
+        let error = guard.rollback(anyhow::anyhow!("late failure")).await;
+        assert!(error.to_string().contains("rolled back"));
+        assert_eq!(
+            writer
+                .shutdown_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+        );
+        assert!(writer.parked.lock().unwrap().is_empty());
+        assert_eq!(writer.resolved.load(std::sync::atomic::Ordering::SeqCst), 1,);
+        drop(sender);
+    }
+
+    #[tokio::test]
+    async fn startup_success_regression_delivers_and_shuts_output_down_once() {
+        let (mut sender, receiver) = queue::create_queue(
+            "success-output".to_owned(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 4,
+            },
+        )
+        .unwrap();
+        let writer = Arc::new(ShutdownCountingOutput::new());
+        sender.attach_metrics(writer.metrics());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let mut guard = StartupGuard::new(shutdown_tx);
+        let metrics = writer.metrics();
+        let writer_for_task: Arc<dyn Output> = writer.clone();
+        guard.track(
+            TaskKind::MustJoin,
+            tokio::spawn(async move {
+                queue::run_queue_consumer(
+                    receiver,
+                    writer_for_task,
+                    None,
+                    metrics,
+                    None,
+                    shutdown_rx,
+                )
+                .await;
+            }),
+        );
+        let (shutdown_tx, handles) = guard.commit();
+        let runtime = Runtime {
+            shutdown_tx,
+            handles,
+            config_file: PathBuf::from("success-test.limpid"),
+            compiled_config: compiled_config(""),
+        };
+
+        sender
+            .send(crate::event::QueuedEvent::new(
+                Event::new(
+                    bytes::Bytes::from_static(b"delivered"),
+                    "127.0.0.1:1".parse().unwrap(),
+                ),
+                crate::time::UnixNanos::now(),
+            ))
+            .await
+            .unwrap();
+        writer.consumed.notified().await;
+        runtime.shutdown().await;
+
+        assert_eq!(
+            writer
+                .shutdown_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+        );
+        assert_eq!(writer.resolved.load(std::sync::atomic::Ordering::SeqCst), 1,);
+        assert!(writer.parked.lock().unwrap().is_empty());
+        drop(sender);
+    }
+
+    #[tokio::test]
+    async fn cancelled_startup_guard_transfers_bounded_cleanup_to_runtime() {
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let cleanup_observer = Arc::new(DropCleanupObserver::default());
+        DROP_CLEANUP_RESULT
+            .scope(Arc::clone(&cleanup_observer), async move {
+                let mut guard = StartupGuard::new(shutdown_tx);
+                guard.track(
+                    TaskKind::AbortSafe,
+                    tokio::spawn(async move {
+                        let terminal = shutdown_change_is_terminal(&mut shutdown_rx).await;
+                        let _ = done_tx.send(terminal);
+                    }),
+                );
+                drop(guard);
+            })
+            .await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), done_rx)
+                .await
+                .expect("drop cleanup must not orphan the tracked task")
+                .expect("tracked task must report terminal shutdown")
+        );
+        let cleanup = tokio::time::timeout(Duration::from_millis(100), cleanup_observer.wait())
+            .await
+            .expect("drop cleanup task must finish");
+        assert_eq!(cleanup.abort_safe_incomplete, 0);
+    }
+
+    #[tokio::test]
+    async fn startup_guard_dropped_on_external_thread_uses_captured_executor() {
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let owners = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let cleanup_observer = Arc::new(DropCleanupObserver::default());
+        let guard = DROP_CLEANUP_RESULT
+            .scope(Arc::clone(&cleanup_observer), async {
+                let mut guard = StartupGuard::new(shutdown_tx);
+                let owners_in_task = Arc::clone(&owners);
+                guard.track(
+                    TaskKind::AbortSafe,
+                    tokio::spawn(async move {
+                        struct Owner(Arc<std::sync::atomic::AtomicUsize>);
+                        impl Drop for Owner {
+                            fn drop(&mut self) {
+                                self.0.fetch_sub(1, Ordering::SeqCst);
+                            }
+                        }
+                        owners_in_task.fetch_add(1, Ordering::SeqCst);
+                        let _owner = Owner(owners_in_task);
+                        let _ = shutdown_change_is_terminal(&mut shutdown_rx).await;
+                    }),
+                );
+                tokio::task::yield_now().await;
+                guard
+            })
+            .await;
+        assert_eq!(owners.load(Ordering::SeqCst), 1);
+
+        std::thread::spawn(move || drop(guard)).join().unwrap();
+        let cleanup = tokio::time::timeout(Duration::from_secs(1), cleanup_observer.wait())
+            .await
+            .expect("captured runtime must complete externally-triggered cleanup");
+        assert_eq!(cleanup.abort_safe_incomplete, 0);
+        assert_eq!(owners.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_consumes_completed_handles_once_and_aborts_only_pending_tasks() {
+        let reservation = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = reservation.local_addr().unwrap();
+        let ended = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        struct EndOnDrop(Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for EndOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let first = tokio::spawn(async {});
+        let ended_in_task = Arc::clone(&ended);
+        let blocked = tokio::spawn(async move {
+            let _reservation = reservation;
+            let _end = EndOnDrop(ended_in_task);
+            std::future::pending::<()>().await;
+        });
+        tokio::task::yield_now().await;
+
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let mut handles = vec![
+            TrackedTask {
+                kind: TaskKind::AbortSafe,
+                handle: Some(first),
+            },
+            TrackedTask {
+                kind: TaskKind::AbortSafe,
+                handle: Some(blocked),
+            },
+        ];
+        let cleanup =
+            shutdown_tasks_with_timeout(&shutdown_tx, &mut handles, Duration::from_millis(80))
+                .await;
+
+        assert!(cleanup.forced_abort);
+        assert_eq!(cleanup.abort_safe_incomplete, 0);
+        assert!(handles.iter().all(|task| task.handle.is_none()));
+        assert!(ended.load(Ordering::SeqCst));
+        std::net::TcpListener::bind(address)
+            .expect("aborted cooperative owner must release its socket before return");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cleanup_health_threshold_never_detaches_or_aborts_must_join_task() {
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let finished = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let finished_in_task = Arc::clone(&finished);
+        let handle = tokio::spawn(async move {
+            let _ = release_rx.await;
+            finished_in_task.store(true, Ordering::SeqCst);
+        });
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let mut guard = StartupGuard::new(shutdown_tx);
+        guard.track(TaskKind::MustJoin, handle);
+
+        let rollback = tokio::spawn(async move {
+            guard
+                .rollback_with_timeout(
+                    anyhow::anyhow!("original startup error"),
+                    Duration::from_millis(50),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(50)).await;
+        tokio::task::yield_now().await;
+        assert!(!rollback.is_finished());
+        assert!(!finished.load(Ordering::SeqCst));
+
+        release_tx.send(()).unwrap();
+        let error = rollback.await.unwrap();
+        let chain = format!("{error:#}");
+        assert!(chain.contains("original startup error"), "{chain}");
+        assert!(chain.contains("health threshold"), "{chain}");
+        assert!(finished.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn durability_owners_are_must_join_and_private_network_tasks_are_abort_safe() {
+        let memory = QueueType::Memory;
+        let disk = QueueType::Disk {
+            path: "/tmp/test-wal".to_owned(),
+            max_size: 1024,
+        };
+        assert_eq!(
+            output_task_kind("file", &memory, false, false),
+            TaskKind::MustJoin
+        );
+        assert_eq!(
+            output_task_kind("stdout", &disk, false, false),
+            TaskKind::MustJoin
+        );
+        assert_eq!(
+            output_task_kind("stdout", &memory, true, false),
+            TaskKind::MustJoin
+        );
+        assert_eq!(
+            output_task_kind("stdout", &memory, false, true),
+            TaskKind::MustJoin
+        );
+        assert_eq!(pipeline_task_kind(true, false), TaskKind::MustJoin);
+        assert_eq!(pipeline_task_kind(false, true), TaskKind::MustJoin);
+        assert_eq!(input_task_kind("journal"), TaskKind::MustJoin);
+
+        assert_eq!(
+            output_task_kind("stdout", &memory, false, false),
+            TaskKind::AbortSafe
+        );
+        assert_eq!(
+            output_task_kind("syslog_tcp", &memory, false, false),
+            TaskKind::AbortSafe
+        );
+        assert_eq!(pipeline_task_kind(false, false), TaskKind::AbortSafe);
+        assert_eq!(input_task_kind("syslog_tcp"), TaskKind::AbortSafe);
+    }
+
+    #[tokio::test]
+    async fn startup_rollback_with_full_stdout_pipe_resolves_current_ack() {
+        let (read_fd, write_fd) = full_stdout_pipe();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let mut ctx = crate::modules::BuildContext::for_testing();
+        ctx.shutdown_signal = shutdown_rx;
+        let properties =
+            crate::dsl::module_props::ModuleProperties::from_parts("stdout", Vec::new());
+        let output = Arc::new(
+            crate::modules::output::stdout::StdoutOutput::from_properties(
+                "rollback-stdout",
+                &properties,
+                &ctx,
+            )
+            .unwrap(),
+        );
+        let event = Event::new(
+            Bytes::from_static(b"blocked-rollback"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, mut ack_rx) = QueueAckHandle::for_test();
+        let mut guard = StartupGuard::new(shutdown_tx);
+        guard.track(
+            TaskKind::AbortSafe,
+            tokio::spawn(async move {
+                crate::modules::output::stdout::with_test_stdout_fd(write_fd, async move {
+                    output.consume(&event, ack).await.unwrap();
+                })
+                .await
+                .unwrap();
+            }),
+        );
+        tokio::task::yield_now().await;
+
+        let error = guard
+            .rollback(anyhow::anyhow!("late startup failure"))
+            .await;
+        assert!(format!("{error:#}").contains("late startup failure"));
+        assert!(matches!(
+            ack_rx.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        drop(read_fd);
+    }
+
+    #[tokio::test]
+    async fn normal_shutdown_with_full_stdout_pipe_resolves_current_ack() {
+        let (read_fd, write_fd) = full_stdout_pipe();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let mut ctx = crate::modules::BuildContext::for_testing();
+        ctx.shutdown_signal = shutdown_rx;
+        let properties =
+            crate::dsl::module_props::ModuleProperties::from_parts("stdout", Vec::new());
+        let output = Arc::new(
+            crate::modules::output::stdout::StdoutOutput::from_properties(
+                "shutdown-stdout",
+                &properties,
+                &ctx,
+            )
+            .unwrap(),
+        );
+        let event = Event::new(
+            Bytes::from_static(b"blocked-shutdown"),
+            "127.0.0.1:0".parse().unwrap(),
+        );
+        let (ack, mut ack_rx) = QueueAckHandle::for_test();
+        let handle = tokio::spawn(async move {
+            crate::modules::output::stdout::with_test_stdout_fd(write_fd, async move {
+                output.consume(&event, ack).await.unwrap();
+            })
+            .await
+            .unwrap();
+        });
+        let runtime = Runtime {
+            shutdown_tx,
+            handles: vec![TrackedTask {
+                kind: TaskKind::AbortSafe,
+                handle: Some(handle),
+            }],
+            config_file: PathBuf::from("stdout-shutdown-test.limpid"),
+            compiled_config: compiled_config(""),
+        };
+        tokio::task::yield_now().await;
+
+        runtime.shutdown().await;
+        assert!(matches!(
+            ack_rx.recv().await,
+            Some((_, crate::queue::AckDisposition::Recovered))
+        ));
+        drop(read_fd);
+    }
+
+    #[tokio::test]
+    async fn full_pipe_queue_consumer_is_bounded_and_disposes_once_on_abort() {
+        let (read_fd, write_fd) = full_stdout_pipe();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let mut ctx = crate::modules::BuildContext::for_testing();
+        ctx.shutdown_signal = shutdown_rx.clone();
+        let properties =
+            crate::dsl::module_props::ModuleProperties::from_parts("stdout", Vec::new());
+        let output = Arc::new(
+            crate::modules::output::stdout::StdoutOutput::from_properties(
+                "shutdown-drain-full-pipe",
+                &properties,
+                &ctx,
+            )
+            .unwrap(),
+        );
+        let (sender, receiver) = queue::create_queue(
+            "shutdown-drain-full-pipe".to_string(),
+            QueueConfig {
+                queue_type: QueueType::Memory,
+                capacity: 1,
+            },
+        )
+        .unwrap();
+        sender
+            .send(crate::event::QueuedEvent::new(
+                Event::new(
+                    Bytes::from_static(b"blocked-drain"),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
+                crate::time::UnixNanos::now(),
+            ))
+            .await
+            .unwrap();
+        drop(sender);
+        shutdown_tx.send(true).unwrap();
+
+        let drops = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let drops_in_task = Arc::clone(&drops);
+        let writer: Arc<dyn Output> = output.clone();
+        let metrics = output.metrics();
+        let handle = tokio::spawn(async move {
+            crate::modules::output::stdout::with_test_stdout_fd(write_fd, async move {
+                queue::with_test_implicit_drop_count(drops_in_task, async move {
+                    queue::run_queue_consumer(receiver, writer, None, metrics, None, shutdown_rx)
+                        .await;
+                })
+                .await;
+            })
+            .await
+            .unwrap();
+        });
+        let mut guard = StartupGuard::new(shutdown_tx);
+        guard.track(TaskKind::AbortSafe, handle);
+
+        let started = std::time::Instant::now();
+        let error = guard
+            .rollback_with_timeout(
+                anyhow::anyhow!("forced shutdown"),
+                Duration::from_millis(100),
+            )
+            .await;
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(format!("{error:#}").contains("forced shutdown"));
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert_eq!(output.metrics().events_written.load(Ordering::SeqCst), 0);
+        drop(read_fd);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disk_pipeline_wal_barrier_remains_must_join_past_ten_seconds() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let reservation = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let addr = reservation.local_addr().unwrap();
+        drop(reservation);
+        let wal = dir.path().join("queue");
+        let config = compiled_config(&format!(
+            r#"
+control {{ socket {:?} }}
+def input source {{ type syslog_udp bind "{addr}" }}
+def output sink {{
+    type file
+    path {:?}
+    queue {{ type disk path {:?} max_size "1MB" }}
+}}
+def pipeline p {{ input source; output sink }}
+"#,
+            dir.path().join("control.sock"),
+            dir.path().join("delivered.log"),
+            wal,
+        ));
+        let barrier = queue::TestWalBarrier::new();
+        let completions = Arc::new(StartupTaskCompletionObserver::default());
+        let runtime = STARTUP_TASK_COMPLETIONS
+            .scope(
+                Arc::clone(&completions),
+                queue::with_test_wal_barrier(
+                    Arc::clone(&barrier),
+                    Runtime::start(config, dir.path().join("wal-barrier.limpid")),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let sender = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        sender.send_to(b"<13>wal-exact", addr).unwrap();
+        barrier.wait_reached().await;
+
+        let shutdown = tokio::spawn(runtime.shutdown());
+        while completions.output_queues.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(Duration::from_secs(10)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !shutdown.is_finished(),
+            "WAL producer must remain MustJoin after 10s"
+        );
+
+        barrier.release();
+        shutdown.await.unwrap();
+
+        let (_sender, mut receiver) = queue::create_queue(
+            "wal-proof".to_string(),
+            QueueConfig {
+                queue_type: QueueType::Disk {
+                    path: wal.to_string_lossy().into_owned(),
+                    max_size: 1024 * 1024,
+                },
+                capacity: 1,
+            },
+        )
+        .unwrap();
+        let (persisted, _) = receiver
+            .recv()
+            .await
+            .expect("released WAL write must persist");
+        assert_eq!(&persisted.egress[..], b"<13>wal-exact");
+        assert!(
+            receiver.try_recv().is_none(),
+            "WAL barrier must persist exactly once"
+        );
+    }
+
+    fn batched_output_only_config(name: &str, control_socket: &Path) -> CompiledConfig {
+        compiled_config(&format!(
+            r#"
+control {{ socket {control_socket:?} }}
+def output {name} {{
+    type http
+    peer {{ url "http://127.0.0.1:1/" }}
+    batch_size 100
+}}
+"#
+        ))
+    }
+
+    #[tokio::test]
+    async fn post_output_preactivation_error_shuts_real_batched_actor_once() {
+        let output_name = "preactivation_error_batched";
+        let observer = crate::modules::output::batched::observe_shutdown_for_testing(output_name);
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(
+            dir.path(),
+            <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o700),
+        )
+        .unwrap();
+        let reached = Arc::new(tokio::sync::Notify::new());
+        let result = POST_OUTPUT_PREACTIVATION_FAILURE
+            .scope(
+                std::cell::RefCell::new(Some(PostOutputFailure {
+                    mode: PostOutputFailureMode::Error,
+                    reached,
+                    enqueue_probe: true,
+                })),
+                Runtime::start(
+                    batched_output_only_config(output_name, &dir.path().join("control.sock")),
+                    PathBuf::from("preactivation-error.limpid"),
+                ),
+            )
+            .await;
+        let error = match result {
+            Ok(runtime) => {
+                runtime.shutdown().await;
+                panic!("failpoint must reject startup");
+            }
+            Err(error) => error,
+        };
+        assert!(
+            format!("{error:#}").contains("post-output preactivation failure"),
+            "{error:#}"
+        );
+        tokio::time::timeout(Duration::from_secs(2), observer.wait_for_completion())
+            .await
+            .expect("real batched output shutdown must complete");
+        assert_eq!(observer.calls(), 1);
+        assert_eq!(observer.completions(), 1);
+        assert_eq!(observer.resolved_dispositions(), 1);
+    }
+
+    #[tokio::test]
+    async fn post_output_preactivation_cancellation_completes_guard_and_batched_actor_cleanup() {
+        let output_name = "preactivation_cancel_batched";
+        let observer = crate::modules::output::batched::observe_shutdown_for_testing(output_name);
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(
+            dir.path(),
+            <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o700),
+        )
+        .unwrap();
+        let reached = Arc::new(tokio::sync::Notify::new());
+        let reached_for_task = Arc::clone(&reached);
+        let cleanup_observer = Arc::new(DropCleanupObserver::default());
+        let startup = tokio::spawn(DROP_CLEANUP_RESULT.scope(
+            Arc::clone(&cleanup_observer),
+            POST_OUTPUT_PREACTIVATION_FAILURE.scope(
+                std::cell::RefCell::new(Some(PostOutputFailure {
+                    mode: PostOutputFailureMode::Park,
+                    reached: reached_for_task,
+                    enqueue_probe: true,
+                })),
+                Runtime::start(
+                    batched_output_only_config(output_name, &dir.path().join("control.sock")),
+                    PathBuf::from("preactivation-cancel.limpid"),
+                ),
+            ),
+        ));
+
+        reached.notified().await;
+        startup.abort();
+        let cancellation = startup.await;
+        assert!(matches!(cancellation, Err(error) if error.is_cancelled()));
+        let cleanup = tokio::time::timeout(Duration::from_secs(2), cleanup_observer.wait())
+            .await
+            .expect("drop fallback cleanup must finish");
+        assert_eq!(cleanup.abort_safe_incomplete, 0);
+        tokio::time::timeout(Duration::from_secs(2), observer.wait_for_completion())
+            .await
+            .expect("real batched output actor must complete after cancellation");
+        assert_eq!(observer.calls(), 1);
+        assert_eq!(observer.completions(), 1);
+        assert_eq!(observer.resolved_dispositions(), 1);
+    }
+
     #[cfg(unix)]
     fn write_ltp_test_identity(path: &Path) -> String {
         use base64::Engine as _;
@@ -1156,6 +2321,103 @@ mod tests {
         let mut spki = crate::ltp::ED25519_SPKI_PREFIX.to_vec();
         spki.extend_from_slice(pair.public_key().as_ref());
         base64::engine::general_purpose::STANDARD.encode(spki)
+    }
+
+    #[cfg(unix)]
+    async fn assert_late_failure_scenario() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let node_key = dir.path().join("node.pem");
+        let peer_key = dir.path().join("peer.pem");
+        let _node_spki = write_ltp_test_identity(&node_key);
+        let peer_spki = write_ltp_test_identity(&peer_key);
+        let reservation = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let bind = reservation.local_addr().unwrap();
+        drop(reservation);
+        let control_socket = dir.path().join("control.sock");
+        let delivered = dir.path().join("delivered.log");
+        let source = format!(
+            r#"
+node_id "node"
+node_key {node_key:?}
+control {{ socket {control_socket:?} }}
+def input inbound {{
+    type ltp
+    bind "{bind}"
+    peer {{ node_id "peer" pubkey {peer_spki:?} }}
+}}
+def output delivered {{ type file path {delivered:?} }}
+def pipeline receive {{ input inbound; output delivered }}
+"#,
+        );
+
+        // Establish and stop the old runtime first: this is the reload shape
+        // whose same-port restoration must remain possible after a candidate
+        // fails late in startup.
+        let old = Runtime::start(compiled_config(&source), dir.path().join("old.limpid"))
+            .await
+            .unwrap();
+        old.shutdown().await;
+
+        let completions = Arc::new(StartupTaskCompletionObserver::default());
+        let candidate = STARTUP_TASK_COMPLETIONS
+            .scope(
+                Arc::clone(&completions),
+                LATE_POST_LISTENER_FAILURE.scope(
+                    std::cell::Cell::new(true),
+                    Runtime::start(
+                        compiled_config(&source),
+                        dir.path().join("candidate.limpid"),
+                    ),
+                ),
+            )
+            .await;
+        let error = match candidate {
+            Ok(runtime) => {
+                runtime.shutdown().await;
+                panic!("late failpoint must reject candidate");
+            }
+            Err(error) => error,
+        };
+        let chain = format!("{error:#}");
+        assert!(
+            chain.contains("late post-listener startup failure"),
+            "{chain}"
+        );
+        assert!(chain.contains("rolled back all started tasks"), "{chain}");
+        assert_eq!(completions.output_queues.load(Ordering::SeqCst), 1);
+        assert_eq!(completions.pipelines.load(Ordering::SeqCst), 1);
+
+        let probe = std::net::TcpListener::bind(bind)
+            .expect("candidate rollback must release the real LTP listener immediately");
+        drop(probe);
+
+        let restored = Runtime::start(compiled_config(&source), dir.path().join("restored.limpid"))
+            .await
+            .expect("old runtime must restore on the same port after candidate rollback");
+        restored.shutdown().await;
+        std::net::TcpListener::bind(bind)
+            .expect("normal shutdown must leave no orphan listener or runtime task");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn late_post_listener_failure_rolls_back_all_started_tasks() {
+        assert_late_failure_scenario().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_candidate_releases_same_port_before_old_restore() {
+        assert_late_failure_scenario().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn startup_error_leaves_no_orphan_socket_or_task() {
+        assert_late_failure_scenario().await;
     }
 
     #[cfg(unix)]
@@ -2311,8 +3573,19 @@ def pipeline p { process a }
 
     #[tokio::test]
     async fn startup_preserves_metric_registration_errors_from_real_factories() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(
+            dir.path(),
+            <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o700),
+        )
+        .unwrap();
         let config = CompiledConfig::from_config(
-            parse_config("def output conflicting { type stdout }").expect("parse"),
+            parse_config(&format!(
+                "control {{ socket {:?} }} def output conflicting {{ type stdout }}",
+                dir.path().join("control.sock")
+            ))
+            .expect("parse"),
         )
         .expect("compile");
         let registry = Arc::new(Registry::new());
@@ -2357,6 +3630,140 @@ def pipeline p { process a }
             .await
             .expect("public start must use the working registry-wired startup path");
         runtime.shutdown().await;
+    }
+
+    fn listener_startup_config(
+        input_body: &str,
+        control_socket: &Path,
+        output_path: &Path,
+    ) -> CompiledConfig {
+        compiled_config(&format!(
+            r#"
+control {{ socket {control_socket:?} }}
+def input source {{ {input_body} }}
+def output sink {{ type file path {output_path:?} }}
+def pipeline p {{ input source; output sink }}
+"#
+        ))
+    }
+
+    async fn runtime_start_error(config: CompiledConfig, path: PathBuf) -> anyhow::Error {
+        match Runtime::start(config, path).await {
+            Ok(runtime) => {
+                runtime.shutdown().await;
+                panic!("runtime startup unexpectedly succeeded")
+            }
+            Err(error) => error,
+        }
+    }
+
+    #[tokio::test]
+    async fn occupied_syslog_tcp_and_udp_fail_runtime_start_before_commit() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let tcp = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let tcp_addr = tcp.local_addr().unwrap();
+        let tcp_error = runtime_start_error(
+            listener_startup_config(
+                &format!("type syslog_tcp bind \"{tcp_addr}\""),
+                &dir.path().join("tcp-control.sock"),
+                &dir.path().join("tcp.log"),
+            ),
+            dir.path().join("tcp.limpid"),
+        )
+        .await;
+        assert!(format!("{tcp_error:#}").contains("failed to start input 'source'"));
+
+        let udp = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let udp_addr = udp.local_addr().unwrap();
+        let udp_error = runtime_start_error(
+            listener_startup_config(
+                &format!("type syslog_udp bind \"{udp_addr}\""),
+                &dir.path().join("udp-control.sock"),
+                &dir.path().join("udp.log"),
+            ),
+            dir.path().join("udp.limpid"),
+        )
+        .await;
+        assert!(format!("{udp_error:#}").contains("failed to start input 'source'"));
+    }
+
+    #[tokio::test]
+    async fn invalid_syslog_tls_and_unix_bind_fail_runtime_start_before_commit() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let tls_body = format!(
+            "type syslog_tcp bind \"127.0.0.1:0\" tls {{ cert {:?} key {:?} }}",
+            dir.path().join("missing-cert.pem"),
+            dir.path().join("missing-key.pem")
+        );
+        let tls_error = runtime_start_error(
+            listener_startup_config(
+                &tls_body,
+                &dir.path().join("tls-control.sock"),
+                &dir.path().join("tls.log"),
+            ),
+            dir.path().join("tls.limpid"),
+        )
+        .await;
+        assert!(format!("{tls_error:#}").contains("failed to start input 'source'"));
+
+        let long_name = "s".repeat(140);
+        let unix_path = dir.path().join(long_name);
+        let unix_error = runtime_start_error(
+            listener_startup_config(
+                &format!("type unix_socket path {unix_path:?}"),
+                &dir.path().join("unix-control.sock"),
+                &dir.path().join("unix.log"),
+            ),
+            dir.path().join("unix.limpid"),
+        )
+        .await;
+        assert!(format!("{unix_error:#}").contains("failed to start input 'source'"));
+        assert!(!unix_path.exists());
+    }
+
+    #[tokio::test]
+    async fn control_bind_failure_rolls_back_started_resources() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let control_path = dir.path().join("c".repeat(140));
+        let config = compiled_config(&format!(
+            "control {{ socket {control_path:?} }} def output sink {{ type file path {:?} }}",
+            dir.path().join("sink.log")
+        ));
+        let error = runtime_start_error(config, dir.path().join("control-fail.limpid")).await;
+        assert!(format!("{error:#}").contains("failed to bind"));
+        assert!(!control_path.exists());
+    }
+
+    #[tokio::test]
+    async fn occupied_control_socket_rejects_start_and_preserves_active_owner() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let control_path = dir.path().join("control.sock");
+        let active = std::os::unix::net::UnixListener::bind(&control_path).unwrap();
+        let config = compiled_config(&format!(
+            "control {{ socket {control_path:?} }} def output sink {{ type file path {:?} }}",
+            dir.path().join("sink.log")
+        ));
+
+        let error = runtime_start_error(config, dir.path().join("occupied-control.limpid")).await;
+        assert!(format!("{error:#}").contains("active listener"));
+        std::os::unix::net::UnixStream::connect(&control_path)
+            .expect("failed startup must not unlink the active owner's socket");
+
+        drop(active);
+        std::fs::remove_file(&control_path).unwrap();
+        let rebound = std::os::unix::net::UnixListener::bind(&control_path)
+            .expect("failed startup must permit immediate same-resource rebind");
+        drop(rebound);
     }
 
     async fn assert_startup_build_info(
@@ -2995,5 +4402,121 @@ def pipeline p { process a }
             !body.contains("event_rx.try_recv()"),
             "pipeline worker shutdown must not use try_recv() — permit-holder race",
         );
+    }
+
+    #[test]
+    fn startup_is_guarded_until_all_listener_handles_are_registered() {
+        let src = include_str!("runtime.rs");
+        assert!(src.contains(&["struct Startup", "Guard"].concat()));
+        assert!(src.contains(&["startup_guard.", "commit"].concat()));
+        assert!(src.contains(&["late_post_listener", "_failure"].concat()));
+    }
+
+    #[test]
+    fn startup_transaction_mutant_sensitivity() {
+        let src = include_str!("runtime.rs");
+        let production = &src[..src.find("#[cfg(test)]\nmod tests").unwrap()];
+        let guard = production.find("StartupGuard::new").unwrap();
+        assert!(
+            production.find("validate_control_socket_parent").unwrap() < guard,
+            "control validation must stay before the first guarded task spawn",
+        );
+        assert!(
+            production
+                .find("PipelineWorker::new_with_process_metrics")
+                .unwrap()
+                < guard,
+            "pipeline/process-metric planning must stay pre-spawn",
+        );
+        assert!(
+            production.find("input_queue_sizes.insert").unwrap() < guard,
+            "input existence and queue-size parsing must stay pre-spawn",
+        );
+        let output_factory = production.find(".create_output(").unwrap();
+        assert!(guard < output_factory, "guard must own output resources");
+        let output_consumer = production[output_factory..]
+            .find("startup_guard.track(")
+            .unwrap()
+            + output_factory;
+        let post_output_edge = production[output_consumer..]
+            .find("post_output_preactivation_failure(&mut sender)")
+            .unwrap()
+            + output_consumer;
+        assert!(output_factory < output_consumer && output_consumer < post_output_edge);
+        assert!(production[output_consumer..post_output_edge].contains("output_task_kind"));
+        let listeners = production.find("start_listener_groups").unwrap();
+        let failpoint = production.rfind("late_post_listener_failure()").unwrap();
+        let commit = production.rfind("startup_guard.commit()").unwrap();
+        assert!(listeners < failpoint && failpoint < commit);
+        let rollback = production.find("async fn rollback").unwrap();
+        let rollback_body = &production[rollback..production.find("fn commit").unwrap()];
+        assert!(rollback_body.contains("shutdown_tasks"));
+        assert!(!rollback_body.contains(".abort()"));
+        let cleanup = &production[production.find("shutdown_tasks_with_timeout").unwrap()..guard];
+        assert!(cleanup.contains("task.handle = None"));
+        assert!(cleanup.contains("task.handle.take()"));
+        assert!(cleanup.contains("graceful_deadline"));
+        assert!(cleanup.contains("overall_deadline"));
+        assert!(cleanup.contains("TaskKind::AbortSafe"));
+        assert!(cleanup.contains("TaskKind::MustJoin"));
+        assert!(cleanup.contains("Await every remaining owner before returning"));
+    }
+
+    #[tokio::test]
+    async fn closed_shutdown_watch_is_terminal_for_pipeline_worker() {
+        let (sender, mut receiver) = watch::channel(false);
+        drop(sender);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                shutdown_change_is_terminal(&mut receiver),
+            )
+            .await
+            .expect("closed watch must resolve without spinning")
+        );
+        let marker = ["shutdown_change_is_terminal", "(&mut shutdown)"].concat();
+        assert!(include_str!("runtime.rs").contains(&marker));
+    }
+
+    #[tokio::test]
+    async fn closed_pipeline_watch_drains_already_queued_event_before_exit() {
+        let registry = Registry::new();
+        let worker = Arc::new(
+            PipelineWorker::new(
+                pipeline_def("def pipeline p { input i; finish }"),
+                &registry,
+            )
+            .unwrap(),
+        );
+        let workers = vec![Arc::clone(&worker)];
+        let ctx = PipelineContext {
+            output_senders: Arc::new(HashMap::new()),
+            disk_outputs: Arc::new(HashSet::new()),
+            config: Arc::new(compiled_config("")),
+            funcs: Arc::new(FunctionRegistry::new()),
+            tap: TapRegistry::new(),
+            error_log: None,
+            error_log_fallback: crate::error_log::ErrorLogFallback::default(),
+        };
+        let (event_tx, event_rx) = mpsc::channel(1);
+        event_tx
+            .send(Event::new(
+                Bytes::from_static(b"queued-before-watch-close"),
+                "127.0.0.1:1".parse().unwrap(),
+            ))
+            .await
+            .unwrap();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        drop(shutdown_tx);
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            run_pipeline_workers(event_rx, &workers, &ctx, "i", shutdown_rx),
+        )
+        .await
+        .expect("closed watch must terminate after draining the input channel");
+        assert_eq!(worker.metrics.events_received.load(Ordering::Relaxed), 1);
+        assert_eq!(worker.metrics.events_discarded.load(Ordering::Relaxed), 1);
+        assert!(event_tx.is_closed());
     }
 }


### PR DESCRIPTION
## Summary

- Make Runtime startup transactional through real input/control readiness and rollback all tracked resources on startup failure or cancellation.
- Separate cancel-safe tasks from durable MustJoin owners so stdout/network obey bounded abort while file, WAL, DLQ, and journal work is never detached.
- Replace blocking stdout worker writes with serialized nonblocking AsyncFd transport while preserving regular-file redirection, shutdown drain, exact acknowledgements, and retryable initialization.

## Validation

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- Linux Rust 1.95: cargo test --workspace --all-targets --all-features
- Linux Rust 1.95: cargo clippy --workspace --all-targets --all-features -- -D warnings
- Occupied input/control readiness rollback and same-port restore
- Journal closed-watch reader join
- Disk WAL MustJoin barrier and exact persistence
- Writable/full-pipe stdout shutdown behavior
- Regular-file stdout subprocess and concurrent shared-fd initialization
- Independent review: CLEAN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated startup checks so listeners and inputs report readiness before the pipeline begins.
  - Improved output handling for pipes, terminals, and files, including serialized writes and partial-write recovery.
  - Added safer stale socket detection and cleanup.

- **Bug Fixes**
  - Shutdown now completes reliably when control signals are closed or interrupted.
  - Startup failures clean up resources consistently and provide clearer errors.
  - Runtime and server failures are surfaced instead of being silently logged.
  - Failed events are routed to the dead-letter queue with updated metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->