### PR TITLE
fix(journal): follow rotations

### DIFF
--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -442,6 +442,8 @@ fn collect_entry_fields(journal: &mut Journal) -> Result<JsonMap<String, JsonVal
     Ok(map)
 }
 
+const JOURNAL_SHUTDOWN_QUANTUM: Duration = Duration::from_millis(100);
+
 /// Sleep up to `total` but wake early when `shutdown` is set.
 ///
 /// The journal reader's idle path used to be a plain
@@ -452,16 +454,32 @@ fn collect_entry_fields(journal: &mut Journal) -> Result<JsonMap<String, JsonVal
 /// in small quanta and re-checking the flag bounds shutdown latency
 /// to roughly one quantum regardless of `poll_interval`.
 fn interruptible_sleep(shutdown: &AtomicBool, total: Duration) {
-    const QUANTUM: Duration = Duration::from_millis(100);
     let mut remaining = total;
     while remaining > Duration::ZERO {
         if shutdown.load(Ordering::Relaxed) {
             return;
         }
-        let nap = remaining.min(QUANTUM);
+        let nap = remaining.min(JOURNAL_SHUTDOWN_QUANTUM);
         std::thread::sleep(nap);
         remaining = remaining.saturating_sub(nap);
     }
+}
+
+/// Back off after an immediate `sd_journal_wait` failure.
+///
+/// Positive configured intervals retain their exact behavior. Only
+/// zero is raised to the existing shutdown quantum so a persistent
+/// libsystemd error cannot busy-spin while shutdown remains bounded.
+fn backoff_after_journal_wait_error<F>(shutdown: &AtomicBool, poll_interval: Duration, sleep: F)
+where
+    F: FnOnce(&AtomicBool, Duration),
+{
+    let delay = if poll_interval.is_zero() {
+        JOURNAL_SHUTDOWN_QUANTUM
+    } else {
+        poll_interval
+    };
+    sleep(shutdown, delay);
 }
 
 /// Wait for journal change notification without letting libsystemd
@@ -644,7 +662,11 @@ fn run_journal_reader(
                         warn!("journal: wait error: {}", e);
                         // A persistent libsystemd error must not turn
                         // the reader into a busy loop.
-                        interruptible_sleep(&shutdown, poll_interval);
+                        backoff_after_journal_wait_error(
+                            &shutdown,
+                            poll_interval,
+                            interruptible_sleep,
+                        );
                     }
                 }
             }
@@ -806,6 +828,31 @@ mod tests {
                 .to_string()
                 .contains("synthetic sd_journal_wait failure")
         );
