### PR TITLE
fix(check): respect csv_parse resolution

### DIFF
--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -529,7 +529,7 @@ pub(super) fn analyze_process_stmt(
                         namespace,
                         name,
                         args,
-                        block_arg: _,
+                        block_arg,
                     },
                 ..
             },
@@ -541,13 +541,15 @@ pub(super) fn analyze_process_stmt(
             // separate arg-only pass — `check_types(call, …)` already
             // walks `args`.
             expr_types::check_types(call, pipeline_name, bindings, registry, None, diagnostics);
-            parser_effects::apply_parser_effects(
-                namespace.as_deref(),
-                name,
-                args,
-                registry,
-                bindings,
-            );
+            if block_arg.is_none() {
+                parser_effects::apply_parser_effects(
+                    namespace.as_deref(),
+                    name,
+                    args,
+                    registry,
+                    bindings,
+                );
+            }
         }
         ProcessStatement::ExprStmt(e) => {
             expr_types::check_types(e, pipeline_name, bindings, registry, None, diagnostics);
@@ -662,6 +664,55 @@ mod tests {
             assert_eq!(bindings.get_workspace(&path), Some(&nullable_string));
         }
         assert!(errors(&diags).is_empty(), "got: {diags:?}");
+    }
+
+    #[test]
+    fn block_form_csv_parse_does_not_merge_fields_into_workspace() {
+        let src = r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        csv_parse(ingress, ["host"]) { |value| value }
+        workspace.copy = workspace.host
+    }
+    output o
+}
+"#;
+
+        let cfg = parse_config(src).expect("config should parse");
+        let compiled = CompiledConfig::from_config(cfg).expect("compile");
+        let pipeline = compiled.pipelines.get("p").expect("pipeline p");
+        let stmt = pipeline
+            .body
+            .iter()
+            .find_map(|stmt| match stmt {
+                PipelineStatement::ProcessChain(elements) => {
+                    elements.iter().find_map(|element| match element {
+                        ProcessChainElement::Inline(statements) => statements.first(),
+                        ProcessChainElement::Named(_) => None,
+                    })
+                }
+                _ => None,
+            })
+            .expect("parsed inline process statement");
+        let ProcessStatement::ExprStmt(Expr {
+            kind: ExprKind::FuncCall { block_arg, .. },
+            ..
+        }) = stmt
+        else {
+            panic!("expected parsed block-form function call, got {stmt:?}");
+        };
+        assert!(block_arg.is_some(), "parser must retain the block argument");
+
+        let registry = registry();
+        let mut bindings = Bindings::new();
+        let mut diags = Vec::new();
+        analyze_process_stmt(stmt, "p", &registry, &mut bindings, &mut diags);
+
+        let host = vec!["workspace".to_string(), "host".to_string()];
+        assert_eq!(bindings.get_workspace(&host), None);
     }
 
     #[test]

