### PR TITLE
chore(release): prepare 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-09-06
+
+> Hyphenated HTTP headers and more reliable validation.
+
+0.8.2 accepts hyphenated configuration property keys for HTTP headers,
+makes output regression tests wait for explicit progress, and adds automated
+release metadata and documentation checks.
+
+### Fixed — hyphenated HTTP header names
+
+HTTP output header maps now accept names such as `DD-API-KEY` and
+`X-Custom-Header`. The change is limited to property keys: expression
+identifiers and subtraction syntax remain unchanged. Header delivery was
+checked through a local HTTP receiver and Datadog log intake.
+
+### Fixed — output tests synchronize with delivery and readiness
+
+OTLP tests now wait for the delivery acknowledgement before shutdown.
+Full-pipe stdout tests distinguish pending readiness from an actual
+`EAGAIN` backoff, preserving shutdown, byte-exact drain, and acknowledgement
+assertions. The macOS retry timing test waits for observed progress instead
+of a fixed number of scheduler yields and checks the 10 ms boundary.
+These changes affect tests, not production output behavior.
+
+### Changed — release metadata and documentation preflight
+
+CI and the release workflow now check product versions, workspace dependencies,
+lockfile versions, release notes and titles, and rendered documentation links
+and anchors. Remote link checks distinguish missing destinations from transient
+network failures. The pinned mdBook configuration preserves README page targets
+alongside the book entry page. Both workflows use the existing audited
+`actions/setup-python` v6.2.0 pin.
+
 ## [0.8.1] - 2026-09-02
 
 > Single execution IR, safer queues, and lower hot-path overhead.
@@ -2487,7 +2520,8 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/naoto256/limpid/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/naoto256/limpid/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/naoto256/limpid/compare/v0.7.15...v0.8.0
 [0.7.15]: https://github.com/naoto256/limpid/compare/v0.7.14...v0.7.15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-metrics-schema"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-limpid-metrics-schema = { version = "0.8.1", path = "crates/limpid-metrics-schema" }
+limpid-metrics-schema = { version = "0.8.2", path = "crates/limpid-metrics-schema" }
 base64 = "0.22.1"
 pem = "3.0.6"
 ring = "0.17.14"

--- a/crates/limpid-metrics-schema/Cargo.toml
+++ b/crates/limpid-metrics-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-metrics-schema"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Wire DTOs for limpid schema-v1 metrics snapshots"
 license.workspace = true

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -831,7 +831,7 @@ mod tests {
                 "type": "gauge",
                 "help": "Build information for the running limpid node.",
                 "series": [{
-                    "labels": {"node_id": "edge-a", "version": "0.8.1"},
+                    "labels": {"node_id": "edge-a", "version": "0.8.2"},
                     "value": 1
                 }]
             }]
@@ -842,7 +842,7 @@ mod tests {
             concat!(
                 "# HELP limpid_build_info Build information for the running limpid node.\n",
                 "# TYPE limpid_build_info gauge\n",
-                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.1\"} 1\n\n"
+                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.2\"} 1\n\n"
             )
         );
     }

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1404,7 +1404,7 @@ def pipeline p { input i; output o }
             .build()
             .expect("test metric registration must succeed");
         received.inc();
-        crate::metrics::register_build_info(&metrics, "0.8.1", "control-node")
+        crate::metrics::register_build_info(&metrics, "0.8.2", "control-node")
             .expect("build info registration must succeed");
 
         let server = ControlServer::new(
@@ -1499,7 +1499,7 @@ def pipeline p { input i; output o }
         assert_eq!(
             build_info["series"],
             serde_json::json!([{
-                "labels": {"node_id": "control-node", "version": "0.8.1"},
+                "labels": {"node_id": "control-node", "version": "0.8.2"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -1699,7 +1699,7 @@ mod registry_tests {
     #[test]
     fn build_info_is_one_prepopulated_gauge_with_fixed_labels() {
         let registry = Registry::new();
-        super::register_build_info(&registry, "0.8.1", "node-a").expect("build info must register");
+        super::register_build_info(&registry, "0.8.2", "node-a").expect("build info must register");
 
         let snapshot = snapshot_json(&registry);
         let family = metric(&snapshot, "limpid_build_info");
@@ -1711,7 +1711,7 @@ mod registry_tests {
         assert_eq!(
             family["series"],
             serde_json::json!([{
-                "labels": {"node_id": "node-a", "version": "0.8.1"},
+                "labels": {"node_id": "node-a", "version": "0.8.2"},
                 "value": 1
             }])
         );

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -944,7 +944,7 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
         "type": "gauge",
         "help": "Build information for the running limpid node.",
         "series": [{
-            "labels": {"node_id": "edge-a", "version": "0.8.1"},
+            "labels": {"node_id": "edge-a", "version": "0.8.2"},
             "value": 1
         }]
     }));
@@ -962,14 +962,14 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
     assert!(details.contains("gauge"));
     assert!(details.contains("Build information for the running limpid node."));
     assert!(details.contains("node_id: \"edge-a\""));
-    assert!(details.contains("version: \"0.8.1\""));
+    assert!(details.contains("version: \"0.8.2\""));
     assert!(details.contains("value: 1"));
 
     let raw_output = run_stats(&response, &["--raw"]);
     assert!(raw_output.status.success(), "{raw_output:?}");
     let raw = stdout(&raw_output);
     assert!(raw.contains("node_id=\"edge-a\""));
-    assert!(raw.contains("version=\"0.8.1\""));
+    assert!(raw.contains("version=\"0.8.2\""));
 
     let json_output = run_stats(&response, &["--json"]);
     assert!(json_output.status.success(), "{json_output:?}");

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1040,7 +1040,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.1"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.2"`).
 
 ```limpid
 workspace.processed_by_version = version()


### PR DESCRIPTION
## Summary

- Align all four product crate versions, the workspace schema dependency, Cargo.lock, and current version fixtures/examples with 0.8.2.
- Add the 2026-09-06 changelog using the existing tagline, overview, and descriptive-section format. Cover HTTP header keys, output test synchronization, and release/docs preflight checks without changing historical notes or performance figures.
- Update Unreleased and release comparison links. No release is published by this PR.

## Validation

- Independent proportional review: CLEAN.
- Release preflight: metadata, notes/title extraction, built documentation targets/anchors, and selected remote links passed; 9 preflight unit tests passed.
- Focused build-info tests: 4 passed; control tests: 17 passed. Formatting and diff checks passed.
- Fresh commit and push gates passed. Existing unrelated functional suites were not rerun solely for this metadata-only change.

PR #228 remains open for release/0.8.2 to main synchronization.