### PR TITLE
Release 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-09-06
+
+> Quoted header keys with explicit configuration boundaries.
+
+0.8.3 introduces static quoted keys for configuration string maps and restores ordinary identifier syntax for bare property keys. Header names containing hyphens now use quotes, while fixed configuration names and expression identifiers retain their existing syntax.
+
+### Added — static quoted keys in header maps
+
+The `headers` blocks of HTTP, OTLP HTTP, and OTLP gRPC outputs accept static quoted keys such as `"DD-API-KEY" "your-api-key"`. Ordinary names such as `Authorization` may remain bare. Quoted keys decode literal string escapes but do not allow interpolation; the destination protocol's header-name restrictions still apply.
+
+### Changed — migrate bare hyphenated keys to quoted strings
+
+The bare hyphenated property-key syntax introduced in 0.8.2 is withdrawn. Update `DD-API-KEY "your-api-key"` to `"DD-API-KEY" "your-api-key"`, and quote other hyphenated header names in the same way. Bare hyphenated keys now produce a diagnostic with migration guidance. Quoted keys are limited to string-map entries: fixed properties, module `type`, named block maps, and global configuration blocks reject them. Variable names, expression identifiers, and subtraction remain unchanged.
+
+### Changed — header documentation follows the new key syntax
+
+HTTP header examples now quote hyphenated names, and all three output references explain the shared static-key syntax and its boundaries. Regression tests exercise parsing through actual local HTTP and OTLP HTTP/gRPC receivers; the OTLP tests also wait for delivery acknowledgements.
+
 ## [0.8.2] - 2026-09-06
 
 > Hyphenated HTTP headers and more reliable validation.
@@ -2520,7 +2538,8 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/naoto256/limpid/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/naoto256/limpid/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/naoto256/limpid/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/naoto256/limpid/compare/v0.7.15...v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-metrics-schema"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-limpid-metrics-schema = { version = "0.8.2", path = "crates/limpid-metrics-schema" }
+limpid-metrics-schema = { version = "0.8.3", path = "crates/limpid-metrics-schema" }
 base64 = "0.22.1"
 pem = "3.0.6"
 ring = "0.17.14"

--- a/crates/limpid-metrics-schema/Cargo.toml
+++ b/crates/limpid-metrics-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-metrics-schema"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "Wire DTOs for limpid schema-v1 metrics snapshots"
 license.workspace = true

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -831,7 +831,7 @@ mod tests {
                 "type": "gauge",
                 "help": "Build information for the running limpid node.",
                 "series": [{
-                    "labels": {"node_id": "edge-a", "version": "0.8.2"},
+                    "labels": {"node_id": "edge-a", "version": "0.8.3"},
                     "value": 1
                 }]
             }]
@@ -842,7 +842,7 @@ mod tests {
             concat!(
                 "# HELP limpid_build_info Build information for the running limpid node.\n",
                 "# TYPE limpid_build_info gauge\n",
-                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.2\"} 1\n\n"
+                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.3\"} 1\n\n"
             )
         );
     }

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1404,7 +1404,7 @@ def pipeline p { input i; output o }
             .build()
             .expect("test metric registration must succeed");
         received.inc();
