### PR TITLE
Release 0.8.2

### DIFF
--- a/.github/scripts/release_preflight.py
+++ b/.github/scripts/release_preflight.py
@@ -1,0 +1,184 @@
+"""Release-only metadata and rendered documentation gates (Python >= 3.11).
+
+Exit 1 is a source defect; exit 2 is inconclusive network validation.
+No publication, configuration changes, or broad external link crawling.
+"""
+
+import argparse
+import hashlib
+from html.parser import HTMLParser
+from pathlib import Path
+import re
+import sys
+import tomllib
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote, urldefrag, urlsplit
+from urllib.request import Request, urlopen
+
+PRODUCTS = ("limpid", "limpidctl", "limpid-prometheus", "limpid-metrics-schema")
+REPOSITORY_PREFIX = "https://github.com/naoto256/limpid/blob/"
+
+
+class SourceDefect(Exception):
+    pass
+
+
+class NetworkUnavailable(Exception):
+    pass
+
+
+def require(condition, message):
+    if not condition:
+        raise SourceDefect(message)
+
+
+def read_toml(path):
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def release_metadata(root, version):
+    manifests = {name: read_toml(root / "crates" / name / "Cargo.toml") for name in PRODUCTS}
+    version = version or manifests["limpid"]["package"]["version"]
+    require(re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version), "Expected a stable X.Y.Z release version")
+    for name, manifest in manifests.items():
+        require(manifest["package"]["version"] == version, f"Version mismatch: {name}")
+    workspace_schema = read_toml(root / "Cargo.toml")["workspace"]["dependencies"]["limpid-metrics-schema"]
+    require(workspace_schema["version"] == version, "Workspace schema requirement mismatch")
+    for name in PRODUCTS[:-1]:
+        dependency = manifests[name]["dependencies"]["limpid-metrics-schema"]
+        require(dependency.get("workspace") is True, f"Schema requirement must inherit workspace: {name}")
+    packages = read_toml(root / "Cargo.lock")["package"]
+    for name in PRODUCTS:
+        versions = [p["version"] for p in packages if p["name"] == name]
+        require(versions == [version], f"Lock version mismatch: {name}")
+    lines = (root / "CHANGELOG.md").read_text(encoding="utf-8").splitlines(keepends=True)
+    starts = [i for i, line in enumerate(lines) if re.match(r"^## \[" + re.escape(version) + r"\]", line)]
+    require(len(starts) == 1, f"Expected exactly one CHANGELOG section for {version}")
+    section = []
+    for line in lines[starts[0] + 1:]:
+        if line.startswith("## ["):
+            break
+        section.append(line)
+    body = "".join(section)
+    require(body.strip(), "Release notes are empty")
+    tagline = ""
+    for line in section:
+        if line.startswith("##"):
+            break
+        if line.startswith(">"):
+            tagline = re.sub(r"^> ?", "", line).rstrip("\r\n")
+            break
+    title = f"limpid {version}" + (f" — {tagline}" if tagline else "")
+    return version, title, body
+
+
+class Page(HTMLParser):
+    def __init__(self, text):
+        super().__init__(convert_charrefs=True)
+        self.ids = set()
+        self.links = []
+        self.feed(text)
+
+    def handle_starttag(self, tag, attributes):
+        attrs = dict(attributes)
+        if attrs.get("id"):
+            self.ids.add(attrs["id"])
+        if tag == "a" and attrs.get("name"):
+            self.ids.add(attrs["name"])
+        for key in ("href", "src"):
+            if attrs.get(key):
+                self.links.append(attrs[key])
+
+
+def check_book(book):
+    book = book.resolve()
+    require((book / "index.html").is_file(), "Generated book entry index.html is missing")
+    pages = {p.resolve(): Page(p.read_text(encoding="utf-8")) for p in book.rglob("*.html") if p.name != "print.html"}
+    require(pages, "No generated mdBook HTML found")
+    repository_links = set()
+    errors = []
+    for path, page in pages.items():
+        for href in page.links:
+            url = urlsplit(href)
+            if href.startswith(REPOSITORY_PREFIX):
+                # Deliberately selected book-external document references only.
+                destination = url.path
+                if destination.endswith(("/CHANGELOG.md", "/packaging/snippets/README.md")):
+                    repository_links.add(href)
+            if url.scheme or url.netloc:
+                continue
+            target = (book / unquote(url.path).lstrip("/") if url.path.startswith("/") else path.parent / unquote(url.path)).resolve() if url.path else path
+            if target.is_dir():
+                target = target / "index.html"
+            if not target.is_relative_to(book) or not target.is_file():
+                errors.append(f"{path.relative_to(book)}: missing target {href}")
+                continue
+            if url.fragment and target.suffix == ".html":
+                parsed = pages.get(target) or Page(target.read_text(encoding="utf-8"))
+                if unquote(url.fragment) not in parsed.ids:
+                    errors.append(f"{path.relative_to(book)}: missing anchor {href}")
+    require(not errors, "\n".join(errors))
+    return repository_links
+
+
+def fetch_page(url):
+    with urlopen(Request(url, headers={"User-Agent": "limpid-release-preflight"}), timeout=20) as response:
+        return response.read().decode("utf-8")
+
+
+def check_repository_links(links, fetch=fetch_page):
+    cache = {}
+    for link in sorted(links):
+        url, fragment = urldefrag(link)
+        try:
+            if url not in cache:
+                cache[url] = Page(fetch(url))
+        except HTTPError as error:
+            error.close()
+            if error.code in (404, 410):
+                raise SourceDefect(f"Repository document destination absent: {url}") from error
+            raise NetworkUnavailable(f"Repository check inconclusive: HTTP {error.code} for {url}") from error
+        except (URLError, TimeoutError, OSError) as error:
+            raise NetworkUnavailable(f"Repository check inconclusive: {url}") from error
+        if fragment:
+            fragment = unquote(fragment)
+            page = cache[url]
+            require(fragment in page.ids or "user-content-" + fragment in page.ids or "#" + fragment in page.links,
+                    f"Repository document anchor absent: {link}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--version", help="Exact release version; default: limpid manifest version")
+    parser.add_argument("--book", type=Path, help="Already generated mdBook directory")
+    parser.add_argument("--check-remote", action="store_true", help="Validate selected repository links, not arbitrary external sites")
+    parser.add_argument("--notes-output", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+    try:
+        version, title, body = release_metadata(args.root, args.version)
+        if args.check_remote and not args.book:
+            raise SourceDefect("--check-remote requires --book")
+        if args.book:
+            links = check_book(args.book)
+            if args.check_remote:
+                check_repository_links(links)
+        if args.notes_output:
+            args.notes_output.write_text(body, encoding="utf-8")
+        if args.github_output:
+            with args.github_output.open("a", encoding="utf-8") as output:
+                output.write(f"name={title}\n")
+        print(f"Release {version}: {title}")
+        print(f"Notes SHA256: {hashlib.sha256(body.encode()).hexdigest()}")
+    except NetworkUnavailable as error:
+        print(f"INCONCLUSIVE NETWORK: {error}", file=sys.stderr)
+        return 2
+    except (SourceDefect, KeyError, ValueError, OSError) as error:
+        print(f"RELEASE PREFLIGHT FAILED: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_release_preflight.py
+++ b/.github/scripts/test_release_preflight.py
@@ -1,0 +1,97 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from urllib.error import HTTPError, URLError
+
+spec = importlib.util.spec_from_file_location("release_preflight", Path(__file__).with_name("release_preflight.py"))
+preflight = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(preflight)
+REPO = Path(__file__).resolve().parents[2]
+
+
+class ReleasePreflightTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        for name in preflight.PRODUCTS:
+            target = self.root / "crates" / name / "Cargo.toml"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(f'[package]\nname = "{name}"\nversion = "0.8.1"\n'
+                              '[dependencies]\nlimpid-metrics-schema = { workspace = true }\n')
+        (self.root / "Cargo.toml").write_text('[workspace.dependencies]\nlimpid-metrics-schema = { version = "0.8.1" }\n')
+        (self.root / "Cargo.lock").write_text(''.join(
+            f'[[package]]\nname = "{name}"\nversion = "0.8.1"\n' for name in preflight.PRODUCTS))
+        (self.root / "CHANGELOG.md").write_text('## [Unreleased]\n\n## [0.8.1]\n\n> Tagline.\n\nOverview.\n\n### Fixed — Header keys\n\nFacts.\n\n## [0.8.0]\nOld facts.\n')
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_current_release_has_title_and_notes(self):
+        version, title, body = preflight.release_metadata(self.root, None)
+        self.assertTrue(title.startswith(f"limpid {version}"))
+        self.assertIn("###", body)
+
+    def test_repository_release_metadata(self):
+        preflight.release_metadata(REPO, None)
+
+    def test_missing_or_whitespace_notes_fail(self):
+        for text in ["## [Unreleased]\n", "## [0.8.1]\n \n## [0.8.0]\nold\n"]:
+            (self.root / "CHANGELOG.md").write_text(text)
+            with self.assertRaises(preflight.SourceDefect):
+                preflight.release_metadata(self.root, "0.8.1")
+
+    def test_tag_manifest_schema_and_lock_mismatch_fail(self):
+        with self.assertRaises(preflight.SourceDefect):
+            preflight.release_metadata(self.root, "99.0.0")
+        for relative in ["crates/limpidctl/Cargo.toml", "Cargo.toml", "Cargo.lock"]:
+            path = self.root / relative
+            original = path.read_text()
+            path.write_text(original.replace('"0.8.1"', '"99.0.0"', 1))
+            with self.assertRaises(preflight.SourceDefect):
+                preflight.release_metadata(self.root, "0.8.1")
+            path.write_text(original)
+
+    def test_local_target_and_fragment(self):
+        (self.root / "index.html").write_text('<a href="other.html#hello">ok</a>')
+        (self.root / "other.html").write_text('<h2 id="hello">Hello</h2>')
+        self.assertEqual(preflight.check_book(self.root), set())
+        (self.root / "other.html").write_text('<h2 id="wrong">Hello</h2>')
+        with self.assertRaises(preflight.SourceDefect):
+            preflight.check_book(self.root)
+        (self.root / "other.html").unlink()
+        with self.assertRaises(preflight.SourceDefect):
+            preflight.check_book(self.root)
+
+    def test_readme_link_is_not_virtualized_to_index(self):
+        (self.root / "index.html").write_text('<a href="README.html#intro">Introduction</a>')
+        with self.assertRaises(preflight.SourceDefect):
+            preflight.check_book(self.root)
+        (self.root / "README.html").write_text('<h1 id="intro">Introduction</h1>')
+        preflight.check_book(self.root)
+        (self.root / "index.html").unlink()
+        with self.assertRaises(preflight.SourceDefect):
+            preflight.check_book(self.root)
+
+    def test_deleted_branch_is_a_source_defect(self):
+        url = "https://github.com/naoto256/limpid/blob/release/deleted/CHANGELOG.md"
+        def missing(_):
+            raise HTTPError(url, 404, "Not Found", {}, None)
+        with self.assertRaises(preflight.SourceDefect):
+            preflight.check_repository_links({url}, fetch=missing)
+
+    def test_network_failure_is_not_a_source_defect(self):
+        def unavailable(_):
+            raise URLError("temporary DNS failure")
+        with self.assertRaises(preflight.NetworkUnavailable):
+            preflight.check_repository_links({preflight.REPOSITORY_PREFIX + "main/CHANGELOG.md"}, fetch=unavailable)
+
+    def test_repository_fragment_and_selected_destinations(self):
+        url = preflight.REPOSITORY_PREFIX + "main/packaging/snippets/README.md#authoring-conventions"
+        preflight.check_repository_links({url}, fetch=lambda _: '<h2 id="user-content-authoring-conventions">ok</h2>')
+        with self.assertRaises(preflight.SourceDefect):
+            preflight.check_repository_links({url}, fetch=lambda _: '<h2 id="different">no</h2>')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,29 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  release-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # pin-audit:2026-06-03 de0fac2 | v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: '3.11'
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable
+      - name: Test release validation failures
+        run: python3 -m unittest discover -s .github/scripts -p 'test_release_preflight.py'
+      - name: Validate release metadata
+        run: python3 .github/scripts/release_preflight.py
+      - name: Install pinned mdBook
+        run: cargo install mdbook --version 0.5.4 --locked
+      - name: Build and validate documentation
+        # Network errors exit 2 (inconclusive), not a source-defect verdict.
+        # Both outcomes block the check; neither is silently waived.
+        run: |
+          mdbook build docs
+          python3 .github/scripts/release_preflight.py --book docs/book --check-remote
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # pin-audit:2026-06-03 de0fac2 | v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # pin-audit:2026-09-06 e797f83 | v6.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # pin-audit:2026-06-03 a309ff8 | v6.2.0
         with:
           python-version: '3.11'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # pin-audit:2026-06-03 de0fac2 | v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # pin-audit:2026-09-06 e797f83 | v6.0.0
         with:
           python-version: '3.11'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable
 
       - name: Install Python for release preflight
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # pin-audit:2026-09-06 e797f83 | v6.0.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # pin-audit:2026-06-03 a309ff8 | v6.2.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable
 
+      - name: Install Python for release preflight
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Validate tag and extract release notes
+        id: notes
+        run: |
+          python3 .github/scripts/release_preflight.py \
+            --version "${GITHUB_REF_NAME#v}" \
+            --notes-output RELEASE_NOTES.md --github-output "$GITHUB_OUTPUT"
+
       - name: Install system dependencies
         # `libsystemd-dev` is required by the `journal` feature; the
         # remaining packages are `rdkafka-sys` (`libsasl2-dev`,
@@ -58,36 +70,6 @@ jobs:
           cargo deb -p limpid --no-build
           cargo deb -p limpid-prometheus --no-build
 
-      - name: Extract release notes from CHANGELOG
-        id: notes
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          # Body: everything between this version's heading and the next.
-          awk -v ver="$VERSION" '
-            $0 ~ "^## \\["ver"\\]" { found=1; next }
-            found && /^## \[/ { exit }
-            found { print }
-          ' CHANGELOG.md > RELEASE_NOTES.md
-          if [ ! -s RELEASE_NOTES.md ]; then
-            echo "::warning::No CHANGELOG entry found for ${VERSION}; release body will be empty."
-          fi
-          # Tagline (optional): a `> ...` blockquote line immediately
-          # following the version heading. Used as the second clause of
-          # the GitHub Release name (`limpid X.Y.Z — TAGLINE`). Absent →
-          # falls back to plain `limpid X.Y.Z`.
-          TAGLINE=$(awk -v ver="$VERSION" '
-            $0 ~ "^## \\["ver"\\]" { in_section=1; next }
-            in_section && /^>/ { sub(/^> ?/, ""); print; exit }
-            in_section && /^##/ { exit }
-            in_section && /^###/ { exit }
-          ' CHANGELOG.md)
-          if [ -n "$TAGLINE" ]; then
-            NAME="limpid ${VERSION} — ${TAGLINE}"
-          else
-            NAME="limpid ${VERSION}"
-          fi
-          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
-
       - name: Generate checksums
         # SHA256SUMS lets consumers verify asset integrity offline
         # (`sha256sum -c SHA256SUMS`). Basenames (not paths) so the
@@ -106,7 +88,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           # Pass the release title through an env var rather than
           # interpolating `${{ ... }}` into `run:` — the value comes
-          # from CHANGELOG via awk, so it is repo-controlled rather
+          # from CHANGELOG via preflight, so it is repo-controlled rather
           # than attacker-controlled, but expression substitution into
           # a shell command would still be the wrong defense-in-depth
           # shape if a future change ever lets non-repo data flow into

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pin-audit:2026-05-21 29eef33 | stable
 
       - name: Install Python for release preflight
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # pin-audit:2026-09-06 e797f83 | v6.0.0
         with:
           python-version: '3.11'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-09-06
+
+> Hyphenated HTTP headers and more reliable validation.
+
+0.8.2 accepts hyphenated configuration property keys for HTTP headers,
+makes output regression tests wait for explicit progress, and adds automated
+release metadata and documentation checks.
+
+### Fixed — hyphenated HTTP header names
+
+HTTP output header maps now accept names such as `DD-API-KEY` and
+`X-Custom-Header`. The change is limited to property keys: expression
+identifiers and subtraction syntax remain unchanged. Header delivery was
+checked through a local HTTP receiver and Datadog log intake.
+
+### Fixed — output tests synchronize with delivery and readiness
+
+OTLP tests now wait for the delivery acknowledgement before shutdown.
+Full-pipe stdout tests distinguish pending readiness from an actual
+`EAGAIN` backoff, preserving shutdown, byte-exact drain, and acknowledgement
+assertions. The macOS retry timing test waits for observed progress instead
+of a fixed number of scheduler yields and checks the 10 ms boundary.
+These changes affect tests, not production output behavior.
+
+### Changed — release metadata and documentation preflight
+
+CI and the release workflow now check product versions, workspace dependencies,
+lockfile versions, release notes and titles, and rendered documentation links
+and anchors. Remote link checks distinguish missing destinations from transient
+network failures. The pinned mdBook configuration preserves README page targets
+alongside the book entry page. Both workflows use the existing audited
+`actions/setup-python` v6.2.0 pin.
+
 ## [0.8.1] - 2026-09-02
 
 > Single execution IR, safer queues, and lower hot-path overhead.
@@ -2487,7 +2520,8 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/naoto256/limpid/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/naoto256/limpid/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/naoto256/limpid/compare/v0.7.15...v0.8.0
 [0.7.15]: https://github.com/naoto256/limpid/compare/v0.7.14...v0.7.15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-metrics-schema"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-limpid-metrics-schema = { version = "0.8.1", path = "crates/limpid-metrics-schema" }
+limpid-metrics-schema = { version = "0.8.2", path = "crates/limpid-metrics-schema" }
 base64 = "0.22.1"
 pem = "3.0.6"
 ring = "0.17.14"

--- a/crates/limpid-metrics-schema/Cargo.toml
+++ b/crates/limpid-metrics-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-metrics-schema"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Wire DTOs for limpid schema-v1 metrics snapshots"
 license.workspace = true

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -831,7 +831,7 @@ mod tests {
                 "type": "gauge",
                 "help": "Build information for the running limpid node.",
                 "series": [{
-                    "labels": {"node_id": "edge-a", "version": "0.8.1"},
+                    "labels": {"node_id": "edge-a", "version": "0.8.2"},
                     "value": 1
                 }]
             }]
@@ -842,7 +842,7 @@ mod tests {
             concat!(
                 "# HELP limpid_build_info Build information for the running limpid node.\n",
                 "# TYPE limpid_build_info gauge\n",
-                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.1\"} 1\n\n"
+                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.2\"} 1\n\n"
             )
         );
     }

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1404,7 +1404,7 @@ def pipeline p { input i; output o }
             .build()
             .expect("test metric registration must succeed");
         received.inc();
-        crate::metrics::register_build_info(&metrics, "0.8.1", "control-node")
+        crate::metrics::register_build_info(&metrics, "0.8.2", "control-node")
             .expect("build info registration must succeed");
 
         let server = ControlServer::new(
@@ -1499,7 +1499,7 @@ def pipeline p { input i; output o }
         assert_eq!(
             build_info["series"],
             serde_json::json!([{
-                "labels": {"node_id": "control-node", "version": "0.8.1"},
+                "labels": {"node_id": "control-node", "version": "0.8.2"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/dsl/limpid.pest
+++ b/crates/limpid/src/dsl/limpid.pest
@@ -118,9 +118,13 @@ def_output = {
 
 // -- Properties (key-value or nested block) ----------------------------------
 
+// Header maps use names such as `DD-API-KEY`. Keep this separate from
+// expression identifiers so `left-right` remains subtraction.
+property_key = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
+
 property = {
-    ident ~ "{" ~ property* ~ "}"       // nested block: `tls { ... }`
-  | ident ~ expr                         // key-value: `type syslog_udp`, `bind "0.0.0.0:514"`
+    property_key ~ "{" ~ property* ~ "}" // nested block: `tls { ... }`
+  | property_key ~ expr                   // key-value: `type syslog_udp`, `bind "0.0.0.0:514"`
 }
 
 // -- Process definition ------------------------------------------------------

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -1183,6 +1183,52 @@ def input fw_syslog {
     }
 
     #[test]
+    fn hyphenated_header_keys_preserve_names_and_values() {
+        let config = parse_config(
+            r#"
+def output logs {
+    type http
+    headers {
+        DD-API-KEY "test-only-key"
+        X-Custom-Header "value"
+        Authorization "Bearer placeholder"
+    }
+}
+"#,
+        )
+        .unwrap();
+        let Definition::Output(output) = &config.definitions[0] else {
+            panic!("expected output");
+        };
+        assert_eq!(
+            crate::dsl::props::get_string_map(output.properties.user_properties(), "headers"),
+            vec![
+                ("DD-API-KEY".into(), "test-only-key".into()),
+                ("X-Custom-Header".into(), "value".into()),
+                ("Authorization".into(), "Bearer placeholder".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn header_key_support_does_not_change_expression_identifiers() {
+        let config = parse_config("def process p { workspace.result = left-right }").unwrap();
+        let Definition::Process(process) = &config.definitions[0] else {
+            panic!("expected process");
+        };
+        let ProcessStatement::Assign(_, expr) = &process.body[0] else {
+            panic!("expected assignment");
+        };
+        let ExprKind::BinOp(left, BinOp::Sub, right) = &expr.kind else {
+            panic!("expected subtraction");
+        };
+        assert!(matches!(&left.kind, ExprKind::Ident(parts) if parts == &["left"]));
+        assert!(matches!(&right.kind, ExprKind::Ident(parts) if parts == &["right"]));
+        assert!(parse_config("def process hyphen-name { drop }").is_err());
+        assert!(parse_config("def process p { let hyphen-name = 1 }").is_err());
+    }
+
+    #[test]
     fn test_parse_output_with_nested_block() {
         let input = r#"
 def output ama {

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -1699,7 +1699,7 @@ mod registry_tests {
     #[test]
     fn build_info_is_one_prepopulated_gauge_with_fixed_labels() {
         let registry = Registry::new();
-        super::register_build_info(&registry, "0.8.1", "node-a").expect("build info must register");
+        super::register_build_info(&registry, "0.8.2", "node-a").expect("build info must register");
 
         let snapshot = snapshot_json(&registry);
         let family = metric(&snapshot, "limpid_build_info");
@@ -1711,7 +1711,7 @@ mod registry_tests {
         assert_eq!(
             family["series"],
             serde_json::json!([{
-                "labels": {"node_id": "node-a", "version": "0.8.1"},
+                "labels": {"node_id": "node-a", "version": "0.8.2"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -1236,6 +1236,59 @@ mod tests {
         compiled.outputs[name].properties.clone()
     }
 
+    #[tokio::test]
+    async fn parser_spelled_hyphenated_headers_reach_http_receiver() {
+        use axum::{Router, extract::State, http::HeaderMap, routing::post};
+
+        async fn receive(
+            State(tx): State<tokio::sync::mpsc::Sender<HeaderMap>>,
+            headers: HeaderMap,
+        ) -> axum::http::StatusCode {
+            tx.send(headers).await.unwrap();
+            axum::http::StatusCode::ACCEPTED
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route("/", post(receive)).with_state(tx),
+            )
+            .await
+            .unwrap();
+        });
+        let props = parsed_output_props(
+            &format!(
+                r#"
+def output test {{
+    type http
+    peer {{ url "http://{addr}/" }}
+    batch_size 1
+    headers {{ DD-API-KEY "test-only-key" X-Custom-Header "exact-value" }}
+}}
+"#
+            ),
+            "test",
+        );
+        let output = HttpOutput::from_properties(
+            "test",
+            &props,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        consume(&output, &event_with("hello")).await.unwrap();
+        let received = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+        output.shutdown(None).await.unwrap();
+        server.abort();
+        let _ = server.await;
+        let headers = received.unwrap().unwrap();
+        assert_eq!(headers["dd-api-key"], "test-only-key");
+        assert_eq!(headers["x-custom-header"], "exact-value");
+        assert!(!headers.contains_key("dd_api_key"));
+    }
+
     #[test]
     fn verify_false_with_client_identity_parses_ok() {
         // Even with `verify false`, a tls block carrying client

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -850,6 +850,7 @@ mod tests {
 
     struct RecordingLogs {
         received: Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+        response_gate: Option<Arc<tokio::sync::Semaphore>>,
     }
 
     #[tonic::async_trait]
@@ -860,6 +861,9 @@ mod tests {
         ) -> std::result::Result<tonic::Response<ExportLogsServiceResponse>, tonic::Status>
         {
             self.received.lock().await.push(request.into_inner());
+            if let Some(gate) = &self.response_gate {
+                gate.acquire().await.unwrap().forget();
+            }
             Ok(tonic::Response::new(ExportLogsServiceResponse {
                 partial_success: None,
             }))
@@ -875,8 +879,10 @@ mod tests {
         let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
 
         let received = Arc::new(Mutex::new(Vec::new()));
+        let response_gate = Arc::new(tokio::sync::Semaphore::new(0));
         let svc = RecordingLogs {
             received: Arc::clone(&received),
+            response_gate: Some(Arc::clone(&response_gate)),
         };
         let server = tokio::spawn(async move {
             let _ = tonic::transport::Server::builder()
@@ -902,14 +908,35 @@ mod tests {
             .prepare(vec![payload.clone()])
             .unwrap()
             .encoded_len() as u64;
-        consume(&output, &event_with_egress(payload)).await.unwrap();
+        let mut acknowledgements = consume_with_handle(&output, &event_with_egress(payload))
+            .await
+            .unwrap();
 
         let probe = || {
             let g = received.try_lock().ok()?;
             if g.is_empty() { None } else { Some(g.clone()) }
         };
         let got = wait_for(probe).await;
+        // Capturing a request is not delivery: hold the response so this
+        // interleaving is deterministic, rather than relying on scheduler luck.
+        assert_eq!(output.metrics.bytes_written.load(Ordering::Relaxed), 0);
+        assert!(matches!(
+            acknowledgements.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+        response_gate.add_permits(1);
+        let (_, disposition) =
+            tokio::time::timeout(Duration::from_secs(5), acknowledgements.recv())
+                .await
+                .expect("delivery acknowledgement timed out")
+                .expect("acknowledgement channel closed without resolution");
+        assert!(matches!(
+            disposition,
+            crate::queue::AckDisposition::Delivered
+        ));
+        output.shutdown(None).await.unwrap();
         server.abort();
+        let _ = server.await;
 
         assert_eq!(got.len(), 1);
         let lr = &got[0].resource_logs[0].scope_logs[0].log_records[0];
@@ -1194,6 +1221,7 @@ mod tests {
         let received = Arc::new(Mutex::new(Vec::new()));
         let svc = RecordingLogs {
             received: Arc::clone(&received),
+            response_gate: None,
         };
         let server = tokio::spawn(async move {
             let _ = tonic::transport::Server::builder()
@@ -1396,6 +1424,7 @@ mod tests {
         let received = Arc::new(Mutex::new(Vec::new()));
         let svc = RecordingLogs {
             received: Arc::clone(&received),
+            response_gate: None,
         };
         let server = tokio::spawn(async move {
             let _ = tonic::transport::Server::builder()

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -1199,10 +1199,22 @@ mod metrics_registration_tests {
                 "neither normal nor drain mode may retry before 10 ms"
             );
             assert!(!task.is_finished());
+            let retry_at = tokio::time::Instant::now() + std::time::Duration::from_millis(1);
             tokio::time::advance(std::time::Duration::from_millis(1)).await;
-            for _ in 0..32 {
-                tokio::task::yield_now().await;
-            }
+            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                // The counter retains progress if notification preceded this
+                // wait; current_thread cannot interleave the load and await.
+                while observer
+                    .waiting_count
+                    .load(std::sync::atomic::Ordering::SeqCst)
+                    < 2
+                {
+                    observer.waiting.notified().await;
+                }
+            })
+            .await
+            .expect("the next readiness attempt must be observed");
+            assert_eq!(tokio::time::Instant::now(), retry_at);
             assert_eq!(
                 observer
                     .waiting_count

--- a/crates/limpid/src/modules/output/stdout.rs
+++ b/crates/limpid/src/modules/output/stdout.rs
@@ -107,6 +107,10 @@ struct WriteObserver {
     backoff_count: std::sync::atomic::AtomicUsize,
     #[cfg(target_os = "macos")]
     backing_off: tokio::sync::Notify,
+    // Simulate one false writable notification without relying on a kernel
+    // to report readiness for a pipe that cannot accept the frame.
+    #[cfg(target_os = "macos")]
+    inject_would_block: std::sync::atomic::AtomicBool,
 }
 
 impl StdoutTransport {
@@ -306,8 +310,17 @@ impl StdoutTransport {
                     }
                 }
             };
-            match readiness.try_io(|inner| raw_write(inner.get_ref().as_raw_fd(), &frame[offset..]))
-            {
+            match readiness.try_io(|inner| {
+                #[cfg(all(test, target_os = "macos"))]
+                if self.observer.as_ref().is_some_and(|observer| {
+                    observer
+                        .inject_would_block
+                        .swap(false, std::sync::atomic::Ordering::SeqCst)
+                }) {
+                    return Err(io::Error::from(io::ErrorKind::WouldBlock));
+                }
+                raw_write(inner.get_ref().as_raw_fd(), &frame[offset..])
+            }) {
                 Ok(Ok(0)) => {
                     return Err(StdoutWriteError {
                         source: io::Error::new(
@@ -937,6 +950,23 @@ mod metrics_registration_tests {
         .unwrap()
     }
 
+    async fn wait_for_write_attempt(observer: &WriteObserver) {
+        // This counts entry into the readiness stage, not Poll::Pending.
+        // Callers separately assert a full pipe, no completed frame/ACK, and
+        // a pending writer before supplying shutdown or reader progress.
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while observer
+                .waiting_count
+                .load(std::sync::atomic::Ordering::SeqCst)
+                == 0
+            {
+                observer.waiting.notified().await;
+            }
+        })
+        .await
+        .expect("writer must enter the readiness stage");
+    }
+
     fn assert_output_duplicate(error: &MetricsError, label_value: &str, diagnostic: &str) {
         let (name, labelset) = match error {
             MetricsError::DuplicateSeries { name, labelset } => (name, labelset),
@@ -965,6 +995,10 @@ mod metrics_registration_tests {
         let (read_fd, write_fd) = unix_pipe();
         let capacity = fill_pipe(write_fd.as_raw_fd());
         assert!(capacity > 0);
+        assert_eq!(
+            raw_write(write_fd.as_raw_fd(), b"x").unwrap_err().kind(),
+            io::ErrorKind::WouldBlock
+        );
         let observer = Arc::new(WriteObserver::default());
         let transport = StdoutTransport::from_owned(write_fd, Some(Arc::clone(&observer))).unwrap();
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -975,49 +1009,20 @@ mod metrics_registration_tests {
         );
         let (ack, mut ack_rx) = QueueAckHandle::for_test();
         let task_output = Arc::clone(&output);
-        let task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
+        let mut task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
             task_output.consume(&event, ack).await
         }));
 
-        #[cfg(target_os = "macos")]
-        while observer
-            .backoff_count
-            .load(std::sync::atomic::Ordering::SeqCst)
-            == 0
-        {
-            observer.backing_off.notified().await;
-        }
-        #[cfg(not(target_os = "macos"))]
-        while observer
-            .waiting_count
-            .load(std::sync::atomic::Ordering::SeqCst)
-            == 0
-        {
-            observer.waiting.notified().await;
-        }
-        let readiness_waits = observer
-            .waiting_count
-            .load(std::sync::atomic::Ordering::SeqCst);
-        #[cfg(target_os = "macos")]
+        wait_for_write_attempt(&observer).await;
         assert!(
-            tokio::time::timeout(
-                std::time::Duration::from_millis(2),
-                observer.waiting.notified()
-            )
-            .await
-            .is_err(),
-            "a full pipe must not immediately re-enter writable readiness"
+            tokio::time::timeout(std::time::Duration::from_millis(10), &mut task)
+                .await
+                .is_err()
         );
-        #[cfg(not(target_os = "macos"))]
-        for _ in 0..32 {
-            tokio::task::yield_now().await;
-        }
+        assert!(!task.is_finished(), "the full pipe must hold the frame");
         assert_eq!(
-            observer
-                .waiting_count
-                .load(std::sync::atomic::Ordering::SeqCst),
-            readiness_waits,
-            "a full pipe must stay parked on readiness rather than busy-spin"
+            observer.written.load(std::sync::atomic::Ordering::SeqCst),
+            0
         );
         assert!(ack_rx.try_recv().is_err());
         shutdown_tx.send(true).unwrap();
@@ -1047,6 +1052,10 @@ mod metrics_registration_tests {
         let (read_fd, write_fd) = unix_pipe();
         let capacity = fill_pipe(write_fd.as_raw_fd());
         assert!(capacity > 0);
+        assert_eq!(
+            raw_write(write_fd.as_raw_fd(), b"x").unwrap_err().kind(),
+            io::ErrorKind::WouldBlock
+        );
         let observer = Arc::new(WriteObserver::default());
         let transport = StdoutTransport::from_owned(write_fd, Some(Arc::clone(&observer))).unwrap();
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -1057,17 +1066,28 @@ mod metrics_registration_tests {
         );
         let (ack, mut ack_rx) = QueueAckHandle::for_test();
         let task_output = Arc::clone(&output);
-        let task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
+        let mut task = tokio::spawn(TEST_STDOUT_TRANSPORT.scope(transport, async move {
             task_output.consume(&event, ack).await
         }));
 
-        while observer
-            .backoff_count
-            .load(std::sync::atomic::Ordering::SeqCst)
-            == 0
-        {
-            observer.backing_off.notified().await;
-        }
+        wait_for_write_attempt(&observer).await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), &mut task)
+                .await
+                .is_err()
+        );
+        assert!(
+            !task.is_finished(),
+            "the frame must wait for reader progress"
+        );
+        assert_eq!(
+            observer.written.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert!(matches!(
+            ack_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
 
         let read_fd = async_owned_fd(read_fd);
         let observed = tokio::time::timeout(
@@ -1078,7 +1098,11 @@ mod metrics_registration_tests {
         .expect("reader progress must make the pending frame writable");
         assert!(observed[..capacity].iter().all(|byte| *byte == b'x'));
         assert_eq!(&observed[capacity..], b"resumed\n");
-        task.await.unwrap().unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("draining the pipe must complete the writer")
+            .unwrap()
+            .unwrap();
         assert!(matches!(
             ack_rx.recv().await,
             Some((_, crate::queue::AckDisposition::Delivered))
@@ -1125,6 +1149,78 @@ mod metrics_registration_tests {
             0,
             "a successful write must not pay the Darwin EAGAIN backoff"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test(start_paused = true)]
+    async fn false_readiness_eagain_backs_off_before_retrying() {
+        for drain in [false, true] {
+            let (_read_fd, write_fd) = unix_pipe();
+            let observer = Arc::new(WriteObserver::default());
+            observer
+                .inject_would_block
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            let transport =
+                StdoutTransport::from_owned(write_fd, Some(Arc::clone(&observer))).unwrap();
+            let (_shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+            let task = tokio::spawn(async move {
+                transport
+                    .write_frame_mode(b"backoff\n", &mut shutdown_rx, drain)
+                    .await
+            });
+            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                while observer
+                    .backoff_count
+                    .load(std::sync::atomic::Ordering::SeqCst)
+                    == 0
+                {
+                    observer.backing_off.notified().await;
+                }
+            })
+            .await
+            .expect("the injected false readiness must reach EAGAIN");
+            assert_eq!(
+                observer
+                    .waiting_count
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                1
+            );
+            assert_eq!(
+                observer.written.load(std::sync::atomic::Ordering::SeqCst),
+                0
+            );
+            tokio::time::advance(std::time::Duration::from_millis(9)).await;
+            tokio::task::yield_now().await;
+            assert_eq!(
+                observer
+                    .waiting_count
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "neither normal nor drain mode may retry before 10 ms"
+            );
+            assert!(!task.is_finished());
+            tokio::time::advance(std::time::Duration::from_millis(1)).await;
+            for _ in 0..32 {
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(
+                observer
+                    .waiting_count
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                2,
+                "the 10 ms backoff must release the next readiness attempt"
+            );
+            assert_eq!(
+                observer
+                    .backoff_count
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                1
+            );
+            // This test pins retry timing, not a second kernel readiness edge.
+            // Normal delivery and shutdown ACKs are covered by the real pipes.
+            task.abort();
+            let _ = task.await;
+        }
     }
 
     #[tokio::test]

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -944,7 +944,7 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
         "type": "gauge",
         "help": "Build information for the running limpid node.",
         "series": [{
-            "labels": {"node_id": "edge-a", "version": "0.8.1"},
+            "labels": {"node_id": "edge-a", "version": "0.8.2"},
             "value": 1
         }]
     }));
@@ -962,14 +962,14 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
     assert!(details.contains("gauge"));
     assert!(details.contains("Build information for the running limpid node."));
     assert!(details.contains("node_id: \"edge-a\""));
-    assert!(details.contains("version: \"0.8.1\""));
+    assert!(details.contains("version: \"0.8.2\""));
     assert!(details.contains("value: 1"));
 
     let raw_output = run_stats(&response, &["--raw"]);
     assert!(raw_output.status.success(), "{raw_output:?}");
     let raw = stdout(&raw_output);
     assert!(raw.contains("node_id=\"edge-a\""));
-    assert!(raw.contains("version=\"0.8.1\""));
+    assert!(raw.contains("version=\"0.8.2\""));
 
     let json_output = run_stats(&response, &["--json"]);
     assert!(json_output.status.success(), "{json_output:?}");

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,5 +4,12 @@ description = "Log pipelines, limpid as intent."
 authors = ["Naoto Morishima"]
 language = "en"
 
+# Preserve README destinations used by the Markdown source. The index
+# preprocessor renames chapters without repairing these relative links.
+[build]
+use-default-preprocessors = false
+
+[preprocessor.links]
+
 [output.html]
 git-repository-url = "https://github.com/naoto256/limpid"

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1040,7 +1040,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.1"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.2"`).
 
 ```limpid
 workspace.processed_by_version = version()


### PR DESCRIPTION
## Summary

Merge `release/0.8.2` into `main` for the limpid 0.8.2 release, including the fixes from #227 and release preparation from #229.

- Accept hyphenated HTTP header property keys while preserving expression identifiers and subtraction.
- Make OTLP delivery acknowledgement and stdout readiness tests deterministic, including bounded retry synchronization and backoff timing checks.
- Validate release versions, extracted notes, and documentation links before publication; reuse the existing audited `actions/setup-python` v6.2.0 pin.
- Update all four product crates, internal schema requirements, lockfile, and current version fixtures to 0.8.2. Add the 0.8.2 changelog and release notes in the established format, preserving historical sections.

## Validation

- Independently reviewed changes from #227 and #229; workspace tests, clippy, focused regression tests, and release metadata/documentation checks passed.
- Datadog log delivery for the HTTP header fix was confirmed.
- All five CI jobs passed on the updated release branch and this PR; CodeQL Rust analysis is tracked separately in the PR checks.

This PR contains eight commits across 22 files. Merging prepares `main` for tagging; it does not itself create the v0.8.2 tag or publish release assets.

The earlier unsupported action-audit claim was withdrawn. The final Python setup pin reuses the existing audit dated 2026-06-03; no new bundle audit is claimed.
