### PR TITLE
Expand practical routing and destination recipes

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -41,8 +41,8 @@ The four-package version assertion catches version mismatches, not semantic
 unreleased-feature drift; review the exact content before publication. There is no next site.
 
 The Recipes index and detail pages use `/recipes/`; `/docs/pipelines/` remains
-the DSL pipeline reference. The eight recipe sources live in `src/`: archive, filtering and thinning, Loki, Elasticsearch, Datadog,
-CloudWatch, AMA, and CEF to AMP. Archival routes every sender to a file; filtering
+the DSL pipeline reference. The ten recipe sources live in `src/`: archive, filtering and thinning, branching, Loki, Elasticsearch, Datadog,
+Better Stack, CloudWatch, AMA, and CEF to AMP. Archival routes every sender to a file; filtering
 and table-based suppression are separate examples in Recipe 02. Recipes are
 authored configurations with receiver prerequisites; changes must preserve their
 actual validation boundaries. Rendering is not an integration test.

--- a/site/lib/content.js
+++ b/site/lib/content.js
@@ -145,7 +145,7 @@ export function pages() {
   });
   recipes.push({
     kind: "recipe",
-    title: "Map CEF fields to Log Analytics columns via AMP",
+    title: "Send CEF to Log Analytics via AMP",
     number: 7,
     description:
       "Put CEF fields into OTLP attributes that AMP can map to CommonSecurityLog columns—not just a message body.",
@@ -158,7 +158,7 @@ export function pages() {
   });
   recipes.splice(1, 0, {
     kind: "recipe",
-    title: "Send syslog to Loki with JSON or OTLP",
+    title: "Send syslog to Loki",
     description:
       "Choose native JSON or OTLP, control label placement, and preserve the original log line.",
     route: "recipes/loki-http-json/index.html",
@@ -173,7 +173,7 @@ export function pages() {
   });
   recipes.splice(2, 0, {
     kind: "recipe",
-    title: "Send syslog to Elasticsearch with Bulk or OTLP",
+    title: "Send syslog to Elasticsearch",
     description:
       "Build searchable JSON documents, or let Elasticsearch ingest OTLP logs directly.",
     route: "recipes/elasticsearch/index.html",
@@ -185,9 +185,9 @@ export function pages() {
   });
   recipes.splice(3, 0, {
     kind: "recipe",
-    title: "Send syslog directly to Datadog",
+    title: "Send syslog to Datadog",
     description:
-      "Preserve the original line, add searchable context, and send JSON to Datadog's HTTPS intake.",
+      "Preserve the original line and send searchable context to Datadog with JSON or OTLP.",
     route: "recipes/datadog/index.html",
     content: markdown(
       readFileSync(new URL("../src/datadog.md", import.meta.url), "utf8"),
@@ -198,7 +198,7 @@ export function pages() {
   recipes.splice(4, 0, {
     kind: "recipe",
     number: 5,
-    title: "Send syslog to Amazon CloudWatch Logs with JSON or OTLP",
+    title: "Send syslog to Amazon CloudWatch Logs",
     description:
       "Choose JSON fields or OTLP attributes, with direct HTTPS ingestion into an AWS log group.",
     route: "recipes/cloudwatch/index.html",
@@ -217,6 +217,33 @@ export function pages() {
     content: markdown(
       readFileSync(
         new URL("../src/filter-and-thin.md", import.meta.url),
+        "utf8",
+      ),
+      "pipelines/examples.md",
+    ),
+    siteRecipe: true,
+  });
+  recipes.splice(5, 0, {
+    kind: "recipe",
+    title: "Send syslog to Better Stack",
+    description:
+      "Keep the original log line and add searchable fields with JSON or OpenTelemetry over HTTPS.",
+    route: "recipes/better-stack/index.html",
+    content: markdown(
+      readFileSync(new URL("../src/better-stack.md", import.meta.url), "utf8"),
+      "pipelines/examples.md",
+    ),
+    siteRecipe: true,
+  });
+  recipes.splice(2, 0, {
+    kind: "recipe",
+    title: "Archive every log and forward selected events",
+    description:
+      "Archive every line, forward selected severities, and create a separate structured copy for urgent events.",
+    route: "recipes/branch-and-forward/index.html",
+    content: markdown(
+      readFileSync(
+        new URL("../src/branch-and-forward.md", import.meta.url),
         "utf8",
       ),
       "pipelines/examples.md",

--- a/site/src/better-stack.md
+++ b/site/src/better-stack.md
@@ -1,12 +1,14 @@
-# Send syslog to Datadog
+# Send syslog to Better Stack
 
-Keep the original syslog line and add searchable context before sending it directly to Datadog. Choose JSON fields and Datadog tags, or an OpenTelemetry log body with resource and log attributes. Neither route needs a Datadog Agent or an intermediate collector.
+Send the original syslog line directly to Better Stack over HTTPS. Use JSON for a message with a few searchable fields, or OTLP for an OpenTelemetry log body, resource, and attributes. Neither route needs an intermediate collector.
 
-## Configure the Datadog destination
+## Configure the Better Stack source
 
-Use an API key from the Datadog organization that should receive the logs. Both examples use **AP1**; choose the endpoint for your organization's Datadog site, not the web application's URL. JSON and OTLP have different intake hosts. See the [Send logs API](https://docs.datadoghq.com/api/latest/logs/#send-logs) and [OTLP logs intake](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/logs/) for the corresponding endpoints and payload requirements.
+In Better Stack, open **Sources** and choose **Connect source**. Give the source a name and select the platform matching the data you will send: HTTP for the JSON route, or follow the OpenTelemetry setup for OTLP. Platform selection controls automatic parsing; do not select a device-specific format merely because a syslog line is carried inside the message. See [source setup](https://betterstack.com/docs/logs/logging-start/) and [OpenTelemetry ingestion](https://betterstack.com/docs/logs/open-telemetry/).
 
-Use the static header objects shown below. `DD_API_KEY` is not the same header as `DD-API-KEY`; the lowercase `dd-api-key` spelling in the OTLP example is equivalent because HTTP header names are case-insensitive.
+Copy the source's **Ingesting host** and **Source token** from its configuration. Both examples use `ingesting-host.example` as a placeholder: replace it with that exact host, not the dashboard URL or a host copied from another source. Authenticate with `Authorization: Bearer <SOURCE_TOKEN>`. This is the source's ingestion token, not a management API token; the display name and numeric source ID are not needed in the request.
+
+Replace the token only in a private configuration readable by the service account. Header values are literal strings, not environment-variable templates. Keep the real token out of Git, shell history, and shared diagnostics, and leave TLS certificate verification enabled.
 
 ## Choose raw forwarding or parsed fields
 
@@ -26,44 +28,40 @@ Save it as `event.json`. For the parsed variations, keep the [snippet library](h
 
 ## Option A: choose the JSON fields
 
+The [HTTP ingestion endpoint](https://betterstack.com/docs/logs/ingesting-data/http/logs/) accepts a JSON object at `/`. Put the original line in `message` and add fields you want to search by.
+
 ```limpid
 def input syslog_local {
     type syslog_udp
     bind "127.0.0.1:5514"
 }
 
-def output datadog {
+def output betterstack {
     type http
-    peer { url "https://http-intake.logs.ap1.datadoghq.com/api/v2/logs" }
+    peer { url "https://ingesting-host.example/" }
     content_type "application/json"
     batch_size 1
     headers {
-        "DD-API-KEY": "<DATADOG_API_KEY>"
+        "Authorization": "Bearer <SOURCE_TOKEN>"
     }
 }
 
-def process datadog_document {
+def process betterstack_document {
     egress = to_json({
         message: ingress,
         service: "syslog-forwarder",
-        ddsource: "syslog",
-        hostname: "host01",
-        ddtags: "env:production,route:syslog"
+        route: "json"
     })
 }
 
-def pipeline syslog_to_datadog {
+def pipeline syslog_to_betterstack {
     input syslog_local
-    process datadog_document
-    output datadog
+    process betterstack_document
+    output betterstack
 }
 ```
 
-Replace the API-key placeholder only in a private configuration readable by the service account. Do not commit the real key, paste it into command history, or include it in shared diagnostics. Keep HTTPS certificate verification enabled.
-
-`message: ingress` sends the complete received line, including its syslog header. `to_json` handles quotes, backslashes, and non-ASCII text; do not construct JSON by concatenating unescaped log text. Each event is one JSON object, so keep `batch_size 1` for this configuration rather than joining objects into an invalid JSON document.
-
-`service`, `ddsource`, and `ddtags` provide searchable context. The fixed `hostname` is illustrative: replace it with the appropriate host identity for your logs. A collector receiving multiple devices should derive that value from validated event data rather than assigning every sender the collector's identity.
+`message: ingress` preserves the whole received line, including its syslog header. `to_json` escapes quotes, backslashes, and non-ASCII text. Keep `batch_size 1` here: this process produces one JSON object per event, not a JSON array for a multi-event batch. Without a `dt` field, Better Stack uses reception time for the event timestamp.
 
 ### Parse FortiGate fields before sending JSON
 
@@ -85,15 +83,14 @@ def process fortigate_document {
         severity_number: workspace.lsis.parsed.severity_number,
         source: { ip: workspace.lsis.parsed.src_endpoint.ip, port: workspace.lsis.parsed.src_endpoint.port },
         destination: { ip: workspace.lsis.parsed.dst_endpoint.ip, port: workspace.lsis.parsed.dst_endpoint.port },
-        rule: { name: workspace.lsis.parsed.finding_info.title },
-        ddsource: "fortigate"
+        rule: { name: workspace.lsis.parsed.finding_info.title }
     })
 }
 
-def pipeline syslog_to_datadog {
+def pipeline syslog_to_betterstack {
     input syslog_local
     process parse_syslog | parse_cef | fortigate_timezone | parse_fortigate_cef | fortigate_document
-    output datadog
+    output betterstack
 }
 ```
 
@@ -103,7 +100,7 @@ Expand the received JSON event and inspect its nested `source`, `destination`, a
 
 ## Option B: preserve OTLP structure
 
-Use this configuration instead of Option A. Place the matching [compose_otlp.limpid snippet](https://github.com/naoto256/limpid/blob/v0.8.4/packaging/snippets/composers/compose_otlp.limpid) beside the configuration file. Datadog's direct OTLP logs intake accepts HTTP Protobuf at `/v1/logs`.
+Use this configuration instead of the JSON configuration. Place the matching [compose_otlp.limpid snippet](https://github.com/naoto256/limpid/blob/v0.8.4/packaging/snippets/composers/compose_otlp.limpid) beside your configuration file. The endpoint is `/v1/logs` on the source's ingesting host, with the same Bearer authentication.
 
 ```limpid
 include "compose_otlp.limpid"
@@ -113,17 +110,17 @@ def input syslog_local {
     bind "127.0.0.1:5514"
 }
 
-def output datadog {
+def output betterstack {
     type otlp_http
     protocol http_protobuf
-    peer { endpoint "https://otlp.ap1.datadoghq.com/v1/logs" }
+    peer { endpoint "https://ingesting-host.example/v1/logs" }
     batch_size 1
     headers {
-        "dd-api-key": "<DATADOG_API_KEY>"
+        "Authorization": "Bearer <SOURCE_TOKEN>"
     }
 }
 
-def process datadog_log {
+def process betterstack_log {
     workspace.lsis.shed.otlp.resource.attributes = [
         { key: "service.name", value: { string_value: "syslog-forwarder" } }
     ]
@@ -134,14 +131,14 @@ def process datadog_log {
     ]
 }
 
-def pipeline syslog_to_datadog {
+def pipeline syslog_to_betterstack {
     input syslog_local
-    process datadog_log | compose_otlp | otlp_to_egress
-    output datadog
+    process betterstack_log | compose_otlp | otlp_to_egress
+    output betterstack
 }
 ```
 
-The original line goes into the OTLP body. `service.name` identifies the service on the resource, while `route` is a log attribute. `compose_otlp` builds the protobuf payload and `otlp_to_egress` passes it to the output. The timestamp is limpid's receive time; this example does not parse the timestamp inside the syslog text. Header values are static strings, so replace the API-key placeholder in the private configuration rather than using an environment-variable template.
+The adapter supplies the original line as the log body, identifies the service on the resource, and adds `route` as a log attribute. `compose_otlp` builds the protobuf payload; `otlp_to_egress` passes it to the output. This example uses limpid's receive time rather than parsing a timestamp from the syslog text. See the [OTLP/HTTP output reference](../outputs/otlp_http.md) for transport and partial-rejection handling.
 
 ### Parse FortiGate fields before composing OTLP
 
@@ -156,11 +153,11 @@ def process fortigate_timezone {
     workspace.fortigate_cef.timezone = "UTC"
 }
 
-def pipeline syslog_to_datadog {
+def pipeline syslog_to_betterstack {
     input syslog_local
     process parse_syslog | parse_cef | fortigate_timezone | parse_fortigate_cef
           | fortigate_cef_to_otlp | compose_otlp | otlp_to_egress
-    output datadog
+    output betterstack
 }
 ```
 
@@ -176,7 +173,7 @@ The parser extracts device facts; its bundled `fortigate_cef_to_otlp` adapter ch
 
 This adapter does not invent `service.name` or an instrumentation scope. Here, `source.ip` means the endpoint inside the firewall event, not the sender of the UDP packet. If you also need the full wire line in the OTLP body, set `workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }` in a separate process **after** the adapter and before the composer.
 
-In Log Explorer, locate `Example.Signature` in the body, then expand resource and log attributes. Do not reuse the raw example's service/route filters: the FortiGate adapter does not set them. Receiver pipelines may normalize field names or remap severity and timestamps; inspect the stored event before making saved searches.
+In Live Tail, locate `Example.Signature` in the body, then expand resource and log attributes. Do not reuse the raw example's service/route filters: the FortiGate adapter does not set them. Receiver pipelines may normalize field names or remap severity and timestamps; inspect the stored event before making saved searches.
 
 ### Inspect the parsed variation locally
 
@@ -184,13 +181,13 @@ Save one assembled variation as `fortigate.conf` and use the sample `event.json`
 
 ```sh
 limpid --check --config fortigate.conf
-limpid --test-pipeline syslog_to_datadog --config fortigate.conf --input "$(cat event.json)"
+limpid --test-pipeline syslog_to_betterstack --config fortigate.conf --input "$(cat event.json)"
 ```
 
 Test mode processes the event without starting the listener or sending to the destination. JSON egress can be read directly; OTLP egress is protobuf bytes, not a readable JSON trace. To inspect it locally, temporarily append a process with `egress = to_json(otlp.decode_resourcelog_protobuf(egress))` after `otlp_to_egress`, run test mode, then remove that inspection process before sending to an OTLP output. Confirm the destination's stored fields separately when you enable delivery. A different FortiGate category can populate different fields or be rejected by the parser.
 
-## Find the logs in Datadog
+## Inspect the received logs
 
-Open **Log Explorer** in the same Datadog site and organization, select a recent time range, and filter by `service:syslog-forwarder`. For Option A, you can also use `source:syslog`; Option B does not set that Datadog source tag. Find a distinctive string from your input and expand the event to inspect the original line and context. Intake acceptance and a searchable log are separate observations; an onboarding screen still waiting for logs does not by itself establish that delivery failed.
+Open the source's Live Tail, select a recent time range, and find a distinctive string from your log. Expand the event to inspect the full JSON `message` or OTLP body, service context, and `route`. Check quotes, backslashes, and non-ASCII text in the event itself, not just the abbreviated list display or an AI explanation.
 
-Check the organization's ingestion pipelines, exclusion filters, and index routing if accepted logs do not appear in the expected search. Request retries are not an exactly-once guarantee. This example does not establish outage recovery, throughput, or retention guarantees.
+If the displayed fields differ from your payload, check the source platform's parser and any configured transformations. An accepted request and the final stored event are different checkpoints. For missing JSON events, check the host/token pair, ingestion pause state, and quota; HTTP `403` indicates an invalid source token and `402` indicates a quota or spending limit. For OTLP, also check partial rejection rather than treating every HTTP success as acceptance of every record. Retries can create duplicates after an ambiguous response.

--- a/site/src/branch-and-forward.md
+++ b/site/src/branch-and-forward.md
@@ -1,0 +1,75 @@
+# Archive every log and forward selected events
+
+Keep a complete local archive while sending only useful events to another syslog server. Give urgent events a separate JSON output without changing the copies already sent elsewhere.
+
+## Branch after the archive
+
+Each `output` takes a copy of the event at that point in the pipeline. It does not end processing. Write the archive first, then select and transform the downstream copies.
+
+```limpid
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
+
+def input syslog_local {
+    type syslog_udp
+    bind "0.0.0.0:514"
+}
+
+def output archive {
+    type file
+    path "/var/log/limpid/all.log"
+}
+
+def output downstream {
+    type syslog_tcp
+    peer { host "192.0.2.20" port 514 }
+}
+
+def output urgent {
+    type file
+    path "/var/log/limpid/urgent.jsonl"
+}
+
+def process urgent_document {
+    egress = to_json({
+        message: ingress,
+        hostname: workspace.syslog.hostname,
+        severity: workspace.syslog.severity
+    })
+}
+
+def pipeline archive_and_forward {
+    input syslog_local
+    output archive
+    process parse_syslog
+
+    if workspace.syslog.severity != null {
+        if workspace.syslog.severity <= 4 {
+            output downstream
+        }
+        if workspace.syslog.severity <= 3 {
+            process urgent_document
+            output urgent
+        }
+    }
+}
+```
+
+Create the file directories and grant the service write access. Replace the documentation address with the downstream server, reserve the listener port, and restrict incoming traffic to intended senders. This example uses plain TCP on a trusted network; configure TLS when the transport requires it.
+
+## Follow each copy
+
+Syslog severity uses smaller numbers for more urgent events. This pipeline forwards warning and more urgent messages (0–4); error and more urgent messages (0–3) also get a JSON record.
+
+| Event             | Local archive | Downstream syslog | Urgent JSON       |
+| ----------------- | ------------- | ----------------- | ----------------- |
+| Informational (6) | Original line | —                 | —                 |
+| Warning (4)       | Original line | Original line     | —                 |
+| Error (3)         | Original line | Original line     | Structured record |
+
+The last branch rewrites `egress`, not `ingress`. The archive and syslog copies have already been taken, so both retain the original line. If parsing fails, the earlier archive output has already been queued; the error stops later processing. If parsing succeeds without a severity, neither conditional branch runs.
+
+These are independent output queues, not an atomic transaction across destinations. Queuing an archive copy does not mean its disk write has finished, or that the remote server has received another copy. Size queues and configure durable error logging for your delivery requirements.
+
+No `drop` is needed here: an event can simply reach the end after its archive output. A `drop` or `finish` placed before another branch would stop that branch too. Use separate `if` statements when an event should reach more than one destination; use an exclusive `switch` when only one destination should be selected.
+
+See the [routing contract](./routing.md) for output-copy and termination semantics.

--- a/site/src/cef-to-amp.md
+++ b/site/src/cef-to-amp.md
@@ -1,4 +1,4 @@
-# Map CEF fields to Log Analytics columns via AMP
+# Send CEF to Log Analytics via AMP
 
 A CEF event can reach the receiver and still leave the columns you need empty. Sending a message is not the same as making its fields available to the destination's mapping.
 
@@ -23,6 +23,7 @@ This is an AMP exporter mapping—not the facility filtering in the AMA recipe. 
 The packaged `parse_cef` and `cef_to_otlp` processes handle generic CEF. The small process between the adapter and `compose_otlp` adds the destination-specific column projection. Vendor-specific interpretation belongs in a vendor parser/adapter, not in the generic composer.
 
 ```limpid
+include "/usr/share/limpid/snippets/parsers/parse_syslog.limpid"
 include "/usr/share/limpid/snippets/parsers/parse_cef.limpid"
 include "/usr/share/limpid/snippets/composers/compose_otlp.limpid"
 
@@ -65,7 +66,7 @@ def process project_common_security_log {
 
 def pipeline cef_to_log_analytics {
     input cef_tcp
-    process { workspace.syslog = syslog.parse(ingress) }
+    process parse_syslog
     if not starts_with(workspace.syslog.msg, "CEF:") { drop }
     process parse_cef | cef_to_otlp | project_common_security_log
           | compose_otlp | otlp_to_egress

--- a/site/src/cloudwatch.md
+++ b/site/src/cloudwatch.md
@@ -1,4 +1,4 @@
-# Send syslog to Amazon CloudWatch Logs with JSON or OTLP
+# Send syslog to Amazon CloudWatch Logs
 
 Send logs directly to CloudWatch Logs over HTTPS. Choose a JSON document when you want to define the stored fields, or OTLP when you want to preserve resource and log-record attributes.
 
@@ -19,7 +19,7 @@ This route uses a bearer token, not an AWS access-key ID and secret. AWS recomme
 
 Both examples use Tokyo (`ap-northeast-1`). Change the endpoint region, log group, and log stream together to match your destination. Replace `<CLOUDWATCH_LOGS_TOKEN>` only in a private configuration readable by the service account. Never commit the token or place it in a shared URL or diagnostic output. Keep TLS certificate verification enabled.
 
-Use **limpid 0.8.4 or later** and the static header objects shown below.
+Use the static header objects shown below.
 
 ## Option A: choose the JSON fields
 

--- a/site/src/elasticsearch.md
+++ b/site/src/elasticsearch.md
@@ -1,4 +1,4 @@
-# Send syslog to Elasticsearch with Bulk or OTLP
+# Send syslog to Elasticsearch
 
 Make syslog searchable in Elasticsearch without a Logstash hop. Build a JSON document when you want to choose its fields, or emit an OTLP log record when you want a telemetry-shaped document. Use Kibana to explore the resulting index or data stream.
 
@@ -19,6 +19,22 @@ For Bulk, prepare the `limpid-syslog` index or its index template, field mapping
 The configurations below use a local HTTP endpoint at `127.0.0.1:9200`. Replace it with your deployment's endpoint and configure its HTTPS trust and authentication in both limpid and the query client. Do not disable authentication to match the example. Keep API keys out of shared configuration files.
 
 Elasticsearch's native endpoint is not the APM Server endpoint. For Elastic Cloud or a Collector-based topology, use the endpoint and routing policy provided by that deployment. See the [native OTLP endpoint guide](https://www.elastic.co/docs/manage-data/ingest/otlp-endpoint).
+
+## Choose raw forwarding or parsed fields
+
+Each option starts by forwarding the original line without parsing it. Its FortiGate variation then extracts fields from a CEF-formatted IPS event. Use the same sample for both:
+
+```json
+{
+  "ingress": "<134>Sep  6 10:00:00 fw01 CEF:0|Fortinet|Fortigate|v7.4.11|16384|utm:ips signature|7|deviceExternalId=FG-EXAMPLE cat=utm:ips FTNTFGTsubtype=ips FTNTFGTseverity=high src=192.0.2.10 spt=36208 dst=198.51.100.5 dpt=9100 proto=6 act=detected FTNTFGTattack=Example.Signature FTNTFGTattackid=12345 msg=Example attack detected",
+  "source": {
+    "ip": "192.0.2.1",
+    "port": 514
+  }
+}
+```
+
+Save it as `event.json`. For the parsed variations, keep the [snippet library](https://github.com/naoto256/limpid/tree/v0.8.4/packaging/snippets) from the same release as your binary under `packaging/snippets/` beside the configuration. Keep its directory structure for helper includes. The example declares the device timezone as `UTC`; replace that with the device's actual IANA timezone or fixed offset. RFC 3164 has no year, so the parser supplies the runtime year. This sample is FortiGate **CEF**, not FortiGate's other syslog formats.
 
 ## Option A: choose the document with Bulk
 
@@ -56,6 +72,94 @@ Keep `batch_size 1` for this configuration: each event already contains its acti
 ### HTTP success is not per-document success
 
 Elasticsearch can return HTTP 200 with `errors: true` and failed entries in `items`. limpid's generic HTTP output checks the HTTP status; it does **not** interpret Elasticsearch's item-level results. A mapping rejection can therefore be acknowledged at the transport layer without the document being indexed. A disk queue does not close that gap. Where per-document recovery is required, use a Bulk-aware ingestion component and monitor rejected items. See the [Bulk API response contract](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk).
+
+### Parse FortiGate fields before indexing
+
+Create a new index with explicit field types before sending the parsed variation. In Kibana Dev Tools:
+
+```http
+PUT limpid-fortigate
+{
+  "mappings": {
+    "properties": {
+      "message": { "type": "text" },
+      "event_time": { "type": "date", "format": "epoch_millis" },
+      "severity_number": { "type": "integer" },
+      "source": { "properties": {
+        "ip": { "type": "ip" },
+        "port": { "type": "integer" }
+      }},
+      "destination": { "properties": {
+        "ip": { "type": "ip" },
+        "port": { "type": "integer" }
+      }},
+      "rule": { "properties": {
+        "name": { "type": "keyword" }
+      }}
+    }
+  }
+}
+```
+
+Use an unused index name if this index already exists with different mappings; field types cannot simply be changed in place. Keep Option A's input and output, but change the output URL to `http://127.0.0.1:9200/limpid-fortigate/_bulk`. Replace its pipeline with this fragment:
+
+```limpid
+include "packaging/snippets/parsers/parse_syslog.limpid"
+include "packaging/snippets/parsers/parse_cef.limpid"
+include "packaging/snippets/parsers/parse_fortigate_cef.limpid"
+
+def process fortigate_timezone {
+    workspace.fortigate_cef.timezone = "UTC"
+}
+
+def process fortigate_document {
+    let document = {
+        message: ingress,
+        event_time: to_int(workspace.lsis.parsed.time / 1000000),
+        severity_number: workspace.lsis.parsed.severity_number,
+        source: {
+            ip: workspace.lsis.parsed.src_endpoint.ip,
+            port: workspace.lsis.parsed.src_endpoint.port
+        },
+        destination: {
+            ip: workspace.lsis.parsed.dst_endpoint.ip,
+            port: workspace.lsis.parsed.dst_endpoint.port
+        },
+        rule: { name: workspace.lsis.parsed.finding_info.title }
+    }
+    egress = to_json({ index: {} }) + "\n" + to_json(document) + "\n"
+}
+
+def pipeline syslog_to_elastic {
+    input syslog_local
+    process parse_syslog | parse_cef | fortigate_timezone | parse_fortigate_cef | fortigate_document
+    output elasticsearch
+}
+```
+
+The document retains the full original line in `message`, but now IPs support IP queries, ports support numeric ranges, and the rule name supports exact filtering and aggregation. `event_time` is the parsed device time in epoch milliseconds; use it as the Kibana data view's time field. CEF priority `7` becomes `severity_number=19`, independently of the outer syslog PRI.
+
+For example, this query combines an IP subnet with a destination port and counts events by detection rule:
+
+```http
+GET limpid-fortigate/_search
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        { "term": { "source.ip": "192.0.2.0/24" } },
+        { "term": { "destination.port": 9100 } }
+      ]
+    }
+  },
+  "aggs": {
+    "rules": { "terms": { "field": "rule.name" } }
+  }
+}
+```
+
+The sample matches with `rule.name=Example.Signature`, source port `36208`, and destination IP `198.51.100.5`. The Bulk item-level failure caveat above still applies: a successful HTTP status alone does not prove these mappings accepted the document. See [explicit mapping](https://www.elastic.co/docs/manage-data/data-store/mapping/explicit-mapping) and the [IP field type](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/ip).
 
 ## Option B: send an OTLP log record
 
@@ -106,6 +210,81 @@ Elasticsearch stores the OTLP values in these fields:
 | Log timestamp             | `@timestamp`                       |
 
 That is intentionally different from the Bulk example's hand-built `message` and `received` fields. Changing the output protocol alone does not make those two document shapes identical.
+
+### Parse FortiGate fields before composing OTLP
+
+Keep Option B's input, output, and composer include. Replace its pipeline with this fragment. Do not call the original body-only process: it would overwrite the parsed event time or adapter fields.
+
+```limpid
+include "packaging/snippets/parsers/parse_syslog.limpid"
+include "packaging/snippets/parsers/parse_cef.limpid"
+include "packaging/snippets/parsers/parse_fortigate_cef.limpid"
+
+def process fortigate_timezone {
+    workspace.fortigate_cef.timezone = "UTC"
+}
+
+def pipeline syslog_to_elastic {
+    input syslog_local
+    process parse_syslog | parse_cef | fortigate_timezone | parse_fortigate_cef
+          | fortigate_cef_to_otlp | compose_otlp | otlp_to_egress
+    output elasticsearch
+}
+```
+
+The parser extracts device facts; its bundled `fortigate_cef_to_otlp` adapter chooses their OTLP locations. The shared composer supplies the wire format. For this sample:
+
+| Location                   | Result                                                                                                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Resource attributes        | `observer.vendor=Fortinet`, `observer.product=Fortigate`, `observer.type=firewall`                                                                          |
+| Log attributes             | `source.ip=192.0.2.10`, `source.port=36208`, `destination.ip=198.51.100.5`, `destination.port=9100`, `rule.name=Example.Signature`, `event.action=detected` |
+| Body                       | CEF message beginning `CEF:0\|Fortinet\|Fortigate\|`, without the syslog wrapper                                                                            |
+| Event time / observed time | Parsed device time / limpid receipt time                                                                                                                    |
+| SeverityNumber             | `19`, from CEF priority `7`                                                                                                                                 |
+
+This adapter does not invent `service.name` or an instrumentation scope. Here, `source.ip` means the endpoint inside the firewall event, not the sender of the UDP packet. If you also need the full wire line in the OTLP body, set `workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }` in a separate process **after** the adapter and before the composer.
+
+Elasticsearch's native OTLP endpoint manages the data-stream template. The Bulk mapping above does not apply to it. With the native OTel mappings in Elasticsearch 9.5, these fields are already typed:
+
+| Field                                                   | Type      | Use                                  |
+| ------------------------------------------------------- | --------- | ------------------------------------ |
+| `attributes.source.ip`, `attributes.destination.ip`     | `ip`      | Address or subnet filters            |
+| `attributes.source.port`, `attributes.destination.port` | `long`    | Numeric filters and ranges           |
+| `attributes.rule.name`                                  | `keyword` | Exact matches and terms aggregations |
+| `@timestamp`                                            | `date`    | Device event-time filter             |
+
+Check `_field_caps` on your destination if its version or templates differ; do not replace the managed template with the Bulk mapping. The body remains in `body.text`, vendor identity in `resource.attributes.observer.vendor`, and severity in `severity_number`.
+
+The equivalent structured query uses the OTLP field paths:
+
+```http
+GET logs-generic.otel-default/_search
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        { "term": { "attributes.source.ip": "192.0.2.0/24" } },
+        { "term": { "attributes.destination.port": 9100 } }
+      ]
+    }
+  },
+  "aggs": {
+    "rules": { "terms": { "field": "attributes.rule.name" } }
+  }
+}
+```
+
+### Inspect the parsed variation locally
+
+Save one assembled variation as `fortigate.conf` and use the sample `event.json` above:
+
+```sh
+limpid --check --config fortigate.conf
+limpid --test-pipeline syslog_to_elastic --config fortigate.conf --input "$(cat event.json)"
+```
+
+Test mode processes the event without starting the listener or sending to the destination. JSON egress can be read directly; OTLP egress is protobuf bytes, not a readable JSON trace. To inspect it locally, temporarily append a process with `egress = to_json(otlp.decode_resourcelog_protobuf(egress))` after `otlp_to_egress`, run test mode, then remove that inspection process before sending to an OTLP output. Confirm the destination's stored fields separately when you enable delivery. A different FortiGate category can populate different fields or be rejected by the parser.
 
 ## Find the logs in Kibana
 

--- a/site/src/loki-http-json.md
+++ b/site/src/loki-http-json.md
@@ -1,4 +1,4 @@
-# Send syslog to Loki with JSON or OTLP
+# Send syslog to Loki
 
 Send syslog to Loki in either of two ways: build its native JSON push payload, or send an OTLP log record and let Loki map the attributes. Both keep the original log line; the difference is who defines the stream labels and metadata.
 
@@ -11,6 +11,22 @@ Send syslog to Loki in either of two ways: build its native JSON push payload, o
 | Additional fields | In the line, or optional structured metadata | OTLP attributes mapped to structured metadata |
 
 Choose one route for a given event unless duplicate ingestion is intentional. The examples below are alternatives, not two outputs to enable together.
+
+## Choose raw forwarding or parsed fields
+
+Each option starts by forwarding the original line without parsing it. Its FortiGate variation then extracts fields from a CEF-formatted IPS event. Use the same sample for both:
+
+```json
+{
+  "ingress": "<134>Sep  6 10:00:00 fw01 CEF:0|Fortinet|Fortigate|v7.4.11|16384|utm:ips signature|7|deviceExternalId=FG-EXAMPLE cat=utm:ips FTNTFGTsubtype=ips FTNTFGTseverity=high src=192.0.2.10 spt=36208 dst=198.51.100.5 dpt=9100 proto=6 act=detected FTNTFGTattack=Example.Signature FTNTFGTattackid=12345 msg=Example attack detected",
+  "source": {
+    "ip": "192.0.2.1",
+    "port": 514
+  }
+}
+```
+
+Save it as `event.json`. For the parsed variations, keep the [snippet library](https://github.com/naoto256/limpid/tree/v0.8.4/packaging/snippets) from the same release as your binary under `packaging/snippets/` beside the configuration. Keep its directory structure for helper includes. The example declares the device timezone as `UTC`; replace that with the device's actual IANA timezone or fixed offset. RFC 3164 has no year, so the parser supplies the runtime year. This sample is FortiGate **CEF**, not FortiGate's other syslog formats.
 
 ## Option A: build Loki's JSON payload
 
@@ -78,6 +94,47 @@ Send a valid syslog message carrying a distinct test marker, then query only tha
 
 Compare the complete stored line, including punctuation and non-ASCII characters. A successful HTTP request is useful evidence, but querying the record confirms that it is available to readers. Also inspect output failures and the error log; delivery retries are not an exactly-once guarantee.
 
+### Parse FortiGate fields before sending JSON
+
+Keep Option A's input and output definitions. Replace its pipeline with the following includes, processes, and pipeline; do not run both pipelines on the same input. The original forwarding process may remain unused.
+
+```limpid
+include "packaging/snippets/parsers/parse_syslog.limpid"
+include "packaging/snippets/parsers/parse_cef.limpid"
+include "packaging/snippets/parsers/parse_fortigate_cef.limpid"
+
+def process fortigate_timezone {
+    workspace.fortigate_cef.timezone = "UTC"
+}
+
+def process fortigate_document {
+    let document = {
+        message: ingress,
+        event_time_unix_nano: workspace.lsis.parsed.time,
+        severity_number: workspace.lsis.parsed.severity_number,
+        source: { ip: workspace.lsis.parsed.src_endpoint.ip, port: workspace.lsis.parsed.src_endpoint.port },
+        destination: { ip: workspace.lsis.parsed.dst_endpoint.ip, port: workspace.lsis.parsed.dst_endpoint.port },
+        rule: { name: workspace.lsis.parsed.finding_info.title }
+    }
+    egress = to_json({
+        streams: [{
+            stream: { job: "fortigate" },
+            values: [["${workspace.lsis.parsed.time}", to_json(document)]]
+        }]
+    })
+}
+
+def pipeline syslog_to_loki {
+    input syslog_local
+    process parse_syslog | parse_cef | fortigate_timezone | parse_fortigate_cef | fortigate_document
+    output loki
+}
+```
+
+The sample produces `source.ip = 192.0.2.10`, `destination.port = 9100`, `rule.name = Example.Signature`, and `severity_number = 19`. This severity comes from the FortiGate CEF priority, not the outer syslog PRI. `message` still contains the complete original line. `event_time_unix_nano` is a numeric field containing the parsed device time, also used as Loki's string nanosecond timestamp.
+
+The log line is now a JSON document. Query `{job="fortigate"} | json | source_ip="192.0.2.10"`. These fields are parsed from the line at query time, not stored as stream labels. This JSON variation adds no high-cardinality address labels and does not use structured metadata.
+
 ## Option B: send OTLP and map attributes in Loki
 
 Use Loki's native OTLP/HTTP endpoint, with the full `/otlp/v1/logs` path: limpid does not append `/v1/logs`. This is not Loki's JSON push API, even though both use HTTP. The example selects protobuf transport explicitly.
@@ -97,7 +154,7 @@ def input syslog_local {
 def output loki_otlp {
     type otlp_http
     peer { endpoint "http://127.0.0.1:3100/otlp/v1/logs" }
-    protocol "http_protobuf"
+    protocol http_protobuf
     batch_size 1
 }
 
@@ -159,3 +216,49 @@ Loki normalizes dots in attribute names to underscores. Select the stream with t
 The address above is a documentation placeholder. Keeping sender addresses out of index labels avoids creating a new stream for every address. Resource attributes and log attributes are different locations: putting `service.name` in log attributes will not satisfy the resource-attribute indexing rule above.
 
 See Grafana's [native OTLP ingestion and mapping guide](https://grafana.com/docs/loki/latest/send-data/otel/) and [structured metadata requirements](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/). The same HTTPS, gateway authentication, and tenant-selection considerations described for Option A apply here. Do not disable verification or authentication to make this example work remotely.
+
+### Parse FortiGate fields before composing OTLP
+
+Keep Option B's input, output, and composer include. Replace its pipeline with this fragment. Do not call the original body-only process: it would overwrite the parsed event time or adapter fields.
+
+```limpid
+include "packaging/snippets/parsers/parse_syslog.limpid"
+include "packaging/snippets/parsers/parse_cef.limpid"
+include "packaging/snippets/parsers/parse_fortigate_cef.limpid"
+
+def process fortigate_timezone {
+    workspace.fortigate_cef.timezone = "UTC"
+}
+
+def pipeline syslog_to_loki {
+    input syslog_local
+    process parse_syslog | parse_cef | fortigate_timezone | parse_fortigate_cef
+          | fortigate_cef_to_otlp | compose_otlp | otlp_to_egress
+    output loki_otlp
+}
+```
+
+The parser extracts device facts; its bundled `fortigate_cef_to_otlp` adapter chooses their OTLP locations. The shared composer supplies the wire format. For this sample:
+
+| Location                   | Result                                                                                                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Resource attributes        | `observer.vendor=Fortinet`, `observer.product=Fortigate`, `observer.type=firewall`                                                                          |
+| Log attributes             | `source.ip=192.0.2.10`, `source.port=36208`, `destination.ip=198.51.100.5`, `destination.port=9100`, `rule.name=Example.Signature`, `event.action=detected` |
+| Body                       | CEF message beginning `CEF:0\|Fortinet\|Fortigate\|`, without the syslog wrapper                                                                            |
+| Event time / observed time | Parsed device time / limpid receipt time                                                                                                                    |
+| SeverityNumber             | `19`, from CEF priority `7`                                                                                                                                 |
+
+This adapter does not invent `service.name` or an instrumentation scope. Here, `source.ip` means the endpoint inside the firewall event, not the sender of the UDP packet. If you also need the full wire line in the OTLP body, set `workspace.lsis.shed.otlp.log_record.body = { string_value: ingress }` in a separate process **after** the adapter and before the composer.
+
+For this variation, add `observer.type` beside `service.name` in the receiver fragment above, under the `index_label` attributes list. Otherwise the raw example's service-only policy selects no label from this resource. Query `{observer_type="firewall"} | source_ip="192.0.2.10"`; event attributes become structured metadata, including `rule_name` and `destination_port`, not index labels. Keep the same schema and structured-metadata prerequisites.
+
+### Inspect the parsed variation locally
+
+Save one assembled variation as `fortigate.conf` and use the sample `event.json` above:
+
+```sh
+limpid --check --config fortigate.conf
+limpid --test-pipeline syslog_to_loki --config fortigate.conf --input "$(cat event.json)"
+```
+
+Test mode processes the event without starting the listener or sending to the destination. JSON egress can be read directly; OTLP egress is protobuf bytes, not a readable JSON trace. To inspect it locally, temporarily append a process with `egress = to_json(otlp.decode_resourcelog_protobuf(egress))` after `otlp_to_egress`, run test mode, then remove that inspection process before sending to an OTLP output. Confirm the destination's stored fields separately when you enable delivery. A different FortiGate category can populate different fields or be rejected by the parser.

--- a/site/src/pages.11ty.js
+++ b/site/src/pages.11ty.js
@@ -53,12 +53,12 @@ function content(page) {
       .join("")}</div></main>`;
   if (page.kind === "recipes")
     return `<main id="main" class="landing"><div class="eyebrow">RECIPES / STABLE ${release}</div><h1>Start with<br>a concrete problem.</h1><p class="lede">Configuration recipes for concrete logging problems. Read the assumptions, then adapt the inputs and destinations to your environment.</p><div class="recipe-list"><a href="${url("recipes/fortigate-cef-to-ocsf/")}"><span class="number">00</span><div><span class="eyebrow">DOCUMENTED CONFIGURATION</span><h2>Run the homepage example: FortiGate CEF to OCSF</h2><p>Parse a FortiGate CEF event, compose an OCSF record, and inspect the result locally.</p></div><span>→</span></a></div>${[
-      ["Processing", page.recipes.slice(0, 2)],
-      ["Destinations", page.recipes.slice(2)],
+      ["Processing", page.recipes.slice(0, 3)],
+      ["Destinations", page.recipes.slice(3)],
     ]
       .map(
         ([title, recipes]) =>
-          `<section><h2>${title}</h2><div class="recipe-list">${recipes.map((r) => `<a href="${url(r.route)}"><span class="number">0${r.number}</span><div><span class="eyebrow">DOCUMENTED CONFIGURATION</span><h2>${escape(r.title)}</h2><p>${escape(r.description)}</p></div><span>→</span></a>`).join("")}</div></section>`,
+          `<section><h2>${title}</h2><div class="recipe-list">${recipes.map((r) => `<a href="${url(r.route)}"><span class="number">${String(r.number).padStart(2, "0")}</span><div><span class="eyebrow">DOCUMENTED CONFIGURATION</span><h2>${escape(r.title)}</h2><p>${escape(r.description)}</p></div><span>→</span></a>`).join("")}</div></section>`,
       )
       .join(
         "",
@@ -76,6 +76,6 @@ export default class {
     };
   }
   render({ entry }) {
-    return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="google-site-verification" content="S-EqEKp48UJAW41lZX5p1lCX1WOcv23Zq_XZxVzEsNk" /><title>${escape(entry.title)} — limpid</title><link rel="canonical" href="${escape(canonical(entry.route))}"><meta name="description" content="Readable log pipelines. Documentation and practical configurations for limpid ${release}."><link rel="stylesheet" href="${url("style.css")}"><link rel="icon" type="image/svg+xml" href="${url("mark.svg")}"><script type="module" src="${url("copy-code.js")}"></script></head><body><a class="skip" href="#main">Skip to content</a><header><a class="brand" href="${url()}"><img class="brand-mark" src="${url("mark.svg")}" width="42.5" height="37" alt="">limpid<span class="version">v${release}</span></a><nav aria-label="Main"><a href="${url("docs/")}">Docs</a><a href="${url("recipes/")}">Recipes</a><a class="github" href="${repository}">GitHub ↗</a></nav></header>${content(entry)}<footer><a class="brand" href="${url()}">limpid</a><p>Log pipelines, limpid as intent.</p><a href="${repository}/releases/tag/v${release}">Stable ${release} ↗</a><span>MIT / Apache-2.0</span></footer></body></html>`;
+    return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="google-site-verification" content="S-EqEKp48UJAW41lZX5p1lCX1WOcv23Zq_XZxVzEsNk" /><title>${escape(entry.title)} — limpid</title><link rel="canonical" href="${escape(canonical(entry.route))}"><meta name="description" content="Readable log pipelines. Documentation and practical configurations for limpid ${release}."><link rel="stylesheet" href="${url("style.css")}"><link rel="icon" type="image/svg+xml" href="${url("mark.svg")}"><script type="module" src="${url("copy-code.js")}"></script></head><body><a class="skip" href="#main">Skip to content</a><header><a class="brand" href="${url()}"><img class="brand-mark" src="${url("mark.svg")}" width="42.5" height="37" alt="">limpid<span class="version">v${release}</span></a><nav aria-label="Main"><a href="${url("docs/")}">Docs</a><a href="${url("recipes/")}">Recipes</a><a class="github" href="${repository}">GitHub ↗</a></nav></header><div class="page-scroll" tabindex="0" role="region" aria-label="Page content">${content(entry)}<footer><a class="brand" href="${url()}">limpid</a><p>Log pipelines, limpid as intent.</p><a href="${repository}/releases/tag/v${release}">Stable ${release} ↗</a><span>MIT / Apache-2.0</span></footer></div></body></html>`;
   }
 }

--- a/site/src/style.css
+++ b/site/src/style.css
@@ -6,6 +6,8 @@
   --blue: #1457dd;
   --night: #11202b;
   --mint: #a7efd8;
+  --header-height: 92px;
+  --header-background: rgb(248 250 251 / 80%);
 
   font-family:
     Inter,
@@ -22,8 +24,24 @@
 * {
   box-sizing: border-box;
 }
+html {
+  height: 100%;
+  overflow: hidden;
+}
 body {
   margin: 0;
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+}
+.page-scroll {
+  grid-area: 1 / 1;
+  min-height: 0;
+  padding-top: var(--header-height);
+  overflow: auto;
+  overscroll-behavior-y: contain;
+  scroll-padding-top: calc(var(--header-height) + 16px);
 }
 a {
   color: inherit;
@@ -38,9 +56,17 @@ summary:focus-visible {
   outline-offset: 5px;
 }
 header {
+  grid-area: 1 / 1;
+  align-self: start;
+  position: relative;
+  z-index: 5;
+  background: var(--header-background);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
   max-width: 1440px;
-  margin: auto;
-  min-height: 92px;
+  width: 100%;
+  margin: 0 auto;
+  min-height: var(--header-height);
   padding: 24px 6%;
   display: flex;
   justify-content: space-between;
@@ -624,9 +650,11 @@ footer p {
   }
 }
 @media (max-width: 640px) {
+  :root {
+    --header-height: 78px;
+  }
   header {
     padding: 20px 5%;
-    min-height: 75px;
   }
   header nav {
     gap: 20px;

--- a/site/test/content.test.mjs
+++ b/site/test/content.test.mjs
@@ -6,6 +6,45 @@ import MarkdownIt from "markdown-it";
 import PageTemplate from "../src/pages.11ty.js";
 import { url, origin } from "../lib/config.js";
 
+test("branching recipe preserves earlier output copies and AMP uses the syslog snippet", () => {
+  const source = readFileSync("src/branch-and-forward.md", "utf8");
+  const entry = pages().find(
+    (p) => p.route === "recipes/branch-and-forward/index.html",
+  );
+  assert.equal(entry.number, 3);
+  const fence = source.match(/```limpid\n([\s\S]*?)```/)[1];
+  assert.match(fence, /output archive\s+process parse_syslog/);
+  assert.match(fence, /severity <= 4/);
+  assert.match(fence, /severity <= 3/);
+  assert.match(fence, /process urgent_document\s+output urgent/);
+  const rendered = entry.content
+    .match(/<pre><code[^>]*>([\s\S]*?)<\/code>/)[1]
+    .replace(/<span class="[^"]+">|<\/span>/g, "");
+  assert.equal(rendered, new MarkdownIt().utils.escapeHtml(fence));
+  const amp = readFileSync("src/cef-to-amp.md", "utf8");
+  assert.match(
+    amp,
+    /include "\/usr\/share\/limpid\/snippets\/parsers\/parse_syslog.limpid"/,
+  );
+  assert.match(amp, /process parse_syslog\n/);
+  assert.ok(!amp.includes("syslog.parse(ingress)"));
+});
+
+test("header stays outside the keyboard-accessible content scroller", () => {
+  const renderer = new PageTemplate();
+  for (const entry of pages()) {
+    const html = renderer.render({ entry });
+    assert.match(
+      html,
+      /<\/header><div class="page-scroll" tabindex="0" role="region" aria-label="Page content"><main /,
+    );
+    assert.match(html, /<\/footer><\/div><\/body>/);
+    assert.equal((html.match(/class="page-scroll"/g) || []).length, 1);
+    assert.match(html, /href="#main"/);
+    assert.match(html, /<main id="main"/);
+  }
+});
+
 test("shared head includes exactly one static Search Console verification tag", () => {
   const tag =
     '<meta name="google-site-verification" content="S-EqEKp48UJAW41lZX5p1lCX1WOcv23Zq_XZxVzEsNk" />';
@@ -61,17 +100,18 @@ test("filtering is second and archival never drops messages", () => {
   assert.match(archive, /default \{ output other \}/);
 });
 
-test("Datadog is fifth and preserves its header and JSON payload", () => {
+test("Datadog is sixth and documents JSON and direct OTLP with literal payloads", () => {
   const recipes = pages().filter((page) => page.kind === "recipe");
-  assert.equal(recipes[4].route, "recipes/datadog/index.html");
-  assert.equal(recipes[5].route, "recipes/cloudwatch/index.html");
-  assert.equal(recipes[5].number, 6);
+  assert.equal(recipes[5].route, "recipes/datadog/index.html");
+  assert.equal(recipes[6].route, "recipes/better-stack/index.html");
+  assert.equal(recipes[7].route, "recipes/cloudwatch/index.html");
+  assert.equal(recipes[7].number, 8);
   assert.deepEqual(
     recipes.map((recipe, index) => recipe.number ?? index + 1),
-    [1, 2, 3, 4, 5, 6, 7, 8],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
   );
-  assert.equal(recipes[6].route, "recipes/ama-forwarding/index.html");
-  assert.equal(recipes[7].route, "recipes/cef-to-amp/index.html");
+  assert.equal(recipes[8].route, "recipes/ama-forwarding/index.html");
+  assert.equal(recipes[9].route, "recipes/cef-to-amp/index.html");
   const source = readFileSync("src/datadog.md", "utf8");
   for (const text of [
     '"DD-API-KEY":',
@@ -79,15 +119,149 @@ test("Datadog is fifth and preserves its header and JSON payload", () => {
     "/api/v2/logs",
     "batch_size 1",
     "message: ingress",
-    "0.8.4",
+    "## Option A: choose the JSON fields",
+    "## Option B: preserve OTLP structure",
+    '"dd-api-key": "<DATADOG_API_KEY>"',
+    'endpoint "https://otlp.ap1.datadoghq.com/v1/logs"',
+    "protocol http_protobuf",
+    "body = { string_value: ingress }",
+    "compose_otlp | otlp_to_egress",
     "Log Explorer",
   ])
     assert.ok(source.includes(text), text);
-  const payload = source.match(/```limpid\n([\s\S]*?)```/)[1];
-  const rendered = recipes[4].content
-    .match(/<pre><code[^>]*>([\s\S]*?)<\/code>/)[1]
-    .replace(/<span class="[^"]+">|<\/span>/g, "");
-  assert.equal(rendered, new MarkdownIt().utils.escapeHtml(payload));
+  const payloads = [...source.matchAll(/```limpid\n([\s\S]*?)```/g)].map(
+    (m) => m[1],
+  );
+  const rendered = [
+    ...recipes[5].content.matchAll(
+      /<pre><code class="language-limpid">([\s\S]*?)<\/code>/g,
+    ),
+  ].map((m) => m[1].replace(/<span class="[^"]+">|<\/span>/g, ""));
+  assert.equal(payloads.length, 4);
+  assert.deepEqual(
+    rendered,
+    payloads.map((p) => new MarkdownIt().utils.escapeHtml(p)),
+  );
+});
+
+test("FortiGate variations distinguish raw JSON and parsed OTLP on three destinations", () => {
+  let sample;
+  for (const name of ["datadog", "better-stack", "loki-http-json"]) {
+    const source = readFileSync(`src/${name}.md`, "utf8");
+    const event = JSON.parse(source.match(/```json\n([\s\S]*?)```/)[1]);
+    if (sample) assert.deepEqual(event, sample);
+    sample = event;
+    const fences = [...source.matchAll(/```limpid\n([\s\S]*?)```/g)].map(
+      (m) => m[1],
+    );
+    assert.equal(fences.length, 4);
+    assert.match(
+      fences[1],
+      /parse_syslog \| parse_cef \| fortigate_timezone \| parse_fortigate_cef \| fortigate_document/,
+    );
+    assert.match(
+      fences[1],
+      /event_time_unix_nano: workspace\.lsis\.parsed\.time/,
+    );
+    assert.match(fences[1], /message: ingress/);
+    assert.match(
+      fences[3],
+      /fortigate_cef_to_otlp \| compose_otlp \| otlp_to_egress/,
+    );
+    assert.doesNotMatch(
+      fences[3],
+      /process (?:datadog_log|betterstack_log|syslog_for_loki)/,
+    );
+    assert.match(fences[3], /workspace\.fortigate_cef\.timezone = "UTC"/);
+    assert.match(
+      fences[3],
+      /process parse_syslog \| parse_cef \| fortigate_timezone \| parse_fortigate_cef/,
+    );
+    assert.ok(source.includes("not the sender of the UDP packet"));
+    assert.ok(source.includes("does not invent `service.name`"));
+    const entry = pages().find((p) => p.route === `recipes/${name}/index.html`);
+    const rendered = [
+      ...entry.content.matchAll(
+        /<pre><code class="language-limpid">([\s\S]*?)<\/code>/g,
+      ),
+    ].map((m) => m[1].replace(/<span class="[^"]+">|<\/span>/g, ""));
+    assert.deepEqual(
+      rendered,
+      fences.map((p) => new MarkdownIt().utils.escapeHtml(p)),
+    );
+    if (name === "loki-http-json") {
+      assert.match(fences[2], /protocol http_protobuf/);
+      assert.ok(source.includes('observer_type="firewall"'));
+      assert.ok(source.includes("add `observer.type` beside `service.name`"));
+    }
+  }
+});
+
+test("destination titles agree across index, page title, and source heading", () => {
+  const entries = pages();
+  const indexHtml = new PageTemplate().render({
+    entry: entries.find((p) => p.kind === "recipes"),
+  });
+  const titles = {
+    "loki-http-json": "Send syslog to Loki",
+    elasticsearch: "Send syslog to Elasticsearch",
+    datadog: "Send syslog to Datadog",
+    "better-stack": "Send syslog to Better Stack",
+    cloudwatch: "Send syslog to Amazon CloudWatch Logs",
+    "ama-forwarding": "Route CEF and Syslog to Log Analytics via AMA",
+    "cef-to-amp": "Send CEF to Log Analytics via AMP",
+  };
+  for (const [name, title] of Object.entries(titles)) {
+    const entry = entries.find((p) => p.route === `recipes/${name}/index.html`);
+    const html = new PageTemplate().render({ entry });
+    assert.equal(entry.title, title);
+    assert.equal(
+      readFileSync(`src/${name}.md`, "utf8").split("\n")[0],
+      `# ${title}`,
+    );
+    assert.ok(indexHtml.includes(title));
+    assert.ok(html.includes(`<title>${title} — limpid</title>`));
+    assert.equal(html.match(/<h1\b[^>]*>(.*?)<\/h1>/s)?.[1], title);
+  }
+});
+
+test("Better Stack documents both transports with literal public placeholders", () => {
+  const source = readFileSync("src/better-stack.md", "utf8");
+  const entry = pages().find(
+    (page) => page.route === "recipes/better-stack/index.html",
+  );
+  assert.equal(entry.number, 7);
+  for (const text of [
+    '"Authorization": "Bearer <SOURCE_TOKEN>"',
+    'url "https://ingesting-host.example/"',
+    'endpoint "https://ingesting-host.example/v1/logs"',
+    "protocol http_protobuf",
+    "message: ingress",
+    "body = { string_value: ingress }",
+    "compose_otlp | otlp_to_egress",
+    "Live Tail",
+    "management API token",
+    "## Option A: choose the JSON fields",
+    "## Option B: preserve OTLP structure",
+  ])
+    assert.ok(source.includes(text), text);
+  assert.doesNotMatch(
+    source,
+    /s2740307|LIMPID_BETTERSTACK_V084|\/tmp\/bs\.txt/,
+  );
+  const payloads = [...source.matchAll(/```limpid\n([\s\S]*?)```/g)].map(
+    (match) => match[1],
+  );
+  const rendered = [
+    ...entry.content.matchAll(
+      /<pre><code class="language-limpid">([\s\S]*?)<\/code>/g,
+    ),
+  ].map((match) => match[1].replace(/<span class="[^"]+">|<\/span>/g, ""));
+  assert.equal(payloads.length, 4);
+  assert.deepEqual(
+    rendered,
+    payloads.map((payload) => new MarkdownIt().utils.escapeHtml(payload)),
+  );
 });
 
 test("archival and filtering recipes preserve every authored fence payload", () => {
@@ -132,9 +306,9 @@ test("AMA recipe pairs PRI rewriting with distinct connector DCRs", () => {
   assert.ok(!html.includes("Imported from the existing pipeline examples"));
 });
 
-test("Loki is third and distinguishes native JSON from OTLP", () => {
+test("Loki is fourth and distinguishes native JSON from OTLP", () => {
   const recipes = pages().filter((p) => p.kind === "recipe");
-  assert.equal(recipes[2].route, "recipes/loki-http-json/index.html");
+  assert.equal(recipes[3].route, "recipes/loki-http-json/index.html");
   const source = readFileSync("src/loki-http-json.md", "utf8");
   for (const text of [
     "batch_size 1",
@@ -148,7 +322,7 @@ test("Loki is third and distinguishes native JSON from OTLP", () => {
   for (const text of [
     "/otlp/v1/logs",
     "type otlp_http",
-    'protocol "http_protobuf"',
+    "protocol http_protobuf",
     'key: "service.name"',
     'key: "source.ip"',
     "allow_structured_metadata: true",
@@ -159,9 +333,9 @@ test("Loki is third and distinguishes native JSON from OTLP", () => {
     assert.ok(source.includes(text), text);
 });
 
-test("Elastic is fourth and documents both ingestion paths and acknowledgement limits", () => {
+test("Elastic is fifth and documents both ingestion paths and acknowledgement limits", () => {
   const recipes = pages().filter((p) => p.kind === "recipe");
-  assert.equal(recipes[3].route, "recipes/elasticsearch/index.html");
+  assert.equal(recipes[4].route, "recipes/elasticsearch/index.html");
   const source = readFileSync("src/elasticsearch.md", "utf8");
   for (const text of [
     "application/x-ndjson",
@@ -183,12 +357,60 @@ test("Elastic is fourth and documents both ingestion paths and acknowledgement l
   );
 });
 
+test("Elasticsearch structured variants bind explicit Bulk mappings and native OTLP query paths", () => {
+  const source = readFileSync("src/elasticsearch.md", "utf8");
+  const sample = JSON.parse(source.match(/```json\n([\s\S]*?)```/)[1]);
+  assert.deepEqual(
+    sample,
+    JSON.parse(
+      readFileSync("src/datadog.md", "utf8").match(/```json\n([\s\S]*?)```/)[1],
+    ),
+  );
+  const requests = [...source.matchAll(/```http\n[^\n]+\n([\s\S]*?)```/g)].map(
+    (m) => JSON.parse(m[1]),
+  );
+  assert.equal(requests.length, 3);
+  const properties = requests[0].mappings.properties;
+  assert.equal(properties.source.properties.ip.type, "ip");
+  assert.equal(properties.destination.properties.port.type, "integer");
+  assert.equal(properties.event_time.format, "epoch_millis");
+  assert.equal(properties.rule.properties.name.type, "keyword");
+  assert.equal(requests[1].aggs.rules.terms.field, "rule.name");
+  assert.equal(requests[2].aggs.rules.terms.field, "attributes.rule.name");
+  const fences = [...source.matchAll(/```limpid\n([\s\S]*?)```/g)].map(
+    (m) => m[1],
+  );
+  assert.equal(fences.length, 4);
+  for (const index of [1, 3])
+    assert.ok(
+      fences[index].includes(
+        "parse_syslog | parse_cef | fortigate_timezone | parse_fortigate_cef",
+      ),
+    );
+  assert.ok(fences[1].includes("to_int(workspace.lsis.parsed.time / 1000000)"));
+  assert.ok(
+    fences[3].includes("fortigate_cef_to_otlp | compose_otlp | otlp_to_egress"),
+  );
+  const entry = pages().find(
+    (p) => p.route === "recipes/elasticsearch/index.html",
+  );
+  const rendered = [
+    ...entry.content.matchAll(
+      /<pre><code class="language-limpid">([\s\S]*?)<\/code>/g,
+    ),
+  ].map((m) => m[1].replace(/<span class="[^"]+">|<\/span>/g, ""));
+  assert.deepEqual(
+    rendered,
+    fences.map((p) => new MarkdownIt().utils.escapeHtml(p)),
+  );
+});
+
 test("AMP recipe pairs OTLP attributes with Log Analytics record mappings", () => {
   const entry = pages().find(
     (page) => page.route === "recipes/cef-to-amp/index.html",
   );
   assert.ok(entry);
-  assert.equal(entry.title, "Map CEF fields to Log Analytics columns via AMP");
+  assert.equal(entry.title, "Send CEF to Log Analytics via AMP");
   const source = readFileSync("src/cef-to-amp.md", "utf8");
   const mapping = JSON.parse(source.match(/```json\n([\s\S]*?)```/)[1]);
   for (const { from, to } of mapping.recordMap) {

--- a/site/test/recovery-recipes.test.mjs
+++ b/site/test/recovery-recipes.test.mjs
@@ -35,7 +35,7 @@ test("home keeps the approved concise copy and links to operational details", ()
   assert.equal((html.match(/class="number"/g) || []).length, 3);
 });
 
-test("existing eight recipes are grouped without renumbering or changing routes", () => {
+test("ten recipes remain grouped with the homepage example first", () => {
   const entries = pages();
   const html = new PageTemplate().render({
     entry: entries.find((p) => p.kind === "recipes"),
@@ -51,9 +51,9 @@ test("existing eight recipes are grouped without renumbering or changing routes"
   );
   assert.deepEqual(
     [...html.matchAll(/class="number">(\d+)<\/span>/g)].map((m) => m[1]),
-    ["00", "01", "02", "03", "04", "05", "06", "07", "08"],
+    ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10"],
   );
-  assert.equal(entries.filter((p) => p.kind === "recipe").length, 8);
+  assert.equal(entries.filter((p) => p.kind === "recipe").length, 10);
   assert.ok(
     entries.find((p) => p.route === "recipes/fortigate-cef-to-ocsf/index.html"),
   );


### PR DESCRIPTION
## Summary

Expand the existing site without changing the runtime, dependencies, or deployment workflow.

- Add Better Stack JSON and OTLP examples and shorten destination titles consistently.
- Add FortiGate CEF structured variants for Datadog, Better Stack, Loki, and Elasticsearch, preserving the original-line examples.
- Add Processing recipe 03 for archive-first conditional fan-out. Renumber the remaining cards through 10 while keeping existing URLs and the homepage example 00.
- Use the packaged `parse_syslog` process in the AMP example.
- Keep the header outside the content scroller, with an owner-approved translucent background and blur. Preserve skip-to-content and keyboard access to the scroller.

## Verification

- Node 24: 39 tests pass; independent related tests: 23 pass.
- Build: 63 generated files; 62 HTML pages with no broken local links or anchors; format and diff checks pass.
- limpid 0.8.4 local `--check` / `--test-pipeline`: branching severities 6/4/3 select the expected output copies; archive and forwarded copies retain their original bytes, while the urgent copy is JSON. AMP projection fields pass after using the syslog snippet.
- Existing structured-example evidence remains separately scoped: local JSON/OTLP payload checks; Elasticsearch generated payload receiver checks; Datadog and Better Stack intake/owner-visible arrivals. No new external sends were performed for branching, AMP, or the UI change. These are not independent end-to-end byte-exact certifications for all destinations.
- Owner checked Safari scrolling and approved the 80% header background. Cross-browser keyboard and history-restoration behavior has not been manually exercised; DOM/accessibility structure and anchor targets are covered by checks.

## Publication

This PR does not deploy the site. After owner merge and successful CI, use the existing main-only manual Pages workflow and verify the published artifact. No Rust release, live daemon, cloud-resource, or GitHub settings changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipes for forwarding syslog to Better Stack and archiving events while selectively forwarding them.
  * Added raw and parsed-field forwarding options for Datadog, Elasticsearch, Loki, and Better Stack.
  * Added FortiGate CEF parsing guidance and OTLP examples across supported destinations.

* **Documentation**
  * Expanded troubleshooting, local inspection, authentication, and verification guidance.
  * Updated recipe titles, organization, numbering, and source inventory.

* **Style**
  * Improved site navigation with a fixed, responsive header and dedicated scrollable content area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->