-        crate::metrics::register_build_info(&metrics, "0.8.2", "control-node")
+        crate::metrics::register_build_info(&metrics, "0.8.3", "control-node")
             .expect("build info registration must succeed");
 
         let server = ControlServer::new(
@@ -1499,7 +1499,7 @@ def pipeline p { input i; output o }
         assert_eq!(
             build_info["series"],
             serde_json::json!([{
-                "labels": {"node_id": "control-node", "version": "0.8.2"},
+                "labels": {"node_id": "control-node", "version": "0.8.3"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/dsl/ast.rs
+++ b/crates/limpid/src/dsl/ast.rs
@@ -69,7 +69,9 @@ pub struct OutputDef {
 
 /// A key-value property or nested block inside input/output definitions.
 ///
-/// `key_span` covers just the key identifier — used by the property
+/// `key_quoted` preserves the key's syntactic form after static decoding;
+/// schema validation permits it only for StringMap entries.
+/// `key_span` covers the key token (including quotes) — used by the property
 /// schema validator to point at the offending key when it is unknown
 /// or mistyped. `value_span` covers the whole value expression — the
 /// analyzer uses it to position a caret when a reference inside that
@@ -80,6 +82,7 @@ pub enum Property {
     /// `key value`  e.g. `type syslog_udp`, `bind "0.0.0.0:514"`
     KeyValue {
         key: String,
+        key_quoted: bool,
         key_span: Option<Span>,
         value: Expr,
         value_span: Option<Span>,
@@ -87,6 +90,7 @@ pub enum Property {
     /// `key { ... }` e.g. `tls { cert "..." }`, `queue { type disk }`
     Block {
         key: String,
+        key_quoted: bool,
         key_span: Option<Span>,
         properties: Vec<Property>,
     },

--- a/crates/limpid/src/dsl/limpid.pest
+++ b/crates/limpid/src/dsl/limpid.pest
@@ -120,7 +120,10 @@ def_output = {
 
 // Header maps use names such as `DD-API-KEY`. Keep this separate from
 // expression identifiers so `left-right` remains subtraction.
-property_key = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
+property_key = { quoted_property_key | invalid_hyphenated_property_key | ident }
+quoted_property_key = @{ "\"" ~ (escape_seq | string_plain_char)* ~ "\"" }
+// Retain a diagnostic-only token so the parser can explain the migration.
+invalid_hyphenated_property_key = @{ ident ~ ("-" ~ (ASCII_ALPHANUMERIC | "_")+)+ }
 
 property = {
     property_key ~ "{" ~ property* ~ "}" // nested block: `tls { ... }`

--- a/crates/limpid/src/dsl/module_props.rs
+++ b/crates/limpid/src/dsl/module_props.rs
@@ -55,6 +55,7 @@ pub struct ModuleProperties {
 /// same sense as an unclosed brace.
 #[derive(Debug, Clone)]
 pub enum ModulePropertyError {
+    QuotedType,
     /// No `type` key was present in the property list.
     Missing,
     /// The `type` key exists but its value is not a bare identifier (e.g.
@@ -80,6 +81,10 @@ pub enum ModulePropertyError {
 impl std::fmt::Display for ModulePropertyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::QuotedType => write!(
+                f,
+                "quoted property keys are only allowed inside a StringMap; use bare type"
+            ),
             Self::Missing => write!(f, "missing required property 'type'"),
             Self::NonIdent { .. } => {
                 write!(
@@ -109,6 +114,18 @@ impl ModuleProperties {
             if key != "type" {
                 user.push(prop);
                 continue;
+            }
+            if matches!(
+                &prop,
+                Property::KeyValue {
+                    key_quoted: true,
+                    ..
+                } | Property::Block {
+                    key_quoted: true,
+                    ..
+                }
+            ) {
+                return Err(ModulePropertyError::QuotedType);
             }
             match &prop {
                 Property::KeyValue {
@@ -193,6 +210,7 @@ mod tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,
@@ -202,6 +220,7 @@ mod tests {
     fn block(key: &str) -> Property {
         Property::Block {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![],
         }

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -139,7 +139,27 @@ fn parse_global_block(pair: Pair<Rule>, file_id: u32) -> Result<GlobalBlock> {
     let properties = inner
         .map(|p| parse_property(p, file_id))
         .collect::<Result<Vec<_>>>()?;
+    // Globals have no StringMap surface. Reject before table/control consumers
+    // can extract keys without going through a module schema.
+    reject_quoted_global_keys(&properties)?;
     Ok(GlobalBlock { name, properties })
+}
+
+fn reject_quoted_global_keys(properties: &[Property]) -> Result<()> {
+    for property in properties {
+        let quoted = match property {
+            Property::KeyValue { key_quoted, .. } | Property::Block { key_quoted, .. } => {
+                *key_quoted
+            }
+        };
+        if quoted {
+            bail!("quoted property keys are only allowed inside a StringMap, not global blocks");
+        }
+        if let Property::Block { properties, .. } = property {
+            reject_quoted_global_keys(properties)?;
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -174,9 +194,31 @@ fn parse_property(pair: Pair<Rule>, file_id: u32) -> Result<Property> {
     let mut inner = pair.into_inner();
     let key_pair = inner.next().expect("pest grammar invariant");
     let key_span = Some(span_of(&key_pair, file_id));
-    let key = key_pair.as_str().to_string();
+    let key_pair = first_inner(key_pair)?;
+    let key_quoted = key_pair.as_rule() == Rule::quoted_property_key;
+    if key_pair.as_rule() == Rule::invalid_hyphenated_property_key {
+        bail!(
+            "hyphenated property key: quote the key inside a StringMap (for example, headers {{ \"DD-API-KEY\" \"...\" }})"
+        );
+    }
+    let key = if key_quoted {
+        let raw = key_pair.as_str();
+        let mut decoded = String::new();
+        // The key grammar excludes interpolation. Decode only literal escapes.
+        process_plain_into(&mut decoded, &raw[1..raw.len() - 1]);
+        decoded
+    } else {
+        key_pair.as_str().to_string()
+    };
 
-    let second = inner.next().expect("pest grammar invariant");
+    let Some(second) = inner.next() else {
+        return Ok(Property::Block {
+            key,
+            key_quoted,
+            key_span,
+            properties: Vec::new(),
+        });
+    };
     match second.as_rule() {
         Rule::property => {
             // nested block: key { property* }
@@ -187,6 +229,7 @@ fn parse_property(pair: Pair<Rule>, file_id: u32) -> Result<Property> {
             }
             Ok(Property::Block {
                 key,
+                key_quoted,
                 key_span,
                 properties: props,
             })
@@ -197,6 +240,7 @@ fn parse_property(pair: Pair<Rule>, file_id: u32) -> Result<Property> {
             let value = parse_expr_from_pair(second, file_id)?;
             Ok(Property::KeyValue {
                 key,
+                key_quoted,
                 key_span,
                 value,
                 value_span,
@@ -1183,14 +1227,14 @@ def input fw_syslog {
     }
 
     #[test]
-    fn hyphenated_header_keys_preserve_names_and_values() {
+    fn quoted_header_keys_preserve_names_and_values() {
         let config = parse_config(
             r#"
 def output logs {
     type http
     headers {
-        DD-API-KEY "test-only-key"
-        X-Custom-Header "value"
+        "DD-API-KEY" "test-only-key"
+        "X-Custom-Header" "value"
         Authorization "Bearer placeholder"
     }
 }
@@ -1208,6 +1252,44 @@ def output logs {
                 ("Authorization".into(), "Bearer placeholder".into()),
             ]
         );
+    }
+
+    #[test]
+    fn quoted_key_migration_rejects_bare_hyphen_with_guidance() {
+        let error =
+            parse_config(r#"def output logs { type http headers { DD-API-KEY "placeholder" } }"#)
+                .unwrap_err();
+        assert!(format!("{error:#}").contains("quote"), "{error:#}");
+    }
+
+    #[test]
+    fn quoted_keys_are_static_and_decode_literal_escapes() {
+        let config = parse_config(
+            r#"def output logs { type http headers { "x-\"quoted\"\\name" "v" "\${literal}" "v" } }"#,
+        ).unwrap();
+        let Definition::Output(output) = &config.definitions[0] else {
+            panic!("output")
+        };
+        let entries =
+            crate::dsl::props::get_string_map(output.properties.user_properties(), "headers");
+        assert_eq!(entries[0].0, "x-\"quoted\"\\name");
+        assert_eq!(entries[1].0, "${literal}");
+        assert!(
+            parse_config(r#"def output logs { type http headers { "${name}" "v" } }"#).is_err()
+        );
+    }
+
+    #[test]
+    fn quoted_global_keys_are_rejected_before_compilation() {
+        for source in [
+            r#"control { "error_log" "placeholder" }"#,
+            r#"table { "example" { type csv path "placeholder" } }"#,
+            r#"tls { "profile" { ca "placeholder" } }"#,
+            r#"table { example { "path" "placeholder" } }"#,
+        ] {
+            let error = parse_config(source).unwrap_err();
+            assert!(format!("{error:#}").contains("quoted"), "{error:#}");
+        }
     }
 
     #[test]

--- a/crates/limpid/src/dsl/props.rs
+++ b/crates/limpid/src/dsl/props.rs
@@ -305,6 +305,7 @@ mod tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -63,7 +63,7 @@ pub enum PropertyValueKind {
     /// values must each be a nested block conforming to the given schema.
     /// `tls { profile_a { ca "..." } profile_b { ca "..." cert "..." key "..." } }`
     BlockMap(&'static [PropertySpec]),
-    /// Open block whose keys are user-defined identifiers (HTTP
+    /// Open block whose keys are identifiers or static quoted strings (HTTP
     /// header names, k8s-style labels, etc.) and whose values must
     /// each be string-shaped. The schema validator never flags an
     /// "unknown key" inside this block — it only checks that every
@@ -155,6 +155,8 @@ pub struct PropertySpec {
 /// versus what the parsed config carries.
 #[derive(Debug, Clone)]
 pub enum SchemaErrorKind {
+    /// Quoted keys belong only to arbitrary-key StringMap entries.
+    QuotedKeyOutsideStringMap,
     /// Property key isn't declared in the schema.
     UnknownKey,
     /// Schema marks `required: true` and the key is absent.
@@ -205,6 +207,7 @@ impl SchemaError {
     pub fn primary_span(&self) -> Option<Span> {
         use SchemaErrorKind::*;
         match self.kind {
+            QuotedKeyOutsideStringMap => self.key_span.or(self.value_span),
             UnknownKey
             | MissingRequired
             | DuplicateKey
@@ -222,6 +225,10 @@ impl std::fmt::Display for SchemaError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use SchemaErrorKind::*;
         match &self.kind {
+            QuotedKeyOutsideStringMap => write!(
+                f,
+                "quoted property keys are only allowed inside a StringMap"
+            ),
             UnknownKey => {
                 write!(f, "unknown property '{}'", self.key)?;
                 if let Some(s) = &self.did_you_mean {
@@ -278,6 +285,10 @@ pub fn validate(props: &[Property], spec: &[PropertySpec]) -> Vec<SchemaError> {
         std::collections::HashMap::new();
 
     for prop in props {
+        if let Some(error) = quoted_key_error(prop) {
+            errs.push(error);
+            continue;
+        }
         let (name, key_span) = match prop {
             Property::KeyValue { key, key_span, .. } => (key.as_str(), *key_span),
             Property::Block { key, key_span, .. } => (key.as_str(), *key_span),
@@ -488,6 +499,10 @@ fn check_one_of(
 fn validate_block_map(properties: &[Property], inner_spec: &[PropertySpec]) -> Vec<SchemaError> {
     let mut errs = Vec::new();
     for prop in properties {
+        if let Some(error) = quoted_key_error(prop) {
+            errs.push(error);
+            continue;
+        }
         match prop {
             Property::Block {
                 properties: inner_properties,
@@ -522,6 +537,7 @@ fn validate_string_map(properties: &[Property]) -> Vec<SchemaError> {
                 key_span,
                 value,
                 value_span,
+                ..
             } => match &value.kind {
                 ExprKind::StringLit(_)
                 | ExprKind::Template(_)
@@ -549,6 +565,30 @@ fn validate_string_map(properties: &[Property]) -> Vec<SchemaError> {
         }
     }
     errs
+}
+
+fn quoted_key_error(prop: &Property) -> Option<SchemaError> {
+    let (key, key_span, quoted) = match prop {
+        Property::KeyValue {
+            key,
+            key_span,
+            key_quoted,
+            ..
+        }
+        | Property::Block {
+            key,
+            key_span,
+            key_quoted,
+            ..
+        } => (key, key_span, key_quoted),
+    };
+    quoted.then(|| SchemaError {
+        kind: SchemaErrorKind::QuotedKeyOutsideStringMap,
+        key: key.clone(),
+        key_span: *key_span,
+        value_span: prop_value_span(prop),
+        did_you_mean: None,
+    })
 }
 
 fn prop_value_span(p: &Property) -> Option<Span> {
@@ -724,6 +764,7 @@ mod tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,
@@ -733,6 +774,7 @@ mod tests {
     fn block(key: &str, properties: Vec<Property>) -> Property {
         Property::Block {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             properties,
         }
@@ -1182,6 +1224,7 @@ mod tests {
         let errs = validate(
             &[Property::Block {
                 key: "tls".into(),
+                key_quoted: false,
                 key_span: None,
                 properties: vec![],
             }],
@@ -1227,9 +1270,11 @@ mod tests {
         let errs = validate(
             &[Property::Block {
                 key: "tls".into(),
+                key_quoted: false,
                 key_span: None,
                 properties: vec![Property::Block {
                     key: "cert".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![],
                 }],
@@ -1363,6 +1408,81 @@ mod tests {
         ];
         let errs = validate(&props, SIMPLE);
         assert_eq!(errs.len(), 4);
+    }
+
+    #[test]
+    fn quoted_keys_are_only_accepted_inside_string_maps() {
+        const S: &[PropertySpec] = &[
+            PropertySpec {
+                name: "headers",
+                required: false,
+                repeatable: false,
+                exclusive_group: None,
+                kind: PropertyValueKind::StringMap,
+            },
+            PropertySpec {
+                name: "peer",
+                required: false,
+                repeatable: false,
+                exclusive_group: None,
+                kind: PropertyValueKind::Block(&[]),
+            },
+        ];
+        for source in [
+            r#"def output logs { type http "headers" { Authorization "v" } }"#,
+            r#"def output logs { type http peer { "url" "v" } }"#,
+        ] {
+            let config = crate::dsl::parser::parse_config(source).unwrap();
+            let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                panic!("output")
+            };
+            let errors = validate(output.properties.user_properties(), S);
+            assert!(
+                errors.iter().any(|e| e.to_string().contains("quoted")),
+                "{errors:?}"
+            );
+        }
+        assert!(crate::dsl::parser::parse_config(r#"def output logs { "type" http }"#).is_err());
+    }
+
+    #[test]
+    fn quoted_string_map_empty_and_protocol_independent_keys() {
+        const MAP: &[PropertySpec] = &[PropertySpec {
+            name: "headers",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::StringMap,
+        }];
+        for source in [
+            r#"def output logs { type http headers {} }"#,
+            r#"def output logs { type http headers { "" "v" "not an HTTP key" "v" Authorization "v" } }"#,
+        ] {
+            let config = crate::dsl::parser::parse_config(source).unwrap();
+            let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                panic!("output")
+            };
+            assert!(validate(output.properties.user_properties(), MAP).is_empty());
+        }
+        const NAMED: &[PropertySpec] = &[PropertySpec {
+            name: "tls",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::BlockMap(&[]),
+        }];
+        let config = crate::dsl::parser::parse_config(
+            r#"def output logs { type http tls { "profile" {} } }"#,
+        )
+        .unwrap();
+        let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+            panic!("output")
+        };
+        assert!(
+            validate(output.properties.user_properties(), NAMED)
+                .iter()
+                .any(|e| matches!(e.kind, SchemaErrorKind::QuotedKeyOutsideStringMap))
+        );
     }
 
     #[test]

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -1699,7 +1699,7 @@ mod registry_tests {
     #[test]
     fn build_info_is_one_prepopulated_gauge_with_fixed_labels() {
         let registry = Registry::new();
-        super::register_build_info(&registry, "0.8.2", "node-a").expect("build info must register");
+        super::register_build_info(&registry, "0.8.3", "node-a").expect("build info must register");
 
         let snapshot = snapshot_json(&registry);
         let family = metric(&snapshot, "limpid_build_info");
@@ -1711,7 +1711,7 @@ mod registry_tests {
         assert_eq!(
             family["series"],
             serde_json::json!([{
-                "labels": {"node_id": "node-a", "version": "0.8.2"},
+                "labels": {"node_id": "node-a", "version": "0.8.3"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/modules/input/ltp.rs
+++ b/crates/limpid/src/modules/input/ltp.rs
@@ -1128,6 +1128,7 @@ mod tests {
     fn string_property(key: &str, value: &str) -> Property {
         Property::KeyValue {
             key: key.to_owned(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::StringLit(value.to_owned())),
             value_span: None,
@@ -1137,6 +1138,7 @@ mod tests {
     fn int_property(key: &str, value: i64) -> Property {
         Property::KeyValue {
             key: key.to_owned(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::IntLit(value)),
             value_span: None,
@@ -1146,6 +1148,7 @@ mod tests {
     fn peer_property(node_id: &str, pubkey: &str) -> Property {
         Property::Block {
             key: "peer".to_owned(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 string_property("node_id", node_id),

--- a/crates/limpid/src/modules/input/otlp/grpc.rs
+++ b/crates/limpid/src/modules/input/otlp/grpc.rs
@@ -352,6 +352,7 @@ mod tests {
     fn rate_limit_property_round_trip() {
         let prop = Property::KeyValue {
             key: "rate_limit".into(),
+            key_quoted: false,
             key_span: None,
             value: crate::dsl::ast::Expr::spanless(crate::dsl::ast::ExprKind::IntLit(2500)),
             value_span: None,
@@ -369,6 +370,7 @@ mod tests {
         let mut props = vec![
             Property::KeyValue {
                 key: "cert".into(),
+                key_quoted: false,
                 key_span: None,
                 value: crate::dsl::ast::Expr::spanless(crate::dsl::ast::ExprKind::StringLit(
                     cert.into(),
@@ -377,6 +379,7 @@ mod tests {
             },
             Property::KeyValue {
                 key: "key".into(),
+                key_quoted: false,
                 key_span: None,
                 value: crate::dsl::ast::Expr::spanless(crate::dsl::ast::ExprKind::StringLit(
                     key.into(),
@@ -387,6 +390,7 @@ mod tests {
         if let Some(c) = ca {
             props.push(Property::KeyValue {
                 key: "ca".into(),
+                key_quoted: false,
                 key_span: None,
                 value: crate::dsl::ast::Expr::spanless(crate::dsl::ast::ExprKind::StringLit(
                     c.into(),
@@ -396,6 +400,7 @@ mod tests {
         }
         Property::Block {
             key: "tls".into(),
+            key_quoted: false,
             key_span: None,
             properties: props,
         }
@@ -433,9 +438,11 @@ mod tests {
     fn tls_block_without_cert_is_rejected() {
         let props = vec![Property::Block {
             key: "tls".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![Property::KeyValue {
                 key: "key".into(),
+                key_quoted: false,
                 key_span: None,
                 value: crate::dsl::ast::Expr::spanless(crate::dsl::ast::ExprKind::StringLit(
                     "/k.pem".into(),

--- a/crates/limpid/src/modules/input/otlp/http.rs
+++ b/crates/limpid/src/modules/input/otlp/http.rs
@@ -465,6 +465,7 @@ mod tests {
     fn prop_str(key: &str, val: &str) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::StringLit(val.to_string())),
             value_span: None,
@@ -474,6 +475,7 @@ mod tests {
     fn prop_int(key: &str, val: i64) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::IntLit(val)),
             value_span: None,
@@ -584,6 +586,7 @@ mod tests {
     fn prop_block(key: &str, properties: Vec<Property>) -> Property {
         Property::Block {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             properties,
         }

--- a/crates/limpid/src/modules/input/syslog_tcp.rs
+++ b/crates/limpid/src/modules/input/syslog_tcp.rs
@@ -1247,6 +1247,7 @@ mod tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,
@@ -1256,6 +1257,7 @@ mod tests {
     fn block(key: &str, properties: Vec<Property>) -> Property {
         Property::Block {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             properties,
         }

--- a/crates/limpid/src/modules/output/file.rs
+++ b/crates/limpid/src/modules/output/file.rs
@@ -2118,6 +2118,7 @@ mod tests {
     fn prop_str(key: &str, val: &str) -> crate::dsl::ast::Property {
         crate::dsl::ast::Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::StringLit(val.to_string())),
             value_span: None,

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -616,6 +616,7 @@ mod tests {
     fn prop_str(key: &str, val: &str) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::StringLit(val.to_string())),
             value_span: None,
@@ -625,6 +626,7 @@ mod tests {
     fn prop_int(key: &str, val: i64) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::IntLit(val)),
             value_span: None,
@@ -634,6 +636,7 @@ mod tests {
     fn prop_bool(key: &str, val: bool) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::BoolLit(val)),
             value_span: None,
@@ -643,6 +646,7 @@ mod tests {
     fn peer_block(url: &str) -> Property {
         Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![prop_str("url", url)],
         }
@@ -651,6 +655,7 @@ mod tests {
     fn ident_prop(key: &str, val: &str) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::Ident(vec![val.to_string()])),
             value_span: None,
@@ -660,6 +665,7 @@ mod tests {
     fn peers_block_with(peers: Vec<Property>) -> Property {
         Property::Block {
             key: "peers".into(),
+            key_quoted: false,
             key_span: None,
             properties: peers,
         }
@@ -674,6 +680,7 @@ mod tests {
     fn fast_retry_block() -> Property {
         Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),
@@ -681,6 +688,7 @@ mod tests {
                 prop_str("max_wait", "1ms"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,
@@ -708,6 +716,7 @@ mod tests {
     fn peer_requires_url() {
         let props = vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![],
         }];
@@ -762,11 +771,13 @@ mod tests {
         // and `output otlp_grpc`.
         let props = vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("url", "http://x:8080/"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![prop_str("ca", "/etc/ca.pem")],
                 },
@@ -793,11 +804,13 @@ mod tests {
         // so no on-disk file is required for the round-trip.
         let props = vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("url", "https://x:8443/"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![],
                 },
@@ -816,11 +829,13 @@ mod tests {
     fn rejects_tls_with_cert_but_no_key() {
         let props = vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("url", "https://x:8443/"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![prop_str("cert", "/c.pem")],
                 },
@@ -1147,6 +1162,7 @@ mod tests {
         let (healthy_addr, received, server) = run_echo_collector().await;
         let retry = Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 2),
@@ -1154,6 +1170,7 @@ mod tests {
                 prop_str("max_wait", "1ms"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,
@@ -1266,7 +1283,7 @@ def output test {{
     type http
     peer {{ url "http://{addr}/" }}
     batch_size 1
-    headers {{ DD-API-KEY "test-only-key" X-Custom-Header "exact-value" }}
+    headers {{ "DD-API-KEY" "test-only-key" "X-Custom-Header" "exact-value" }}
 }}
 "#
             ),
@@ -2150,6 +2167,7 @@ def output o {{
         let url = format!("http://{}/", addr);
         let retry = Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 3),
@@ -2157,6 +2175,7 @@ def output o {{
                 prop_str("max_wait", "1ms"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,
@@ -2223,6 +2242,7 @@ def output o {{
         // in about a second even without the wake bug.
         let slow_retry = Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 2),
@@ -2230,6 +2250,7 @@ def output o {{
                 prop_str("max_wait", "400ms"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,
@@ -2330,6 +2351,7 @@ def output o {{
         // elapsing on its own.
         let slow_retry = Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 5),
@@ -2337,6 +2359,7 @@ def output o {{
                 prop_str("max_wait", "5s"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,
@@ -2405,6 +2428,7 @@ def output o {{
         };
         let retry = Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 5),
@@ -2412,6 +2436,7 @@ def output o {{
                 prop_str("max_wait", "200ms"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,
@@ -2673,6 +2698,7 @@ def output o {{
         // exceed SHUTDOWN_FLUSH_ATTEMPT_TIMEOUT (3s).
         let retry = Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 5),
@@ -2680,6 +2706,7 @@ def output o {{
                 prop_str("max_wait", "5s"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,
@@ -3061,6 +3088,7 @@ def output o {{
         // churning through the retry budget and freeing the permit.
         let long_retry = Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 100),
@@ -3068,6 +3096,7 @@ def output o {{
                 prop_str("max_wait", "5s"),
                 Property::KeyValue {
                     key: "backoff".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::Ident(vec!["fixed".into()])),
                     value_span: None,

--- a/crates/limpid/src/modules/output/kafka.rs
+++ b/crates/limpid/src/modules/output/kafka.rs
@@ -765,6 +765,7 @@ mod tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,
@@ -774,6 +775,7 @@ mod tests {
     fn block(key: &str, properties: Vec<Property>) -> Property {
         Property::Block {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             properties,
         }

--- a/crates/limpid/src/modules/output/ltp.rs
+++ b/crates/limpid/src/modules/output/ltp.rs
@@ -728,6 +728,7 @@ mod tests {
     fn string_property(key: &str, value: &str) -> Property {
         Property::KeyValue {
             key: key.to_owned(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::StringLit(value.to_owned())),
             value_span: None,
@@ -737,6 +738,7 @@ mod tests {
     fn peer_property(node_id: &str, pubkey: &str, endpoint: &str) -> Property {
         Property::Block {
             key: "peer".to_owned(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 string_property("node_id", node_id),
@@ -749,9 +751,11 @@ mod tests {
     fn retry_once_property() -> Property {
         Property::Block {
             key: "retry".to_owned(),
+            key_quoted: false,
             key_span: None,
             properties: vec![Property::KeyValue {
                 key: "max_attempts".to_owned(),
+                key_quoted: false,
                 key_span: None,
                 value: Expr::spanless(ExprKind::IntLit(1)),
                 value_span: None,
@@ -1051,6 +1055,7 @@ mod tests {
         ] {
             let properties = vec![Property::Block {
                 key: "peer".to_owned(),
+                key_quoted: false,
                 key_span: None,
                 properties: vec![
                     (key != "node_id").then(|| string_property("node_id", "peer-a")),

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -505,6 +505,7 @@ mod tests {
     fn prop_str(key: &str, val: &str) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::StringLit(val.to_string())),
             value_span: None,
@@ -514,6 +515,7 @@ mod tests {
     fn prop_int(key: &str, val: i64) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::IntLit(val)),
             value_span: None,
@@ -523,6 +525,7 @@ mod tests {
     fn peer_block(endpoint: &str) -> Property {
         Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![prop_str("endpoint", endpoint)],
         }
@@ -531,6 +534,7 @@ mod tests {
     fn peers_block_with(peers: Vec<Property>) -> Property {
         Property::Block {
             key: "peers".into(),
+            key_quoted: false,
             key_span: None,
             properties: peers,
         }
@@ -559,6 +563,7 @@ mod tests {
     async fn accepts_single_peer_shorthand() {
         let props = vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![prop_str("endpoint", "http://x:4317")],
         }];
@@ -606,11 +611,13 @@ mod tests {
         // in `output otlp_http`.
         let props = vec![peers_block_with(vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("endpoint", "http://collector.example.com:4317"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![prop_str("ca", "/etc/ca.pem")],
                 },
@@ -637,11 +644,13 @@ mod tests {
         // block keeps the test off-disk; the scheme check runs first.
         let props = vec![peers_block_with(vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("endpoint", "https://collector.example.com:4317"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![],
                 },
@@ -687,11 +696,13 @@ mod tests {
     fn rejects_tls_with_key_but_no_cert() {
         let props = vec![peers_block_with(vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("endpoint", "https://x:4317"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![prop_str("key", "/k.pem")],
                 },
@@ -737,6 +748,7 @@ mod tests {
         let mut props = one_peer_props("http://x");
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 2),
@@ -868,6 +880,72 @@ mod tests {
                 partial_success: None,
             }))
         }
+    }
+
+    #[tokio::test]
+    async fn quoted_headers_reach_otlp_grpc_receiver() {
+        struct HeaderReceiver(tokio::sync::mpsc::Sender<tonic::metadata::MetadataMap>);
+        #[tonic::async_trait]
+        impl LogsService for HeaderReceiver {
+            async fn export(
+                &self,
+                request: tonic::Request<ExportLogsServiceRequest>,
+            ) -> std::result::Result<tonic::Response<ExportLogsServiceResponse>, tonic::Status>
+            {
+                self.0.send(request.metadata().clone()).await.unwrap();
+                Ok(tonic::Response::new(ExportLogsServiceResponse {
+                    partial_success: None,
+                }))
+            }
+        }
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let server = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(LogsServiceServer::new(HeaderReceiver(tx)))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+        let cfg = crate::dsl::parser::parse_config(&format!(
+            r#"
+def output test {{
+    type otlp_grpc
+    peer {{ endpoint "http://{addr}" }}
+    batch_size 1
+    headers {{ "X-Custom-Header" "exact-value" Authorization "placeholder" }}
+}}
+"#
+        ))
+        .unwrap();
+        let compiled = crate::pipeline::CompiledConfig::from_config(cfg).unwrap();
+        let output = OtlpGrpcOutput::from_properties(
+            "test",
+            &compiled.outputs["test"].properties,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let (ack, mut acknowledgements) = QueueAckHandle::for_test();
+        output
+            .consume(
+                &event_with_egress(singleton_bytes(1_700_000_000_000_000_000)),
+                ack,
+            )
+            .await
+            .unwrap();
+        let received = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+        let delivered = tokio::time::timeout(Duration::from_secs(5), acknowledgements.recv()).await;
+        output.shutdown(None).await.unwrap();
+        server.abort();
+        let _ = server.await;
+        let headers = received.unwrap().unwrap();
+        assert_eq!(headers.get("x-custom-header").unwrap(), "exact-value");
+        assert_eq!(headers.get("authorization").unwrap(), "placeholder");
+        assert!(matches!(
+            delivered.unwrap().unwrap().1,
+            crate::queue::AckDisposition::Delivered
+        ));
     }
 
     #[tokio::test]
@@ -1119,6 +1197,7 @@ mod tests {
         props.push(prop_int("batch_size", 1));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),
@@ -1291,6 +1370,7 @@ mod tests {
         props.push(prop_str("batch_timeout", "30s"));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),
@@ -1339,6 +1419,7 @@ mod tests {
         // an unreachable peer completes quickly.
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -630,6 +630,7 @@ mod tests {
     fn prop_str(key: &str, val: &str) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::StringLit(val.to_string())),
             value_span: None,
@@ -639,6 +640,7 @@ mod tests {
     fn prop_int(key: &str, val: i64) -> Property {
         Property::KeyValue {
             key: key.to_string(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(ExprKind::IntLit(val)),
             value_span: None,
@@ -648,6 +650,7 @@ mod tests {
     fn peer_block(endpoint: &str) -> Property {
         Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![prop_str("endpoint", endpoint)],
         }
@@ -656,6 +659,7 @@ mod tests {
     fn peers_block_with(peers: Vec<Property>) -> Property {
         Property::Block {
             key: "peers".into(),
+            key_quoted: false,
             key_span: None,
             properties: peers,
         }
@@ -794,6 +798,7 @@ def output o {{
     fn accepts_single_peer_shorthand() {
         let props = vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![prop_str("endpoint", "http://x:4318/v1/logs")],
         }];
@@ -827,6 +832,7 @@ def output o {{
     fn peer_requires_endpoint() {
         let props = vec![peers_block_with(vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![],
         }])];
@@ -915,11 +921,13 @@ def output o {{
     fn rejects_tls_with_cert_but_no_key() {
         let props = vec![peers_block_with(vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("endpoint", "https://x"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![prop_str("cert", "/c.pem")],
                 },
@@ -940,6 +948,7 @@ def output o {{
         let mut props = one_peer_props("http://x");
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 2),
@@ -1152,6 +1161,69 @@ def output o {{
     }
 
     #[tokio::test]
+    async fn quoted_headers_reach_otlp_http_receiver() {
+        use axum::{Router, extract::State, http::HeaderMap, routing::post};
+        async fn receive(
+            State(tx): State<tokio::sync::mpsc::Sender<HeaderMap>>,
+            headers: HeaderMap,
+        ) -> &'static str {
+            tx.send(headers).await.unwrap();
+            ""
+        }
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new()
+                    .route("/v1/logs", post(receive))
+                    .with_state(tx),
+            )
+            .await
+            .unwrap();
+        });
+        let cfg = crate::dsl::parser::parse_config(&format!(
+            r#"
+def output test {{
+    type otlp_http
+    peer {{ endpoint "http://{addr}/v1/logs" }}
+    batch_size 1
+    headers {{ "X-Custom-Header" "exact-value" Authorization "placeholder" }}
+}}
+"#
+        ))
+        .unwrap();
+        let compiled = crate::pipeline::CompiledConfig::from_config(cfg).unwrap();
+        let output = OtlpHttpOutput::from_properties(
+            "test",
+            &compiled.outputs["test"].properties,
+            &crate::modules::BuildContext::for_testing(),
+        )
+        .unwrap();
+        let (ack, mut acknowledgements) = QueueAckHandle::for_test();
+        output
+            .consume(
+                &event_with_egress(singleton_bytes(1_700_000_000_000_000_000)),
+                ack,
+            )
+            .await
+            .unwrap();
+        let received = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+        let delivered = tokio::time::timeout(Duration::from_secs(5), acknowledgements.recv()).await;
+        output.shutdown(None).await.unwrap();
+        server.abort();
+        let _ = server.await;
+        let headers = received.unwrap().unwrap();
+        assert_eq!(headers["x-custom-header"], "exact-value");
+        assert_eq!(headers["authorization"], "placeholder");
+        assert!(matches!(
+            delivered.unwrap().unwrap().1,
+            crate::queue::AckDisposition::Delivered
+        ));
+    }
+
+    #[tokio::test]
     async fn retries_until_success_single_peer() {
         use axum::{
             Router, extract::State, http::StatusCode, response::IntoResponse, routing::post,
@@ -1195,6 +1267,7 @@ def output o {{
         props.push(prop_int("batch_size", 1));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 5),
@@ -1260,6 +1333,7 @@ def output o {{
             prop_int("batch_size", 1),
             Property::Block {
                 key: "retry".into(),
+                key_quoted: false,
                 key_span: None,
                 properties: vec![
                     prop_int("max_attempts", 3),
@@ -1312,6 +1386,7 @@ def output o {{
         props.push(prop_int("batch_size", 1));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 3),
@@ -1372,6 +1447,7 @@ def output o {{
         props.push(prop_int("batch_size", 1));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),
@@ -1416,6 +1492,7 @@ def output o {{
         props.push(prop_int("batch_size", 1));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),
@@ -1698,6 +1775,7 @@ def output o {{
         props.push(prop_str("batch_timeout", "30s"));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),
@@ -1815,11 +1893,13 @@ def output o {{
         // nothing. Fail fast at parse time.
         let props = vec![peers_block_with(vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("endpoint", "http://collector.example.com:4318/v1/logs"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![prop_str("ca", "/etc/ca.pem")],
                 },
@@ -1873,6 +1953,7 @@ def output o {{
         props.push(prop_int("batch_size", 1));
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),
@@ -1935,11 +2016,13 @@ def output o {{
         // before the file read.
         let props = vec![peers_block_with(vec![Property::Block {
             key: "peer".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_str("endpoint", "https://collector.example.com:4318/v1/logs"),
                 Property::Block {
                     key: "tls".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![],
                 },
@@ -1967,6 +2050,7 @@ def output o {{
         // peer fails quickly.
         props.push(Property::Block {
             key: "retry".into(),
+            key_quoted: false,
             key_span: None,
             properties: vec![
                 prop_int("max_attempts", 1),

--- a/crates/limpid/src/modules/output/syslog_tcp.rs
+++ b/crates/limpid/src/modules/output/syslog_tcp.rs
@@ -1147,6 +1147,7 @@ mod tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,
@@ -1156,6 +1157,7 @@ mod tests {
     fn block(key: &str, properties: Vec<Property>) -> Property {
         Property::Block {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             properties,
         }

--- a/crates/limpid/src/modules/output/syslog_udp.rs
+++ b/crates/limpid/src/modules/output/syslog_udp.rs
@@ -619,6 +619,7 @@ mod tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,
@@ -628,6 +629,7 @@ mod tests {
     fn block(key: &str, properties: Vec<Property>) -> Property {
         Property::Block {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             properties,
         }

--- a/crates/limpid/src/modules/output/unix_socket.rs
+++ b/crates/limpid/src/modules/output/unix_socket.rs
@@ -752,6 +752,7 @@ mod tests {
             vec![
                 Property::KeyValue {
                     key: "path".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::StringLit(
                         socket_path.to_str().unwrap().to_string(),
@@ -760,9 +761,11 @@ mod tests {
                 },
                 Property::Block {
                     key: "retry".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![Property::KeyValue {
                         key: "max_attempts".into(),
+                        key_quoted: false,
                         key_span: None,
                         value: Expr::spanless(ExprKind::IntLit(1)),
                         value_span: None,
@@ -842,6 +845,7 @@ mod tests {
             "unix_socket",
             vec![Property::KeyValue {
                 key: "path".into(),
+                key_quoted: false,
                 key_span: None,
                 value: Expr::spanless(ExprKind::StringLit("/tmp/never.sock".into())),
                 value_span: None,
@@ -905,12 +909,14 @@ mod tests {
             vec![
                 Property::KeyValue {
                     key: "path".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::StringLit("/tmp/never.sock".into())),
                     value_span: None,
                 },
                 Property::KeyValue {
                     key: "expected_peer_uid".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::StringLit(user_name.clone())),
                     value_span: None,
@@ -942,12 +948,14 @@ mod tests {
             vec![
                 Property::KeyValue {
                     key: "path".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::StringLit("/tmp/never.sock".into())),
                     value_span: None,
                 },
                 Property::KeyValue {
                     key: "expected_peer_uid".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::StringLit(
                         "definitely_not_a_real_user_xyzzy".into(),
@@ -1013,6 +1021,7 @@ mod tests {
             "unix_socket",
             vec![Property::KeyValue {
                 key: "path".into(),
+                key_quoted: false,
                 key_span: None,
                 value: Expr::spanless(ExprKind::StringLit(
                     socket_path.to_str().unwrap().to_string(),
@@ -1032,6 +1041,7 @@ mod tests {
             vec![
                 Property::KeyValue {
                     key: "path".into(),
+                    key_quoted: false,
                     key_span: None,
                     value: Expr::spanless(ExprKind::StringLit(
                         socket_path.to_str().unwrap().to_string(),
@@ -1040,22 +1050,26 @@ mod tests {
                 },
                 Property::Block {
                     key: "retry".into(),
+                    key_quoted: false,
                     key_span: None,
                     properties: vec![
                         Property::KeyValue {
                             key: "max_attempts".into(),
+                            key_quoted: false,
                             key_span: None,
                             value: Expr::spanless(ExprKind::IntLit(3)),
                             value_span: None,
                         },
                         Property::KeyValue {
                             key: "initial_wait".into(),
+                            key_quoted: false,
                             key_span: None,
                             value: Expr::spanless(ExprKind::StringLit("20ms".into())),
                             value_span: None,
                         },
                         Property::KeyValue {
                             key: "max_wait".into(),
+                            key_quoted: false,
                             key_span: None,
                             value: Expr::spanless(ExprKind::StringLit("20ms".into())),
                             value_span: None,

--- a/crates/limpid/src/queue/mod.rs
+++ b/crates/limpid/src/queue/mod.rs
@@ -3941,6 +3941,7 @@ mod schema_splice_tests {
     fn kv(key: &str, kind: ExprKind) -> Property {
         Property::KeyValue {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             value: Expr::spanless(kind),
             value_span: None,
@@ -3950,6 +3951,7 @@ mod schema_splice_tests {
     fn block(key: &str, properties: Vec<Property>) -> Property {
         Property::Block {
             key: key.into(),
+            key_quoted: false,
             key_span: None,
             properties,
         }

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -944,7 +944,7 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
         "type": "gauge",
         "help": "Build information for the running limpid node.",
         "series": [{
-            "labels": {"node_id": "edge-a", "version": "0.8.2"},
+            "labels": {"node_id": "edge-a", "version": "0.8.3"},
             "value": 1
         }]
     }));
@@ -962,14 +962,14 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
     assert!(details.contains("gauge"));
     assert!(details.contains("Build information for the running limpid node."));
     assert!(details.contains("node_id: \"edge-a\""));
-    assert!(details.contains("version: \"0.8.2\""));
+    assert!(details.contains("version: \"0.8.3\""));
     assert!(details.contains("value: 1"));
 
     let raw_output = run_stats(&response, &["--raw"]);
     assert!(raw_output.status.success(), "{raw_output:?}");
     let raw = stdout(&raw_output);
     assert!(raw.contains("node_id=\"edge-a\""));
-    assert!(raw.contains("version=\"0.8.2\""));
+    assert!(raw.contains("version=\"0.8.3\""));
 
     let json_output = run_stats(&response, &["--json"]);
     assert!(json_output.status.success(), "{json_output:?}");

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1040,7 +1040,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.2"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.3"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/outputs/http.md
+++ b/docs/src/outputs/http.md
@@ -74,10 +74,19 @@ On each send the rotation picks the next available peer (cooldown expired) and t
 
 ### headers block
 
+From 0.8.3, header names containing hyphens must be quoted, for example
+`"DD-API-KEY" "your-api-key"`. Ordinary identifiers such as `Authorization`
+may remain bare. Quoted keys are static strings: `${...}` interpolation is
+not allowed in keys. Literal escapes follow string-value decoding (`\"`,
+`\\`, `\n`, `\t`, and `\$`; unknown escapes retain the backslash).
+Quoting is supported only for entries inside string maps such as `headers`,
+not fixed configuration names such as `type` or `peer`. HTTP header-name
+restrictions still apply to the decoded name.
+
 ```limpid
 headers {
     Authorization "Bearer your-token"
-    X-Custom-Header "value"
+    "X-Custom-Header" "value"
 }
 ```
 
@@ -149,7 +158,7 @@ def output datadog {
     batch_size 50
     compress gzip
     headers {
-        DD-API-KEY "your-api-key"
+        "DD-API-KEY" "your-api-key"
     }
 }
 ```

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -49,6 +49,11 @@ def output otlp_out {
 
 ## Properties
 
+Header keys use the same [static quoted-key syntax](http.md#headers-block)
+as HTTP output. Use `"X-Custom-Header" "value"` for hyphenated names;
+`Authorization` may remain bare. Names are lower-cased for gRPC metadata;
+quoting does not bypass the protocol's name restrictions.
+
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `peer { endpoint tls{...} }` or `peers { peer { ... } ... }` | yes (one of) | — | One or more peer blocks. See [§ peers](#peers) below. |

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -50,6 +50,10 @@ def output otlp_out {
 
 ## Properties
 
+Header keys use the same [static quoted-key syntax](http.md#headers-block)
+as HTTP output. Use `"X-Custom-Header" "value"` for hyphenated names;
+`Authorization` may remain bare. Quoting does not bypass HTTP name restrictions.
+
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `peer { endpoint tls{...} }` or `peers { peer { ... } ... }` | yes (one of) | — | One or more peer blocks. See [§ peers](#peers) below. |


### PR DESCRIPTION
## Summary

Merge the 0.8.3 release branch into main: two commits covering the quoted-key fix and release preparation.

- Allow static quoted keys in configuration string maps, including HTTP and OTLP HTTP/gRPC headers. Ordinary identifier keys remain supported; key interpolation and quoted fixed configuration names are rejected.
- Withdraw bare hyphenated property keys introduced in 0.8.2. Migrate `DD-API-KEY "value"` to `"DD-API-KEY" "value"`; expression identifiers and subtraction retain their existing grammar.
- Prepare all four products, workspace schema dependency, lockfile, current fixtures, and documentation for 0.8.3. Add migration notes while preserving historical release notes.

## Validation

- Independent fix and release-preparation reviews: CLEAN.
- Parser/schema boundary tests and actual local HTTP/OTLP receiver tests, including delivery acknowledgement checks: PASS.
- Fix workspace tests and clippy: PASS. Release-preparation metadata, notes, strict documentation links/anchors, focused build-info tests, formatting, and diff checks: PASS.
- PR #230 and PR #231 CI: SUCCESS.

This PR does not publish a release or deploy to live hosts. Tagging and publication are separate subsequent actions.
