### PR TITLE
fix(dsl): require static objects for configuration string maps

### DIFF
--- a/crates/limpid/src/dsl/limpid.pest
+++ b/crates/limpid/src/dsl/limpid.pest
@@ -127,8 +127,15 @@ invalid_hyphenated_property_key = @{ ident ~ ("-" ~ (ASCII_ALPHANUMERIC | "_")+)
 
 property = {
     property_key ~ "{" ~ property* ~ "}" // nested block: `tls { ... }`
+  | property_key ~ configuration_object
   | property_key ~ expr                   // key-value: `type syslog_udp`, `bind "0.0.0.0:514"`
 }
+
+// Configuration string maps reuse HashLit without broadening expression keys.
+configuration_object = {
+    "{" ~ (configuration_entry ~ ("," ~ configuration_entry)* ~ ","?)? ~ "}"
+}
+configuration_entry = { quoted_property_key ~ ":" ~ expr }
 
 // -- Process definition ------------------------------------------------------
 

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -197,16 +197,10 @@ fn parse_property(pair: Pair<Rule>, file_id: u32) -> Result<Property> {
     let key_pair = first_inner(key_pair)?;
     let key_quoted = key_pair.as_rule() == Rule::quoted_property_key;
     if key_pair.as_rule() == Rule::invalid_hyphenated_property_key {
-        bail!(
-            "hyphenated property key: quote the key inside a StringMap (for example, headers {{ \"DD-API-KEY\" \"...\" }})"
-        );
+        bail!("invalid hyphenated property key");
     }
     let key = if key_quoted {
-        let raw = key_pair.as_str();
-        let mut decoded = String::new();
-        // The key grammar excludes interpolation. Decode only literal escapes.
-        process_plain_into(&mut decoded, &raw[1..raw.len() - 1]);
-        decoded
+        decode_literal_key(key_pair.as_str())
     } else {
         key_pair.as_str().to_string()
     };
@@ -237,7 +231,11 @@ fn parse_property(pair: Pair<Rule>, file_id: u32) -> Result<Property> {
         _ => {
             // key-value: key expr
             let value_span = Some(span_of(&second, file_id));
-            let value = parse_expr_from_pair(second, file_id)?;
+            let value = if second.as_rule() == Rule::configuration_object {
+                parse_hash_lit(second, file_id)?
+            } else {
+                parse_expr_from_pair(second, file_id)?
+            };
             Ok(Property::KeyValue {
                 key,
                 key_quoted,
@@ -1014,17 +1012,25 @@ fn parse_func_args(pair: Pair<Rule>, file_id: u32) -> Result<Vec<Expr>> {
         .collect()
 }
 
+fn decode_literal_key(raw: &str) -> String {
+    let mut decoded = String::new();
+    // The literal-key grammar excludes interpolation; share value escape decoding.
+    process_plain_into(&mut decoded, &raw[1..raw.len() - 1]);
+    decoded
+}
+
 fn parse_hash_lit(pair: Pair<Rule>, file_id: u32) -> Result<Expr> {
     let span = span_of(&pair, file_id);
     let entries = pair
         .into_inner()
         .map(|entry| {
             let mut inner = entry.into_inner();
-            let key = inner
-                .next()
-                .expect("pest grammar invariant")
-                .as_str()
-                .to_string();
+            let key = inner.next().expect("pest grammar invariant");
+            let key = if key.as_rule() == Rule::quoted_property_key {
+                decode_literal_key(key.as_str())
+            } else {
+                key.as_str().to_string()
+            };
             let value =
                 parse_expr_from_pair(inner.next().expect("pest grammar invariant"), file_id)?;
             Ok((key, value))
@@ -1233,9 +1239,9 @@ def input fw_syslog {
 def output logs {
     type http
     headers {
-        "DD-API-KEY" "test-only-key"
-        "X-Custom-Header" "value"
-        Authorization "Bearer placeholder"
+        "DD-API-KEY": "test-only-key",
+        "X-Custom-Header": "value",
+        "Authorization": "Bearer placeholder"
     }
 }
 "#,
@@ -1255,17 +1261,17 @@ def output logs {
     }
 
     #[test]
-    fn quoted_key_migration_rejects_bare_hyphen_with_guidance() {
+    fn property_key_rejects_bare_hyphen() {
         let error =
             parse_config(r#"def output logs { type http headers { DD-API-KEY "placeholder" } }"#)
                 .unwrap_err();
-        assert!(format!("{error:#}").contains("quote"), "{error:#}");
+        assert!(format!("{error:#}").contains("invalid"), "{error:#}");
     }
 
     #[test]
     fn quoted_keys_are_static_and_decode_literal_escapes() {
         let config = parse_config(
-            r#"def output logs { type http headers { "x-\"quoted\"\\name" "v" "\${literal}" "v" } }"#,
+            r#"def output logs { type http headers { "x-\"quoted\"\\name": "v", "\${literal}": "v" } }"#,
         ).unwrap();
         let Definition::Output(output) = &config.definitions[0] else {
             panic!("output")

--- a/crates/limpid/src/dsl/props.rs
+++ b/crates/limpid/src/dsl/props.rs
@@ -207,38 +207,23 @@ pub fn get_block<'a>(props: &'a [Property], key: &str) -> Option<&'a Vec<Propert
     None
 }
 
-/// Extract a `StringMap`-shaped sub-block as a list of `(key, value)`
-/// pairs. The block's key set is open (HTTP header names, k8s-style
-/// labels, etc.) and every value is rendered to `String` through the
-/// same rules `get_string` uses (`StringLit` / `Template` source
-/// reconstruction / `Ident` joined by `.` / `IntLit` decimal).
-///
-/// Returns `Vec::new()` when the block is absent. The analyzer flags
-/// non-string entries via the schema (`PropertyValueKind::StringMap`),
-/// so callers here can safely drop them without re-reporting.
+/// Extract a schema-validated static StringMap object without evaluating values.
+/// Missing maps and the syntactically shared empty block both yield no entries.
 pub fn get_string_map(props: &[Property], key: &str) -> Vec<(String, String)> {
-    let Some(block) = get_block(props, key) else {
+    let Some(Expr {
+        kind: ExprKind::HashLit(entries),
+        ..
+    }) = get_expr(props, key)
+    else {
         return Vec::new();
     };
-    let mut out = Vec::new();
-    for prop in block {
-        if let Property::KeyValue {
-            key: k,
-            value: expr,
-            ..
-        } = prop
-            && let Some(val) = match &expr.kind {
-                ExprKind::StringLit(s) => Some(s.clone()),
-                ExprKind::Template(frags) => Some(template_to_source(frags)),
-                ExprKind::Ident(parts) => Some(parts.join(".")),
-                ExprKind::IntLit(n) => Some(n.to_string()),
-                _ => None,
-            }
-        {
-            out.push((k.clone(), val));
-        }
-    }
-    out
+    entries
+        .iter()
+        .filter_map(|(key, value)| match &value.kind {
+            ExprKind::StringLit(value) => Some((key.clone(), value.clone())),
+            _ => None, // Rejected by StringMap schema before module construction.
+        })
+        .collect()
 }
 
 /// Parse size strings like "1GB", "512MB", "1024" (bytes).

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -63,12 +63,8 @@ pub enum PropertyValueKind {
     /// values must each be a nested block conforming to the given schema.
     /// `tls { profile_a { ca "..." } profile_b { ca "..." cert "..." key "..." } }`
     BlockMap(&'static [PropertySpec]),
-    /// Open block whose keys are identifiers or static quoted strings (HTTP
-    /// header names, k8s-style labels, etc.) and whose values must
-    /// each be string-shaped. The schema validator never flags an
-    /// "unknown key" inside this block — it only checks that every
-    /// entry is a key-value (not a nested sub-block) with a
-    /// string-shaped value.
+    /// Object with arbitrary literal keys and StringLit values only.
+    /// No expression evaluation, template reconstruction, or value coercion.
     StringMap,
     /// Value can be one of multiple shapes. Used for keys that accept
     /// either an inline block or a reference identifier.
@@ -85,9 +81,7 @@ impl PropertyValueKind {
     fn expects_block_outer_shape(self) -> bool {
         matches!(
             self,
-            PropertyValueKind::Block(_)
-                | PropertyValueKind::BlockMap(_)
-                | PropertyValueKind::StringMap
+            PropertyValueKind::Block(_) | PropertyValueKind::BlockMap(_)
         )
     }
 
@@ -385,12 +379,18 @@ fn check_property(
             }],
         },
         PropertyValueKind::StringMap => match prop {
-            Property::Block { properties, .. } => validate_string_map(properties),
-            Property::KeyValue { value_span, .. } => vec![SchemaError {
-                kind: SchemaErrorKind::ExpectedBlock,
+            // `{}` is syntactically shared with empty ordinary blocks.
+            Property::Block { properties, .. } if properties.is_empty() => Vec::new(),
+            Property::KeyValue {
+                value, value_span, ..
+            } => validate_string_map(key, value, key_span, *value_span),
+            Property::Block { .. } => vec![SchemaError {
+                kind: SchemaErrorKind::TypeMismatch {
+                    expected: "a static string object",
+                },
                 key: key.to_string(),
                 key_span,
-                value_span: *value_span,
+                value_span: None,
                 did_you_mean: None,
             }],
         },
@@ -447,7 +447,7 @@ fn check_one_of(
     // wrote a Block and the real problem is one missing inner key.
     //
     // Structural match is decided by comparing the variant's expected
-    // outer shape (`Block` / `BlockMap` / `StringMap` → block-shaped;
+    // outer shape (`Block` / `BlockMap` → block-shaped;
     // everything else → scalar-shaped) against the actual `Property`
     // variant. Earlier this filter walked the per-variant error list
     // looking for `ExpectedBlock` / `ExpectedValue` kinds, which
@@ -525,46 +525,37 @@ fn validate_block_map(properties: &[Property], inner_spec: &[PropertySpec]) -> V
     errs
 }
 
-/// Validate a `StringMap`-kind block: every entry must be a key-value
-/// with a string-shaped value. The key set is open, so there is no
-/// unknown-key check.
-fn validate_string_map(properties: &[Property]) -> Vec<SchemaError> {
-    let mut errs = Vec::new();
-    for prop in properties {
-        match prop {
-            Property::KeyValue {
-                key,
-                key_span,
-                value,
-                value_span,
-                ..
-            } => match &value.kind {
-                ExprKind::StringLit(_)
-                | ExprKind::Template(_)
-                | ExprKind::Ident(_)
-                | ExprKind::IntLit(_) => {}
-                _ => errs.push(SchemaError {
-                    kind: SchemaErrorKind::TypeMismatch {
-                        expected: "a string",
-                    },
-                    key: key.clone(),
-                    key_span: *key_span,
-                    value_span: *value_span,
-                    did_you_mean: None,
-                }),
+/// The parser stores literal keys in HashLit; values must remain literal too.
+fn validate_string_map(
+    key: &str,
+    value: &Expr,
+    key_span: Option<Span>,
+    value_span: Option<Span>,
+) -> Vec<SchemaError> {
+    let ExprKind::HashLit(entries) = &value.kind else {
+        return vec![SchemaError {
+            kind: SchemaErrorKind::TypeMismatch {
+                expected: "a static string object",
             },
-            Property::Block { key, key_span, .. } => {
-                errs.push(SchemaError {
-                    kind: SchemaErrorKind::ExpectedValue,
-                    key: key.clone(),
-                    key_span: *key_span,
-                    value_span: None,
-                    did_you_mean: None,
-                });
-            }
-        }
-    }
-    errs
+            key: key.to_string(),
+            key_span,
+            value_span,
+            did_you_mean: None,
+        }];
+    };
+    entries
+        .iter()
+        .filter(|(_, value)| !matches!(value.kind, ExprKind::StringLit(_)))
+        .map(|(name, value)| SchemaError {
+            kind: SchemaErrorKind::TypeMismatch {
+                expected: "a static string",
+            },
+            key: name.clone(),
+            key_span,
+            value_span: Some(value.span),
+            did_you_mean: None,
+        })
+        .collect()
 }
 
 fn quoted_key_error(prop: &Property) -> Option<SchemaError> {
@@ -1411,6 +1402,124 @@ mod tests {
     }
 
     #[test]
+    fn static_header_objects_parse_validate_and_extract() {
+        const MAP: &[PropertySpec] = &[PropertySpec {
+            name: "headers",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::StringMap,
+        }];
+        for (body, expected) in [
+            (r#"{}"#, vec![]),
+            (
+                r#"{ "DD-API-KEY": "test-only", "Authorization": "Bearer literal" }"#,
+                vec![
+                    ("DD-API-KEY".to_string(), "test-only".to_string()),
+                    ("Authorization".to_string(), "Bearer literal".to_string()),
+                ],
+            ),
+            (
+                r#"{ "X-\"Key": "line\nvalue" }"#,
+                vec![("X-\"Key".to_string(), "line\nvalue".to_string())],
+            ),
+        ] {
+            let config = crate::dsl::parser::parse_config(&format!(
+                "def output logs {{ type http headers {body} }}"
+            ))
+            .unwrap();
+            let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                panic!("output")
+            };
+            let props = output.properties.user_properties();
+            assert!(validate(props, MAP).is_empty(), "{body}");
+            assert_eq!(
+                crate::dsl::props::get_string_map(props, "headers"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn static_header_objects_reject_dynamic_values_and_old_blocks() {
+        const MAP: &[PropertySpec] = &[PropertySpec {
+            name: "headers",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::StringMap,
+        }];
+        for body in [
+            r#"{ "Authorization" "v" }"#,
+            r#"{ Authorization "v" }"#,
+            r#"{ "x": "${env.TOKEN}" }"#,
+            r#"{ "x": token }"#,
+            r#"{ "x": to_json(workspace) }"#,
+            r#"{ "x": 1 }"#,
+            r#"{ "x": true }"#,
+            r#"{ "x": null }"#,
+            r#"{ "x": [] }"#,
+            r#"{ "x": { inner: "v" } }"#,
+            r#"{ "${env.KEY}": "v" }"#,
+        ] {
+            if let Ok(config) = crate::dsl::parser::parse_config(&format!(
+                "def output logs {{ type http headers {body} }}"
+            )) {
+                let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                    panic!("output")
+                };
+                assert!(
+                    !validate(output.properties.user_properties(), MAP).is_empty(),
+                    "accepted {body}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn static_objects_do_not_replace_ordinary_blocks() {
+        const S: &[PropertySpec] = &[
+            PropertySpec {
+                name: "peer",
+                required: false,
+                repeatable: false,
+                exclusive_group: None,
+                kind: PropertyValueKind::Block(&[]),
+            },
+            PropertySpec {
+                name: "tls",
+                required: false,
+                repeatable: false,
+                exclusive_group: None,
+                kind: PropertyValueKind::BlockMap(&[]),
+            },
+        ];
+        for body in [
+            r#"peer { "url": "v" }"#,
+            r#"tls { "profile": "v" }"#,
+            r#""peer" {}"#,
+        ] {
+            let config = crate::dsl::parser::parse_config(&format!(
+                "def output logs {{ type http {body} }}"
+            ))
+            .unwrap();
+            let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                panic!("output")
+            };
+            assert!(
+                !validate(output.properties.user_properties(), S).is_empty(),
+                "accepted {body}"
+            );
+        }
+        let config =
+            crate::dsl::parser::parse_config("def output logs { type http peer {} }").unwrap();
+        let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+            panic!("output")
+        };
+        assert!(validate(output.properties.user_properties(), S).is_empty());
+    }
+
+    #[test]
     fn quoted_keys_are_only_accepted_inside_string_maps() {
         const S: &[PropertySpec] = &[
             PropertySpec {
@@ -1456,7 +1565,7 @@ mod tests {
         }];
         for source in [
             r#"def output logs { type http headers {} }"#,
-            r#"def output logs { type http headers { "" "v" "not an HTTP key" "v" Authorization "v" } }"#,
+            r#"def output logs { type http headers { "": "v", "not an HTTP key": "v", "Authorization": "v" } }"#,
         ] {
             let config = crate::dsl::parser::parse_config(source).unwrap();
             let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
@@ -1494,12 +1603,18 @@ mod tests {
             exclusive_group: None,
             kind: PropertyValueKind::StringMap,
         }];
-        let props = vec![block(
+        let props = vec![kv(
             "headers",
-            vec![
-                kv("Authorization", ExprKind::StringLit("Bearer xxx".into())),
-                kv("X-Tenant", ExprKind::Ident(vec!["acme".into()])),
-            ],
+            ExprKind::HashLit(vec![
+                (
+                    "Authorization".into(),
+                    Expr::new(ExprKind::StringLit("Bearer xxx".into()), Span::dummy()),
+                ),
+                (
+                    "X-Tenant".into(),
+                    Expr::new(ExprKind::StringLit("acme".into()), Span::dummy()),
+                ),
+            ]),
         )];
         assert!(validate(&props, S).is_empty());
     }

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -23,7 +23,7 @@
 //!     }
 //!     method POST
 //!     content_type "application/json"
-//!     headers { Authorization "Bearer xxx" }
+//!     headers { "Authorization": "Bearer xxx" }
 //! }
 //! ```
 //!
@@ -1283,7 +1283,7 @@ def output test {{
     type http
     peer {{ url "http://{addr}/" }}
     batch_size 1
-    headers {{ "DD-API-KEY" "test-only-key" "X-Custom-Header" "exact-value" }}
+    headers {{ "DD-API-KEY": "test-only-key", "X-Custom-Header": "exact-value" }}
 }}
 "#
             ),

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -21,7 +21,7 @@
 //!     batch_size 512
 //!     batch_timeout "5s"
 //!     headers {
-//!         Authorization "Bearer ${env.OTLP_TOKEN}"
+//!         "Authorization": "Bearer your-token"
 //!     }
 //! }
 //! ```
@@ -914,7 +914,7 @@ def output test {{
     type otlp_grpc
     peer {{ endpoint "http://{addr}" }}
     batch_size 1
-    headers {{ "X-Custom-Header" "exact-value" Authorization "placeholder" }}
+    headers {{ "X-Custom-Header": "exact-value", "Authorization": "placeholder" }}
 }}
 "#
         ))

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -23,7 +23,7 @@
 //!     batch_size 512
 //!     batch_timeout "5s"
 //!     headers {
-//!         Authorization "Bearer ${env.OTLP_TOKEN}"
+//!         "Authorization": "Bearer your-token"
 //!     }
 //! }
 //! ```
@@ -1189,7 +1189,7 @@ def output test {{
     type otlp_http
     peer {{ endpoint "http://{addr}/v1/logs" }}
     batch_size 1
-    headers {{ "X-Custom-Header" "exact-value" Authorization "placeholder" }}
+    headers {{ "X-Custom-Header": "exact-value", "Authorization": "placeholder" }}
 }}
 "#
         ))

--- a/docs/src/outputs/http.md
+++ b/docs/src/outputs/http.md
@@ -28,7 +28,7 @@ def output es_cluster {
     batch_timeout "5s"
     compress gzip
     headers {
-        Authorization "Basic <base64(user:password)>"
+        "Authorization": "Basic <base64(user:password)>"
     }
 }
 ```
@@ -74,19 +74,19 @@ On each send the rotation picks the next available peer (cooldown expired) and t
 
 ### headers block
 
-From 0.8.3, header names containing hyphens must be quoted, for example
-`"DD-API-KEY" "your-api-key"`. Ordinary identifiers such as `Authorization`
-may remain bare. Quoted keys are static strings: `${...}` interpolation is
-not allowed in keys. Literal escapes follow string-value decoding (`\"`,
+Headers are a static string object: separate keys and values with `:` and
+entries with `,`. Keys and values must be literal strings; `${...}` interpolation,
+variables, function calls, and non-string values are not accepted.
+Literal escapes follow string-value decoding (`\"`,
 `\\`, `\n`, `\t`, and `\$`; unknown escapes retain the backslash).
-Quoting is supported only for entries inside string maps such as `headers`,
+This configuration object syntax is supported for string maps such as `headers`,
 not fixed configuration names such as `type` or `peer`. HTTP header-name
 restrictions still apply to the decoded name.
 
 ```limpid
 headers {
-    Authorization "Bearer your-token"
-    "X-Custom-Header" "value"
+    "Authorization": "Bearer your-token",
+    "X-Custom-Header": "value"
 }
 ```
 
@@ -144,7 +144,7 @@ def output splunk {
     type http
     peer { url "https://splunk:8088/services/collector/event" }
     headers {
-        Authorization "Splunk your-hec-token"
+        "Authorization": "Splunk your-hec-token"
     }
 }
 ```
@@ -158,7 +158,7 @@ def output datadog {
     batch_size 50
     compress gzip
     headers {
-        "DD-API-KEY" "your-api-key"
+        "DD-API-KEY": "your-api-key"
     }
 }
 ```

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -60,7 +60,7 @@ quoting does not bypass the protocol's name restrictions.
 | `batch_size` | no | `1` | Flush after this many Events. `1` ships every Event immediately. |
 | `batch_timeout` | no | `5s` | Flush deferred Events after this duration. |
 | `batch_level` | no | `none` | One of `none` / `resource` / `scope`. See [§ batch_level](#batch_level). |
-| `headers` | no | — | gRPC metadata added to every batch. Keys are lower-cased per HTTP/2 / gRPC convention; tonic rejects mixed-case (e.g. `Authorization`). |
+| `headers` | no | — | gRPC metadata added to every batch. Configured mixed-case keys (e.g. `Authorization`) are accepted and normalized to lowercase before sending; metadata name and value restrictions still apply. |
 | `retry { max_attempts initial_wait max_wait backoff }` | no | shared default (5 attempts, 1s → 60s exponential) | Per-flush retry budget. Inside one budget the rotation transparently picks the next available peer; the budget caps total attempts across all peers for a single batch. |
 
 ### peers

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -28,7 +28,7 @@ def output otlp_out {
     batch_size 512
     batch_timeout "5s"
     headers {
-        Authorization "Bearer ${env.OTLP_TOKEN}"
+        "Authorization": "Bearer your-token"
     }
 }
 ```
@@ -49,9 +49,9 @@ def output otlp_out {
 
 ## Properties
 
-Header keys use the same [static quoted-key syntax](http.md#headers-block)
-as HTTP output. Use `"X-Custom-Header" "value"` for hyphenated names;
-`Authorization` may remain bare. Names are lower-cased for gRPC metadata;
+Headers use the same [static string object syntax](http.md#headers-block)
+as HTTP output: `"X-Custom-Header": "value"`. Keys and values are literal strings.
+Names are lower-cased for gRPC metadata;
 quoting does not bypass the protocol's name restrictions.
 
 | Property | Required | Default | Description |

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -29,7 +29,7 @@ def output otlp_out {
     batch_size 512
     batch_timeout "5s"
     headers {
-        Authorization "Bearer ${env.OTLP_TOKEN}"
+        "Authorization": "Bearer your-token"
     }
 }
 ```
@@ -50,9 +50,9 @@ def output otlp_out {
 
 ## Properties
 
-Header keys use the same [static quoted-key syntax](http.md#headers-block)
-as HTTP output. Use `"X-Custom-Header" "value"` for hyphenated names;
-`Authorization` may remain bare. Quoting does not bypass HTTP name restrictions.
+Headers use the same [static string object syntax](http.md#headers-block)
+as HTTP output: `"X-Custom-Header": "value"`. Keys and values are literal strings;
+quoting does not bypass HTTP name restrictions.
 
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|

--- a/docs/src/pipelines/examples.md
+++ b/docs/src/pipelines/examples.md
@@ -115,7 +115,7 @@ def output elasticsearch {
     batch_size 100
     batch_timeout "5s"
     headers {
-        Authorization "Basic <base64(user:password)>"
+        "Authorization": "Basic <base64(user:password)>"
     }
 }
 


### PR DESCRIPTION
## Summary
- Use static string objects for configuration StringMap values, including HTTP and OTLP headers, while reusing HashLit parsing and literal escape decoding.
- Reject dynamic or non-string values and nonempty legacy blocks; retain empty objects and ordinary block/expression boundaries.
- Update header documentation and exercise actual HTTP, OTLP HTTP, and gRPC receiver paths.

## Validation
- Test-first rejection/acceptance coverage, including escapes, fixed keys, BlockMap, and legacy blocks.
- Workspace all-targets tests pass (limpid: 1213 passed, 1 ignored); final focused boundaries, clippy, formatting, and diff checks pass.
- mdBook 0.5.4 and strict release/documentation preflight pass.
- Independent review is clean. No live changes or external test sends; version preparation follows separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Syntax**
  - Updated `headers` configuration to use static string objects with quoted keys, colon separators, and comma-delimited entries.
  - Header values must now be literal strings; dynamic expressions and non-string values are not accepted.
  - Existing nested-block and space-separated header forms are no longer supported for string maps.

- **Documentation**
  - Updated HTTP, OTLP, and pipeline examples to reflect the new header syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->