+    }
+
+    #[test]
+    fn journal_wait_error_backoff_clamps_only_zero_across_immediate_retries() {
+        let shutdown = AtomicBool::new(false);
+        let mut observed = Vec::new();
+
+        // Model repeated sd_journal_wait failures that return without
+        // blocking. Every retry must still request a real delay; a
+        // Duration::ZERO mutant makes all four observations zero.
+        for _ in 0..4 {
+            backoff_after_journal_wait_error(&shutdown, Duration::ZERO, |_, delay| {
+                observed.push(delay);
+            });
+        }
+        assert_eq!(observed, vec![Duration::from_millis(100); 4]);
+
+        // Existing positive configuration is authoritative and must
+        // pass through byte-for-byte rather than being rounded to the
+        // error floor.
+        let configured = Duration::from_micros(37);
+        backoff_after_journal_wait_error(&shutdown, configured, |_, delay| {
+            observed.push(delay);
+        });
+        assert_eq!(observed.last(), Some(&configured));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/limpid/src/modules/input/journal.rs
+++ b/crates/limpid/src/modules/input/journal.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use super::journal_sys::Journal;
+use super::journal_sys::{Journal, JournalWaitResult};
 use anyhow::Result;
 
 async fn shutdown_change_is_terminal(shutdown: &mut tokio::sync::watch::Receiver<bool>) -> bool {
@@ -464,6 +464,34 @@ fn interruptible_sleep(shutdown: &AtomicBool, total: Duration) {
     }
 }
 
+/// Wait for journal change notification without letting libsystemd
+/// hide the reader from shutdown for longer than one sleep quantum.
+/// Returning `None` means shutdown was already requested and the
+/// caller should leave the reader loop without entering the wait.
+fn wait_for_journal_change<F>(
+    shutdown: &AtomicBool,
+    poll_interval: Duration,
+    wait: F,
+) -> Result<Option<JournalWaitResult>>
+where
+    F: FnOnce(u64) -> Result<JournalWaitResult>,
+{
+    const MAX_WAIT: Duration = Duration::from_millis(100);
+    const MIN_WAIT: Duration = Duration::from_micros(1);
+
+    if shutdown.load(Ordering::Relaxed) {
+        return Ok(None);
+    }
+
+    // The historical idle sleep checked shutdown every 100 ms. Keep
+    // that bound while using libsystemd's canonical change processing
+    // path. A zero poll interval is raised to one microsecond so a
+    // misconfigured reader cannot turn EOF into a pure userspace loop.
+    let timeout = poll_interval.min(MAX_WAIT).max(MIN_WAIT);
+    let timeout_usec = u64::try_from(timeout.as_micros()).expect("bounded timeout fits in u64");
+    wait(timeout_usec).map(Some)
+}
+
 /// Synchronous journal reader running in a blocking thread.
 fn run_journal_reader(
     matches: Vec<String>,
@@ -600,8 +628,25 @@ fn run_journal_reader(
                 }
             }
             Ok(_) => {
-                // No more entries, wait
-                interruptible_sleep(&shutdown, poll_interval);
+                // At EOF, libsystemd must process its inotify state so
+                // APPEND and, critically, rotation INVALIDATE events
+                // refresh this same long-lived handle's file set.
+                match wait_for_journal_change(&shutdown, poll_interval, |timeout_usec| {
+                    journal.wait(timeout_usec)
+                }) {
+                    Ok(Some(
+                        JournalWaitResult::Nop
+                        | JournalWaitResult::Append
+                        | JournalWaitResult::Invalidate,
+                    )) => {}
+                    Ok(None) => break,
+                    Err(e) => {
+                        warn!("journal: wait error: {}", e);
+                        // A persistent libsystemd error must not turn
+                        // the reader into a busy loop.
+                        interruptible_sleep(&shutdown, poll_interval);
+                    }
+                }
             }
             Err(e) => {
                 warn!("journal: read error: {}", e);
@@ -708,8 +753,143 @@ fn save_cursor(path: &PathBuf, cursor: &str) {
 
 #[cfg(test)]
 mod tests {
+    use super::super::journal_sys::JournalWaitResult;
     use super::*;
     use std::time::Instant;
+
+    #[test]
+    fn journal_wait_timeout_is_bounded_and_nop_is_preserved() {
+        let shutdown = AtomicBool::new(false);
+        let mut observed_timeout = None;
+        let result = wait_for_journal_change(&shutdown, Duration::from_secs(30), |timeout_usec| {
+            observed_timeout = Some(timeout_usec);
+            Ok(JournalWaitResult::Nop)
+        })
+        .unwrap();
+
+        assert_eq!(result, Some(JournalWaitResult::Nop));
+        assert_eq!(observed_timeout, Some(100_000));
+    }
+
+    #[test]
+    fn journal_wait_skips_blocking_call_after_shutdown() {
+        let shutdown = AtomicBool::new(true);
+        let result = wait_for_journal_change(&shutdown, Duration::from_secs(30), |_| {
+            panic!("shutdown must be checked before entering sd_journal_wait")
+        })
+        .unwrap();
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn journal_wait_preserves_append_and_invalidate_notifications() {
+        let shutdown = AtomicBool::new(false);
+        for expected in [JournalWaitResult::Append, JournalWaitResult::Invalidate] {
+            let result =
+                wait_for_journal_change(&shutdown, Duration::from_secs(1), |_| Ok(expected))
+                    .unwrap();
+            assert_eq!(result, Some(expected));
+        }
+    }
+
+    #[test]
+    fn journal_wait_propagates_libsystemd_errors() {
+        let shutdown = AtomicBool::new(false);
+        let error = wait_for_journal_change(&shutdown, Duration::from_secs(1), |_| {
+            anyhow::bail!("synthetic sd_journal_wait failure")
+        })
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("synthetic sd_journal_wait failure")
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "mutates the host journal; run explicitly on the controlled Linux builder"]
+    fn long_lived_reader_follows_journal_rotation_without_restart() {
+        use std::process::Command;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let identifier = format!("limpid-rotation-test-{}-{nonce}", std::process::id());
+        let before = format!("before-rotation-{nonce}");
+        let after = format!("after-rotation-{nonce}");
+
+        let (entry_tx, mut entry_rx) = tokio::sync::mpsc::channel(8);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let reader_shutdown = Arc::clone(&shutdown);
+        let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+        let reader_identifier = identifier.clone();
+        let reader = std::thread::spawn(move || {
+            run_journal_reader(
+                vec![format!("SYSLOG_IDENTIFIER={reader_identifier}")],
+                None,
+                Duration::from_secs(2),
+                entry_tx,
+                reader_shutdown,
+                startup_tx,
+            );
+        });
+
+        assert_eq!(startup_rx.blocking_recv().unwrap(), Ok(()));
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+
+        let emit = |message: &str| {
+            let status = Command::new("logger")
+                .args(["-t", &identifier, message])
+                .status()
+                .expect("logger must be installed on the controlled builder");
+            assert!(status.success(), "logger failed with {status}");
+        };
+        let receive = |rx: &mut tokio::sync::mpsc::Receiver<(Vec<u8>, String)>, expected: &str| {
+            runtime
+                .block_on(async { tokio::time::timeout(Duration::from_secs(10), rx.recv()).await })
+                .unwrap_or_else(|_| {
+                    panic!("reader timed out waiting for controlled journal entry: {expected}")
+                })
+                .expect("reader channel closed unexpectedly")
+        };
+
+        emit(&before);
+        let (before_bytes, before_cursor) = receive(&mut entry_rx, "before rotation");
+        assert!(
+            String::from_utf8_lossy(&before_bytes).contains(&before),
+            "pre-rotation entry must be consumed"
+        );
+
+        let rotate = Command::new("sudo")
+            .args(["-n", "journalctl", "--rotate"])
+            .status()
+            .expect("sudo and journalctl must be installed on the controlled builder");
+        assert!(rotate.success(), "journalctl --rotate failed with {rotate}");
+
+        emit(&after);
+        let (after_bytes, after_cursor) = receive(&mut entry_rx, "after rotation");
+        assert!(
+            String::from_utf8_lossy(&after_bytes).contains(&after),
+            "same reader must consume the post-rotation entry"
+        );
+        assert_ne!(
+            before_cursor, after_cursor,
+            "the long-lived reader cursor must advance across rotation"
+        );
+
+        shutdown.store(true, Ordering::Relaxed);
+        reader
+            .join()
+            .expect("journal reader must stop cooperatively");
+    }
 
     #[test]
     fn interruptible_sleep_returns_promptly_when_flag_set_before_call() {

--- a/crates/limpid/src/modules/input/journal_sys.rs
+++ b/crates/limpid/src/modules/input/journal_sys.rs
@@ -24,6 +24,10 @@ use std::ptr;
 
 use anyhow::{Result, bail};
 
+const SD_JOURNAL_NOP: c_int = 0;
+const SD_JOURNAL_APPEND: c_int = 1;
+const SD_JOURNAL_INVALIDATE: c_int = 2;
+
 /// Opaque `sd_journal` handle. Only ever touched behind a pointer —
 /// its layout is libsystemd's business, not ours.
 #[repr(C)]
@@ -35,6 +39,7 @@ unsafe extern "C" {
     fn sd_journal_open(ret: *mut *mut SdJournal, flags: c_int) -> c_int;
     fn sd_journal_close(j: *mut SdJournal);
     fn sd_journal_next(j: *mut SdJournal) -> c_int;
+    fn sd_journal_wait(j: *mut SdJournal, timeout_usec: u64) -> c_int;
     fn sd_journal_previous(j: *mut SdJournal) -> c_int;
     fn sd_journal_add_match(j: *mut SdJournal, data: *const c_void, size: usize) -> c_int;
     fn sd_journal_seek_tail(j: *mut SdJournal) -> c_int;
@@ -93,6 +98,16 @@ impl<'a> JournalField<'a> {
 
 pub struct Journal {
     ptr: *mut SdJournal,
+}
+
+/// Change classification returned by `sd_journal_wait` (and
+/// `sd_journal_process`). `Invalidate` includes journal rotation and
+/// vacuuming; callers must re-check the same handle with `next()`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JournalWaitResult {
+    Nop,
+    Append,
+    Invalidate,
 }
 
 impl Journal {
@@ -159,6 +174,17 @@ impl Journal {
             bail!("sd_journal_next failed: {}", errno_msg(rc));
         }
         Ok(rc)
+    }
+
+    /// Wait for journal changes for at most `timeout_usec` microseconds.
+    ///
+    /// `sd_journal_wait` performs the required `sd_journal_process`
+    /// step internally and returns its `NOP` / `APPEND` / `INVALIDATE`
+    /// classification. In particular, `INVALIDATE` is the rotation
+    /// signal that makes a long-lived handle notice the new active file.
+    pub fn wait(&mut self, timeout_usec: u64) -> Result<JournalWaitResult> {
+        let rc = unsafe { sd_journal_wait(self.ptr, timeout_usec) };
+        classify_wait_result(rc)
     }
 
     pub fn previous(&mut self) -> Result<c_int> {
@@ -251,4 +277,35 @@ impl Drop for Journal {
 /// negative errno-style code on failure (`sd-journal(3)`).
 fn errno_msg(rc: c_int) -> String {
     std::io::Error::from_raw_os_error(-rc).to_string()
+}
+
+fn classify_wait_result(rc: c_int) -> Result<JournalWaitResult> {
+    match rc {
+        SD_JOURNAL_NOP => Ok(JournalWaitResult::Nop),
+        SD_JOURNAL_APPEND => Ok(JournalWaitResult::Append),
+        SD_JOURNAL_INVALIDATE => Ok(JournalWaitResult::Invalidate),
+        rc if rc < 0 => bail!("sd_journal_wait failed: {}", errno_msg(rc)),
+        rc => bail!("sd_journal_wait returned unexpected result: {rc}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_result_constants_match_the_sd_journal_contract() {
+        assert_eq!(classify_wait_result(0).unwrap(), JournalWaitResult::Nop);
+        assert_eq!(classify_wait_result(1).unwrap(), JournalWaitResult::Append);
+        assert_eq!(
+            classify_wait_result(2).unwrap(),
+            JournalWaitResult::Invalidate
+        );
+    }
+
+    #[test]
+    fn wait_result_rejects_errno_and_unknown_positive_values() {
+        assert!(classify_wait_result(-libc::EIO).is_err());
+        assert!(classify_wait_result(3).is_err());
+    }
 }


### PR DESCRIPTION
## Summary

- Follow journal rotations on the same sd-journal handle by waiting at EOF and processing SD_JOURNAL_APPEND and SD_JOURNAL_INVALIDATE notifications.
- Preserve cursor resume and skip behavior, match filters, first-start semantics, and bounded shutdown without an EOF busy loop.
- Bind the canonical sd_journal_wait path and cover timeout, shutdown, notification, and error results.

## Validation

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- Linux Rust 1.95: cargo test --workspace --all-targets --all-features
- Linux Rust 1.95: cargo clippy --workspace --all-targets --all-features -- -D warnings
- Linux controlled journal rotation: consume a pre-rotation entry, rotate, append a post-rotation entry, and advance the cursor with the same long-lived reader
- Focused sd-journal wait tests for timeout, shutdown, APPEND, INVALIDATE, and error results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved journal monitoring reliability when entries are appended or the journal is rotated.
  * Added bounded waiting and shutdown checks to prevent prolonged blocking.
  * Added fallback handling for persistent wait errors while remaining interruptible.
  * Improved handling of journal notifications and invalid wait results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->