--- a/crates/limpid/src/check/mod.rs
+++ b/crates/limpid/src/check/mod.rs
@@ -603,7 +603,27 @@ pub(super) fn analyze_process_stmt(
 mod tests {
     use super::*;
     use crate::dsl::parser::parse_config;
+    use crate::functions::table::TableStore;
     use crate::pipeline::CompiledConfig;
+
+    fn registry() -> FunctionRegistry {
+        let mut registry = FunctionRegistry::new();
+        let table_store = TableStore::from_configs(vec![]).unwrap();
+        crate::functions::register_builtins(&mut registry, table_store);
+        registry
+    }
+
+    fn csv_call(field_names: Expr) -> Expr {
+        Expr::spanless(ExprKind::FuncCall {
+            namespace: None,
+            name: "csv_parse".to_string(),
+            args: vec![
+                Expr::spanless(ExprKind::Ident(vec!["ingress".to_string()])),
+                field_names,
+            ],
+            block_arg: None,
+        })
+    }
 
     fn analyze_str(src: &str) -> Vec<Diagnostic> {
         let cfg = parse_config(src).expect("config should parse");
@@ -622,6 +642,52 @@ mod tests {
     }
 
     // ----- workspace produce / consume -----------------------------------
+
+    #[test]
+    fn bare_csv_parse_routes_literal_fields_through_process_analysis() {
+        let registry = registry();
+        let fields = Expr::spanless(ExprKind::ArrayLit(vec![
+            Expr::spanless(ExprKind::StringLit("host".to_string())),
+            Expr::spanless(ExprKind::StringLit("status".to_string())),
+        ]));
+        let stmt = ProcessStatement::ExprStmt(csv_call(fields));
+        let mut bindings = Bindings::new();
+        let mut diags = Vec::new();
+
+        analyze_process_stmt(&stmt, "p", &registry, &mut bindings, &mut diags);
+
+        let nullable_string = FieldType::union(FieldType::String, FieldType::Null);
+        for key in ["host", "status"] {
+            let path = vec!["workspace".to_string(), key.to_string()];
+            assert_eq!(bindings.get_workspace(&path), Some(&nullable_string));
+        }
+        assert!(errors(&diags).is_empty(), "got: {diags:?}");
+    }
+
+    #[test]
+    fn csv_parse_expression_result_does_not_merge_into_workspace() {
+        let registry = registry();
+        let fields = Expr::spanless(ExprKind::ArrayLit(vec![Expr::spanless(
+            ExprKind::StringLit("host".to_string()),
+        )]));
+        let stmt = ProcessStatement::Assign(
+            AssignTarget::Workspace(vec!["parsed".to_string()]),
+            csv_call(fields),
+        );
+        let mut bindings = Bindings::new();
+        let mut diags = Vec::new();
+
+        analyze_process_stmt(&stmt, "p", &registry, &mut bindings, &mut diags);
+
+        let parsed = vec!["workspace".to_string(), "parsed".to_string()];
+        let host = vec!["workspace".to_string(), "host".to_string()];
+        assert_eq!(
+            bindings.get_workspace(&parsed),
+            Some(&FieldType::union(FieldType::Object, FieldType::Null))
+        );
+        assert_eq!(bindings.get_workspace(&host), None);
+        assert!(errors(&diags).is_empty(), "got: {diags:?}");
+    }
 
     #[test]
     fn output_referencing_unproduced_workspace_key_errors() {

--- a/crates/limpid/src/check/parser_effects.rs
+++ b/crates/limpid/src/check/parser_effects.rs
@@ -21,6 +21,16 @@ pub(super) fn apply_parser_effects(
     registry: &FunctionRegistry,
     bindings: &mut Bindings,
 ) {
+    if namespace.is_none()
+        && name == "csv_parse"
+        && args.len() == 2
+        && !registry.is_user_function(name)
+        && registry.signature(None, name).is_some()
+    {
+        apply_csv_parse_effect(args, bindings);
+        return;
+    }
+
     let Some(info) = registry.parser(namespace, name) else {
         // Not a parser — nothing to merge into workspace. Side-effect-
         // only functions (`table_upsert`, `table_delete`) return Null
@@ -72,6 +82,42 @@ pub(super) fn apply_parser_effects(
     }
 }
 
+/// `csv_parse` derives its output keys from the literal `field_names`
+/// argument rather than a registry-level parser schema. Mirror only the
+/// names the DSL can address as `workspace.<ident>`; dynamic or malformed
+/// declarations remain unknown instead of widening workspace.
+fn apply_csv_parse_effect(args: &[Expr], bindings: &mut Bindings) {
+    let Some(Expr {
+        kind: ExprKind::ArrayLit(field_names),
+        ..
+    }) = args.get(1)
+    else {
+        return;
+    };
+
+    let nullable_string = FieldType::union(FieldType::String, FieldType::Null);
+    for field_name in field_names {
+        let ExprKind::StringLit(field_name) = &field_name.kind else {
+            continue;
+        };
+        if !is_dsl_identifier(field_name) {
+            continue;
+        }
+
+        let path = vec!["workspace".to_string(), field_name.clone()];
+        bindings.bind_workspace(&path, nullable_string.clone());
+    }
+}
+
+fn is_dsl_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
 /// Best-effort type from a literal-shaped expression. Used for
 /// HashLit defaults inference in parser calls; non-literal entries
 /// fall through to `Any`.
@@ -91,13 +137,24 @@ fn literal_type(e: &Expr) -> FieldType {
 mod tests {
     use super::*;
     use crate::dsl::ast::Expr;
+    use crate::dsl::parser::parse_config;
     use crate::functions::FunctionRegistry;
     use crate::functions::table::TableStore;
+    use crate::pipeline::CompiledConfig;
 
     fn registry() -> FunctionRegistry {
         let mut reg = FunctionRegistry::new();
         let table_store = TableStore::from_configs(vec![]).unwrap();
         crate::functions::register_builtins(&mut reg, table_store);
+        reg
+    }
+
+    fn shadowed_registry() -> FunctionRegistry {
+        let mut reg = registry();
+        let config = parse_config("def function csv_parse(text, names) { null }").unwrap();
+        let compiled = CompiledConfig::from_config(config).unwrap();
+        crate::functions::register_user_functions(&mut reg, &compiled);
+        assert!(reg.is_user_function("csv_parse"));
         reg
     }
 
@@ -117,8 +174,135 @@ mod tests {
         Expr::spanless(ExprKind::HashLit(owned))
     }
 
+    fn array(items: Vec<Expr>) -> Expr {
+        Expr::spanless(ExprKind::ArrayLit(items))
+    }
+
     fn ws(key: &str) -> Vec<String> {
         vec!["workspace".to_string(), key.to_string()]
+    }
+
+    #[test]
+    fn csv_parse_literal_field_names_bind_nullable_strings() {
+        let reg = registry();
+        let mut bindings = Bindings::new();
+        let args = vec![
+            ident("ingress"),
+            array(vec![string("host"), string("status")]),
+        ];
+
+        apply_parser_effects(None, "csv_parse", &args, &reg, &mut bindings);
+
+        let nullable_string = FieldType::union(FieldType::String, FieldType::Null);
+        assert_eq!(bindings.get_workspace(&ws("host")), Some(&nullable_string));
+        assert_eq!(
+            bindings.get_workspace(&ws("status")),
+            Some(&nullable_string)
+        );
+        assert!(!bindings.is_workspace_wildcard());
+    }
+
+    #[test]
+    fn csv_parse_literal_field_names_skip_unaddressable_entries() {
+        let reg = registry();
+        let mut bindings = Bindings::new();
+        let args = vec![
+            ident("ingress"),
+            array(vec![
+                string("first"),
+                string(""),
+                string("a.b"),
+                string("has space"),
+                string("1leading"),
+                Expr::spanless(ExprKind::IntLit(7)),
+                string("_last"),
+            ]),
+        ];
+
+        apply_parser_effects(None, "csv_parse", &args, &reg, &mut bindings);
+
+        let nullable_string = FieldType::union(FieldType::String, FieldType::Null);
+        assert_eq!(bindings.get_workspace(&ws("first")), Some(&nullable_string));
+        assert_eq!(bindings.get_workspace(&ws("_last")), Some(&nullable_string));
+        for skipped in ["", "a.b", "has space", "1leading"] {
+            assert_eq!(bindings.get_workspace(&ws(skipped)), None, "{skipped}");
+        }
+        assert!(!bindings.is_workspace_wildcard());
+    }
+
+    #[test]
+    fn csv_parse_dynamic_or_namespaced_fields_do_not_create_bindings() {
+        let reg = registry();
+
+        for (namespace, fields) in [
+            (None, ident("field_names")),
+            (None, string("not-an-array")),
+            (Some("custom"), array(vec![string("invented")])),
+        ] {
+            let mut bindings = Bindings::new();
+            let args = vec![ident("ingress"), fields];
+            apply_parser_effects(namespace, "csv_parse", &args, &reg, &mut bindings);
+            assert_eq!(bindings.get_workspace(&ws("invented")), None);
+            assert!(!bindings.is_workspace_wildcard());
+        }
+    }
+
+    #[test]
+    fn csv_parse_duplicate_names_keep_one_honest_binding() {
+        let reg = registry();
+        let mut bindings = Bindings::new();
+        let args = vec![
+            ident("ingress"),
+            array(vec![string("value"), string("value")]),
+        ];
+
+        apply_parser_effects(None, "csv_parse", &args, &reg, &mut bindings);
+
+        assert_eq!(
+            bindings.get_workspace(&ws("value")),
+            Some(&FieldType::union(FieldType::String, FieldType::Null))
+        );
+        assert_eq!(bindings.workspace_keys().count(), 1);
+    }
+
+    #[test]
+    fn user_csv_parse_shadow_does_not_fabricate_builtin_fields() {
+        let reg = shadowed_registry();
+        let mut bindings = Bindings::new();
+        let args = vec![ident("ingress"), array(vec![string("host")])];
+
+        apply_parser_effects(None, "csv_parse", &args, &reg, &mut bindings);
+
+        assert_eq!(bindings.get_workspace(&ws("host")), None);
+        assert!(!bindings.is_workspace_wildcard());
+    }
+
+    #[test]
+    fn csv_parse_requires_registered_builtin_and_exact_arity() {
+        let fields = array(vec![string("host")]);
+
+        let unregistered = FunctionRegistry::new();
+        let mut bindings = Bindings::new();
+        apply_parser_effects(
+            None,
+            "csv_parse",
+            &[ident("ingress"), fields.clone()],
+            &unregistered,
+            &mut bindings,
+        );
+        assert_eq!(bindings.get_workspace(&ws("host")), None);
+
+        let reg = registry();
+        for args in [
+            vec![],
+            vec![ident("ingress")],
+            vec![ident("ingress"), fields.clone(), string("extra")],
+        ] {
+            let mut bindings = Bindings::new();
+            apply_parser_effects(None, "csv_parse", &args, &reg, &mut bindings);
+            assert_eq!(bindings.get_workspace(&ws("host")), None, "{args:?}");
+            assert!(!bindings.is_workspace_wildcard());
+        }
     }
 
     // parse_kv 3-arg form: defaults sits at args[2]. The pre-fix

--- a/crates/limpid/src/functions/primitives/csv_parse.rs
+++ b/crates/limpid/src/functions/primitives/csv_parse.rs
@@ -79,3 +79,81 @@ fn parse<'bump>(
     }
     builder.finish()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dsl::value::ArrayBuilder;
+
+    fn names<'bump>(arena: &'bump EventArena<'bump>, values: &[Option<&str>]) -> Value<'bump> {
+        let mut builder = ArrayBuilder::with_capacity(arena, values.len());
+        for value in values {
+            builder.push(match value {
+                Some(value) => Value::String(arena.alloc_str(value)),
+                None => Value::Int(7),
+            });
+        }
+        builder.finish()
+    }
+
+    #[test]
+    fn extra_cells_are_dropped_and_empty_names_keep_position() {
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let text = Value::String("one,ignored,two,extra");
+        let fields = names(&arena, &[Some("first"), Some(""), Some("third")]);
+
+        let Value::Object(entries) = parse(&arena, &text, &fields) else {
+            panic!("csv_parse should return an object");
+        };
+        assert_eq!(
+            entries,
+            [
+                ("first", Value::String("one")),
+                ("third", Value::String("two")),
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_empty_and_non_string_named_cells_are_honest() {
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let text = Value::String("one,");
+        let fields = names(
+            &arena,
+            &[Some("first"), Some("empty"), None, Some("missing")],
+        );
+
+        let Value::Object(entries) = parse(&arena, &text, &fields) else {
+            panic!("csv_parse should return an object");
+        };
+        assert_eq!(
+            entries,
+            [
+                ("first", Value::String("one")),
+                ("empty", Value::Null),
+                ("missing", Value::Null),
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicate_names_preserve_runtime_order_for_last_wins_merge() {
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let text = Value::String("first,second");
+        let fields = names(&arena, &[Some("value"), Some("value")]);
+
+        let Value::Object(entries) = parse(&arena, &text, &fields) else {
+            panic!("csv_parse should return an object");
+        };
+        assert_eq!(
+            entries,
+            [
+                ("value", Value::String("first")),
+                ("value", Value::String("second")),
+            ]
+        );
+    }
+}

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -741,6 +741,44 @@ def pipeline p {
 }
 
 #[test]
+fn block_form_csv_parse_does_not_bind_fields_and_routes_runtime_error() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("csv_block_arg.conf");
+    fs::write(
+        &conf,
+        r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        csv_parse(ingress, ["host"]) { |value| value }
+        workspace.copy = workspace.host
+    }
+    output o
+}
+"#,
+    )
+    .unwrap();
+
+    let runtime = run_test_pipeline(&conf);
+
+    assert!(
+        runtime.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&runtime.stderr)
+    );
+    let runtime_stdout = String::from_utf8_lossy(&runtime.stdout);
+    assert!(runtime_stdout.contains("[error_log]"), "{runtime_stdout}");
+    assert!(
+        runtime_stdout.contains("function `csv_parse` does not accept a block argument"),
+        "{runtime_stdout}"
+    );
+    assert!(!runtime_stdout.contains("[output]"), "{runtime_stdout}");
+    assert!(!runtime_stdout.contains("\"host\""), "{runtime_stdout}");
+}
+
+#[test]
 fn check_resolves_user_function_from_include_closure() {
     let dir = TempDir::new().unwrap();
     fs::write(

--- a/crates/limpid/tests/cli_check.rs
+++ b/crates/limpid/tests/cli_check.rs
@@ -645,6 +645,101 @@ def pipeline p {
     );
 }
 
+fn run_test_pipeline(config: &std::path::Path) -> std::process::Output {
+    Command::new(limpid_bin())
+        .arg("--config")
+        .arg(config)
+        .arg("--test-pipeline")
+        .arg("p")
+        .output()
+        .expect("failed to spawn limpid test pipeline")
+}
+
+#[test]
+fn user_csv_parse_shadow_passes_ultra_strict_and_leaves_runtime_workspace_unchanged() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("csv_shadow.conf");
+    fs::write(
+        &conf,
+        r#"
+def function csv_parse(text, names) { null }
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        csv_parse(ingress, ["host"])
+        workspace.copy = workspace.host
+        workspace.marker = "user-function"
+    }
+    output o
+}
+"#,
+    )
+    .unwrap();
+
+    let checked = run_with_flags(&conf, &["--ultra-strict"]);
+    assert!(
+        checked.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&checked.stderr)
+    );
+
+    let runtime = run_test_pipeline(&conf);
+    assert!(
+        runtime.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&runtime.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&runtime.stdout);
+    assert!(stdout.contains("user-function"), "{stdout}");
+    assert!(!stdout.contains("\"host\""), "{stdout}");
+}
+
+#[test]
+fn builtin_csv_parse_wrong_arity_does_not_fabricate_fields_and_routes_runtime_error() {
+    let dir = TempDir::new().unwrap();
+    let conf = dir.path().join("csv_wrong_arity.conf");
+    fs::write(
+        &conf,
+        r#"
+def input i { type syslog_tcp bind "0.0.0.0:514" }
+def output o { type stdout }
+def pipeline p {
+    input i
+    process {
+        csv_parse(ingress, ["host"], "extra")
+        workspace.copy = workspace.host
+    }
+    output o
+}
+"#,
+    )
+    .unwrap();
+
+    let checked = run_with_flags(&conf, &["--ultra-strict"]);
+    assert!(
+        checked.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&checked.stderr)
+    );
+
+    let runtime = run_test_pipeline(&conf);
+    assert!(
+        runtime.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&runtime.stderr)
+    );
+    let runtime_stdout = String::from_utf8_lossy(&runtime.stdout);
+    assert!(runtime_stdout.contains("[error_log]"), "{runtime_stdout}");
+    assert!(
+        runtime_stdout.contains("csv_parse() expects 2 arguments, got 3"),
+        "{runtime_stdout}"
+    );
+    assert!(!runtime_stdout.contains("[output]"), "{runtime_stdout}");
+    assert!(!runtime_stdout.contains("\"host\""), "{runtime_stdout}");
+}
+
 #[test]
 fn check_resolves_user_function_from_include_closure() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- teach the analyzer to expose literal csv_parse field names after a bare statement
- require the flat builtin to resolve with exact arity and no user-function shadow before adding bindings
- keep dynamic, malformed, namespaced, unregistered, and expression uses fail-closed
- preserve runtime csv_parse behavior while pinning empty, missing, extra, duplicate, shadowing, and wrong-arity cases

## Validation

- focused csv_parse analyzer and runtime tests
- cargo test --workspace on macOS, including the merged stdout readiness regression
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- Linux Rust 1.95: cargo test --workspace --all-targets --all-features
- Linux Rust 1.95: cargo clippy --workspace --all-targets --all-features -- -D warnings
- git diff --check

The earlier macOS stdout readiness blocker was outside this candidate and is resolved in the current release/0.8.1 base; its focused regression and the fresh full workspace run pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `csv_parse` field detection during validation, including nullable string fields and duplicate-name handling.
  * Workspace bindings now accurately reflect whether `csv_parse` is used directly or assigned as an object.

* **Bug Fixes**
  * Invalid, dynamic, namespaced, shadowed, or incorrectly parameterized calls no longer create misleading fields.
  * Runtime handling now preserves null values, column positions, and last-value-wins behavior for duplicate names.
  * Incorrect argument counts are reported clearly without producing fabricated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->