### PR TITLE
Release 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Pre-1.0 releases may introduce breaking changes freely as the DSL and runtime sh
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-09-06
+
+> Static string objects for explicit header configuration.
+
+0.8.4 represents configuration string maps as static objects. HTTP, OTLP HTTP, and OTLP gRPC headers share literal string keys and values without expression evaluation, while ordinary configuration blocks and general expression syntax remain unchanged.
+
+### Changed — static objects for configuration string maps
+
+Header maps use object entries such as `"Authorization": "Bearer your-token"`. Keys decode literal escapes, and values must be string literals; interpolation, variables, function calls, and non-string values are rejected. Nonempty legacy header blocks are no longer accepted, while empty maps remain valid. The change reuses existing hash-literal parsing without extending general expression object-key syntax or fixed configuration names.
+
+### Fixed — gRPC header normalization documentation
+
+The gRPC output reference now states that configured mixed-case header keys are accepted and normalized to lowercase before sending. Protocol metadata name and value restrictions still apply. HTTP and OTLP examples consistently use static header objects, with parser-to-receiver regression tests covering all three output paths.
+
 ## [0.8.3] - 2026-09-06
 
 > Quoted header keys with explicit configuration boundaries.
@@ -2538,7 +2552,8 @@ See `docs/src/operations/upgrade-0.3.md` for end-to-end migration recipes includ
 
 Initial public release. Rust + tokio log pipeline daemon replacing rsyslog / syslog-ng / fluentd with a single readable DSL (`def input`, `def process`, `def output`, `def pipeline`). Includes syslog (UDP/TCP/ TLS) / tail / journal / unix socket inputs; file / HTTP / Kafka / TCP / UDP / unix socket / stdout outputs; in-DSL expression language with parsers (JSON / KV / CEF / syslog), regex, string templates, tables with TTL, GeoIP; control socket (`limpidctl tap`, `stats`, `health`); hot reload via `SIGHUP` with automatic rollback; per-output disk-backed queues.
 
-[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.3...HEAD
+[Unreleased]: https://github.com/naoto256/limpid/compare/v0.8.4...HEAD
+[0.8.4]: https://github.com/naoto256/limpid/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/naoto256/limpid/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/naoto256/limpid/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/naoto256/limpid/compare/v0.8.0...v0.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "limpid"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-metrics-schema"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "limpid-prometheus"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "clap",
  "http-body-util",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "limpidctl"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-limpid-metrics-schema = { version = "0.8.3", path = "crates/limpid-metrics-schema" }
+limpid-metrics-schema = { version = "0.8.4", path = "crates/limpid-metrics-schema" }
 base64 = "0.22.1"
 pem = "3.0.6"
 ring = "0.17.14"

--- a/crates/limpid-metrics-schema/Cargo.toml
+++ b/crates/limpid-metrics-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-metrics-schema"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Wire DTOs for limpid schema-v1 metrics snapshots"
 license.workspace = true

--- a/crates/limpid-prometheus/Cargo.toml
+++ b/crates/limpid-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid-prometheus"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Prometheus exporter for limpid — converts control socket JSON to Prometheus text format"
 license.workspace = true

--- a/crates/limpid-prometheus/src/main.rs
+++ b/crates/limpid-prometheus/src/main.rs
@@ -831,7 +831,7 @@ mod tests {
                 "type": "gauge",
                 "help": "Build information for the running limpid node.",
                 "series": [{
-                    "labels": {"node_id": "edge-a", "version": "0.8.3"},
+                    "labels": {"node_id": "edge-a", "version": "0.8.4"},
                     "value": 1
                 }]
             }]
@@ -842,7 +842,7 @@ mod tests {
             concat!(
                 "# HELP limpid_build_info Build information for the running limpid node.\n",
                 "# TYPE limpid_build_info gauge\n",
-                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.3\"} 1\n\n"
+                "limpid_build_info{node_id=\"edge-a\",version=\"0.8.4\"} 1\n\n"
             )
         );
     }

--- a/crates/limpid/Cargo.toml
+++ b/crates/limpid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpid"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Log pipelines, limpid as intent."
 license.workspace = true

--- a/crates/limpid/src/control.rs
+++ b/crates/limpid/src/control.rs
@@ -1404,7 +1404,7 @@ def pipeline p { input i; output o }
             .build()
             .expect("test metric registration must succeed");
         received.inc();
