### PR TITLE
perf(ltp): reduce history allocations

### DIFF
--- a/crates/limpid/src/error_log.rs
+++ b/crates/limpid/src/error_log.rs
@@ -151,7 +151,7 @@ impl ErroredEventContext {
                     event.source,
                     event.ingress.clone(),
                     event.ingress.clone(),
-                    event.ltp_stamps(),
+                    event.ltp_stamps_arc(),
                 );
                 let mut event_json = ev.to_json_value();
                 if let serde_json::Value::Object(ref mut map) = event_json {
@@ -187,7 +187,7 @@ impl ErroredEventContext {
                     event.source,
                     event.ingress.clone(),
                     event.egress.clone(),
-                    event.ltp_stamps(),
+                    event.ltp_stamps_arc(),
                 );
                 let mut event_json = ev.to_json_value();
                 if let serde_json::Value::Object(ref mut map) = event_json {

--- a/crates/limpid/src/event.rs
+++ b/crates/limpid/src/event.rs
@@ -189,7 +189,7 @@ pub struct OwnedEvent {
     /// LTP hop history is persisted and forwarded but intentionally absent
     /// from the DSL workspace. Sharing the immutable slice keeps ordinary
     /// event clones cheap.
-    ltp_stamps: Arc<[crate::ltp::HopStamp]>,
+    ltp_stamps: Option<Arc<[crate::ltp::HopStamp]>>,
     /// Optional drop-fired ack used by inputs that persist a cursor
     /// (tail / journal). `None` for inputs that don't have a position to
     /// advance (syslog, OTLP, unix_socket, …) and for events synthesised
@@ -251,7 +251,7 @@ impl OwnedEvent {
             egress: ingress.clone(),
             ingress,
             workspace: HashMap::new(),
-            ltp_stamps: Arc::from([]),
+            ltp_stamps: None,
             ack: None,
         }
     }
@@ -270,7 +270,7 @@ impl OwnedEvent {
             egress: ingress.clone(),
             ingress,
             workspace: HashMap::new(),
-            ltp_stamps: Arc::from([]),
+            ltp_stamps: None,
             ack: Some(ack),
         }
     }
@@ -281,11 +281,16 @@ impl OwnedEvent {
     }
 
     pub(crate) fn ltp_stamps(&self) -> &[crate::ltp::HopStamp] {
-        &self.ltp_stamps
+        self.ltp_stamps.as_deref().unwrap_or(&[])
     }
 
-    pub(crate) fn ltp_stamps_arc(&self) -> Arc<[crate::ltp::HopStamp]> {
-        Arc::clone(&self.ltp_stamps)
+    pub(crate) fn ltp_stamps_arc(&self) -> Option<Arc<[crate::ltp::HopStamp]>> {
+        self.ltp_stamps.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_ltp_history_storage(&self) -> bool {
+        self.ltp_stamps.is_some()
     }
 
     pub(crate) fn from_ltp_parts(
@@ -302,7 +307,7 @@ impl OwnedEvent {
             ingress: payload.clone(),
             egress: payload,
             workspace: HashMap::new(),
-            ltp_stamps: Arc::from(stamps),
+            ltp_stamps: (!stamps.is_empty()).then(|| Arc::from(stamps)),
             ack: None,
         }
     }
@@ -313,7 +318,7 @@ impl OwnedEvent {
         source: SocketAddr,
         ingress: Bytes,
         egress: Bytes,
-        stamps: Arc<[crate::ltp::HopStamp]>,
+        stamps: Option<Arc<[crate::ltp::HopStamp]>>,
     ) -> Self {
         Self {
             key,
@@ -322,7 +327,7 @@ impl OwnedEvent {
             ingress,
             egress,
             workspace: HashMap::new(),
-            ltp_stamps: stamps,
+            ltp_stamps: stamps.filter(|stamps| !stamps.is_empty()),
             ack: None,
         }
     }
@@ -345,7 +350,7 @@ impl OwnedEvent {
             source: self.source,
             ingress: self.ingress.clone(),
             egress: self.egress.clone(),
-            ltp_stamps: Arc::clone(&self.ltp_stamps),
+            ltp_stamps: self.ltp_stamps.clone(),
             workspace,
         }
     }
@@ -397,11 +402,11 @@ impl OwnedEvent {
         map.insert("source".into(), JsonValue::Object(source_obj));
         map.insert("ingress".into(), bytes_to_json(&self.ingress));
         map.insert("egress".into(), bytes_to_json(&self.egress));
-        if !self.ltp_stamps.is_empty() {
+        if let Some(stamps) = &self.ltp_stamps {
             map.insert(
                 "ltp_stamps".into(),
                 JsonValue::Array(
-                    self.ltp_stamps
+                    stamps
                         .iter()
                         .map(|stamp| {
                             serde_json::json!({
@@ -483,10 +488,10 @@ impl OwnedEvent {
             .and_then(json_to_bytes)
             .unwrap_or_else(|| ingress.clone());
 
-        let ltp_stamps: Arc<[crate::ltp::HopStamp]> = match v.get("ltp_stamps") {
-            None => Arc::from([]),
-            Some(JsonValue::Array(stamps)) => Arc::from(
-                stamps
+        let ltp_stamps: Option<Arc<[crate::ltp::HopStamp]>> = match v.get("ltp_stamps") {
+            None => None,
+            Some(JsonValue::Array(stamps)) => {
+                let stamps = stamps
                     .iter()
                     .map(|stamp| {
                         Some(crate::ltp::HopStamp {
@@ -495,8 +500,9 @@ impl OwnedEvent {
                             departure_unix_nano: stamp.get("departure_unix_nano")?.as_u64()?,
                         })
                     })
-                    .collect::<Option<Vec<_>>>()?,
-            ),
+                    .collect::<Option<Vec<_>>>()?;
+                (!stamps.is_empty()).then(|| Arc::from(stamps))
+            }
             Some(_) => return None,
         };
 
@@ -563,7 +569,7 @@ pub struct BorrowedEvent<'bump> {
     pub source: SocketAddr,
     pub ingress: Bytes,
     pub egress: Bytes,
-    ltp_stamps: Arc<[crate::ltp::HopStamp]>,
+    ltp_stamps: Option<Arc<[crate::ltp::HopStamp]>>,
     pub workspace: bumpalo::collections::Vec<'bump, (&'bump str, Value<'bump>)>,
 }
 
@@ -571,6 +577,11 @@ impl<'bump> BorrowedEvent<'bump> {
     /// Return this event's immutable identity.
     pub fn key(&self) -> uuid::Uuid {
         self.key
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_ltp_history_storage(&self) -> bool {
+        self.ltp_stamps.is_some()
     }
 
     /// Heap-allocate a fresh [`OwnedEvent`] from this borrowed view.
@@ -588,7 +599,7 @@ impl<'bump> BorrowedEvent<'bump> {
             source: self.source,
             ingress: self.ingress.clone(),
             egress: self.egress.clone(),
-            ltp_stamps: Arc::clone(&self.ltp_stamps),
+            ltp_stamps: self.ltp_stamps.clone(),
             workspace,
             // BorrowedEvent does not carry an ack — it's the per-event arena
             // view. Cloning back to owned for DLQ / disk-queue persistence
@@ -631,7 +642,7 @@ impl<'bump> BorrowedEvent<'bump> {
             source: self.source,
             ingress: self.ingress.clone(),
             egress: self.egress.clone(),
-            ltp_stamps: Arc::clone(&self.ltp_stamps),
+            ltp_stamps: self.ltp_stamps.clone(),
             // `HashMap::new()` here does not allocate a backing table
             // — that only happens on the first `insert`. So this is a
             // zero-heap-touch construction; the four Bytes/scalar
@@ -680,7 +691,7 @@ impl<'bump> BorrowedEvent<'bump> {
             source: self.source,
             ingress: self.ingress.clone(),
             egress: self.egress.clone(),
-            ltp_stamps: Arc::clone(&self.ltp_stamps),
+            ltp_stamps: self.ltp_stamps.clone(),
             workspace,
         }
     }
@@ -798,6 +809,45 @@ mod boundary_tests {
     }
 
     #[test]
+    fn ordinary_event_keeps_absent_ltp_history_through_all_snapshot_paths() {
+        let event = OwnedEvent::new(
+            Bytes::from_static(b"ordinary"),
+            "192.0.2.10:5140".parse().unwrap(),
+        );
+        assert!(!event.has_ltp_history_storage());
+        let (ack_tx, _ack_rx) = tokio::sync::mpsc::unbounded_channel();
+        let ack_event = OwnedEvent::with_ack(
+            Bytes::from_static(b"ordinary-with-ack"),
+            "192.0.2.10:5140".parse().unwrap(),
+            Arc::new(AckHandle::new(
+                AckPosition::Offset {
+                    generation: 1,
+                    offset: 1,
+                },
+                ack_tx,
+            )),
+        );
+        assert!(!ack_event.has_ltp_history_storage());
+
+        let bump = bumpalo::Bump::new();
+        let arena = EventArena::new(&bump);
+        let borrowed = event.view_in(&arena);
+        assert!(!borrowed.has_ltp_history_storage());
+        assert!(!borrowed.snapshot_in(&arena).has_ltp_history_storage());
+        assert!(!borrowed.to_owned().has_ltp_history_storage());
+        assert!(
+            !borrowed
+                .to_owned_without_workspace()
+                .has_ltp_history_storage()
+        );
+
+        let process = crate::pipeline::ProcessEvent::from_owned(&event);
+        let output = crate::pipeline::OutputEvent::from_owned(&event);
+        assert!(!process.has_ltp_history_storage());
+        assert!(!output.has_ltp_history_storage());
+    }
+
+    #[test]
     fn to_json_value_then_from_json_round_trips_event() {
         // This boundary is exercised every time a disk-queue replay /
         // tap snapshot / error-log entry / inject command needs to
@@ -854,6 +904,7 @@ mod boundary_tests {
 
         let persisted = event.to_json_string();
         let recovered = OwnedEvent::from_json(&persisted).unwrap();
+        assert!(recovered.has_ltp_history_storage());
         assert_eq!(recovered.ltp_stamps(), stamps);
 
         let tap = event.to_json_value_without_workspace();
@@ -864,6 +915,10 @@ mod boundary_tests {
         let arena = EventArena::new(&bump);
         let round_trip = event.view_in(&arena).to_owned();
         assert_eq!(round_trip.ltp_stamps(), stamps);
+        assert!(Arc::ptr_eq(
+            event.ltp_stamps_arc().as_ref().unwrap(),
+            round_trip.ltp_stamps_arc().as_ref().unwrap()
+        ));
     }
 
     #[test]
@@ -873,6 +928,14 @@ mod boundary_tests {
         json.as_object_mut().unwrap().remove("ltp_stamps");
         let recovered = OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).unwrap();
         assert!(recovered.ltp_stamps().is_empty());
+        assert!(!recovered.has_ltp_history_storage());
+
+        json.as_object_mut()
+            .unwrap()
+            .insert("ltp_stamps".into(), JsonValue::Array(Vec::new()));
+        let recovered = OwnedEvent::from_json(&serde_json::to_string(&json).unwrap()).unwrap();
+        assert!(recovered.ltp_stamps().is_empty());
+        assert!(!recovered.has_ltp_history_storage());
     }
 
     #[test]

--- a/crates/limpid/src/modules/output/ltp.rs
+++ b/crates/limpid/src/modules/output/ltp.rs
@@ -377,6 +377,8 @@ fn event_meta(
 struct WorkingEventMeta {
     meta: LtpMeta,
     local_stamp: usize,
+    #[cfg(test)]
+    requested_capacity: usize,
 }
 
 #[cfg(test)]
@@ -390,28 +392,32 @@ impl LtpOutput {
             crate::time::UnixNanos::from_datetime(event.received_at).to_wire_u64();
         #[cfg(test)]
         STAMP_CLONE_COUNT.set(STAMP_CLONE_COUNT.get() + 1);
-        let mut stamps = event.ltp_stamps().to_vec();
-        let local_stamp = match stamps.last() {
+        let prefix = event.ltp_stamps();
+        let reuses_pending_local = matches!(
+            prefix.last(),
             Some(stamp)
-                if stamp.node_id == self.node_id.as_ref() && stamp.departure_unix_nano == 0 =>
-            {
-                stamps.len() - 1
-            }
-            _ => {
-                stamps.push(HopStamp {
-                    node_id: self.node_id.to_string(),
-                    arrival_unix_nano,
-                    departure_unix_nano: 0,
-                });
-                stamps.len() - 1
-            }
-        };
+                if stamp.node_id == self.node_id.as_ref() && stamp.departure_unix_nano == 0
+        );
+        let append_count = usize::from(!reuses_pending_local);
+        let requested_capacity = prefix.len() + append_count;
+        let mut stamps = Vec::with_capacity(requested_capacity);
+        stamps.extend_from_slice(prefix);
+        if !reuses_pending_local {
+            stamps.push(HopStamp {
+                node_id: self.node_id.to_string(),
+                arrival_unix_nano,
+                departure_unix_nano: 0,
+            });
+        }
+        let local_stamp = stamps.len() - 1;
         WorkingEventMeta {
             meta: LtpMeta {
                 key: event.key().as_bytes().to_vec(),
                 stamps,
             },
             local_stamp,
+            #[cfg(test)]
+            requested_capacity,
         }
     }
 
@@ -1129,6 +1135,10 @@ mod tests {
         crate::time::UnixNanos::new(200)
     }
 
+    fn now_300() -> crate::time::UnixNanos {
+        crate::time::UnixNanos::new(300)
+    }
+
     fn now_negative() -> crate::time::UnixNanos {
         crate::time::UnixNanos::new(-1)
     }
@@ -1159,6 +1169,7 @@ mod tests {
         );
 
         let mut working = output.working_event_meta(&event);
+        assert_eq!(working.requested_capacity, 1);
         let frame = output.event_frame(&mut working, &event.egress).unwrap();
         let (meta, payload) = crate::ltp::decode_frame(&frame).unwrap();
         assert_eq!(meta.key, event.key().as_bytes());
@@ -1211,6 +1222,54 @@ mod tests {
             assert_ne!(meta.stamps[15].departure_unix_nano, 0);
             assert_eq!(payload, Bytes::from_static(b"payload"));
         }
+    }
+
+    #[test]
+    fn fanout_outputs_build_independent_exact_capacity_metadata_without_mutating_prefix() {
+        let stamps = vec![HopStamp {
+            node_id: "peer".to_owned(),
+            arrival_unix_nano: 1,
+            departure_unix_nano: 2,
+        }];
+        let event = Event::from_ltp_parts(
+            uuid::Uuid::now_v7(),
+            Utc.timestamp_nanos(100),
+            "127.0.0.1:7514".parse().unwrap(),
+            Bytes::from_static(b"payload"),
+            stamps.clone(),
+        );
+        let mut output_a = output_for("127.0.0.1:1");
+        output_a.now = now_200;
+        let mut output_b = output_for("127.0.0.1:2");
+        output_b.node_id = Arc::from("node-b");
+        output_b.now = now_300;
+
+        let mut working_a = output_a.working_event_meta(&event);
+        let mut working_b = output_b.working_event_meta(&event);
+
+        assert_eq!(working_b.meta.stamps[0], stamps[0]);
+        assert_eq!(working_a.requested_capacity, stamps.len() + 1);
+        assert_eq!(working_b.requested_capacity, stamps.len() + 1);
+        let frame_a = output_a.event_frame(&mut working_a, &event.egress).unwrap();
+        let frame_b = output_b.event_frame(&mut working_b, &event.egress).unwrap();
+        let (meta_a, _) = crate::ltp::decode_frame(&frame_a).unwrap();
+        let (meta_b, _) = crate::ltp::decode_frame(&frame_b).unwrap();
+        assert_eq!(meta_a.stamps[1].node_id, "node-a");
+        assert_eq!(meta_a.stamps[1].departure_unix_nano, 200);
+        assert_eq!(meta_b.stamps[1].node_id, "node-b");
+        assert_eq!(meta_b.stamps[1].departure_unix_nano, 300);
+        assert_eq!(event.ltp_stamps(), stamps);
+
+        let source = include_str!("ltp.rs");
+        let body = source
+            .split("fn working_event_meta")
+            .nth(1)
+            .and_then(|tail| tail.split("fn event_frame").next())
+            .expect("working_event_meta source");
+        assert!(!body.contains("ltp_stamps().to_vec()"));
+        assert_eq!(body.matches("Vec::with_capacity").count(), 1);
+        assert!(body.contains("let mut stamps = Vec::with_capacity(requested_capacity);"));
+        assert!(body.contains("extend_from_slice"));
     }
 
     #[test]

--- a/crates/limpid/src/pipeline/execution.rs
+++ b/crates/limpid/src/pipeline/execution.rs
@@ -105,7 +105,7 @@ pub struct ProcessEvent {
     pub source: std::net::SocketAddr,
     pub received_at: chrono::DateTime<chrono::Utc>,
     pub ingress: bytes::Bytes,
-    ltp_stamps: std::sync::Arc<[crate::ltp::HopStamp]>,
+    ltp_stamps: Option<std::sync::Arc<[crate::ltp::HopStamp]>>,
 }
 
 /// Output-flavor event snapshot for the DLQ.
@@ -121,7 +121,7 @@ pub struct OutputEvent {
     pub received_at: chrono::DateTime<chrono::Utc>,
     pub ingress: bytes::Bytes,
     pub egress: bytes::Bytes,
-    ltp_stamps: std::sync::Arc<[crate::ltp::HopStamp]>,
+    ltp_stamps: Option<std::sync::Arc<[crate::ltp::HopStamp]>>,
 }
 
 impl ProcessEvent {
@@ -141,8 +141,18 @@ impl ProcessEvent {
         self.key
     }
 
-    pub(crate) fn ltp_stamps(&self) -> std::sync::Arc<[crate::ltp::HopStamp]> {
-        std::sync::Arc::clone(&self.ltp_stamps)
+    #[allow(dead_code)] // slice-view contract retained for snapshot consumers
+    pub(crate) fn ltp_stamps(&self) -> &[crate::ltp::HopStamp] {
+        self.ltp_stamps.as_deref().unwrap_or(&[])
+    }
+
+    pub(crate) fn ltp_stamps_arc(&self) -> Option<std::sync::Arc<[crate::ltp::HopStamp]>> {
+        self.ltp_stamps.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_ltp_history_storage(&self) -> bool {
+        self.ltp_stamps.is_some()
     }
 }
 
@@ -164,8 +174,18 @@ impl OutputEvent {
         self.key
     }
 
-    pub(crate) fn ltp_stamps(&self) -> std::sync::Arc<[crate::ltp::HopStamp]> {
-        std::sync::Arc::clone(&self.ltp_stamps)
+    #[allow(dead_code)] // slice-view contract retained for snapshot consumers
+    pub(crate) fn ltp_stamps(&self) -> &[crate::ltp::HopStamp] {
+        self.ltp_stamps.as_deref().unwrap_or(&[])
+    }
+
+    pub(crate) fn ltp_stamps_arc(&self) -> Option<std::sync::Arc<[crate::ltp::HopStamp]>> {
+        self.ltp_stamps.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_ltp_history_storage(&self) -> bool {
+        self.ltp_stamps.is_some()
     }
 }
 


### PR DESCRIPTION
## Summary

- represent empty LTP history as `None`, avoiding the per-event empty `Arc` allocation and its reference-count traffic
- allocate each output's independent working stamp vector with the exact requested capacity for the reachable prefix-plus-append shape
- preserve non-empty history identity, persistence/replay, tap and DLQ JSON, fan-out isolation, retry-local metadata, and the WAL partial-EOF fix in the base branch

## Performance evidence

The empty-history change showed a causal improvement in the preregistered B and D workloads (+1.218638% and +0.667591%); A was +0.752683% with a confidence interval crossing zero.

The exact-capacity layer was neutral in its dedicated allocation workload (+0.078468%, confidence interval crossing zero). Its justification is the strictly no-worse allocation shape on the reachable non-empty-plus-append path: one allocation requested at `prefix.len() + append_count`, rather than `to_vec()` followed by possible growth. This PR does not claim a general throughput improvement from that layer.

## Validation

- independent combined review: CLEAN (blocking 0, nonblocking correctness 0)
- focused LTP tests: 94/94; CLI LTP tests: 4/4
- macOS workspace tests, clippy with warnings denied, formatting, and diff checks
- Linux Rust 1.95 all-targets/all-features tests and clippy

The two concerns remain separate logical commits to keep their evidence and rollback boundaries explicit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced memory usage for events that do not contain LTP history.
  * Preserved LTP history consistently when events are copied, recovered, serialized, or routed to multiple outputs.
  * Improved allocation efficiency when creating event history for outputs.
* **Bug Fixes**
  * Corrected recovery handling so existing event history is retained without introducing empty history data.
* **Tests**
  * Added coverage for history preservation, serialization, recovery, fanout, and multiple output events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->