### PR TITLE
chore(release): prepare 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-09-06
+
+> Static string objects for explicit header configuration.
+
+0.8.4 represents configuration string maps as static objects. HTTP, OTLP HTTP, and OTLP gRPC headers share literal string keys and values without expression evaluation, while ordinary configuration blocks and general expression syntax remain unchanged.
+
+### Changed — static objects for configuration string maps
+
+Header maps use object entries such as `"Authorization": "Bearer your-token"`. Keys decode literal escapes, and values must be string literals; interpolation, variables, function calls, and non-string values are rejected. Nonempty legacy header blocks are no longer accepted, while empty maps remain valid. The change reuses existing hash-literal parsing without extending general expression object-key syntax or fixed configuration names.
+
+### Fixed — gRPC header normalization documentation
+
+The gRPC output reference now states that configured mixed-case header keys are accepted and normalized to lowercase before sending. Protocol metadata name and value restrictions still apply. HTTP and OTLP examples consistently use static header objects, with parser-to-receiver regression tests covering all three output paths.
+
 ## [0.8.3] - 2026-09-06
 
 > Quoted header keys with explicit configuration boundaries.
@@ -2538,7 +2552,8 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.3...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.4...HEAD
+[0.8.4]: https://github.com/naoto256/limpid/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/naoto256/limpid/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/naoto256/limpid/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/naoto256/limpid/compare/v0.8.0...v0.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-metrics-schema"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-limpid-metrics-schema = { version = "0.8.3", path = "crates/limpid-metrics-schema" }
+limpid-metrics-schema = { version = "0.8.4", path = "crates/limpid-metrics-schema" }
 base64 = "0.22.1"
 pem = "3.0.6"
 ring = "0.17.14"

--- a/crates/limpid-metrics-schema/Cargo.toml
+++ b/crates/limpid-metrics-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-metrics-schema"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Wire DTOs for limpid schema-v1 metrics snapshots"
 license.workspace = true

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -831,7 +831,7 @@ mod tests {
                 "type": "gauge",
                 "help": "Build information for the running limpid node.",
                 "series": [{
-                    "labels": {"node_id": "edge-a", "version": "0.8.3"},
+                    "labels": {"node_id": "edge-a", "version": "0.8.4"},
                     "value": 1
                 }]
             }]
@@ -842,7 +842,7 @@ mod tests {
             concat!(
                 "# HELP limpid_build_info Build information for the running limpid node.\n",
                 "# TYPE limpid_build_info gauge\n",
-                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.3\"} 1\n\n"
+                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.4\"} 1\n\n"
             )
         );
     }

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1404,7 +1404,7 @@ def pipeline p { input i; output o }
             .build()
             .expect("test metric registration must succeed");
         received.inc();
-        crate::metrics::register_build_info(&metrics, "0.8.3", "control-node")
+        crate::metrics::register_build_info(&metrics, "0.8.4", "control-node")
             .expect("build info registration must succeed");
 
         let server = ControlServer::new(
@@ -1499,7 +1499,7 @@ def pipeline p { input i; output o }
         assert_eq!(
             build_info["series"],
             serde_json::json!([{
-                "labels": {"node_id": "control-node", "version": "0.8.3"},
+                "labels": {"node_id": "control-node", "version": "0.8.4"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -1699,7 +1699,7 @@ mod registry_tests {
     #[test]
     fn build_info_is_one_prepopulated_gauge_with_fixed_labels() {
         let registry = Registry::new();
-        super::register_build_info(&registry, "0.8.3", "node-a").expect("build info must register");
+        super::register_build_info(&registry, "0.8.4", "node-a").expect("build info must register");
 
         let snapshot = snapshot_json(&registry);
         let family = metric(&snapshot, "limpid_build_info");
@@ -1711,7 +1711,7 @@ mod registry_tests {
         assert_eq!(
             family["series"],
             serde_json::json!([{
-                "labels": {"node_id": "node-a", "version": "0.8.3"},
+                "labels": {"node_id": "node-a", "version": "0.8.4"},
                 "value": 1
             }])
         );

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -944,7 +944,7 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
         "type": "gauge",
         "help": "Build information for the running limpid node.",
         "series": [{
-            "labels": {"node_id": "edge-a", "version": "0.8.3"},
+            "labels": {"node_id": "edge-a", "version": "0.8.4"},
             "value": 1
         }]
     }));
@@ -962,14 +962,14 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
     assert!(details.contains("gauge"));
     assert!(details.contains("Build information for the running limpid node."));
     assert!(details.contains("node_id: \"edge-a\""));
-    assert!(details.contains("version: \"0.8.3\""));
+    assert!(details.contains("version: \"0.8.4\""));
     assert!(details.contains("value: 1"));
 
     let raw_output = run_stats(&response, &["--raw"]);
     assert!(raw_output.status.success(), "{raw_output:?}");
     let raw = stdout(&raw_output);
     assert!(raw.contains("node_id=\"edge-a\""));
-    assert!(raw.contains("version=\"0.8.3\""));
+    assert!(raw.contains("version=\"0.8.4\""));
 
     let json_output = run_stats(&response, &["--json"]);
     assert!(json_output.status.success(), "{json_output:?}");

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1040,7 +1040,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.3"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.4"`).
 
 ```limpid
 workspace.processed_by_version = version()


### PR DESCRIPTION
## Summary
- Align four product crates, the workspace schema dependency, lockfile, and current version fixtures with 0.8.4.
- Document static StringMap objects and the gRPC header normalization clarification using the established release-note structure.
- Preserve historical notes and existing documentation anchors; no dedicated migration guide or runtime changes.

## Validation
- Release metadata, extracted title/notes, and strict rendered documentation/source-link checks pass.
- Preflight unit tests: 9 passed. Focused build-info tests: 4 passed. Formatting and diff checks pass.
- Independent proportional review is clean. Release publication and live installation are not performed by this PR.