-        crate::metrics::register_build_info(&metrics, "0.8.3", "control-node")
+        crate::metrics::register_build_info(&metrics, "0.8.4", "control-node")
             .expect("build info registration must succeed");
 
         let server = ControlServer::new(
@@ -1499,7 +1499,7 @@ def pipeline p { input i; output o }
         assert_eq!(
             build_info["series"],
             serde_json::json!([{
-                "labels": {"node_id": "control-node", "version": "0.8.3"},
+                "labels": {"node_id": "control-node", "version": "0.8.4"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/dsl/limpid.pest
+++ b/crates/limpid/src/dsl/limpid.pest
@@ -127,8 +127,15 @@ invalid_hyphenated_property_key = @{ ident ~ ("-" ~ (ASCII_ALPHANUMERIC | "_")+)
 
 property = {
     property_key ~ "{" ~ property* ~ "}" // nested block: `tls { ... }`
+  | property_key ~ configuration_object
   | property_key ~ expr                   // key-value: `type syslog_udp`, `bind "0.0.0.0:514"`
 }
+
+// Configuration string maps reuse HashLit without broadening expression keys.
+configuration_object = {
+    "{" ~ (configuration_entry ~ ("," ~ configuration_entry)* ~ ","?)? ~ "}"
+}
+configuration_entry = { quoted_property_key ~ ":" ~ expr }
 
 // -- Process definition ------------------------------------------------------
 

--- a/crates/limpid/src/dsl/parser.rs
+++ b/crates/limpid/src/dsl/parser.rs
@@ -197,16 +197,10 @@ fn parse_property(pair: Pair<Rule>, file_id: u32) -> Result<Property> {
     let key_pair = first_inner(key_pair)?;
     let key_quoted = key_pair.as_rule() == Rule::quoted_property_key;
     if key_pair.as_rule() == Rule::invalid_hyphenated_property_key {
-        bail!(
-            "hyphenated property key: quote the key inside a StringMap (for example, headers {{ \"DD-API-KEY\" \"...\" }})"
-        );
+        bail!("invalid hyphenated property key");
     }
     let key = if key_quoted {
-        let raw = key_pair.as_str();
-        let mut decoded = String::new();
-        // The key grammar excludes interpolation. Decode only literal escapes.
-        process_plain_into(&mut decoded, &raw[1..raw.len() - 1]);
-        decoded
+        decode_literal_key(key_pair.as_str())
     } else {
         key_pair.as_str().to_string()
     };
@@ -237,7 +231,11 @@ fn parse_property(pair: Pair<Rule>, file_id: u32) -> Result<Property> {
         _ => {
             // key-value: key expr
             let value_span = Some(span_of(&second, file_id));
-            let value = parse_expr_from_pair(second, file_id)?;
+            let value = if second.as_rule() == Rule::configuration_object {
+                parse_hash_lit(second, file_id)?
+            } else {
+                parse_expr_from_pair(second, file_id)?
+            };
             Ok(Property::KeyValue {
                 key,
                 key_quoted,
@@ -1014,17 +1012,25 @@ fn parse_func_args(pair: Pair<Rule>, file_id: u32) -> Result<Vec<Expr>> {
         .collect()
 }
 
+fn decode_literal_key(raw: &str) -> String {
+    let mut decoded = String::new();
+    // The literal-key grammar excludes interpolation; share value escape decoding.
+    process_plain_into(&mut decoded, &raw[1..raw.len() - 1]);
+    decoded
+}
+
 fn parse_hash_lit(pair: Pair<Rule>, file_id: u32) -> Result<Expr> {
     let span = span_of(&pair, file_id);
     let entries = pair
         .into_inner()
         .map(|entry| {
             let mut inner = entry.into_inner();
-            let key = inner
-                .next()
-                .expect("pest grammar invariant")
-                .as_str()
-                .to_string();
+            let key = inner.next().expect("pest grammar invariant");
+            let key = if key.as_rule() == Rule::quoted_property_key {
+                decode_literal_key(key.as_str())
+            } else {
+                key.as_str().to_string()
+            };
             let value =
                 parse_expr_from_pair(inner.next().expect("pest grammar invariant"), file_id)?;
             Ok((key, value))
@@ -1233,9 +1239,9 @@ def input fw_syslog {
 def output logs {
     type http
     headers {
-        "DD-API-KEY" "test-only-key"
-        "X-Custom-Header" "value"
-        Authorization "Bearer placeholder"
+        "DD-API-KEY": "test-only-key",
+        "X-Custom-Header": "value",
+        "Authorization": "Bearer placeholder"
     }
 }
 "#,
@@ -1255,17 +1261,17 @@ def output logs {
     }
 
     #[test]
-    fn quoted_key_migration_rejects_bare_hyphen_with_guidance() {
+    fn property_key_rejects_bare_hyphen() {
         let error =
             parse_config(r#"def output logs { type http headers { DD-API-KEY "placeholder" } }"#)
                 .unwrap_err();
-        assert!(format!("{error:#}").contains("quote"), "{error:#}");
+        assert!(format!("{error:#}").contains("invalid"), "{error:#}");
     }
 
     #[test]
     fn quoted_keys_are_static_and_decode_literal_escapes() {
         let config = parse_config(
-            r#"def output logs { type http headers { "x-\"quoted\"\\name" "v" "\${literal}" "v" } }"#,
+            r#"def output logs { type http headers { "x-\"quoted\"\\name": "v", "\${literal}": "v" } }"#,
         ).unwrap();
         let Definition::Output(output) = &config.definitions[0] else {
             panic!("output")

--- a/crates/limpid/src/dsl/props.rs
+++ b/crates/limpid/src/dsl/props.rs
@@ -207,38 +207,23 @@ pub fn get_block<'a>(props: &'a [Property], key: &str) -> Option<&'a Vec<Propert
     None
 }
 
-/// Extract a `StringMap`-shaped sub-block as a list of `(key, value)`
-/// pairs. The block's key set is open (HTTP header names, k8s-style
-/// labels, etc.) and every value is rendered to `String` through the
-/// same rules `get_string` uses (`StringLit` / `Template` source
-/// reconstruction / `Ident` joined by `.` / `IntLit` decimal).
-///
-/// Returns `Vec::new()` when the block is absent. The analyzer flags
-/// non-string entries via the schema (`PropertyValueKind::StringMap`),
-/// so callers here can safely drop them without re-reporting.
+/// Extract a schema-validated static StringMap object without evaluating values.
+/// Missing maps and the syntactically shared empty block both yield no entries.
 pub fn get_string_map(props: &[Property], key: &str) -> Vec<(String, String)> {
-    let Some(block) = get_block(props, key) else {
+    let Some(Expr {
+        kind: ExprKind::HashLit(entries),
+        ..
+    }) = get_expr(props, key)
+    else {
         return Vec::new();
     };
-    let mut out = Vec::new();
-    for prop in block {
-        if let Property::KeyValue {
-            key: k,
-            value: expr,
-            ..
-        } = prop
-            && let Some(val) = match &expr.kind {
-                ExprKind::StringLit(s) => Some(s.clone()),
-                ExprKind::Template(frags) => Some(template_to_source(frags)),
-                ExprKind::Ident(parts) => Some(parts.join(".")),
-                ExprKind::IntLit(n) => Some(n.to_string()),
-                _ => None,
-            }
-        {
-            out.push((k.clone(), val));
-        }
-    }
-    out
+    entries
+        .iter()
+        .filter_map(|(key, value)| match &value.kind {
+            ExprKind::StringLit(value) => Some((key.clone(), value.clone())),
+            _ => None, // Rejected by StringMap schema before module construction.
+        })
+        .collect()
 }
 
 /// Parse size strings like "1GB", "512MB", "1024" (bytes).

--- a/crates/limpid/src/dsl/schema.rs
+++ b/crates/limpid/src/dsl/schema.rs
@@ -63,12 +63,8 @@ pub enum PropertyValueKind {
     /// values must each be a nested block conforming to the given schema.
     /// `tls { profile_a { ca "..." } profile_b { ca "..." cert "..." key "..." } }`
     BlockMap(&'static [PropertySpec]),
-    /// Open block whose keys are identifiers or static quoted strings (HTTP
-    /// header names, k8s-style labels, etc.) and whose values must
-    /// each be string-shaped. The schema validator never flags an
-    /// "unknown key" inside this block — it only checks that every
-    /// entry is a key-value (not a nested sub-block) with a
-    /// string-shaped value.
+    /// Object with arbitrary literal keys and StringLit values only.
+    /// No expression evaluation, template reconstruction, or value coercion.
     StringMap,
     /// Value can be one of multiple shapes. Used for keys that accept
     /// either an inline block or a reference identifier.
@@ -85,9 +81,7 @@ impl PropertyValueKind {
     fn expects_block_outer_shape(self) -> bool {
         matches!(
             self,
-            PropertyValueKind::Block(_)
-                | PropertyValueKind::BlockMap(_)
-                | PropertyValueKind::StringMap
+            PropertyValueKind::Block(_) | PropertyValueKind::BlockMap(_)
         )
     }
 
@@ -385,12 +379,18 @@ fn check_property(
             }],
         },
         PropertyValueKind::StringMap => match prop {
-            Property::Block { properties, .. } => validate_string_map(properties),
-            Property::KeyValue { value_span, .. } => vec![SchemaError {
-                kind: SchemaErrorKind::ExpectedBlock,
+            // `{}` is syntactically shared with empty ordinary blocks.
+            Property::Block { properties, .. } if properties.is_empty() => Vec::new(),
+            Property::KeyValue {
+                value, value_span, ..
+            } => validate_string_map(key, value, key_span, *value_span),
+            Property::Block { .. } => vec![SchemaError {
+                kind: SchemaErrorKind::TypeMismatch {
+                    expected: "a static string object",
+                },
                 key: key.to_string(),
                 key_span,
-                value_span: *value_span,
+                value_span: None,
                 did_you_mean: None,
             }],
         },
@@ -447,7 +447,7 @@ fn check_one_of(
     // wrote a Block and the real problem is one missing inner key.
     //
     // Structural match is decided by comparing the variant's expected
-    // outer shape (`Block` / `BlockMap` / `StringMap` → block-shaped;
+    // outer shape (`Block` / `BlockMap` → block-shaped;
     // everything else → scalar-shaped) against the actual `Property`
     // variant. Earlier this filter walked the per-variant error list
     // looking for `ExpectedBlock` / `ExpectedValue` kinds, which
@@ -525,46 +525,37 @@ fn validate_block_map(properties: &[Property], inner_spec: &[PropertySpec]) -> V
     errs
 }
 
-/// Validate a `StringMap`-kind block: every entry must be a key-value
-/// with a string-shaped value. The key set is open, so there is no
-/// unknown-key check.
-fn validate_string_map(properties: &[Property]) -> Vec<SchemaError> {
-    let mut errs = Vec::new();
-    for prop in properties {
-        match prop {
-            Property::KeyValue {
-                key,
-                key_span,
-                value,
-                value_span,
-                ..
-            } => match &value.kind {
-                ExprKind::StringLit(_)
-                | ExprKind::Template(_)
-                | ExprKind::Ident(_)
-                | ExprKind::IntLit(_) => {}
-                _ => errs.push(SchemaError {
-                    kind: SchemaErrorKind::TypeMismatch {
-                        expected: "a string",
-                    },
-                    key: key.clone(),
-                    key_span: *key_span,
-                    value_span: *value_span,
-                    did_you_mean: None,
-                }),
+/// The parser stores literal keys in HashLit; values must remain literal too.
+fn validate_string_map(
+    key: &str,
+    value: &Expr,
+    key_span: Option<Span>,
+    value_span: Option<Span>,
+) -> Vec<SchemaError> {
+    let ExprKind::HashLit(entries) = &value.kind else {
+        return vec![SchemaError {
+            kind: SchemaErrorKind::TypeMismatch {
+                expected: "a static string object",
             },
-            Property::Block { key, key_span, .. } => {
-                errs.push(SchemaError {
-                    kind: SchemaErrorKind::ExpectedValue,
-                    key: key.clone(),
-                    key_span: *key_span,
-                    value_span: None,
-                    did_you_mean: None,
-                });
-            }
-        }
-    }
-    errs
+            key: key.to_string(),
+            key_span,
+            value_span,
+            did_you_mean: None,
+        }];
+    };
+    entries
+        .iter()
+        .filter(|(_, value)| !matches!(value.kind, ExprKind::StringLit(_)))
+        .map(|(name, value)| SchemaError {
+            kind: SchemaErrorKind::TypeMismatch {
+                expected: "a static string",
+            },
+            key: name.clone(),
+            key_span,
+            value_span: Some(value.span),
+            did_you_mean: None,
+        })
+        .collect()
 }
 
 fn quoted_key_error(prop: &Property) -> Option<SchemaError> {
@@ -1411,6 +1402,124 @@ mod tests {
     }
 
     #[test]
+    fn static_header_objects_parse_validate_and_extract() {
+        const MAP: &[PropertySpec] = &[PropertySpec {
+            name: "headers",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::StringMap,
+        }];
+        for (body, expected) in [
+            (r#"{}"#, vec![]),
+            (
+                r#"{ "DD-API-KEY": "test-only", "Authorization": "Bearer literal" }"#,
+                vec![
+                    ("DD-API-KEY".to_string(), "test-only".to_string()),
+                    ("Authorization".to_string(), "Bearer literal".to_string()),
+                ],
+            ),
+            (
+                r#"{ "X-\"Key": "line\nvalue" }"#,
+                vec![("X-\"Key".to_string(), "line\nvalue".to_string())],
+            ),
+        ] {
+            let config = crate::dsl::parser::parse_config(&format!(
+                "def output logs {{ type http headers {body} }}"
+            ))
+            .unwrap();
+            let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                panic!("output")
+            };
+            let props = output.properties.user_properties();
+            assert!(validate(props, MAP).is_empty(), "{body}");
+            assert_eq!(
+                crate::dsl::props::get_string_map(props, "headers"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn static_header_objects_reject_dynamic_values_and_old_blocks() {
+        const MAP: &[PropertySpec] = &[PropertySpec {
+            name: "headers",
+            required: false,
+            repeatable: false,
+            exclusive_group: None,
+            kind: PropertyValueKind::StringMap,
+        }];
+        for body in [
+            r#"{ "Authorization" "v" }"#,
+            r#"{ Authorization "v" }"#,
+            r#"{ "x": "${env.TOKEN}" }"#,
+            r#"{ "x": token }"#,
+            r#"{ "x": to_json(workspace) }"#,
+            r#"{ "x": 1 }"#,
+            r#"{ "x": true }"#,
+            r#"{ "x": null }"#,
+            r#"{ "x": [] }"#,
+            r#"{ "x": { inner: "v" } }"#,
+            r#"{ "${env.KEY}": "v" }"#,
+        ] {
+            if let Ok(config) = crate::dsl::parser::parse_config(&format!(
+                "def output logs {{ type http headers {body} }}"
+            )) {
+                let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                    panic!("output")
+                };
+                assert!(
+                    !validate(output.properties.user_properties(), MAP).is_empty(),
+                    "accepted {body}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn static_objects_do_not_replace_ordinary_blocks() {
+        const S: &[PropertySpec] = &[
+            PropertySpec {
+                name: "peer",
+                required: false,
+                repeatable: false,
+                exclusive_group: None,
+                kind: PropertyValueKind::Block(&[]),
+            },
+            PropertySpec {
+                name: "tls",
+                required: false,
+                repeatable: false,
+                exclusive_group: None,
+                kind: PropertyValueKind::BlockMap(&[]),
+            },
+        ];
+        for body in [
+            r#"peer { "url": "v" }"#,
+            r#"tls { "profile": "v" }"#,
+            r#""peer" {}"#,
+        ] {
+            let config = crate::dsl::parser::parse_config(&format!(
+                "def output logs {{ type http {body} }}"
+            ))
+            .unwrap();
+            let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+                panic!("output")
+            };
+            assert!(
+                !validate(output.properties.user_properties(), S).is_empty(),
+                "accepted {body}"
+            );
+        }
+        let config =
+            crate::dsl::parser::parse_config("def output logs { type http peer {} }").unwrap();
+        let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
+            panic!("output")
+        };
+        assert!(validate(output.properties.user_properties(), S).is_empty());
+    }
+
+    #[test]
     fn quoted_keys_are_only_accepted_inside_string_maps() {
         const S: &[PropertySpec] = &[
             PropertySpec {
@@ -1456,7 +1565,7 @@ mod tests {
         }];
         for source in [
             r#"def output logs { type http headers {} }"#,
-            r#"def output logs { type http headers { "" "v" "not an HTTP key" "v" Authorization "v" } }"#,
+            r#"def output logs { type http headers { "": "v", "not an HTTP key": "v", "Authorization": "v" } }"#,
         ] {
             let config = crate::dsl::parser::parse_config(source).unwrap();
             let crate::dsl::ast::Definition::Output(output) = &config.definitions[0] else {
@@ -1494,12 +1603,18 @@ mod tests {
             exclusive_group: None,
             kind: PropertyValueKind::StringMap,
         }];
-        let props = vec![block(
+        let props = vec![kv(
             "headers",
-            vec![
-                kv("Authorization", ExprKind::StringLit("Bearer xxx".into())),
-                kv("X-Tenant", ExprKind::Ident(vec!["acme".into()])),
-            ],
+            ExprKind::HashLit(vec![
+                (
+                    "Authorization".into(),
+                    Expr::new(ExprKind::StringLit("Bearer xxx".into()), Span::dummy()),
+                ),
+                (
+                    "X-Tenant".into(),
+                    Expr::new(ExprKind::StringLit("acme".into()), Span::dummy()),
+                ),
+            ]),
         )];
         assert!(validate(&props, S).is_empty());
     }

--- a/crates/limpid/src/metrics.rs
+++ b/crates/limpid/src/metrics.rs
@@ -1699,7 +1699,7 @@ mod registry_tests {
     #[test]
     fn build_info_is_one_prepopulated_gauge_with_fixed_labels() {
         let registry = Registry::new();
-        super::register_build_info(&registry, "0.8.3", "node-a").expect("build info must register");
+        super::register_build_info(&registry, "0.8.4", "node-a").expect("build info must register");
 
         let snapshot = snapshot_json(&registry);
         let family = metric(&snapshot, "limpid_build_info");
@@ -1711,7 +1711,7 @@ mod registry_tests {
         assert_eq!(
             family["series"],
             serde_json::json!([{
-                "labels": {"node_id": "node-a", "version": "0.8.3"},
+                "labels": {"node_id": "node-a", "version": "0.8.4"},
                 "value": 1
             }])
         );

--- a/crates/limpid/src/modules/output/http.rs
+++ b/crates/limpid/src/modules/output/http.rs
@@ -23,7 +23,7 @@
 //!     }
 //!     method POST
 //!     content_type "application/json"
-//!     headers { Authorization "Bearer xxx" }
+//!     headers { "Authorization": "Bearer xxx" }
 //! }
 //! ```
 //!
@@ -1283,7 +1283,7 @@ def output test {{
     type http
     peer {{ url "http://{addr}/" }}
     batch_size 1
-    headers {{ "DD-API-KEY" "test-only-key" "X-Custom-Header" "exact-value" }}
+    headers {{ "DD-API-KEY": "test-only-key", "X-Custom-Header": "exact-value" }}
 }}
 "#
             ),

--- a/crates/limpid/src/modules/output/otlp/grpc.rs
+++ b/crates/limpid/src/modules/output/otlp/grpc.rs
@@ -21,7 +21,7 @@
 //!     batch_size 512
 //!     batch_timeout "5s"
 //!     headers {
-//!         Authorization "Bearer ${env.OTLP_TOKEN}"
+//!         "Authorization": "Bearer your-token"
 //!     }
 //! }
 //! ```
@@ -914,7 +914,7 @@ def output test {{
     type otlp_grpc
     peer {{ endpoint "http://{addr}" }}
     batch_size 1
-    headers {{ "X-Custom-Header" "exact-value" Authorization "placeholder" }}
+    headers {{ "X-Custom-Header": "exact-value", "Authorization": "placeholder" }}
 }}
 "#
         ))

--- a/crates/limpid/src/modules/output/otlp/http.rs
+++ b/crates/limpid/src/modules/output/otlp/http.rs
@@ -23,7 +23,7 @@
 //!     batch_size 512
 //!     batch_timeout "5s"
 //!     headers {
-//!         Authorization "Bearer ${env.OTLP_TOKEN}"
+//!         "Authorization": "Bearer your-token"
 //!     }
 //! }
 //! ```
@@ -1189,7 +1189,7 @@ def output test {{
     type otlp_http
     peer {{ endpoint "http://{addr}/v1/logs" }}
     batch_size 1
-    headers {{ "X-Custom-Header" "exact-value" Authorization "placeholder" }}
+    headers {{ "X-Custom-Header": "exact-value", "Authorization": "placeholder" }}
 }}
 "#
         ))

--- a/crates/limpidctl/Cargo.toml
+++ b/crates/limpidctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limpidctl"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 description = "Control and debug CLI for limpid"
 license.workspace = true

--- a/crates/limpidctl/tests/stats_schema_v1.rs
+++ b/crates/limpidctl/tests/stats_schema_v1.rs
@@ -944,7 +944,7 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
         "type": "gauge",
         "help": "Build information for the running limpid node.",
         "series": [{
-            "labels": {"node_id": "edge-a", "version": "0.8.3"},
+            "labels": {"node_id": "edge-a", "version": "0.8.4"},
             "value": 1
         }]
     }));
@@ -962,14 +962,14 @@ fn build_info_is_generic_in_details_and_does_not_change_default_or_raw_json() {
     assert!(details.contains("gauge"));
     assert!(details.contains("Build information for the running limpid node."));
     assert!(details.contains("node_id: \"edge-a\""));
-    assert!(details.contains("version: \"0.8.3\""));
+    assert!(details.contains("version: \"0.8.4\""));
     assert!(details.contains("value: 1"));
 
     let raw_output = run_stats(&response, &["--raw"]);
     assert!(raw_output.status.success(), "{raw_output:?}");
     let raw = stdout(&raw_output);
     assert!(raw.contains("node_id=\"edge-a\""));
-    assert!(raw.contains("version=\"0.8.3\""));
+    assert!(raw.contains("version=\"0.8.4\""));
 
     let json_output = run_stats(&response, &["--json"]);
     assert!(json_output.status.success(), "{json_output:?}");

--- a/docs/src/functions/expression-functions.md
+++ b/docs/src/functions/expression-functions.md
@@ -1040,7 +1040,7 @@ Useful for tagging events with the forwarder's identity (e.g. when several limpi
 
 ### version()
 
-Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.3"`).
+Returns the limpid daemon's version string, baked in at compile time (e.g. `"0.8.4"`).
 
 ```limpid
 workspace.processed_by_version = version()

--- a/docs/src/outputs/http.md
+++ b/docs/src/outputs/http.md
@@ -28,7 +28,7 @@ def output es_cluster {
     batch_timeout "5s"
     compress gzip
     headers {
-        Authorization "Basic <base64(user:password)>"
+        "Authorization": "Basic <base64(user:password)>"
     }
 }
 ```
@@ -74,19 +74,19 @@ On each send the rotation picks the next available peer (cooldown expired) and t
 
 ### headers block
 
-From 0.8.3, header names containing hyphens must be quoted, for example
-`"DD-API-KEY" "your-api-key"`. Ordinary identifiers such as `Authorization`
-may remain bare. Quoted keys are static strings: `${...}` interpolation is
-not allowed in keys. Literal escapes follow string-value decoding (`\"`,
+Headers are a static string object: separate keys and values with `:` and
+entries with `,`. Keys and values must be literal strings; `${...}` interpolation,
+variables, function calls, and non-string values are not accepted.
+Literal escapes follow string-value decoding (`\"`,
 `\\`, `\n`, `\t`, and `\$`; unknown escapes retain the backslash).
-Quoting is supported only for entries inside string maps such as `headers`,
+This configuration object syntax is supported for string maps such as `headers`,
 not fixed configuration names such as `type` or `peer`. HTTP header-name
 restrictions still apply to the decoded name.
 
 ```limpid
 headers {
-    Authorization "Bearer your-token"
-    "X-Custom-Header" "value"
+    "Authorization": "Bearer your-token",
+    "X-Custom-Header": "value"
 }
 ```
 
@@ -144,7 +144,7 @@ def output splunk {
     type http
     peer { url "https://splunk:8088/services/collector/event" }
     headers {
-        Authorization "Splunk your-hec-token"
+        "Authorization": "Splunk your-hec-token"
     }
 }
 ```
@@ -158,7 +158,7 @@ def output datadog {
     batch_size 50
     compress gzip
     headers {
-        "DD-API-KEY" "your-api-key"
+        "DD-API-KEY": "your-api-key"
     }
 }
 ```

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -60,7 +60,7 @@ quoting does not bypass the protocol's name restrictions.
 | `batch_size` | no | `1` | Flush after this many Events. `1` ships every Event immediately. |
 | `batch_timeout` | no | `5s` | Flush deferred Events after this duration. |
 | `batch_level` | no | `none` | One of `none` / `resource` / `scope`. See [§ batch_level](#batch_level). |
-| `headers` | no | — | gRPC metadata added to every batch. Keys are lower-cased per HTTP/2 / gRPC convention; tonic rejects mixed-case (e.g. `Authorization`). |
+| `headers` | no | — | gRPC metadata added to every batch. Configured mixed-case keys (e.g. `Authorization`) are accepted and normalized to lowercase before sending; metadata name and value restrictions still apply. |
 | `retry { max_attempts initial_wait max_wait backoff }` | no | shared default (5 attempts, 1s → 60s exponential) | Per-flush retry budget. Inside one budget the rotation transparently picks the next available peer; the budget caps total attempts across all peers for a single batch. |
 
 ### peers

--- a/docs/src/outputs/otlp_grpc.md
+++ b/docs/src/outputs/otlp_grpc.md
@@ -28,7 +28,7 @@ def output otlp_out {
     batch_size 512
     batch_timeout "5s"
     headers {
-        Authorization "Bearer ${env.OTLP_TOKEN}"
+        "Authorization": "Bearer your-token"
     }
 }
 ```
@@ -49,9 +49,9 @@ def output otlp_out {
 
 ## Properties
 
-Header keys use the same [static quoted-key syntax](http.md#headers-block)
-as HTTP output. Use `"X-Custom-Header" "value"` for hyphenated names;
-`Authorization` may remain bare. Names are lower-cased for gRPC metadata;
+Headers use the same [static string object syntax](http.md#headers-block)
+as HTTP output: `"X-Custom-Header": "value"`. Keys and values are literal strings.
+Names are lower-cased for gRPC metadata;
 quoting does not bypass the protocol's name restrictions.
 
 | Property | Required | Default | Description |

--- a/docs/src/outputs/otlp_http.md
+++ b/docs/src/outputs/otlp_http.md
@@ -29,7 +29,7 @@ def output otlp_out {
     batch_size 512
     batch_timeout "5s"
     headers {
-        Authorization "Bearer ${env.OTLP_TOKEN}"
+        "Authorization": "Bearer your-token"
     }
 }
 ```
@@ -50,9 +50,9 @@ def output otlp_out {
 
 ## Properties
 
-Header keys use the same [static quoted-key syntax](http.md#headers-block)
-as HTTP output. Use `"X-Custom-Header" "value"` for hyphenated names;
-`Authorization` may remain bare. Quoting does not bypass HTTP name restrictions.
+Headers use the same [static string object syntax](http.md#headers-block)
+as HTTP output: `"X-Custom-Header": "value"`. Keys and values are literal strings;
+quoting does not bypass HTTP name restrictions.
 
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|

--- a/docs/src/pipelines/examples.md
+++ b/docs/src/pipelines/examples.md
@@ -115,7 +115,7 @@ def output elasticsearch {
     batch_size 100
     batch_timeout "5s"
     headers {
-        Authorization "Basic <base64(user:password)>"
+        "Authorization": "Basic <base64(user:password)>"
     }
 }
 


### PR DESCRIPTION
## Summary
This release branch contains 3 commits across 23 files relative to main.

- Require static string objects for configuration StringMap values, including HTTP and OTLP headers. Reject dynamic/non-string values and nonempty legacy blocks while preserving empty maps and general expression boundaries.
- Correct gRPC metadata key-normalization documentation and update header examples.
- Prepare four product crates, schema dependency, lockfile, current fixtures, and release notes for 0.8.4. This PR does not publish the release.

## Validation
- Independent reviews, local receiver tests, workspace tests, clippy, formatting, and strict release/documentation preflight pass.
- Datadog: 3 successful intake sends; search-side visibility has not been confirmed.
- CloudWatch Logs: JSON and OTLP each returned all 3 expected messages; OTLP attributes matched. Temporary verification resources were removed.
- Release-preparation CI passed. Site publication and live installation are outside this PR.